### PR TITLE
use json.Decoder when possible

### DIFF
--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -3,7 +3,6 @@ package pbs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -105,13 +104,8 @@ func getConfig(cache cache.Cache, id string) ([]Bids, error) {
 
 func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	defer r.Body.Close()
-	b, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	pbsReq := &PBSRequest{}
-	err = json.Unmarshal(b, pbsReq)
+	err := json.NewDecoder(r.Body).Decode(&pbsReq)
 	if err != nil {
 		return nil, err
 	}

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -5,15 +5,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/julienschmidt/httprouter"
-	"github.com/prebid/prebid-server/ssl"
-	metrics "github.com/rcrowley/go-metrics"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"github.com/prebid/prebid-server/ssl"
+	metrics "github.com/rcrowley/go-metrics"
 )
 
 var cookie_domain string
@@ -136,14 +136,8 @@ func VerifyRecaptcha(response string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	gr := new(googleResponse)
-	err = json.Unmarshal(body, &gr)
-	if err != nil {
+	var gr = googleResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
 		return err
 	}
 	if !gr.Success {

--- a/prebid_cache_client/prebid_cache.go
+++ b/prebid_cache_client/prebid_cache.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -77,18 +76,13 @@ func Put(ctx context.Context, objs []*CacheObject) error {
 	if anResp.StatusCode != 200 {
 		return fmt.Errorf("HTTP status code %d", anResp.StatusCode)
 	}
-
 	defer anResp.Body.Close()
-	body, err := ioutil.ReadAll(anResp.Body)
-	if err != nil {
-		return err
-	}
 
 	var resp response
-	err = json.Unmarshal(body, &resp)
-	if err != nil {
+	if err := json.NewDecoder(anResp.Body).Decode(&resp); err != nil {
 		return err
 	}
+
 	if len(resp.Responses) != len(objs) {
 		return fmt.Errorf("Put response length didn't match")
 	}

--- a/prebid_cache_client/prebid_cache_test.go
+++ b/prebid_cache_client/prebid_cache_test.go
@@ -3,7 +3,6 @@ package prebid_cache_client
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,15 +15,9 @@ var delay time.Duration
 
 func DummyPrebidCacheServer(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	var pr putRequest
-	err = json.Unmarshal(body, &pr)
-	if err != nil {
+
+	if err := json.NewDecoder(r.Body).Decode(&pr); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
- json.Decoder accepts an ``io.Reader`` (*http.Request.Body and *http.Response.Body)
- adapters still use io/ioutil for debugging