### PR TITLE
Generate ad server targeting keys for Prebid Mobile on server

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -10,6 +10,7 @@ type App struct {
 
 type Account struct {
 	ID string `json:"id"`
+	PriceGranularity string `json:"price_granularity"`
 }
 
 type Configuration struct {

--- a/cache/postgrescache/postgrescache.go
+++ b/cache/postgrescache/postgrescache.go
@@ -137,8 +137,14 @@ func (s *accountService) Get(key string) (*cache.Account, error) {
 		/* TODO -- We should store failed attempts in the LRU as well to stop from hitting to DB */
 		return nil, err
 	}
+	var priceGranularity string
+	if err := s.shared.db.QueryRow("SELECT price_granularity FROM accounts_account where uuid = $1 LIMIT 1", key).Scan(&priceGranularity); err != nil {
+		/* TODO -- We should store failed attempts in the LRU as well to stop from hitting to DB */
+		return nil, err
+	}
 
 	account.ID = id
+	account.PriceGranularity = priceGranularity
 
 	buf := bytes.Buffer{}
 	if err := gob.NewEncoder(&buf).Encode(&account); err != nil {

--- a/pbs/cpm_bucketmanager.go
+++ b/pbs/cpm_bucketmanager.go
@@ -95,7 +95,7 @@ func getCpmStringValue(cpm float64, config map[string][]map[string]float64) stri
 		if bucketsArr[i]["max"] > bucketMax {
 			bucketMax = bucketsArr[i]["max"]
 		}
-	}	// calculate which bucket cpm is in
+	} // calculate which bucket cpm is in
 	for i := 0; i < len(bucketsArr); i++ {
 		currentBucket := bucketsArr[i]
 		if cpm > bucketMax {

--- a/pbs/cpm_bucketmanager.go
+++ b/pbs/cpm_bucketmanager.go
@@ -1,0 +1,118 @@
+package pbs
+
+import "math"
+import "strconv"
+
+const DEFAULT_PRECISION = 2
+
+func getLowPriceConfig() map[string][]map[string]float64 {
+	return map[string][]map[string]float64{
+		"buckets": []map[string]float64{
+			map[string]float64{
+				"min":       0,
+				"max":       5,
+				"increment": 0.5,
+			},
+		},
+	}
+}
+
+func getMedPriceConfig() map[string][]map[string]float64 {
+	return map[string][]map[string]float64{
+		"buckets": []map[string]float64{
+			map[string]float64{
+				"min":       0,
+				"max":       20,
+				"increment": 0.1,
+			},
+		},
+	}
+}
+
+func getHighPriceConfig() map[string][]map[string]float64 {
+	return map[string][]map[string]float64{
+		"buckets": []map[string]float64{
+			map[string]float64{
+				"min":       0,
+				"max":       20,
+				"increment": 0.01,
+			},
+		},
+	}
+}
+
+func getDensePriceConfig() map[string][]map[string]float64 {
+	return map[string][]map[string]float64{
+		"buckets": []map[string]float64{
+			map[string]float64{
+				"min":       0,
+				"max":       3,
+				"increment": 0.01,
+			},
+			map[string]float64{
+				"min":       3,
+				"max":       8,
+				"increment": 0.05,
+			},
+			map[string]float64{
+				"min":       8,
+				"max":       20,
+				"increment": 0.5,
+			},
+		},
+	}
+}
+
+func getAutoPriceConfig() map[string][]map[string]float64 {
+	return map[string][]map[string]float64{
+		"buckets": []map[string]float64{
+			map[string]float64{
+				"min":       0,
+				"max":       5,
+				"increment": 0.05,
+			},
+			map[string]float64{
+				"min":       5,
+				"max":       10,
+				"increment": 0.1,
+			},
+			map[string]float64{
+				"min":       10,
+				"max":       20,
+				"increment": 0.5,
+			},
+		},
+	}
+}
+
+func getCpmStringValue(cpm float64, config map[string][]map[string]float64) string {
+	bucketsArr := config["buckets"]
+	for i := 0; i < len(bucketsArr); i++ {
+		currentBucket := bucketsArr[i]
+		if cpm >= currentBucket["min"] && cpm < currentBucket["max"] {
+			d := RoundUp(cpm/currentBucket["increment"], DEFAULT_PRECISION)
+			roundedCPM := math.Floor(d) * currentBucket["increment"]
+			return strconv.FormatFloat(roundedCPM, 'f', DEFAULT_PRECISION, 64)
+		}
+	}
+	return ""
+}
+
+func RoundUp(input float64, places int) (newVal float64) {
+	var round float64
+	pow := math.Pow(10, float64(places))
+	digit := pow * input
+	round = math.Ceil(digit)
+	newVal = round / pow
+	return
+}
+
+func GetPriceBucketString(cpm float64) map[string]string {
+	return map[string]string{
+		"low":   getCpmStringValue(cpm, getLowPriceConfig()),
+		"med":   getCpmStringValue(cpm, getMedPriceConfig()),
+		"high":  getCpmStringValue(cpm, getHighPriceConfig()),
+		"auto":  getCpmStringValue(cpm, getAutoPriceConfig()),
+		"dense": getCpmStringValue(cpm, getDensePriceConfig()),
+	}
+}

--- a/pbs/cpm_bucketmanager.go
+++ b/pbs/cpm_bucketmanager.go
@@ -7,8 +7,8 @@ const DEFAULT_PRECISION = 2
 
 func getLowPriceConfig() map[string][]map[string]float64 {
 	return map[string][]map[string]float64{
-		"buckets": []map[string]float64{
-			map[string]float64{
+		"buckets": {
+			{
 				"min":       0,
 				"max":       5,
 				"increment": 0.5,
@@ -19,8 +19,8 @@ func getLowPriceConfig() map[string][]map[string]float64 {
 
 func getMedPriceConfig() map[string][]map[string]float64 {
 	return map[string][]map[string]float64{
-		"buckets": []map[string]float64{
-			map[string]float64{
+		"buckets": {
+			{
 				"min":       0,
 				"max":       20,
 				"increment": 0.1,
@@ -31,8 +31,8 @@ func getMedPriceConfig() map[string][]map[string]float64 {
 
 func getHighPriceConfig() map[string][]map[string]float64 {
 	return map[string][]map[string]float64{
-		"buckets": []map[string]float64{
-			map[string]float64{
+		"buckets": {
+			{
 				"min":       0,
 				"max":       20,
 				"increment": 0.01,
@@ -43,18 +43,18 @@ func getHighPriceConfig() map[string][]map[string]float64 {
 
 func getDensePriceConfig() map[string][]map[string]float64 {
 	return map[string][]map[string]float64{
-		"buckets": []map[string]float64{
-			map[string]float64{
+		"buckets": {
+			{
 				"min":       0,
 				"max":       3,
 				"increment": 0.01,
 			},
-			map[string]float64{
+			{
 				"min":       3,
 				"max":       8,
 				"increment": 0.05,
 			},
-			map[string]float64{
+			{
 				"min":       8,
 				"max":       20,
 				"increment": 0.5,
@@ -65,18 +65,18 @@ func getDensePriceConfig() map[string][]map[string]float64 {
 
 func getAutoPriceConfig() map[string][]map[string]float64 {
 	return map[string][]map[string]float64{
-		"buckets": []map[string]float64{
-			map[string]float64{
+		"buckets": {
+			{
 				"min":       0,
 				"max":       5,
 				"increment": 0.05,
 			},
-			map[string]float64{
+			{
 				"min":       5,
 				"max":       10,
 				"increment": 0.1,
 			},
-			map[string]float64{
+			{
 				"min":       10,
 				"max":       20,
 				"increment": 0.5,

--- a/pbs/cpm_bucketmanager_test.go
+++ b/pbs/cpm_bucketmanager_test.go
@@ -24,15 +24,23 @@ func TestGetPriceBucketString(t *testing.T) {
 		t.Error("Expected 1.87")
 	}
 
-	// TODO (pbm) test more prices
-	// interval := 0.01
-	// price := 0.00
-	// for price < 20.01 {
-	// 	fmt.Println(price)
+	// test a cpm above the max in low price bucket
+	price = 5.72
+	priceMap = GetPriceBucketString(price)
 
-	// 	priceMap := GetPriceBucketString(price)
-	// 	fmt.Println(priceMap)
-
-	// 	price += interval
-	// }
+	if priceMap["low"] != "5.00" {
+		t.Error("Expected 5.00")
+	}
+	if priceMap["med"] != "5.70" {
+		t.Error("Expected 5.70")
+	}
+	if priceMap["high"] != "5.72" {
+		t.Error("Expected 5.72")
+	}
+	if priceMap["auto"] != "5.70" {
+		t.Error("Expected 5.70")
+	}
+	if priceMap["dense"] != "5.70" {
+		t.Error("Expected 5.70")
+	}
 }

--- a/pbs/cpm_bucketmanager_test.go
+++ b/pbs/cpm_bucketmanager_test.go
@@ -1,0 +1,38 @@
+package pbs
+
+import (
+	"testing"
+)
+
+func TestGetPriceBucketString(t *testing.T) {
+	price := 1.87
+	priceMap := GetPriceBucketString(price)
+
+	if priceMap["low"] != "1.50" {
+		t.Error("Expected 1.50")
+	}
+	if priceMap["med"] != "1.80" {
+		t.Error("Expected 1.80")
+	}
+	if priceMap["high"] != "1.87" {
+		t.Error("Expected 1.87")
+	}
+	if priceMap["auto"] != "1.85" {
+		t.Error("Expected 1.85")
+	}
+	if priceMap["dense"] != "1.87" {
+		t.Error("Expected 1.87")
+	}
+
+	// TODO (pbm) test more prices
+	// interval := 0.01
+	// price := 0.00
+	// for price < 20.01 {
+	// 	fmt.Println(price)
+
+	// 	priceMap := GetPriceBucketString(price)
+	// 	fmt.Println(priceMap)
+
+	// 	price += interval
+	// }
+}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -72,6 +72,7 @@ type PBSRequest struct {
 	AccountID     string          `json:"account_id"`
 	Tid           string          `json:"tid"`
 	CacheMarkup   int8            `json:"cache_markup"`
+	SortBids   	  int8            `json:"sort_bids"`
 	Secure        int8            `json:"secure"`
 	TimeoutMillis uint64          `json:"timeout_millis"`
 	AdUnits       []AdUnit        `json:"ad_units"`

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -72,7 +72,8 @@ type PBSRequest struct {
 	AccountID     string          `json:"account_id"`
 	Tid           string          `json:"tid"`
 	CacheMarkup   int8            `json:"cache_markup"`
-	SortBids   	  int8            `json:"sort_bids"`
+	SortBids      int8            `json:"sort_bids"`
+	IsDFP         int8            `json:"is_dfp"`
 	Secure        int8            `json:"secure"`
 	TimeoutMillis uint64          `json:"timeout_millis"`
 	AdUnits       []AdUnit        `json:"ad_units"`

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -73,7 +73,7 @@ type PBSRequest struct {
 	Tid           string          `json:"tid"`
 	CacheMarkup   int8            `json:"cache_markup"`
 	SortBids      int8            `json:"sort_bids"`
-	IsDFP         int8            `json:"is_dfp"`
+	MaxKeyLength  int8            `json:"max_key_length"`
 	Secure        int8            `json:"secure"`
 	TimeoutMillis uint64          `json:"timeout_millis"`
 	AdUnits       []AdUnit        `json:"ad_units"`

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -1,20 +1,20 @@
 package pbs
 
 type PBSBid struct {
-	BidID       		string  `json:"bid_id"`
-	AdUnitCode  		string  `json:"code"`
-	Creative_id 		string  `json:"creative_id,omitempty"`
-	BidderCode  		string  `json:"bidder"`
-	BidHash     		string  `json:"-"` // this is the hash of the bidder's unique bid identifier for blockchain. Should not be sent to browser.
-	Price       		float64 `json:"price"`
-	Currency    		string  `json:"currency,omitempty"`
-	NURL        		string  `json:"nurl,omitempty"`
-	Adm         		string  `json:"adm,omitempty"`
-	Width       		uint64  `json:"width,omitempty"`
-	Height      		uint64  `json:"height,omitempty"`
-	DealId      		string  `json:"deal_id,omitempty"`
-	CacheID     		string  `json:"cache_id,omitempty"`
-	AdServerTargeting   map[string]string `json:"ad_server_targeting,omitempty"`
+	BidID             string            `json:"bid_id"`
+	AdUnitCode        string            `json:"code"`
+	Creative_id       string            `json:"creative_id,omitempty"`
+	BidderCode        string            `json:"bidder"`
+	BidHash           string            `json:"-"` // this is the hash of the bidder's unique bid identifier for blockchain. Should not be sent to browser.
+	Price             float64           `json:"price"`
+	Currency          string            `json:"currency,omitempty"`
+	NURL              string            `json:"nurl,omitempty"`
+	Adm               string            `json:"adm,omitempty"`
+	Width             uint64            `json:"width,omitempty"`
+	Height            uint64            `json:"height,omitempty"`
+	DealId            string            `json:"deal_id,omitempty"`
+	CacheID           string            `json:"cache_id,omitempty"`
+	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`
 }
 
 type PBSBidSlice []*PBSBid

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -26,7 +26,7 @@ func (bids PBSBidSlice) Len() int {
 }
 
 func (bids PBSBidSlice) Less(i, j int) bool {
-	return bids[i].Price + (float64(bids[i].ResponseTime) / 1000000000.0) < bids[j].Price + (float64(bids[j].ResponseTime) / 1000000000.0)
+	return bids[i].Price - (float64(bids[i].ResponseTime) / 1000000000.0) < bids[j].Price - (float64(bids[j].ResponseTime) / 1000000000.0)
 }
 
 func (bids PBSBidSlice) Swap(i, j int) {

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -14,6 +14,7 @@ type PBSBid struct {
 	Height            uint64            `json:"height,omitempty"`
 	DealId            string            `json:"deal_id,omitempty"`
 	CacheID           string            `json:"cache_id,omitempty"`
+	ResponseTime      int               `json:"response_time_ms,omitempty"`
 	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`
 }
 
@@ -25,7 +26,7 @@ func (bids PBSBidSlice) Len() int {
 }
 
 func (bids PBSBidSlice) Less(i, j int) bool {
-	return bids[i].Price < bids[j].Price
+	return bids[i].Price + (float64(bids[i].ResponseTime) / 1000000000.0) < bids[j].Price + (float64(bids[j].ResponseTime) / 1000000000.0)
 }
 
 func (bids PBSBidSlice) Swap(i, j int) {

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -1,19 +1,20 @@
 package pbs
 
 type PBSBid struct {
-	BidID       string  `json:"bid_id"`
-	AdUnitCode  string  `json:"code"`
-	Creative_id string  `json:"creative_id,omitempty"`
-	BidderCode  string  `json:"bidder"`
-	BidHash     string  `json:"-"` // this is the hash of the bidder's unique bid identifier for blockchain. Should not be sent to browser.
-	Price       float64 `json:"price"`
-	Currency    string  `json:"currency,omitempty"`
-	NURL        string  `json:"nurl,omitempty"`
-	Adm         string  `json:"adm,omitempty"`
-	Width       uint64  `json:"width,omitempty"`
-	Height      uint64  `json:"height,omitempty"`
-	DealId      string  `json:"deal_id,omitempty"`
-	CacheID     string  `json:"cache_id,omitempty"`
+	BidID       		string  `json:"bid_id"`
+	AdUnitCode  		string  `json:"code"`
+	Creative_id 		string  `json:"creative_id,omitempty"`
+	BidderCode  		string  `json:"bidder"`
+	BidHash     		string  `json:"-"` // this is the hash of the bidder's unique bid identifier for blockchain. Should not be sent to browser.
+	Price       		float64 `json:"price"`
+	Currency    		string  `json:"currency,omitempty"`
+	NURL        		string  `json:"nurl,omitempty"`
+	Adm         		string  `json:"adm,omitempty"`
+	Width       		uint64  `json:"width,omitempty"`
+	Height      		uint64  `json:"height,omitempty"`
+	DealId      		string  `json:"deal_id,omitempty"`
+	CacheID     		string  `json:"cache_id,omitempty"`
+	AdServerTargeting   map[string]string `json:"ad_server_targeting,omitempty"`
 }
 
 type PBSBidSlice []*PBSBid

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -26,7 +26,9 @@ func (bids PBSBidSlice) Len() int {
 }
 
 func (bids PBSBidSlice) Less(i, j int) bool {
-	return bids[i].Price - (float64(bids[i].ResponseTime) / 1000000000.0) < bids[j].Price - (float64(bids[j].ResponseTime) / 1000000000.0)
+	bidiResponseTimeInNanos := (float64(bids[i].ResponseTime) / 1000000000.0)
+	bidjResponseTimeInNanos := (float64(bids[j].ResponseTime) / 1000000000.0)
+	return bids[i].Price - bidiResponseTimeInNanos < bids[j].Price - bidjResponseTimeInNanos
 }
 
 func (bids PBSBidSlice) Swap(i, j int) {

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -28,7 +28,7 @@ func (bids PBSBidSlice) Len() int {
 func (bids PBSBidSlice) Less(i, j int) bool {
 	bidiResponseTimeInNanos := (float64(bids[i].ResponseTime) / 1000000000.0)
 	bidjResponseTimeInNanos := (float64(bids[j].ResponseTime) / 1000000000.0)
-	return bids[i].Price - bidiResponseTimeInNanos < bids[j].Price - bidjResponseTimeInNanos
+	return bids[i].Price-bidiResponseTimeInNanos < bids[j].Price-bidjResponseTimeInNanos
 }
 
 func (bids PBSBidSlice) Swap(i, j int) {

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -93,7 +93,6 @@ type bidResult struct {
 }
 
 const DEFAULT_PRICE_GRANULARITY = "med"
-const DFP_KEY_STRING_MAX_LENGTH = 20
 
 func min(x, y int) int {
 	if x < y {
@@ -328,10 +327,10 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 				hbPbBidderKey := "hb_pb_" + bid.BidderCode
 				hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
 				hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
-				if pbs_req.IsDFP == 1 {
-					hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
-					hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
-					hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
+				if pbs_req.MaxKeyLength != 0 {
+					hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
+					hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
+					hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), int(pbs_req.MaxKeyLength))]
 				}
 				pbs_kvs := map[string]string{
 					hbPbBidderKey:      roundedCpm,

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -94,6 +94,13 @@ type bidResult struct {
 
 const DEFAULT_PRICE_GRANULARITY = "med"
 
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
 func writeAuctionError(w http.ResponseWriter, s string, err error) {
 	var resp pbs.PBSResponse
 	if err != nil {
@@ -319,9 +326,9 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 				hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
 				hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
 				pbs_kvs := map[string]string{
-					hbPbBidderKey:      roundedCpm,
-					hbBidderBidderKey:  bid.BidderCode,
-					hbCacheIdBidderKey: bid.CacheID,
+					hbPbBidderKey[:min(len(hbPbBidderKey), 20)]:      roundedCpm,
+					hbBidderBidderKey[:min(len(hbBidderBidderKey), 20)]:  bid.BidderCode,
+					hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), 20)]: bid.CacheID,
 				}
 				// For the top bid, we want to add the following additional keys
 				if i == 0 {

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -300,7 +300,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		priceGranularitySetting := DEFAULT_PRICE_GRANULARITY
 
 		// record bids by ad unit code for sorting
-		code_bids := make(map[string]pbs.PBSBidSlice)
+		code_bids := make(map[string]pbs.PBSBidSlice, len(pbs_resp.Bids))
 		for _, bid := range pbs_resp.Bids {
 			code_bids[bid.AdUnitCode] = append(code_bids[bid.AdUnitCode], bid)
 		}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -293,9 +293,9 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 		// record bids by ad unit code for sorting
 		code_bids := make(map[string]pbs.PBSBidSlice)
-        for _, bid :=  range pbs_resp.Bids {
-            code_bids[bid.AdUnitCode] = append(code_bids[bid.AdUnitCode], bid)
-        }
+		for _, bid := range pbs_resp.Bids {
+			code_bids[bid.AdUnitCode] = append(code_bids[bid.AdUnitCode], bid)
+		}
 
 		// loop through ad units to find top bid
 		for _, unit := range pbs_req.AdUnits {
@@ -318,9 +318,9 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 				hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
 				hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
 				pbs_kvs := map[string]string{
-					hbPbBidderKey : roundedCpm,
-					hbBidderBidderKey : bid.BidderCode,
-					hbCacheIdBidderKey : bid.CacheID,
+					hbPbBidderKey:      roundedCpm,
+					hbBidderBidderKey:  bid.BidderCode,
+					hbCacheIdBidderKey: bid.CacheID,
 				}
 				// For the top bid, we want to add the following additional keys
 				if i == 0 {
@@ -328,7 +328,6 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 					pbs_kvs["hb_bidder"] = bid.BidderCode
 					pbs_kvs["hb_cache_id"] = bid.CacheID
 				}
-
 				bid.AdServerTargeting = pbs_kvs
 			}
 		}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -233,6 +233,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 					for _, bid := range bid_list {
 						ametrics.PriceHistogram.Update(int64(bid.Price * 1000))
 						am.PriceHistogram.Update(int64(bid.Price * 1000))
+						bid.ResponseTime = bidder.ResponseTime
 					}
 				} else {
 					bidder.NoBid = true
@@ -287,7 +288,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		}
 	}
 
-	if pbs_req.App != nil {
+	if pbs_req.SortBids == 1 {
 		// TODO (pbm): the below setting is the default for price granularity
 		priceGranularitySetting := DEFAULT_PRICE_GRANULARITY
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -189,7 +189,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(pbs_req.TimeoutMillis))
 	defer cancel()
 
-	_, err = dataCache.Accounts().Get(pbs_req.AccountID)
+	account, err := dataCache.Accounts().Get(pbs_req.AccountID)
 	if err != nil {
 		glog.Info("Invalid account id: ", err)
 		writeAuctionError(w, "Unknown account id", fmt.Errorf("Unknown account"))
@@ -297,8 +297,10 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	}
 
 	if pbs_req.SortBids == 1 {
-		// TODO (pbm): the below setting is the default for price granularity
-		priceGranularitySetting := DEFAULT_PRICE_GRANULARITY
+		priceGranularitySetting := account.PriceGranularity
+		if priceGranularitySetting == "" {
+			priceGranularitySetting = DEFAULT_PRICE_GRANULARITY
+		}
 
 		// record bids by ad unit code for sorting
 		code_bids := make(map[string]pbs.PBSBidSlice, len(pbs_resp.Bids))

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -93,6 +93,7 @@ type bidResult struct {
 }
 
 const DEFAULT_PRICE_GRANULARITY = "med"
+const DFP_KEY_STRING_MAX_LENGTH = 20
 
 func min(x, y int) int {
 	if x < y {
@@ -325,10 +326,15 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 				hbPbBidderKey := "hb_pb_" + bid.BidderCode
 				hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
 				hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
+				if pbs_req.IsDFP == 1 {
+					hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
+					hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
+					hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), DFP_KEY_STRING_MAX_LENGTH)]
+				}
 				pbs_kvs := map[string]string{
-					hbPbBidderKey[:min(len(hbPbBidderKey), 20)]:      roundedCpm,
-					hbBidderBidderKey[:min(len(hbBidderBidderKey), 20)]:  bid.BidderCode,
-					hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), 20)]: bid.CacheID,
+					hbPbBidderKey:      roundedCpm,
+					hbBidderBidderKey:  bid.BidderCode,
+					hbCacheIdBidderKey: bid.CacheID,
 				}
 				// For the top bid, we want to add the following additional keys
 				if i == 0 {

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -31,6 +31,10 @@
             "description": "Sorts bids by price & response time and returns ad server targeting keys for each bid in prebid server response",
             "type": "integer"
         },
+        "is_dfp": {
+            "description": "Returns true if the ad server is dfp. Used to determine whether ad server targeting key strings should be truncated on prebid server",
+            "type": "integer"
+        },
         "app": {
             "type": "object",
             "description": "This object should be included if the ad supported content is a non-browser application (typically in mobile) as opposed to a website. At a minimum, it is useful to provide an App ID or bundle, but this is not strictly required.",

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -27,6 +27,10 @@
             "description": "Caches markup for two-phase response (get response then separate call to get markup)",
             "type": "integer"
         },
+        "sort_bids": {
+            "description": "Sorts bids by price & response time and returns ad server targeting keys for each bid in prebid server response",
+            "type": "integer"
+        },
         "app": {
             "type": "object",
             "description": "This object should be included if the ad supported content is a non-browser application (typically in mobile) as opposed to a website. At a minimum, it is useful to provide an App ID or bundle, but this is not strictly required.",

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -31,8 +31,8 @@
             "description": "Sorts bids by price & response time and returns ad server targeting keys for each bid in prebid server response",
             "type": "integer"
         },
-        "is_dfp": {
-            "description": "Returns true if the ad server is dfp. Used to determine whether ad server targeting key strings should be truncated on prebid server",
+        "max_key_length": {
+            "description": "Used to determine whether ad server targeting key strings should be truncated on prebid server. For DFP max key length should be 20.",
             "type": "integer"
         },
         "app": {


### PR DESCRIPTION
This PR adds ad server targeting keys to the PBSResponse for mobile app requests.

This design allows us to indefinitely expand the functionality of the key generation & granularity settings without app developers having to re-release their apps or us having to simultaneously juggle different versions of the functionality for different versions of Prebid Mobile. Additionally, this allows us to implement the key generation once (on PBS) as opposed to twice (once on iOS, once on Android).

We are adding the ad server targeting keys "hb_pb", "hb_bidder", and "hb_cache_id" to the top bid per ad unit and additionally adding the keys "hb_pb_" + bidder, "hb_bidder_" + bidder, and "hb_cache_id_" + bidder for all of the bids. This mirrors the way it is done on Prebid.js, just moving it to the server instead of the client. 

TODO: Add account settings UI to set the settings in the DB on prebid-site. Once that is done we can pull the settings from the DB on PBS and use the specific setting instead of the default price granularity used in this PR