### PR TITLE
adapter packages - feedback requested

### DIFF
--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -1,0 +1,54 @@
+package adapters
+
+import (
+	"github.com/golang/glog"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
+)
+
+// all is unexported because it may contain adapters that have not been configured
+var all map[string]pbs.Adapter
+
+// Active allows us to access all of the active adapters that have been configured
+var Active map[string]pbs.Adapter
+
+func init() {
+	if Active == nil {
+		Active = map[string]pbs.Adapter{}
+	}
+	if all == nil {
+		all = map[string]pbs.Adapter{}
+	}
+}
+
+// Init is called by each adapter so they can be registered in the global map
+func Init(name string, ex pbs.Adapter) {
+	all[name] = ex
+}
+
+// Get will return back an adapter.
+// If the adapter has not been registered we will return a false boolean
+// example:
+// appnexus, ok := adapters.Get("appnexus")
+func Get(name string) (pbs.Adapter, bool) {
+	if ex, ok := Active[name]; ok {
+		return ex, true
+	}
+	return nil, false
+}
+
+// Configure should be called once.
+func Configure(externalURL string, cfgs map[string]config.Adapter) error {
+
+	for exchange, cfg := range cfgs {
+		ex, ok := all[exchange]
+		if !ok {
+			// TODO: should return the error below or just log? Right now we are just logging the error and not making the adapter accessible
+			glog.Infof("Could not configure exchange: %v", exchange)
+			continue
+		}
+		ex.Configure(externalURL, &cfg)
+		Active[exchange] = ex // attach the adapter to the global Active map
+	}
+	return nil
+}

--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -12,6 +12,7 @@ var all map[string]pbs.Adapter
 // Active allows us to access all of the active adapters that have been configured
 var Active map[string]pbs.Adapter
 
+// init will ensure that we are not appending to a nil map
 func init() {
 	if Active == nil {
 		Active = map[string]pbs.Adapter{}

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -124,6 +124,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 
@@ -169,8 +172,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 			if bidID == "" {
 				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
 			}
-
-			pbid := pbs.PBSBid{
+			bids = append(bids, &pbs.PBSBid{
 				BidID:       bidID,
 				AdUnitCode:  bid.ImpID,
 				BidderCode:  bidder.BidderCode,
@@ -180,8 +182,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				Width:       bid.W,
 				Height:      bid.H,
 				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			})
 		}
 	}
 

--- a/adapters/districtm/districtm.go
+++ b/adapters/districtm/districtm.go
@@ -124,6 +124,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 
@@ -170,7 +173,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
 			}
 
-			pbid := pbs.PBSBid{
+			bids = append(bids, &pbs.PBSBid{
 				BidID:       bidID,
 				AdUnitCode:  bid.ImpID,
 				BidderCode:  bidder.BidderCode,
@@ -180,8 +183,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				Width:       bid.W,
 				Height:      bid.H,
 				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			})
 		}
 	}
 

--- a/adapters/districtm/districtm.go
+++ b/adapters/districtm/districtm.go
@@ -1,0 +1,189 @@
+package districtm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/adapters/openrtb_util"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
+)
+
+// init will register the Adapter with our global exchanges
+func init() {
+	var a = NewAdapter()
+	adapters.Init("districtm", a)
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		URI:  "http://ib.adnxs.com/openrtb2",
+		http: pbs.NewHTTPAdapter(pbs.DefaultHTTPAdapterConfig),
+	}
+}
+
+// Adapter
+type Adapter struct {
+	http         *pbs.HTTPAdapter
+	URI          string
+	usersyncInfo *pbs.UsersyncInfo
+}
+
+// Use will set a shared Use(http *pbs.HTTPAdapter) (optional)
+func (a *Adapter) Use(http *pbs.HTTPAdapter) {
+	a.http = http
+}
+
+// Configure is required. It accepts an external url (required) and optional *config.Adapter
+// After Configure is run, the adapter will be registered as an active PBS exchange
+func (a *Adapter) Configure(externalURL string, config *config.Adapter) {
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=adnxs&uid=$UID", externalURL)
+	usersyncURL := "//ib.adnxs.com/getuid?"
+
+	a.usersyncInfo = &pbs.UsersyncInfo{
+		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		Type:        "redirect",
+		SupportCORS: false,
+	}
+
+	// if no configs are provided then we'll use the default values provided in init()
+	if config == nil {
+		return
+	}
+	return
+}
+
+// Name needs to be unique per adapter
+func (a *Adapter) Name() string {
+	return "DistrictM"
+}
+
+// used for cookies and such
+func (a *Adapter) FamilyName() string {
+	return "adnxs"
+}
+
+func (a *Adapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+	return a.usersyncInfo
+}
+
+type appnexusParams struct {
+	PlacementId int    `json:"placementId"`
+	InvCode     string `json:"invCode"`
+	Member      string `json:"member"`
+}
+
+type appnexusImpExtAppnexus struct {
+	PlacementID int `json:"placement_id"`
+}
+
+type appnexusImpExt struct {
+	Appnexus appnexusImpExtAppnexus `json:"appnexus"`
+}
+
+func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	anReq := openrtb_util.MakeOpenRTBGeneric(req, bidder, a.FamilyName())
+	for i, unit := range bidder.AdUnits {
+		var params appnexusParams
+		err := json.Unmarshal(unit.Params, &params)
+		if err != nil {
+			return nil, err
+		}
+
+		if params.PlacementId == 0 {
+			return nil, errors.New("Missing placementId param")
+		}
+
+		impExt := appnexusImpExt{Appnexus: appnexusImpExtAppnexus{PlacementID: params.PlacementId}}
+		anReq.Imp[i].Ext, err = json.Marshal(&impExt)
+		// TODO: support member + invCode
+	}
+
+	reqJSON, err := json.Marshal(anReq)
+	if err != nil {
+		return nil, err
+	}
+
+	debug := &pbs.BidderDebug{
+		RequestURI: a.URI,
+	}
+
+	if req.IsDebug {
+		debug.RequestBody = string(reqJSON)
+		bidder.Debug = append(bidder.Debug, debug)
+	}
+
+	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
+	httpReq.Header.Add("Accept", "application/json")
+
+	anResp, err := ctxhttp.Do(ctx, a.http.Client, httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	debug.StatusCode = anResp.StatusCode
+
+	if anResp.StatusCode == 204 {
+		return nil, nil
+	}
+
+	if anResp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP status code %d", anResp.StatusCode)
+	}
+
+	defer anResp.Body.Close()
+	body, err := ioutil.ReadAll(anResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.IsDebug {
+		debug.ResponseBody = string(body)
+	}
+
+	var bidResp openrtb.BidResponse
+	err = json.Unmarshal(body, &bidResp)
+	if err != nil {
+		return nil, err
+	}
+
+	bids := make(pbs.PBSBidSlice, 0)
+
+	numBids := 0
+	for _, sb := range bidResp.SeatBid {
+		for _, bid := range sb.Bid {
+			numBids++
+
+			bidID := bidder.LookupBidID(bid.ImpID)
+			if bidID == "" {
+				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
+			}
+
+			pbid := pbs.PBSBid{
+				BidID:       bidID,
+				AdUnitCode:  bid.ImpID,
+				BidderCode:  bidder.BidderCode,
+				Price:       bid.Price,
+				Adm:         bid.AdM,
+				Creative_id: bid.CrID,
+				Width:       bid.W,
+				Height:      bid.H,
+				DealId:      bid.DealID,
+			}
+			bids = append(bids, &pbid)
+		}
+	}
+
+	return bids, nil
+}

--- a/adapters/districtm/districtm_test.go
+++ b/adapters/districtm/districtm_test.go
@@ -1,24 +1,22 @@
-package adapters
+package districtm
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/prebid/prebid-server/pbs"
-
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
-func TestAppNexusInvalidCall(t *testing.T) {
+func TestDistrictMInvalidCall(t *testing.T) {
 
-	an := NewAppNexusAdapter(DefaultHTTPAdapterConfig, "localhost")
-	an.URI = "blah"
+	an := NewAdapter()
+	an.URI = "dummy"
 	s := an.Name()
 	if s == "" {
 		t.Fatal("Missing name")
@@ -33,7 +31,7 @@ func TestAppNexusInvalidCall(t *testing.T) {
 	}
 }
 
-func TestAppNexusTimeout(t *testing.T) {
+func TestDistrictMTimeout(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,8 +40,7 @@ func TestAppNexusTimeout(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	an := NewAdapter()
 	an.URI = server.URL
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
@@ -70,7 +67,7 @@ func TestAppNexusTimeout(t *testing.T) {
 	}
 }
 
-func TestAppNexusInvalidJson(t *testing.T) {
+func TestDistrictMInvalidJson(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,8 +76,7 @@ func TestAppNexusInvalidJson(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	an := NewAdapter()
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -105,7 +101,7 @@ func TestAppNexusInvalidJson(t *testing.T) {
 	}
 }
 
-func TestAppNexusInvalidStatusCode(t *testing.T) {
+func TestDistrictMInvalidStatusCode(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -115,8 +111,7 @@ func TestAppNexusInvalidStatusCode(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	an := NewAdapter()
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -142,8 +137,7 @@ func TestAppNexusInvalidStatusCode(t *testing.T) {
 }
 
 func TestMissingPlacementId(t *testing.T) {
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	an := NewAdapter()
 	an.URI = "dummy"
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -168,7 +162,7 @@ func TestMissingPlacementId(t *testing.T) {
 	}
 }
 
-func TestAppNexusBasicResponse(t *testing.T) {
+func TestDistrictMBasicResponse(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -202,8 +196,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	)
 	defer server.Close()
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, "localhost")
+	an := NewAdapter()
 	an.URI = server.URL
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}
@@ -232,16 +225,18 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	}
 }
 
-func TestAppNexusUserSyncInfo(t *testing.T) {
+func TestDistrictMUserSyncInfo(t *testing.T) {
 
-	an := NewAppNexusAdapter(DefaultHTTPAdapterConfig, "localhost")
-	if an.usersyncInfo.URL != "//ib.adnxs.com/getuid?localhost%2Fsetuid%3Fbidder%3Dadnxs%26uid%3D%24UID" {
+	an := NewAdapter()
+	an.Configure("localhost", nil)
+
+	if an.GetUsersyncInfo().URL != "//ib.adnxs.com/getuid?localhost%2Fsetuid%3Fbidder%3Dadnxs%26uid%3D%24UID" {
 		t.Fatalf("should have matched")
 	}
-	if an.usersyncInfo.Type != "redirect" {
+	if an.GetUsersyncInfo().Type != "redirect" {
 		t.Fatalf("should be redirect")
 	}
-	if an.usersyncInfo.SupportCORS != false {
+	if an.GetUsersyncInfo().SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
 }

--- a/adapters/facebook/facebook.go
+++ b/adapters/facebook/facebook.go
@@ -85,7 +85,7 @@ type fbResult struct {
 }
 
 func (a *Adapter) CallOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result fbResult, err error) {
-	httpReq, _ := http.NewRequest("POST", a.URI, &reqJSON)
+	httpReq, err := http.NewRequest("POST", a.URI, &reqJSON)
 	if err != nil {
 		return
 	}
@@ -100,7 +100,10 @@ func (a *Adapter) CallOne(ctx context.Context, req *pbs.PBSRequest, reqJSON byte
 	result.statusCode = anResp.StatusCode
 
 	defer anResp.Body.Close()
-	body, _ := ioutil.ReadAll(anResp.Body)
+	body, err := ioutil.ReadAll(anResp.Body)
+	if err != nil {
+		return
+	}
 	result.responseBody = string(body)
 
 	if anResp.StatusCode != 200 {

--- a/adapters/facebook/facebook_test.go
+++ b/adapters/facebook/facebook_test.go
@@ -1,21 +1,20 @@
-package adapters
+package facebook
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/prebid/prebid-server/cache/dummycache"
-	"github.com/prebid/prebid-server/pbs"
-
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type tagInfo struct {
@@ -173,8 +172,8 @@ func TestFacebookBasicResponse(t *testing.T) {
 		bid:         3.22,
 	}
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewFacebookAdapter(&conf, fmt.Sprintf("%d", fbdata.partnerID), "localhost")
+	an := NewAdapter()
+	an.Configure("localhost", &config.Adapter{PlatformID: fmt.Sprintf("%d", fbdata.partnerID), UserSyncURL: ""})
 	an.URI = server.URL
 
 	pbin := pbs.PBSRequest{
@@ -286,7 +285,9 @@ func TestFacebookBasicResponse(t *testing.T) {
 func TestFacebookUserSyncInfo(t *testing.T) {
 	url := "https://www.facebook.com/audiencenetwork/idsync/?partner=partnerId&callback=localhost%2Fsetuid%3Fbidder%3DaudienceNetwork%26uid%3D%24UID"
 
-	an := NewFacebookAdapter(DefaultHTTPAdapterConfig, "partnerId", url)
+	an := NewAdapter()
+	an.Configure("localhost", &config.Adapter{PlatformID: "partnerId", UserSyncURL: url})
+
 	if an.usersyncInfo.URL != url {
 		t.Fatalf("should have matched")
 	}

--- a/adapters/indexExchange/indexExchange.go
+++ b/adapters/indexExchange/indexExchange.go
@@ -116,6 +116,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(j))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 
@@ -162,7 +165,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
 			}
 
-			pbid := pbs.PBSBid{
+			bids = append(bids, &pbs.PBSBid{
 				BidID:       bidID,
 				AdUnitCode:  bidder.AdUnits[i].Code, // todo: check this
 				BidderCode:  bidder.BidderCode,
@@ -172,8 +175,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				Width:       bid.W,
 				Height:      bid.H,
 				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			})
 		}
 	}
 	return bids, nil

--- a/adapters/openrtb_util/openrtb_util.go
+++ b/adapters/openrtb_util/openrtb_util.go
@@ -1,12 +1,11 @@
-package adapters
+package openrtb_util
 
 import (
-	"github.com/prebid/prebid-server/pbs"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
-func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
+func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
 
 	imps := make([]openrtb.Imp, len(bidder.AdUnits))
 	for i, unit := range bidder.AdUnits {

--- a/adapters/openrtb_util/openrtb_util_test.go
+++ b/adapters/openrtb_util/openrtb_util_test.go
@@ -1,12 +1,12 @@
-package adapters
+package openrtb_util
 
 import (
-	"github.com/prebid/prebid-server/pbs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func TestOpenRTB(t *testing.T) {
@@ -26,7 +26,7 @@ func TestOpenRTB(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
@@ -44,6 +44,6 @@ func TestOpenRTBNoSize(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 	assert.Equal(t, resp.Imp[0].ID, "")
 }

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -1,4 +1,4 @@
-package adapters
+package pubmatic
 
 import (
 	"bytes"
@@ -10,28 +10,69 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/prebid/openrtb"
-	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/adapters/openrtb_util"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
 )
 
-type PubmaticAdapter struct {
-	http         *HTTPAdapter
+// init will register the Adapter with our global exchanges
+func init() {
+	var a = NewAdapter()
+	adapters.Init("pubmatic", a)
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		URI:  "http://openbid-useast.pubmatic.com/translator?",
+		http: pbs.NewHTTPAdapter(pbs.DefaultHTTPAdapterConfig),
+	}
+}
+
+type Adapter struct {
+	http         *pbs.HTTPAdapter
 	URI          string
 	usersyncInfo *pbs.UsersyncInfo
 }
 
+// Use will set a shared Use(http *pbs.HTTPAdapter) (optional)
+func (a *Adapter) Use(http *pbs.HTTPAdapter) {
+	a.http = http
+}
+
+// Configure is required. It accepts an external url (required) and optional *config.Adapter
+// After Configure is run, the adapter will be registered as an active PBS exchange
+func (a *Adapter) Configure(externalURL string, config *config.Adapter) {
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pubmatic&uid=", externalURL)
+	usersyncURL := "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
+
+	a.usersyncInfo = &pbs.UsersyncInfo{
+		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		Type:        "iframe",
+		SupportCORS: false,
+	}
+
+	// if no configs are provided then we'll use the default values provided in init()
+	if config == nil {
+		return
+	}
+	return
+}
+
 /* Name - export adapter name */
-func (a *PubmaticAdapter) Name() string {
+func (a *Adapter) Name() string {
 	return "Pubmatic"
 }
 
 // used for cookies and such
-func (a *PubmaticAdapter) FamilyName() string {
+func (a *Adapter) FamilyName() string {
 	return "pubmatic"
 }
 
-func (a *PubmaticAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+func (a *Adapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
@@ -40,8 +81,8 @@ type pubmaticParams struct {
 	AdSlot      string `json:"adSlot"`
 }
 
-func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	pbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	pbReq := openrtb_util.MakeOpenRTBGeneric(req, bidder, a.FamilyName())
 	for i, unit := range bidder.AdUnits {
 		var params pubmaticParams
 		err := json.Unmarshal(unit.Params, &params)
@@ -142,22 +183,4 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	}
 
 	return bids, nil
-}
-
-func NewPubmaticAdapter(config *HTTPAdapterConfig, uri string, externalURL string) *PubmaticAdapter {
-	a := NewHTTPAdapter(config)
-	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pubmatic&uid=", externalURL)
-	usersyncURL := "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
-
-	info := &pbs.UsersyncInfo{
-		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
-		Type:        "iframe",
-		SupportCORS: false,
-	}
-
-	return &PubmaticAdapter{
-		http:         a,
-		URI:          uri,
-		usersyncInfo: info,
-	}
 }

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -117,6 +117,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 	httpReq.AddCookie(&http.Cookie{
@@ -167,7 +170,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				return nil, errors.New(fmt.Sprintf("Unknown ad unit code '%s'", bid.ImpID))
 			}
 
-			pbid := pbs.PBSBid{
+			bids = append(bids, &pbs.PBSBid{
 				BidID:       bidID,
 				AdUnitCode:  bid.ImpID,
 				BidderCode:  bidder.BidderCode,
@@ -177,8 +180,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				Width:       bid.W,
 				Height:      bid.H,
 				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			})
 		}
 	}
 

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -1,0 +1,288 @@
+package pubmatic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/pbs"
+)
+
+func TestPubmaticInvalidCall(t *testing.T) {
+
+	an := NewAdapter()
+	an.URI = "dummy"
+
+	s := an.Name()
+	if s == "" {
+		t.Fatal("Missing name")
+	}
+
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("No error received for invalid request")
+	}
+}
+
+func TestPubmaticTimeout(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-time.After(2 * time.Millisecond)
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"publisherId\": \"10\", \"adSlot\": \"12\"}"),
+			},
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil || err != context.DeadlineExceeded {
+		t.Fatalf("No timeout received for timed out request: %v", err)
+	}
+}
+
+func TestPubmaticInvalidJson(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "Blah")
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"publisherId\": \"10\", \"adSlot\": \"12\"}"),
+			},
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("No error received for invalid request")
+	}
+}
+
+func TestPubmaticInvalidStatusCode(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Send 404
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"publisherId\": \"10\", \"adSlot\": \"12\"}"),
+			},
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("No error received for invalid request")
+	}
+}
+
+func TestPubmaticMissingPublisherId(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Send 404
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"adSlot\": \"12\"}"),
+			},
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("No error received for missing publisherId")
+	}
+}
+
+func TestPubmaticMissingAdSlot(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Send 404
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"PublisherId\": \"10\"}"),
+			},
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("No error received for missing adSlot")
+	}
+}
+
+func TestPubmaticBasicResponse(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := openrtb.BidResponse{
+				SeatBid: []openrtb.SeatBid{
+					{
+						Bid: []openrtb.Bid{
+							{
+								ID:     "1234",
+								ImpID:  "unitCode",
+								Price:  1.0,
+								AdM:    "Content",
+								CrID:   "567",
+								W:      10,
+								H:      12,
+								DealID: "5",
+							},
+						},
+					},
+				},
+			}
+
+			js, err := json.Marshal(resp)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(js)
+		}),
+	)
+	defer server.Close()
+
+	an := NewAdapter()
+	an.URI = server.URL
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:  "unitCode",
+				BidID: "bidid",
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Params: json.RawMessage("{\"publisherId\": \"10\", \"adSlot\": \"12\"}"),
+			},
+		},
+	}
+	bids, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err != nil {
+		t.Fatalf("Should not have gotten an error: %v", err)
+	}
+	if len(bids) != 1 {
+		t.Fatalf("Should have received one bid")
+	}
+}
+
+func TestPubmaticUserSyncInfo(t *testing.T) {
+
+	an := NewAdapter()
+	an.Configure("localhost", nil)
+
+	if an.usersyncInfo.URL != "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect=localhost%2Fsetuid%3Fbidder%3Dpubmatic%26uid%3D" {
+		t.Fatalf("should have matched")
+	}
+	if an.usersyncInfo.Type != "iframe" {
+		t.Fatalf("should be iframe")
+	}
+	if an.usersyncInfo.SupportCORS != false {
+		t.Fatalf("should have been false")
+	}
+
+}

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -140,6 +140,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -1,4 +1,4 @@
-package adapters
+package pulsepoint
 
 import (
 	"bytes"
@@ -12,28 +12,69 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prebid/openrtb"
-	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/adapters/openrtb_util"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
 )
 
-type PulsePointAdapter struct {
-	http         *HTTPAdapter
+// init will register the Adapter with our global exchanges
+func init() {
+	var a = NewAdapter()
+	adapters.Init("pulsepoint", a)
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		URI:  "http://bid.contextweb.com/header/s/ortb/prebid-s2s",
+		http: pbs.NewHTTPAdapter(pbs.DefaultHTTPAdapterConfig),
+	}
+}
+
+type Adapter struct {
+	http         *pbs.HTTPAdapter
 	URI          string
 	usersyncInfo *pbs.UsersyncInfo
 }
 
+// Use will set a shared Use(http *pbs.HTTPAdapter) (optional)
+func (a *Adapter) Use(http *pbs.HTTPAdapter) {
+	a.http = http
+}
+
+// Configure is required. It accepts an external url (required) and optional *config.Adapter
+// After Configure is run, the adapter will be registered as an active PBS exchange
+func (a *Adapter) Configure(externalURL string, config *config.Adapter) {
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pulsepoint&uid=%s", externalURL, "%%VGUID%%")
+	usersyncURL := "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl="
+
+	a.usersyncInfo = &pbs.UsersyncInfo{
+		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		Type:        "redirect",
+		SupportCORS: false,
+	}
+
+	// if no configs are provided then we'll use the default values provided in init()
+	if config == nil {
+		return
+	}
+	return
+}
+
 // adapter name
-func (a *PulsePointAdapter) Name() string {
+func (a *Adapter) Name() string {
 	return "pulsepoint"
 }
 
 // used for cookies and such
-func (a *PulsePointAdapter) FamilyName() string {
+func (a *Adapter) FamilyName() string {
 	return "pulsepoint"
 }
 
-func (a *PulsePointAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+func (a *Adapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
@@ -44,8 +85,8 @@ type PulsepointParams struct {
 	AdSize      string `json:"cf"`
 }
 
-func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	ppReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	ppReq := openrtb_util.MakeOpenRTBGeneric(req, bidder, a.FamilyName())
 	for i, unit := range bidder.AdUnits {
 		var params PulsepointParams
 		err := json.Unmarshal(unit.Params, &params)
@@ -157,22 +198,4 @@ func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 	}
 
 	return bids, nil
-}
-
-func NewPulsePointAdapter(config *HTTPAdapterConfig, uri string, externalURL string) *PulsePointAdapter {
-	a := NewHTTPAdapter(config)
-	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pulsepoint&uid=%s", externalURL, "%%VGUID%%")
-	usersyncURL := "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl="
-
-	info := &pbs.UsersyncInfo{
-		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
-		Type:        "redirect",
-		SupportCORS: false,
-	}
-
-	return &PulsePointAdapter{
-		http:         a,
-		URI:          uri,
-		usersyncInfo: info,
-	}
 }

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -1,4 +1,4 @@
-package adapters
+package pulsepoint
 
 import (
 	"bytes"
@@ -28,7 +28,7 @@ type PulsePointOrtbMockService struct {
  * Verify adapter names are setup correctly.
  */
 func TestPulsePointAdapterNames(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := NewAdapter()
 	VerifyStringValue(adapter.Name(), "pulsepoint", t)
 	VerifyStringValue(adapter.FamilyName(), "pulsepoint", t)
 }
@@ -37,16 +37,17 @@ func TestPulsePointAdapterNames(t *testing.T) {
  * Verifies the user sync parameters.
  */
 func TestPulsePointUserSyncInfo(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := NewAdapter()
+	adapter.Configure("localhost", nil)
 	VerifyStringValue(adapter.GetUsersyncInfo().Type, "redirect", t)
-	VerifyStringValue(adapter.GetUsersyncInfo().URL, "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl=http%3A%2F%2Flocalhost%2Fsetuid%3Fbidder%3Dpulsepoint%26uid%3D%25%25VGUID%25%25", t)
+	VerifyStringValue(adapter.GetUsersyncInfo().URL, "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl=localhost%2Fsetuid%3Fbidder%3Dpulsepoint%26uid%3D%25%25VGUID%25%25", t)
 }
 
 /**
  * Test required parameters not sent
  */
 func TestPulsePointRequiredBidParameters(t *testing.T) {
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, "http://localhost/bid", "http://localhost")
+	adapter := NewAdapter()
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
@@ -86,9 +87,9 @@ func TestPulsePointOpenRTBRequest(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	adapter.Call(ctx, req, bidder)
-	fmt.Println(service.LastBidRequest)
 	VerifyIntValue(len(service.LastBidRequest.Imp), 1, t)
 	VerifyStringValue(service.LastBidRequest.Imp[0].TagID, "1001", t)
 	VerifyStringValue(service.LastBidRequest.Site.Publisher.ID, "2001", t)
@@ -105,7 +106,8 @@ func TestPulsePointBiddingBehavior(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(1, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// number of bids should be 1
 	VerifyIntValue(len(bids), 1, t)
@@ -128,7 +130,8 @@ func TestPulsePointMultiImpPartialBidding(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -147,7 +150,8 @@ func TestPulsePointMultiImpPassback(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -165,7 +169,8 @@ func TestPulsePointMultiImpAllBid(t *testing.T) {
 	ctx := context.TODO()
 	req := SampleRequest(2, t)
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// two impressions sent.
 	// number of bids should be 1
@@ -189,7 +194,8 @@ func TestMobileAppRequest(t *testing.T) {
 		Name: "facebook",
 	}
 	bidder := req.Bidders[0]
-	adapter := NewPulsePointAdapter(DefaultHTTPAdapterConfig, server.URL, "http://localhost")
+	adapter := NewAdapter()
+	adapter.URI = server.URL
 	bids, _ := adapter.Call(ctx, req, bidder)
 	// one mobile app impression sent.
 	// verify appropriate fields are sent to pulsepoint endpoint.

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -251,6 +251,9 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 	}
 
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
+	if err != nil {
+		return nil, err
+	}
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 	httpReq.Header.Add("User-Agent", "prebid-server/1.0")
@@ -298,7 +301,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
 			}
 
-			pbid := pbs.PBSBid{
+			bids = append(bids, &pbs.PBSBid{
 				BidID:       bidID,
 				AdUnitCode:  bid.ImpID,
 				BidderCode:  bidder.BidderCode,
@@ -308,8 +311,7 @@ func (a *Adapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBS
 				Width:       bid.W,
 				Height:      bid.H,
 				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			})
 		}
 	}
 

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1,21 +1,20 @@
-package adapters
+package rubicon
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/prebid/prebid-server/cache/dummycache"
-	"github.com/prebid/prebid-server/pbs"
-
-	"fmt"
-
 	"github.com/prebid/openrtb"
+	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 type rubiTagInfo struct {
@@ -199,8 +198,9 @@ func TestRubiconBasicResponse(t *testing.T) {
 		bid:    3.22,
 	}
 
-	conf := *DefaultHTTPAdapterConfig
-	an := NewRubiconAdapter(&conf, "uri", rubidata.xapiuser, rubidata.xapipass, "localhost/usersync")
+	an := NewAdapter()
+
+	an.Configure("localhost/usersync", &config.Adapter{XAPI: config.AdapterXAPI{Username: rubidata.xapiuser, Password: rubidata.xapipass}})
 	an.URI = server.URL
 
 	pbin := pbs.PBSRequest{
@@ -303,7 +303,8 @@ func TestRubiconBasicResponse(t *testing.T) {
 func TestRubiconUserSyncInfo(t *testing.T) {
 	url := "https://pixel.rubiconproject.com/exchange/sync.php?p=prebid"
 
-	an := NewRubiconAdapter(DefaultHTTPAdapterConfig, "uri", "xuser", "xpass", url)
+	an := NewAdapter()
+	an.Configure("localhost", &config.Adapter{UserSyncURL: url, XAPI: config.AdapterXAPI{Username: rubidata.xapiuser, Password: rubidata.xapipass}})
 	if an.usersyncInfo.URL != url {
 		t.Fatalf("should have matched")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -21,13 +21,15 @@ type Configuration struct {
 }
 
 type Adapter struct {
-	Endpoint    string `mapstructure:"endpoint"` // Required
-	UserSyncURL string `mapstructure:"usersync_url"`
-	PlatformID  string `mapstructure:"platform_id"` // needed for Facebook
-	XAPI        struct {
-		Username string `mapstructure:"username"`
-		Password string `mapstructure:"password"`
-	} `mapstructure:"xapi"` // needed for Rubicon
+	Endpoint    string      `mapstructure:"endpoint"`     // optional (useful for testing)
+	UserSyncURL string      `mapstructure:"usersync_url"` // optional (useful for testing)
+	PlatformID  string      `mapstructure:"platform_id"`  // needed for Facebook
+	XAPI        AdapterXAPI `mapstructure:"xapi"`         // needed for Rubicon
+}
+
+type AdapterXAPI struct {
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
 }
 
 type Metrics struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -91,54 +91,54 @@ adapters:
 `)
 
 func cmpStrings(t *testing.T, key string, a string, b string) {
-    if a != b {
-        t.Errorf("%s: %s != %s", key, a, b)
-    }
+	if a != b {
+		t.Errorf("%s: %s != %s", key, a, b)
+	}
 }
 
 func cmpInts(t *testing.T, key string, a int, b int) {
-    if a != b {
-        t.Errorf("%s: %d != %d", key, a, b)
-    }
+	if a != b {
+		t.Errorf("%s: %d != %d", key, a, b)
+	}
 }
 
 func TestFullConfig(t *testing.T) {
-    viper.SetConfigType("yaml")
-    viper.ReadConfig(bytes.NewBuffer(fullConfig))
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(fullConfig))
 	cfg, err := config.New()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-    cmpStrings(t, "cookie domain", cfg.CookieDomain, "adnxs.com")
-    cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid.adnxs.com/")
-    cmpStrings(t, "host", cfg.Host, "prebid.adnxs.com")
-    cmpInts(t, "port", cfg.Port, 1234)
-    cmpInts(t, "admin_port", cfg.AdminPort, 5678)
-    if cfg.DefaultTimeout != 123 {
-        t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
-    }
-    cmpStrings(t, "prebid_cache_url", cfg.CacheURL, "http://prebidcache.net/test/a1?qs=something")
-    if cfg.RequireUUID2 != true {
-        t.Errorf("RequireUUID2 was false")
-    }
-    cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
-    cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
-    cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")
-    cmpStrings(t, "metrics.username", cfg.Metrics.Username, "admin")
-    cmpStrings(t, "metrics.password", cfg.Metrics.Password, "admin1324")
-    cmpStrings(t, "datacache.type", cfg.DataCache.Type, "postgres")
-    cmpStrings(t, "datacache.filename", cfg.DataCache.Filename, "/usr/db/db.db")
-    cmpStrings(t, "datacache.dbname", cfg.DataCache.Database, "pbsdb")
-    cmpStrings(t, "datacache.host", cfg.DataCache.Host, "postgres.internal")
-    cmpStrings(t, "datacache.user", cfg.DataCache.Username, "dbadmin")
-    cmpStrings(t, "datacache.password", cfg.DataCache.Password, "db2342")
-    cmpInts(t, "datacache.cache_size", cfg.DataCache.CacheSize, 10000000)
-    cmpInts(t, "datacache.ttl_seconds", cfg.DataCache.TTLSeconds, 3600)
-    cmpStrings(t, "adapters.rubicon.endpoint", cfg.Adapters["rubicon"].Endpoint, "http://rubitest.com/api")
-    cmpStrings(t, "adapters.rubicon.usersync_url", cfg.Adapters["rubicon"].UserSyncURL, "http://pixel.rubiconproject.com/sync.php?p=prebid")
-    cmpStrings(t, "adapters.rubicon.xapi.username", cfg.Adapters["rubicon"].XAPI.Username, "rubiuser")
-    cmpStrings(t, "adapters.rubicon.xapi.password", cfg.Adapters["rubicon"].XAPI.Password, "rubipw23")
-    cmpStrings(t, "adapters.facebook.endpoint", cfg.Adapters["facebook"].Endpoint, "http://facebook.com/pbs")
-    cmpStrings(t, "adapters.facebook.usersync_url", cfg.Adapters["facebook"].UserSyncURL, "http://facebook.com/ortb/prebid-s2s")
-    cmpStrings(t, "adapters.facebook.platform_id", cfg.Adapters["facebook"].PlatformID, "abcdefgh1234")
+	cmpStrings(t, "cookie domain", cfg.CookieDomain, "adnxs.com")
+	cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid.adnxs.com/")
+	cmpStrings(t, "host", cfg.Host, "prebid.adnxs.com")
+	cmpInts(t, "port", cfg.Port, 1234)
+	cmpInts(t, "admin_port", cfg.AdminPort, 5678)
+	if cfg.DefaultTimeout != 123 {
+		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
+	}
+	cmpStrings(t, "prebid_cache_url", cfg.CacheURL, "http://prebidcache.net/test/a1?qs=something")
+	if cfg.RequireUUID2 != true {
+		t.Errorf("RequireUUID2 was false")
+	}
+	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
+	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
+	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")
+	cmpStrings(t, "metrics.username", cfg.Metrics.Username, "admin")
+	cmpStrings(t, "metrics.password", cfg.Metrics.Password, "admin1324")
+	cmpStrings(t, "datacache.type", cfg.DataCache.Type, "postgres")
+	cmpStrings(t, "datacache.filename", cfg.DataCache.Filename, "/usr/db/db.db")
+	cmpStrings(t, "datacache.dbname", cfg.DataCache.Database, "pbsdb")
+	cmpStrings(t, "datacache.host", cfg.DataCache.Host, "postgres.internal")
+	cmpStrings(t, "datacache.user", cfg.DataCache.Username, "dbadmin")
+	cmpStrings(t, "datacache.password", cfg.DataCache.Password, "db2342")
+	cmpInts(t, "datacache.cache_size", cfg.DataCache.CacheSize, 10000000)
+	cmpInts(t, "datacache.ttl_seconds", cfg.DataCache.TTLSeconds, 3600)
+	cmpStrings(t, "adapters.rubicon.endpoint", cfg.Adapters["rubicon"].Endpoint, "http://rubitest.com/api")
+	cmpStrings(t, "adapters.rubicon.usersync_url", cfg.Adapters["rubicon"].UserSyncURL, "http://pixel.rubiconproject.com/sync.php?p=prebid")
+	cmpStrings(t, "adapters.rubicon.xapi.username", cfg.Adapters["rubicon"].XAPI.Username, "rubiuser")
+	cmpStrings(t, "adapters.rubicon.xapi.password", cfg.Adapters["rubicon"].XAPI.Password, "rubipw23")
+	cmpStrings(t, "adapters.facebook.endpoint", cfg.Adapters["facebook"].Endpoint, "http://facebook.com/pbs")
+	cmpStrings(t, "adapters.facebook.usersync_url", cfg.Adapters["facebook"].UserSyncURL, "http://facebook.com/ortb/prebid-s2s")
+	cmpStrings(t, "adapters.facebook.platform_id", cfg.Adapters["facebook"].PlatformID, "abcdefgh1234")
 }

--- a/pbs/adapters.go
+++ b/pbs/adapters.go
@@ -1,19 +1,21 @@
-package adapters
+package pbs
 
 import (
 	"context"
 	"crypto/tls"
-	"github.com/prebid/prebid-server/pbs"
-	"github.com/prebid/prebid-server/ssl"
 	"net/http"
 	"time"
+
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/ssl"
 )
 
 type Adapter interface {
-	Name() string
-	FamilyName() string
-	GetUsersyncInfo() *pbs.UsersyncInfo
-	Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error)
+	Configure(string, *config.Adapter) // Configure is required
+	Name() string                      // Name should be unique
+	FamilyName() string                // FamilyName is used for cookies
+	GetUsersyncInfo() *UsersyncInfo
+	Call(ctx context.Context, req *PBSRequest, bidder *PBSBidder) (PBSBidSlice, error)
 }
 
 type HTTPAdapterConfig struct {

--- a/pbs/http.go
+++ b/pbs/http.go
@@ -1,4 +1,4 @@
-package prebid
+package pbs
 
 import (
 	"net"

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/cache"
-	"github.com/prebid/prebid-server/prebid"
 )
 
 const MAX_BIDDERS = 8
@@ -135,7 +134,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		}
 
 		pbsReq.Device.UA = r.Header.Get("User-Agent")
-		pbsReq.Device.IP = prebid.GetIP(r)
+		pbsReq.Device.IP = GetIP(r)
 
 		pbsReq.Url = r.Header.Get("Referer") // must be specified in the header
 		// TODO: this should explicitly put us in test mode
@@ -178,7 +177,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		pbsReq.IsDebug = true
 	}
 
-	if prebid.IsSecure(r) {
+	if IsSecure(r) {
 		pbsReq.Secure = 1
 	}
 


### PR DESCRIPTION
Trying to standardize how adapters are initialized and used throughout pbs (this is a continuation of https://github.com/prebid/prebid-server/pull/38) 

1. added a new Configure() method to the ``adapter.Adapter`` interface
1.1. ``Configure`` accepts a required ExternalURL and optional ``*config.Adapter`` (used by Rubicon and Facebook)
1.2. most adapters can accept a nil pointer and will use the default configurations already defined
1.3. ``configure.Adapter`` now has ``config.AdapterXAPI`` so we can properly test Rubicon

2. adapters are now in their own packages
2.1. this required adding a new DistrictM subpackage (used the same code from AppNexus)
2.2. there is now an openrtb_util subpackage that provides shared functionality for our adapters
2.3. Facebook's name has been changed from "audienceNetwork" to "facebook" because that is what we use in the configurations ("audienceNetwork" is still the FamilyName)

3. Each adapter when initialized uses its own ``HTTPAdapter`` since that's the current behavior in pbs_light.go
3.1 the ``pbs.Adapter`` interface allows for changing this behavior via ``Use(http *pbs.HTTPAdapter)``

4. the ``prebid-server/adapters`` package now contains logic for coordinating each of the active adapters/exchanges
4.1 moved ``adapters.Adapter`` to ``pbs.Adapter``
4.2 moved ``prebid-server/prebid`` to ``prebid-server/pbs`` (nothing related to adapters, just some tidying up)

5. All of the adapters can be configured using the shared ``config.Adapter`` via ``prebid-server/config``
5.1 The ``adapters`` package has a ``Configure(string, map[string]config.Adapter)`` function that will configure all of the adapters provided by the configuration
5.2 This will help us enable adapters/exchanges based off of the configuration provided instead of enabling all exchanges