### PR TITLE
If bidder.BidID is empty, set a random UUID for BidId for all PBS requests

### DIFF
--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -220,7 +220,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				pbsReq.Bidders = append(pbsReq.Bidders, bidder)
 			}
 			if b.BidID == "" {
-				rand.Seed(time.Now().UnixNano())
 				b.BidID = fmt.Sprintf("%d", rand.Int63())
 			}
 

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -220,6 +220,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				pbsReq.Bidders = append(pbsReq.Bidders, bidder)
 			}
 			if b.BidID == "" {
+				rand.Seed(time.Now().UnixNano())
 				b.BidID = fmt.Sprintf("%d", rand.Int63())
 			}
 

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -3,6 +3,7 @@ package pbs
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -217,6 +218,9 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 					bidder.AdUnitCode = unit.Code
 				}
 				pbsReq.Bidders = append(pbsReq.Bidders, bidder)
+			}
+			if b.BidID == "" {
+				b.BidID = fmt.Sprintf("%d", rand.Int63())
 			}
 
 			pau := PBSAdUnit{

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -76,6 +76,12 @@ func TestParseSimpleRequest(t *testing.T) {
 	if len(pbs_req.Bidders[2].AdUnits) != 1 {
 		t.Errorf("Index bidder should have 1 ad unit")
 	}
+	if pbs_req.Bidders[1].AdUnits[0].BidID == "" {
+		t.Errorf("UUID should have been generated for empty BidID")
+	}
+	if pbs_req.Bidders[2].AdUnits[0].BidID == "" {
+		t.Errorf("UUID should have been generated for empty BidID")
+	}
 }
 
 func TestHeaderParsing(t *testing.T) {

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -77,10 +77,10 @@ func TestParseSimpleRequest(t *testing.T) {
 		t.Errorf("Index bidder should have 1 ad unit")
 	}
 	if pbs_req.Bidders[1].AdUnits[0].BidID == "" {
-		t.Errorf("UUID should have been generated for empty BidID")
+		t.Errorf("ID should have been generated for empty BidID")
 	}
 	if pbs_req.Bidders[2].AdUnits[0].BidID == "" {
-		t.Errorf("UUID should have been generated for empty BidID")
+		t.Errorf("ID should have been generated for empty BidID")
 	}
 }
 


### PR DESCRIPTION
We don't need bidId to be set on the pbs request for mobile. @mkendall07 and I discussed and decided if bidId is ever empty in PBS request that we should generate a UUID to use as bidId when parsing the request. Added unit tests.