### PR TITLE
send requests with no cookies to adapters; allow them to opt out

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -12,6 +12,7 @@ import (
 type Adapter interface {
 	Name() string
 	FamilyName() string
+	SkipNoCookies() bool
 	GetUsersyncInfo() *pbs.UsersyncInfo
 	Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error)
 }

--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -38,6 +38,10 @@ func (a *AppNexusAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *AppNexusAdapter) SkipNoCookies() bool {
+	return false
+}
+
 type KeyVal struct {
 	Key    string   `json:"key,omitempty"`
 	Values []string `json:"value,omitempty"`

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -41,6 +41,10 @@ func (a *FacebookAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *FacebookAdapter) SkipNoCookies() bool {
+	return false
+}
+
 type facebookParams struct {
 	PlacementId string `json:"placementId"`
 }

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -37,6 +37,10 @@ func (a *IndexAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *IndexAdapter) SkipNoCookies() bool {
+	return false
+}
+
 type indexParams struct {
 	SiteID int `json:"siteID"`
 }

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -35,6 +35,10 @@ func (a *PubmaticAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *PubmaticAdapter) SkipNoCookies() bool {
+	return false
+}
+
 type pubmaticParams struct {
 	PublisherId string `json:"publisherId"`
 	AdSlot      string `json:"adSlot"`

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -37,6 +37,10 @@ func (a *PulsePointAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *PulsePointAdapter) SkipNoCookies() bool {
+	return false
+}
+
 // parameters for pulsepoint adapter.
 type PulsepointParams struct {
 	PublisherId int    `json:"cp"`

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -39,6 +39,10 @@ func (a *RubiconAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
 	return a.usersyncInfo
 }
 
+func (a *RubiconAdapter) SkipNoCookies() bool {
+	return false
+}
+
 type rubiconParams struct {
 	AccountId int `json:"accountId"`
 	SiteId    int `json:"siteId"`

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -274,7 +274,9 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 				bidder.NoCookie = true
 				bidder.UsersyncInfo = ex.GetUsersyncInfo()
 				ametrics.NoCookieMeter.Mark(1)
-				continue
+				if ex.SkipNoCookies() {
+					continue
+				}
 			}
 			sentBids++
 			go func(bidder *pbs.PBSBidder) {


### PR DESCRIPTION
Defaulting to send no-cookies to all adapters; this will help client-side analytics show same numbers as bidders get called.