### PR TITLE
Fix pubmatic user sync

### DIFF
--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -146,7 +146,7 @@ func NewPubmaticAdapter(config *HTTPAdapterConfig, uri string, externalURL strin
 	usersyncURL := "http://ads.pubmatic.com/AdServer/js/user_sync.html?p=31445&s=21446&predirect="
 
 	info := &pbs.UsersyncInfo{
-		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		URL:         fmt.Sprintf("%s%s", usersyncURL, redirect_uri),
 		Type:        "iframe",
 		SupportCORS: false,
 	}

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -9,10 +9,7 @@ import (
 	"github.com/prebid/prebid-server/pbs"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-
 	"golang.org/x/net/context/ctxhttp"
-
 	"github.com/prebid/openrtb"
 )
 
@@ -143,7 +140,7 @@ func NewPubmaticAdapter(config *HTTPAdapterConfig, uri string, externalURL strin
 	a := NewHTTPAdapter(config)
 
 	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pubmatic&uid=$UID", externalURL)
-	usersyncURL := "http://ads.pubmatic.com/AdServer/js/user_sync.html?p=31445&s=21446&predirect="
+	usersyncURL := "http://ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
 
 	info := &pbs.UsersyncInfo{
 		URL:         fmt.Sprintf("%s%s", usersyncURL, redirect_uri),

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/pbs"
+	"golang.org/x/net/context/ctxhttp"
 	"io/ioutil"
 	"net/http"
-	"golang.org/x/net/context/ctxhttp"
-	"github.com/prebid/openrtb"
 )
 
 type PubmaticAdapter struct {


### PR DESCRIPTION
pubmatic already encodes their URL so it got double encoded on the client. 
@asweeney86 @bokelley 