### PR TITLE
update rubicon adapter to split requests

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -50,3 +50,11 @@ func NewHTTPAdapter(c *HTTPAdapterConfig) *HTTPAdapter {
 		},
 	}
 }
+
+// used for callOne (possibly pull all of the shared code here)
+type callOneResult struct {
+	statusCode   int
+	responseBody string
+	bid          *pbs.PBSBid
+	Error        error
+}

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -45,14 +45,7 @@ type facebookParams struct {
 	PlacementId string `json:"placementId"`
 }
 
-type fbResult struct {
-	statusCode   int
-	responseBody string
-	bid          *pbs.PBSBid
-	Error        error
-}
-
-func (a *FacebookAdapter) CallOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result fbResult, err error) {
+func (a *FacebookAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result callOneResult, err error) {
 	httpReq, _ := http.NewRequest("POST", a.URI, &reqJSON)
 	httpReq.Header.Add("Content-Type", "application/json")
 	httpReq.Header.Add("Accept", "application/json")
@@ -132,10 +125,10 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		}
 	}
 
-	ch := make(chan fbResult)
+	ch := make(chan callOneResult)
 	for i, _ := range bidder.AdUnits {
 		go func(bidder *pbs.PBSBidder, reqJSON bytes.Buffer) {
-			result, err := a.CallOne(ctx, req, reqJSON)
+			result, err := a.callOne(ctx, req, reqJSON)
 			result.Error = err
 			if result.bid != nil {
 				result.bid.BidderCode = bidder.BidderCode

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -263,7 +263,7 @@ func TestFacebookBasicResponse(t *testing.T) {
 	}
 
 	// same test but with one request timing out
-	fbdata.tags[0].delay = 5 * time.Millisecond
+	fbdata.tags[0].delay = 20 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -156,10 +156,67 @@ func parseRubiconSizes(sizes []openrtb.Format) (primary int, alt []int, err erro
 	return
 }
 
-func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	rpReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+func (a *RubiconAdapter) CallOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result fbResult, err error) {
+	httpReq, err := http.NewRequest("POST", a.URI, &reqJSON)
+	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
+	httpReq.Header.Add("Accept", "application/json")
+	httpReq.Header.Add("User-Agent", "prebid-server/1.0")
+	httpReq.SetBasicAuth(a.XAPIUsername, a.XAPIPassword)
 
+	anResp, e := ctxhttp.Do(ctx, a.http.Client, httpReq)
+	if e != nil {
+		err = e
+		return
+	}
+
+	defer anResp.Body.Close()
+	body, _ := ioutil.ReadAll(anResp.Body)
+	result.responseBody = string(body)
+
+	result.statusCode = anResp.StatusCode
+
+	if anResp.StatusCode == 204 {
+		return
+	}
+
+	if anResp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP status %d; body: %s", anResp.StatusCode, result.responseBody)
+		return
+	}
+
+	var bidResp openrtb.BidResponse
+	err = json.Unmarshal(body, &bidResp)
+	if err != nil {
+		return
+	}
+	if len(bidResp.SeatBid) == 0 {
+		return
+	}
+	if len(bidResp.SeatBid[0].Bid) == 0 {
+		return
+	}
+	bid := bidResp.SeatBid[0].Bid[0]
+
+	result.bid = &pbs.PBSBid{
+		AdUnitCode:  bid.ImpID,
+		Price:       bid.Price,
+		Adm:         bid.AdM,
+		Creative_id: bid.CrID,
+		Width:       bid.W,
+		Height:      bid.H,
+		DealId:      bid.DealID,
+	}
+	return
+}
+
+func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	requests := make([]bytes.Buffer, len(bidder.AdUnits))
 	for i, unit := range bidder.AdUnits {
+		rubiReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+
+		// only grab this ad unit
+		rubiReq.Imp = rubiReq.Imp[i : i+1]
+
 		var params rubiconParams
 		err := json.Unmarshal(unit.Params, &params)
 		if err != nil {
@@ -175,7 +232,7 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 			return nil, errors.New("Missing zoneId param")
 		}
 		impExt := rubiconImpExt{RP: rubiconImpExtRP{ZoneID: params.ZoneId}}
-		rpReq.Imp[i].Ext, err = json.Marshal(&impExt)
+		rubiReq.Imp[0].Ext, err = json.Marshal(&impExt)
 
 		primarySizeID, altSizeIDs, err := parseRubiconSizes(unit.Sizes)
 		if err != nil {
@@ -183,99 +240,69 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 		}
 
 		bannerExt := rubiconBannerExt{RP: rubiconBannerExtRP{SizeID: primarySizeID, AltSizeIDs: altSizeIDs, MIME: "text/html"}}
-		rpReq.Imp[i].Banner.Ext, err = json.Marshal(&bannerExt)
-		// params are per-unit, so site may overwrite itself
+		rubiReq.Imp[0].Banner.Ext, err = json.Marshal(&bannerExt)
 		siteExt := rubiconSiteExt{RP: rubiconSiteExtRP{SiteID: params.SiteId}}
 		pubExt := rubiconPubExt{RP: rubiconPubExtRP{AccountID: params.AccountId}}
-		if rpReq.Site != nil {
-			rpReq.Site.Ext, err = json.Marshal(&siteExt)
-			rpReq.Site.Publisher = &openrtb.Publisher{}
-			rpReq.Site.Publisher.Ext, err = json.Marshal(&pubExt)
+		if rubiReq.Site != nil {
+			rubiReq.Site.Ext, err = json.Marshal(&siteExt)
+			rubiReq.Site.Publisher = &openrtb.Publisher{}
+			rubiReq.Site.Publisher.Ext, err = json.Marshal(&pubExt)
 		}
-		if rpReq.App != nil {
-			rpReq.App.Ext, err = json.Marshal(&siteExt)
-			rpReq.App.Publisher = &openrtb.Publisher{}
-			rpReq.App.Publisher.Ext, err = json.Marshal(&pubExt)
+		if rubiReq.App != nil {
+			rubiReq.App.Ext, err = json.Marshal(&siteExt)
+			rubiReq.App.Publisher = &openrtb.Publisher{}
+			rubiReq.App.Publisher.Ext, err = json.Marshal(&pubExt)
+		}
+
+		err = json.NewEncoder(&requests[i]).Encode(rubiReq)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	reqJSON, err := json.Marshal(rpReq)
-	if err != nil {
-		return nil, err
+	ch := make(chan fbResult)
+	for i, _ := range bidder.AdUnits {
+		go func(bidder *pbs.PBSBidder, reqJSON bytes.Buffer) {
+			result, err := a.CallOne(ctx, req, reqJSON)
+			result.Error = err
+			if result.bid != nil {
+				result.bid.BidderCode = bidder.BidderCode
+				result.bid.BidID = bidder.LookupBidID(result.bid.AdUnitCode)
+				if result.bid.BidID == "" {
+					result.Error = fmt.Errorf("Unknown ad unit code '%s'", result.bid.AdUnitCode)
+					result.bid = nil
+				}
+			}
+			ch <- result
+		}(bidder, requests[i])
 	}
 
-	debug := &pbs.BidderDebug{
-		RequestURI: a.URI,
-	}
-
-	if req.IsDebug {
-		debug.RequestBody = string(reqJSON)
-		bidder.Debug = append(bidder.Debug, debug)
-	}
-
-	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
-	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
-	httpReq.Header.Add("Accept", "application/json")
-	httpReq.Header.Add("User-Agent", "prebid-server/1.0")
-	httpReq.SetBasicAuth(a.XAPIUsername, a.XAPIPassword)
-	// todo: add basic auth
-
-	anResp, err := ctxhttp.Do(ctx, a.http.Client, httpReq)
-	if err != nil {
-		return nil, err
-	}
-
-	defer anResp.Body.Close()
-	body, _ := ioutil.ReadAll(anResp.Body)
-	responseBody := string(body)
-
-	debug.StatusCode = anResp.StatusCode
-
-	if anResp.StatusCode == 204 {
-		return nil, nil
-	}
-
-	if anResp.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP status %d; body: %s", anResp.StatusCode, responseBody)
-	}
-
-	if req.IsDebug {
-		debug.ResponseBody = responseBody
-	}
-
-	var bidResp openrtb.BidResponse
-	err = json.Unmarshal(body, &bidResp)
-	if err != nil {
-		return nil, err
-	}
+	var err error
 
 	bids := make(pbs.PBSBidSlice, 0)
-
-	numBids := 0
-	for _, sb := range bidResp.SeatBid {
-		for _, bid := range sb.Bid {
-			numBids++
-
-			bidID := bidder.LookupBidID(bid.ImpID)
-			if bidID == "" {
-				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
+	for i := 0; i < len(bidder.AdUnits); i++ {
+		result := <-ch
+		if result.bid != nil {
+			bids = append(bids, result.bid)
+		}
+		if req.IsDebug {
+			debug := &pbs.BidderDebug{
+				RequestURI:   a.URI,
+				RequestBody:  requests[i].String(),
+				StatusCode:   result.statusCode,
+				ResponseBody: result.responseBody,
 			}
-
-			pbid := pbs.PBSBid{
-				BidID:       bidID,
-				AdUnitCode:  bid.ImpID,
-				BidderCode:  bidder.BidderCode,
-				Price:       bid.Price,
-				Adm:         bid.AdM,
-				Creative_id: bid.CrID,
-				Width:       bid.W,
-				Height:      bid.H,
-				DealId:      bid.DealID,
-			}
-			bids = append(bids, &pbid)
+			bidder.Debug = append(bidder.Debug, debug)
+		}
+		if result.Error != nil {
+			fmt.Printf("Error in rubicon adapter: %v", result.Error)
+			err = result.Error
 		}
 	}
 
+	if len(bids) == 0 {
+		return nil, err
+	}
 	return bids, nil
 }
 

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -307,7 +307,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	}
 
 	// same test but with request timing out
-	rubidata.delay = 5 * time.Millisecond
+	rubidata.delay = 20 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -63,6 +63,30 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(breq.Imp) > 1 {
+		http.Error(w, "Rubicon adapter only supports one Imp per request", http.StatusInternalServerError)
+		return
+	}
+	imp := breq.Imp[0]
+	var rix rubiconImpExt
+	err = json.Unmarshal(imp.Ext, &rix)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ix := -1
+
+	for i, tag := range rubidata.tags {
+		if rix.RP.ZoneID == tag.zoneID {
+			ix = i
+		}
+	}
+	if ix == -1 {
+		http.Error(w, fmt.Sprintf("Zone %d not found", rix.RP.ZoneID), http.StatusInternalServerError)
+		return
+	}
+
 	resp := openrtb.BidResponse{
 		ID:    "a-random-id",
 		BidID: "another-random-id",
@@ -75,46 +99,34 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	for i, imp := range breq.Imp {
-		var rix rubiconImpExt
-		err = json.Unmarshal(imp.Ext, &rix)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if rix.RP.ZoneID != rubidata.tags[i].zoneID {
-			http.Error(w, fmt.Sprintf("Zone ID '%d' doesn't match '%d", rix.RP.ZoneID, rubidata.tags[i].zoneID), http.StatusInternalServerError)
-			return
-		}
-		if imp.Banner == nil {
-			http.Error(w, fmt.Sprintf("No banner object sent"), http.StatusInternalServerError)
-			return
-		}
-		var bix rubiconBannerExt
-		err = json.Unmarshal(imp.Banner.Ext, &bix)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if bix.RP.SizeID != 10 { // 300x600
-			http.Error(w, fmt.Sprintf("Primary size ID isn't 10"), http.StatusInternalServerError)
-			return
-		}
-		if len(bix.RP.AltSizeIDs) != 1 || bix.RP.AltSizeIDs[0] != 15 { // 300x250
-			http.Error(w, fmt.Sprintf("Alt size ID isn't 15"), http.StatusInternalServerError)
-			return
-		}
-		if bix.RP.MIME != "text/html" {
-			http.Error(w, fmt.Sprintf("MIME isn't text/html"), http.StatusInternalServerError)
-			return
-		}
+	if imp.Banner == nil {
+		http.Error(w, fmt.Sprintf("No banner object sent"), http.StatusInternalServerError)
+		return
+	}
+	var bix rubiconBannerExt
+	err = json.Unmarshal(imp.Banner.Ext, &bix)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if bix.RP.SizeID != 10 { // 300x600
+		http.Error(w, fmt.Sprintf("Primary size ID isn't 10"), http.StatusInternalServerError)
+		return
+	}
+	if len(bix.RP.AltSizeIDs) != 1 || bix.RP.AltSizeIDs[0] != 15 { // 300x250
+		http.Error(w, fmt.Sprintf("Alt size ID isn't 15"), http.StatusInternalServerError)
+		return
+	}
+	if bix.RP.MIME != "text/html" {
+		http.Error(w, fmt.Sprintf("MIME isn't text/html"), http.StatusInternalServerError)
+		return
+	}
 
-		resp.SeatBid[0].Bid[i] = openrtb.Bid{
-			ID:    "random-id",
-			ImpID: imp.ID,
-			Price: rubidata.tags[i].bid,
-			AdM:   rubidata.tags[i].content,
-		}
+	resp.SeatBid[0].Bid[0] = openrtb.Bid{
+		ID:    "random-id",
+		ImpID: imp.ID,
+		Price: rubidata.tags[ix].bid,
+		AdM:   rubidata.tags[ix].content,
 	}
 
 	if breq.Site == nil {


### PR DESCRIPTION
Rubicon adapter appears unable to handle multiple Imp objects per request; splitting them out to send multiple requests with one Imp each.