### PR TITLE
Added metrics to capture the number of user sync requests per bidder.

### DIFF
--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -311,7 +311,8 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	pc := pbs.ParseUIDCookie(req)
 	pc.UIDs["adnxs"] = andata.buyerUID
 	fakewriter := httptest.NewRecorder()
-	pbs.SetUIDCookie(fakewriter, pc)
+	userSync := pbs.UserSyncDeps{}
+	userSync.SetUIDCookie(fakewriter, pc)
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -215,7 +215,8 @@ func TestFacebookBasicResponse(t *testing.T) {
 	pc := pbs.ParseUIDCookie(req)
 	pc.UIDs["audienceNetwork"] = fbdata.buyerUID
 	fakewriter := httptest.NewRecorder()
-	pbs.SetUIDCookie(fakewriter, pc)
+	userSync := pbs.UserSyncDeps{}
+	userSync.SetUIDCookie(fakewriter, pc)
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()

--- a/adapters/pulsepoint_test.go
+++ b/adapters/pulsepoint_test.go
@@ -267,7 +267,8 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	pc := pbs.ParseUIDCookie(httpReq)
 	pc.UIDs["pulsepoint"] = "pulsepointUser123"
 	fakewriter := httptest.NewRecorder()
-	pbs.SetUIDCookie(fakewriter, pc)
+	userSync := pbs.UserSyncDeps{}
+	userSync.SetUIDCookie(fakewriter, pc)
 	httpReq.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 	// parse the http request
 	cacheClient, _ := dummycache.New()

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -262,7 +262,8 @@ func TestRubiconBasicResponse(t *testing.T) {
 	pc := pbs.ParseUIDCookie(req)
 	pc.UIDs["rubicon"] = rubidata.buyerUID
 	fakewriter := httptest.NewRecorder()
-	pbs.SetUIDCookie(fakewriter, pc)
+	userSync := pbs.UserSyncDeps{}
+	userSync.SetUIDCookie(fakewriter, pc)
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -25,6 +25,7 @@ const (
 	BID_PRICES              = "prebidserver.bid_response_cpm_cents"
 	BID_COUNT               = "prebidserver.bid_count"
 
+	USERSYNC_COUNT           = "prebidserver.usersync_count"
 	COOKIESYNC_REQUEST_COUNT = "prebidserver.cookiesync_request_count"
 )
 
@@ -195,4 +196,12 @@ func (influx *pbsInflux) StartBidderRequest(
 // StartCookieSyncRequest implements part of the PBSMetrics interface.
 func (influx *pbsInflux) StartCookieSyncRequest() {
 	influx.registry.getOrRegisterMeter(COOKIESYNC_REQUEST_COUNT, nil).Mark(1)
+}
+
+// StartCookieSyncRequest implements part of the PBSMetrics interface.
+func (influx *pbsInflux) DoneUserSync(bidderCode string) {
+	tags := map[string]string{
+		"bidderCode": bidderCode,
+	}
+	influx.registry.getOrRegisterMeter(USERSYNC_COUNT, tags).Mark(1)
 }

--- a/metrics/influx/influx_test.go
+++ b/metrics/influx/influx_test.go
@@ -55,7 +55,7 @@ func TestBidderWithCookie(t *testing.T) {
 
 	bidInfo1 := &coreMetrics.BidRequestInfo{
 		BidderCode: "bidder1",
-		HasCookie: true,
+		HasCookie:  true,
 	}
 	var count int64
 	doBidderStart(t, influx, aucInfo, bidInfo1).BidderResponded(nil, errors.New("Internal bidder error"))
@@ -84,7 +84,7 @@ func TestBidderNoCookie(t *testing.T) {
 	}
 	bidInfo2 := &coreMetrics.BidRequestInfo{
 		BidderCode: "bidder1",
-		HasCookie: false,
+		HasCookie:  false,
 	}
 	mockResponse := []float64{0.07, 0.08}
 	doBidderStart(t, influx, aucInfo, bidInfo2).BidderResponded(mockResponse, nil)
@@ -114,7 +114,7 @@ func TestBidderSkipNoCookie(t *testing.T) {
 	}
 	bidInfo := &coreMetrics.BidRequestInfo{
 		BidderCode: "bidder1",
-		HasCookie: false,
+		HasCookie:  false,
 	}
 	doBidderStart(t, influx, aucInfo, bidInfo).BidderSkipped()
 
@@ -163,6 +163,18 @@ func TestRespTypeForBidderParsing(t *testing.T) {
 
 	if makeRespTypeForBidder(timeout) != "timeout" {
 		t.Errorf("Bidders with generic errors should count events as tag type=\"error\". Got %s", makeRespTypeForBidder(timeout))
+	}
+}
+
+func TestUserSyncEvent(t *testing.T) {
+	registry := taggableRegistry{delegate: metrics.NewRegistry()}
+	influx := &pbsInflux{registry: &registry}
+	influx.DoneUserSync("mock_bidder")
+
+	expectedTags := map[string]string{"bidderCode": "mock_bidder"}
+	count := influx.registry.getOrRegisterMeter(USERSYNC_COUNT, expectedTags).Snapshot().Count()
+	if count != 1 {
+		t.Errorf("Expected 1 usersync event. Got %d", count)
 	}
 }
 

--- a/metrics/nometrics.go
+++ b/metrics/nometrics.go
@@ -17,6 +17,8 @@ func (m *nilPBSMetrics) StartBidderRequest(auctionRequestInfo *AuctionRequestInf
 	return &nilBidderRequestFollowups{}
 }
 
+func (m *nilPBSMetrics) DoneUserSync(bidderCode string) {}
+
 func (m *nilPBSMetrics) StartCookieSyncRequest() {}
 
 type nilAuctionRequestFollowups struct{}

--- a/metrics/pbsmetrics.go
+++ b/metrics/pbsmetrics.go
@@ -3,7 +3,6 @@ package metrics
 // The metrics module contains APIs which export metrics to some sort of aggregation service.
 // It should not import any other PBS modules, to avoid surprise circular dependencies.
 
-
 // PBSMetrics logs useful metrics to InfluxDB.
 //
 // Implementations of this interface should be threadsafe, so they can be used in multiple goroutines.
@@ -16,6 +15,10 @@ type PBSMetrics interface {
 
 	// StartCookieSyncRequest should be called each time the /cookie_sync endpoint is hit.
 	StartCookieSyncRequest()
+
+	// DoneUserSync should be called each time the /setuid endpoint is used to successfully sync
+	// user IDs for some bidder.
+	DoneUserSync(bidderCode string)
 }
 
 // RequestSource is the list of sources where requests might come from.

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -788,8 +788,9 @@ func serve(cfg *config.Configuration) error {
 		glog.Fatal(http.ListenAndServe(adminURI, nil))
 	}()
 
+	metricsExporter := chooseMetrics(cfg)
 	deps := PrebidServerDependencies{
-		metrics: chooseMetrics(cfg),
+		metrics: metricsExporter,
 	}
 
 	router := httprouter.New()
@@ -801,7 +802,17 @@ func serve(cfg *config.Configuration) error {
 	router.GET("/ip", getIP)
 	router.ServeFiles("/static/*filepath", http.Dir("static"))
 
-	pbs.InitUsersyncHandlers(router, metricsRegistry, cfg.CookieDomain, cfg.ExternalURL, cfg.RecaptchaSecret)
+	userSyncDeps := &pbs.UserSyncDeps{
+		Cookie_domain:    cfg.CookieDomain,
+		External_url:     cfg.ExternalURL,
+		Recaptcha_secret: cfg.RecaptchaSecret,
+		Metrics:          metricsExporter,
+	}
+
+	router.GET("/getuids", userSyncDeps.GetUIDs)
+	router.GET("/setuid", userSyncDeps.SetUID)
+	router.POST("/optout", userSyncDeps.OptOut)
+	router.GET("/optout", userSyncDeps.OptOut)
 
 	pbc.InitPrebidCache(cfg.CacheURL)
 


### PR DESCRIPTION
Some bidders want to know how many times their IDs get synced with prebid-server. This diff will capture those metrics.

I opened this against the `gometrics-metrics` branch so that the diff is clear. If #83 gets merged first, I can re-target it against master.