### PR TITLE
Use uint16 for W&H in rubicon sizemap

### DIFF
--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -79,8 +79,8 @@ type rubiconBannerExt struct {
 }
 
 type rubiSize struct {
-	w uint64
-	h uint64
+	w uint16
+	h uint16
 }
 
 var rubiSizeMap = map[rubiSize]int{
@@ -128,7 +128,7 @@ var rubiSizeMap = map[rubiSize]int{
 }
 
 func lookupSize(s openrtb.Format) (int, error) {
-	if sz, ok := rubiSizeMap[rubiSize{w: s.W, h: s.H}]; ok {
+	if sz, ok := rubiSizeMap[rubiSize{w: uint16(s.W), h: uint16(s.H)}]; ok {
 		return sz, nil
 	}
 	return 0, fmt.Errorf("Size %dx%d not found", s.W, s.H)


### PR DESCRIPTION
The maximum width and height for rubicon fits into a uint16, by using
a smaller int size we can be nicer to the cache.