### PR TITLE
change package name from adapters to adapters_test

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -3,10 +3,11 @@ package adapters
 import (
 	"context"
 	"crypto/tls"
-	"github.com/prebid/prebid-server/pbs"
-	"github.com/prebid/prebid-server/ssl"
 	"net/http"
 	"time"
+
+	"github.com/prebid/prebid-server/pbs"
+	"github.com/prebid/prebid-server/ssl"
 )
 
 type Adapter interface {

--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -10,11 +10,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/prebid/prebid-server/pbs"
-
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type AppNexusAdapter struct {

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -1,22 +1,22 @@
-package adapters
+package adapters_test
 
 import (
 	"context"
 	"encoding/json"
-	"github.com/prebid/prebid-server/pbs"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func TestAppNexusInvalidCall(t *testing.T) {
 
-	an := NewAppNexusAdapter(DefaultHTTPAdapterConfig, "localhost")
+	an := adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, "localhost")
 	an.URI = "blah"
 	s := an.Name()
 	if s == "" {
@@ -41,8 +41,8 @@ func TestAppNexusTimeout(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewAppNexusAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
@@ -78,8 +78,8 @@ func TestAppNexusInvalidJson(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewAppNexusAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -114,8 +114,8 @@ func TestAppNexusInvalidStatusCode(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewAppNexusAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -141,8 +141,8 @@ func TestAppNexusInvalidStatusCode(t *testing.T) {
 }
 
 func TestMissingPlacementId(t *testing.T) {
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewAppNexusAdapter(&conf, "localhost")
 	an.URI = "dummy"
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -201,8 +201,8 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewAppNexusAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -233,14 +233,14 @@ func TestAppNexusBasicResponse(t *testing.T) {
 
 func TestAppNexusUserSyncInfo(t *testing.T) {
 
-	an := NewAppNexusAdapter(DefaultHTTPAdapterConfig, "localhost")
-	if an.usersyncInfo.URL != "//ib.adnxs.com/getuid?localhost%2Fsetuid%3Fbidder%3Dadnxs%26uid%3D%24UID" {
+	an := adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, "localhost")
+	if an.GetUsersyncInfo().URL != "//ib.adnxs.com/getuid?localhost%2Fsetuid%3Fbidder%3Dadnxs%26uid%3D%24UID" {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "redirect" {
+	if an.GetUsersyncInfo().Type != "redirect" {
 		t.Fatalf("should be redirect")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 }

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"strings"
 
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/pbs"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 type FacebookAdapter struct {

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -1,20 +1,20 @@
-package adapters
+package adapters_test
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/prebid/prebid-server/cache"
-	"github.com/prebid/prebid-server/pbs"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/cache"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type tagInfo struct {
@@ -172,8 +172,8 @@ func TestFacebookBasicResponse(t *testing.T) {
 		bid:         3.22,
 	}
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewFacebookAdapter(&conf, fmt.Sprintf("%d", fbdata.partnerID), "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewFacebookAdapter(&conf, fmt.Sprintf("%d", fbdata.partnerID), "localhost")
 	an.URI = server.URL
 
 	pbin := pbs.PBSRequest{
@@ -284,14 +284,14 @@ func TestFacebookBasicResponse(t *testing.T) {
 func TestFacebookUserSyncInfo(t *testing.T) {
 	url := "https://www.facebook.com/audiencenetwork/idsync/?partner=partnerId&callback=localhost%2Fsetuid%3Fbidder%3DaudienceNetwork%26uid%3D%24UID"
 
-	an := NewFacebookAdapter(DefaultHTTPAdapterConfig, "partnerId", url)
-	if an.usersyncInfo.URL != url {
+	an := adapters.NewFacebookAdapter(adapters.DefaultHTTPAdapterConfig, "partnerId", url)
+	if an.GetUsersyncInfo().URL != url {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "redirect" {
+	if an.GetUsersyncInfo().Type != "redirect" {
 		t.Fatalf("should be redirect")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 }

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -10,11 +10,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/prebid/prebid-server/pbs"
-
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type IndexAdapter struct {

--- a/adapters/index_test.go
+++ b/adapters/index_test.go
@@ -1,22 +1,22 @@
-package adapters
+package adapters_test
 
 import (
 	"context"
 	"encoding/json"
-	"github.com/prebid/prebid-server/pbs"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func TestIndexInvalidCall(t *testing.T) {
 
-	an := NewIndexAdapter(DefaultHTTPAdapterConfig, "localhost")
+	an := adapters.NewIndexAdapter(adapters.DefaultHTTPAdapterConfig, "localhost")
 	an.URI = "blah"
 	s := an.Name()
 	if s == "" {
@@ -41,8 +41,8 @@ func TestIndexTimeout(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewIndexAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewIndexAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
@@ -78,8 +78,8 @@ func TestIndexInvalidJson(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewIndexAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewIndexAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -114,8 +114,8 @@ func TestIndexInvalidStatusCode(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewIndexAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewIndexAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -150,8 +150,8 @@ func TestIndexMissingSiteId(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewIndexAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewIndexAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -209,8 +209,8 @@ func TestIndexBasicResponse(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewIndexAdapter(&conf, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewIndexAdapter(&conf, "localhost")
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -241,14 +241,14 @@ func TestIndexBasicResponse(t *testing.T) {
 
 func TestIndexUserSyncInfo(t *testing.T) {
 
-	an := NewIndexAdapter(DefaultHTTPAdapterConfig, "localhost")
-	if an.usersyncInfo.URL != "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D__UID__" {
+	an := adapters.NewIndexAdapter(adapters.DefaultHTTPAdapterConfig, "localhost")
+	if an.GetUsersyncInfo().URL != "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D__UID__" {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "redirect" {
+	if an.GetUsersyncInfo().Type != "redirect" {
 		t.Fatalf("should be redirect")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 }

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -1,10 +1,14 @@
 package adapters
 
 import (
-	"github.com/prebid/prebid-server/pbs"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
+
+// MakeOpenRTBGeneric makes makeOpenRTBGeneric public
+func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
+	return makeOpenRTBGeneric(req, bidder, bidderFamily)
+}
 
 func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
 

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -1,12 +1,13 @@
-package adapters
+package adapters_test
 
 import (
-	"github.com/prebid/prebid-server/pbs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func TestOpenRTB(t *testing.T) {
@@ -26,7 +27,7 @@ func TestOpenRTB(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := adapters.MakeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
@@ -44,6 +45,6 @@ func TestOpenRTBNoSize(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := adapters.MakeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 	assert.Equal(t, resp.Imp[0].ID, "")
 }

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"net/url"
 
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/pbs"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 type PubmaticAdapter struct {

--- a/adapters/pubmatic_test.go
+++ b/adapters/pubmatic_test.go
@@ -1,22 +1,22 @@
-package adapters
+package adapters_test
 
 import (
 	"context"
 	"encoding/json"
-	"github.com/prebid/prebid-server/pbs"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func TestPubmaticInvalidCall(t *testing.T) {
 
-	an := NewPubmaticAdapter(DefaultHTTPAdapterConfig, "blah", "localhost")
+	an := adapters.NewPubmaticAdapter(adapters.DefaultHTTPAdapterConfig, "blah", "localhost")
 
 	s := an.Name()
 	if s == "" {
@@ -41,8 +41,8 @@ func TestPubmaticTimeout(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
@@ -77,8 +77,8 @@ func TestPubmaticInvalidJson(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{
@@ -112,8 +112,8 @@ func TestPubmaticInvalidStatusCode(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{
@@ -147,8 +147,8 @@ func TestPubmaticMissingPublisherId(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{
@@ -182,8 +182,8 @@ func TestPubmaticMissingAdSlot(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{
@@ -241,8 +241,8 @@ func TestPubmaticBasicResponse(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewPubmaticAdapter(&conf, server.URL, "localhost")
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := adapters.NewPubmaticAdapter(&conf, server.URL, "localhost")
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{
@@ -272,14 +272,14 @@ func TestPubmaticBasicResponse(t *testing.T) {
 
 func TestPubmaticUserSyncInfo(t *testing.T) {
 
-	an := NewPubmaticAdapter(DefaultHTTPAdapterConfig, "pubmaticUrl", "localhost")
-	if an.usersyncInfo.URL != "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect=localhost%2Fsetuid%3Fbidder%3Dpubmatic%26uid%3D" {
+	an := adapters.NewPubmaticAdapter(adapters.DefaultHTTPAdapterConfig, "pubmaticUrl", "localhost")
+	if an.GetUsersyncInfo().URL != "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect=localhost%2Fsetuid%3Fbidder%3Dpubmatic%26uid%3D" {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "iframe" {
+	if an.GetUsersyncInfo().Type != "iframe" {
 		t.Fatalf("should be iframe")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -12,9 +12,10 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/pbs"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 type PulsePointAdapter struct {

--- a/adapters/pulsepoint_test.go
+++ b/adapters/pulsepoint_test.go
@@ -1,18 +1,20 @@
-package adapters
+package adapters_test
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prebid/openrtb"
-	"github.com/prebid/prebid-server/cache"
-	"github.com/prebid/prebid-server/pbs"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/cache"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 /**
@@ -27,7 +29,7 @@ type PulsePointOrtbMockService struct {
  * Verify adapter names are setup correctly.
  */
 func TestPulsePointAdapterNames(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
 	VerifyStringValue(adapter.Name(), "pulsepoint", t)
 	VerifyStringValue(adapter.FamilyName(), "pulsepoint", t)
 }
@@ -36,7 +38,7 @@ func TestPulsePointAdapterNames(t *testing.T) {
  * Verifies the user sync parameters.
  */
 func TestPulsePointUserSyncInfo(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
 	VerifyStringValue(adapter.GetUsersyncInfo().Type, "redirect", t)
 	VerifyStringValue(adapter.GetUsersyncInfo().URL, "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl=http%3A%2F%2Flocalhost%2Fsetuid%3Fbidder%3Dpulsepoint%26uid%3D%25%25VGUID%25%25", t)
 }
@@ -45,7 +47,7 @@ func TestPulsePointUserSyncInfo(t *testing.T) {
  * Test required parameters not sent
  */
 func TestPulsePointRequiredBidParameters(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
@@ -85,7 +87,7 @@ func TestPulsePointOpenRTBRequest(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	adapter.Call(ctx, req, bidder)
 	fmt.Println(service.LastBidRequest)
 	VerifyIntValue(len(service.LastBidRequest.Imp), 1, t)
@@ -104,7 +106,7 @@ func TestPulsePointBiddingBehavior(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// number of bids should be 1
 	VerifyIntValue(len(bids), 1, t)
@@ -127,7 +129,7 @@ func TestPulsePointMultiImpPartialBidding(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -146,7 +148,7 @@ func TestPulsePointMultiImpPassback(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -164,7 +166,7 @@ func TestPulsePointMultiImpAllBid(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -188,7 +190,7 @@ func TestMobileAppRequest(t *testing.T) {
 		Name: "facebook",
 	}
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := adapters.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, server.URL, "http://localhost")
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// one mobile app impression sent.
 	// verify appropriate fields are sent to pulsepoint endpoint.

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -9,11 +9,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/prebid/prebid-server/pbs"
-
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type RubiconAdapter struct {

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -1,20 +1,22 @@
-package adapters
+package adapters_test
 
 import (
 	"testing"
+
+	"github.com/prebid/prebid-server/adapters"
 )
 
 func TestRubiconUserSyncInfo(t *testing.T) {
 	url := "https://pixel.rubiconproject.com/exchange/sync.php?p=prebid"
 
-	an := NewRubiconAdapter(DefaultHTTPAdapterConfig, "uri", "xuser", "xpass", url)
-	if an.usersyncInfo.URL != url {
+	an := adapters.NewRubiconAdapter(adapters.DefaultHTTPAdapterConfig, "uri", "xuser", "xpass", url)
+	if an.GetUsersyncInfo().URL != url {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "redirect" {
+	if an.GetUsersyncInfo().Type != "redirect" {
 		t.Fatalf("should be redirect")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 


### PR DESCRIPTION
- by changing the package name to "adapters_test" we're able to import the prebid-server/adapters package in our unit tests
  - unit tests were using the unexported usersyncInfo attribute instead of the GetUsersyncInfo() method
  - makeOpenRTBGeneric was unexportable so MakeOpenRTBGeneric has been added