### PR TITLE
Add video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Server side component to offload prebid processing to the cloud
 # Discussion group for development / adapter testing
 http://redditadops.slack.com channel headerbidding-dev
 
-# Current Status of Adapters (May 15, 2017)
+# Current Status of Adapters (Aug 21, 2017)
 Working on live sites:
-- AppNexus web
+- AppNexus Web
+- Audience Network (Facebook) Web
+- Rubicon Web
+- Index Exchange Web
 
 In testing:
-- Facebook web
-- Rubicon web
 
-Under development / pending testing:
-- Pubmatic (waiting for clean & stable usersync endpoint and param compatibility with client-side prebid)
-- Index Exchange (waiting for stable endpoint)
-- PulsePoint (in code review)
+Under development/ testing
+- Pubmatic web
+- PulsePoint Web
 
 # How it works
 The client (typically prebid.js) sends a JSON request to Prebid Server at `/auction`. See static/pbs_request.json for the format.

--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -68,7 +68,8 @@ type appnexusImpExt struct {
 }
 
 func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	anReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	anReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
 
 	uri := a.URI
 	for i, unit := range bidder.AdUnits {

--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -68,8 +68,8 @@ type appnexusImpExt struct {
 }
 
 func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	anReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	anReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), supportedMediaTypes, true)
 
 	uri := a.URI
 	for i, unit := range bidder.AdUnits {

--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -69,8 +69,11 @@ type appnexusImpExt struct {
 
 func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	anReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), supportedMediaTypes, true)
+	anReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), supportedMediaTypes, true)
 
+	if err != nil {
+		return pbs.PBSBidSlice{}, err
+	}
 	uri := a.URI
 	for i, unit := range bidder.AdUnits {
 		var params appnexusParams

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -276,7 +276,8 @@ func TestAppNexusBasicResponse(t *testing.T) {
 		}
 
 		pbin.AdUnits[i] = pbs.AdUnit{
-			Code: tag.code,
+			Code:       tag.code,
+			MediaTypes: []string{"BANNER"},
 			Sizes: []openrtb.Format{
 				{
 					W: 300,

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -349,6 +349,9 @@ func TestAppNexusBasicResponse(t *testing.T) {
 				if bid.Adm != tag.content {
 					t.Errorf("Incorrect bid markup '%s' expected '%s'", bid.Adm, tag.content)
 				}
+				if bid.CreativeMediaType != pbs.MEDIA_TYPE_BANNER {
+					t.Errorf("Incorrect CreativeMediaType '%s' expected '%s'", bid.CreativeMediaType, pbs.MEDIA_TYPE_BANNER)
+				}
 			}
 		}
 		if !matched {

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -115,10 +115,10 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		fbReq.Ext = a.platformJSON
 
 		// only grab this ad unit
-		fbReq.Imp = fbReq.Imp[i : i+1]
 
 		// check whether BANNER Imp exists for that adUnit
-		if fbReq.Imp != nil {
+		if fbReq.Imp != nil && len(fbReq.Imp) > 0 {
+			fbReq.Imp = fbReq.Imp[i : i+1]
 
 			if fbReq.Site != nil {
 				fbReq.Site.Publisher = &openrtb.Publisher{ID: s[0]}
@@ -140,10 +140,10 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		fbReq.Ext = a.platformJSON
 
 		// only grab this ad unit
-		fbReq.Imp = fbReq.Imp[i : i+1]
 
-		// check whether BANNER Imp exists for that adUnit
-		if fbReq.Imp != nil {
+		// check whether VIDEO Imp exists for that adUnit
+		if fbReq.Imp != nil && len(fbReq.Imp) > 0 {
+			fbReq.Imp = fbReq.Imp[i : i+1]
 
 			if fbReq.Site != nil {
 				fbReq.Site.Publisher = &openrtb.Publisher{ID: s[0]}

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -95,7 +95,12 @@ func (a *FacebookAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJ
 }
 
 func (a *FacebookAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, placementId string, mtype pbs.MediaType, pubId string, unitInd int) (openrtb.BidRequest, error) {
-	fbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{mtype}, true)
+	fbReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{mtype}, true)
+
+	if err != nil {
+		return openrtb.BidRequest{}, err
+	}
+
 	fbReq.Ext = a.platformJSON
 
 	if fbReq.Imp != nil && len(fbReq.Imp) > 0 {

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -111,7 +111,6 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			return nil, fmt.Errorf("Invalid placementId param '%s'", params.PlacementId)
 		}
 
-
 		fbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 		fbReq.Ext = a.platformJSON
 
@@ -130,7 +129,7 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			fbReq.Imp[0].TagID = params.PlacementId
 
 			err = json.NewEncoder(&requests[reqIndex]).Encode(fbReq)
-			reqIndex = reqIndex +1
+			reqIndex = reqIndex + 1
 			if err != nil {
 				return nil, err
 			}
@@ -155,7 +154,7 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			fbReq.Imp[0].TagID = params.PlacementId
 
 			err = json.NewEncoder(&requests[reqIndex]).Encode(fbReq)
-			reqIndex = reqIndex +1
+			reqIndex = reqIndex + 1
 			if err != nil {
 				return nil, err
 			}

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -182,7 +182,8 @@ func TestFacebookBasicResponse(t *testing.T) {
 	}
 	for i, tag := range fbdata.tags {
 		pbin.AdUnits[i] = pbs.AdUnit{
-			Code: tag.code,
+			Code:       tag.code,
+			MediaTypes: []string{"BANNER"},
 			Sizes: []openrtb.Format{
 				{
 					W: 300,

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -50,7 +50,11 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 		return nil, fmt.Errorf("Index doesn't support apps")
 	}
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	indexReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	indexReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+
+	if err != nil {
+		return pbs.PBSBidSlice{}, err
+	}
 
 	for i, unit := range bidder.AdUnits {
 		var params indexParams

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -49,7 +49,9 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 	if req.App != nil {
 		return nil, fmt.Errorf("Index doesn't support apps")
 	}
-	indexReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	indexReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+
 	for i, unit := range bidder.AdUnits {
 		var params indexParams
 		err := json.Unmarshal(unit.Params, &params)

--- a/adapters/index_test.go
+++ b/adapters/index_test.go
@@ -52,7 +52,8 @@ func TestIndexTimeout(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -86,7 +87,8 @@ func TestIndexInvalidJson(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -121,7 +123,8 @@ func TestIndexInvalidStatusCode(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -156,7 +159,8 @@ func TestIndexMissingSiteId(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -214,8 +218,9 @@ func TestIndexBasicResponse(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code:  "unitCode",
-				BidID: "bidid",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
+				BidID:      "bidid",
 				Sizes: []openrtb.Format{
 					{
 						W: 10,

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -50,6 +50,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 						newImp.Video = &openrtb.Video{
 							MIMEs:          mimes,
 							MinDuration:    unit.Video.Minduration,
+							MaxDuration:    unit.Video.Maxduration,
 							W:              unit.Sizes[0].W,
 							H:              unit.Sizes[0].H,
 							StartDelay:     unit.Video.Startdelay,
@@ -57,6 +58,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 						}
 					default:
 						// Error - unknown media type
+						continue
 					}
 					imps[ind] = newImp
 					ind = ind + 1
@@ -85,6 +87,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 					newImp.Video = &openrtb.Video{
 						MIMEs:          mimes,
 						MinDuration:    unit.Video.Minduration,
+						MaxDuration:    unit.Video.Maxduration,
 						W:              unit.Sizes[0].W,
 						H:              unit.Sizes[0].H,
 						StartDelay:     unit.Video.Startdelay,
@@ -92,6 +95,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 					}
 				default:
 					// Error - unknown media type
+					continue
 				}
 			}
 			imps[ind] = newImp

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -67,28 +67,28 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			}
 			for _, mType := range unit.MediaTypes {
 				switch mType {
-					case pbs.MEDIA_TYPE_BANNER:
-						newImp.Banner = &openrtb.Banner{
-							W:        unit.Sizes[0].W,
-							H:        unit.Sizes[0].H,
-							Format:   unit.Sizes,
-							TopFrame: unit.TopFrame,
-						}
-					case pbs.MEDIA_TYPE_VIDEO:
-						mimes := make([]string, len(unit.Video.Mimes))
-						copy(mimes, unit.Video.Mimes)
-						pbm := make([]int8, 1)
-						pbm[0] = unit.Video.PlaybackMethod
-						newImp.Video = &openrtb.Video{
-							MIMEs:          mimes,
-							MinDuration:    unit.Video.Minduration,
-							W:              unit.Sizes[0].W,
-							H:              unit.Sizes[0].H,
-							StartDelay:     unit.Video.Startdelay,
-							PlaybackMethod: pbm,
-						}
-					default:
-						// Error - unknown media type
+				case pbs.MEDIA_TYPE_BANNER:
+					newImp.Banner = &openrtb.Banner{
+						W:        unit.Sizes[0].W,
+						H:        unit.Sizes[0].H,
+						Format:   unit.Sizes,
+						TopFrame: unit.TopFrame,
+					}
+				case pbs.MEDIA_TYPE_VIDEO:
+					mimes := make([]string, len(unit.Video.Mimes))
+					copy(mimes, unit.Video.Mimes)
+					pbm := make([]int8, 1)
+					pbm[0] = unit.Video.PlaybackMethod
+					newImp.Video = &openrtb.Video{
+						MIMEs:          mimes,
+						MinDuration:    unit.Video.Minduration,
+						W:              unit.Sizes[0].W,
+						H:              unit.Sizes[0].H,
+						StartDelay:     unit.Video.Startdelay,
+						PlaybackMethod: pbm,
+					}
+				default:
+					// Error - unknown media type
 				}
 			}
 			imps[i] = newImp
@@ -98,7 +98,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 	if req.App != nil {
 		return openrtb.BidRequest{
 			ID:     req.Tid,
-			Imp:    imps,
+			Imp:    imps[:ind],
 			App:    req.App,
 			Device: req.Device,
 			User:   req.User,
@@ -112,7 +112,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 
 	return openrtb.BidRequest{
 		ID:  req.Tid,
-		Imp: imps,
+		Imp: imps[:ind],
 		Site: &openrtb.Site{
 			Domain: req.Domain,
 			Page:   req.Url,

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"github.com/prebid/prebid-server/pbs"
 
+	"errors"
 	"github.com/prebid/openrtb"
 )
 
@@ -44,6 +45,10 @@ func makeBanner(unit pbs.PBSAdUnit) *openrtb.Banner {
 }
 
 func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
+	// empty mimes array is a sign of uninitialized Video object
+	if len(unit.Video.Mimes) < 1 {
+		return nil
+	}
 	mimes := make([]string, len(unit.Video.Mimes))
 	copy(mimes, unit.Video.Mimes)
 	pbm := make([]int8, 1)
@@ -59,7 +64,7 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	}
 }
 
-func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string, allowedMediatypes []pbs.MediaType, singleMediaTypeImp bool) openrtb.BidRequest {
+func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string, allowedMediatypes []pbs.MediaType, singleMediaTypeImp bool) (openrtb.BidRequest, error) {
 
 	imps := make([]openrtb.Imp, len(bidder.AdUnits)*len(allowedMediatypes))
 	ind := 0
@@ -84,7 +89,11 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 				case pbs.MEDIA_TYPE_BANNER:
 					newImp.Banner = makeBanner(unit)
 				case pbs.MEDIA_TYPE_VIDEO:
-					newImp.Video = makeVideo(unit)
+					video := makeVideo(unit)
+					if video == nil {
+						return openrtb.BidRequest{}, errors.New("Invalid AdUnit: VIDEO media type with no video data")
+					}
+					newImp.Video = video
 				default:
 					// Error - unknown media type
 					continue
@@ -132,7 +141,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			},
 			AT:   1,
 			TMax: req.TimeoutMillis,
-		}
+		}, nil
 	}
 
 	return openrtb.BidRequest{
@@ -153,5 +162,5 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		},
 		AT:   1,
 		TMax: req.TimeoutMillis,
-	}
+	}, nil
 }

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -6,25 +6,76 @@ import (
 	"github.com/prebid/openrtb"
 )
 
-func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
+func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string, mediatypes []MediaType, singleMediaTypeImp bool) openrtb.BidRequest {
 
-	imps := make([]openrtb.Imp, len(bidder.AdUnits))
+	imps := make([]openrtb.Imp, len(bidder.AdUnits)*len(mediatypes))
+	ind := 0
 	for i, unit := range bidder.AdUnits {
 		if len(unit.Sizes) <= 0 {
 			continue
 		}
 
-		imps[i] = openrtb.Imp{
-			ID: unit.Code,
-			Banner: &openrtb.Banner{
-				W:        unit.Sizes[0].W,
-				H:        unit.Sizes[0].H,
-				Format:   unit.Sizes,
-				TopFrame: unit.TopFrame,
-			},
-			Secure: req.Secure,
-			// pmp
-			// ext
+		if singleMediaTypeImp {
+			for _, mType := range mediatypes {
+				newImp := openrtb.Imp{
+					ID:     unit.Code,
+					Secure: req.Secure,
+				}
+				switch mType {
+				case BANNER:
+					newImp.Banner = &openrtb.Banner{
+						W:        unit.Sizes[0].W,
+						H:        unit.Sizes[0].H,
+						Format:   unit.Sizes,
+						TopFrame: unit.TopFrame,
+					}
+				case VIDEO:
+					mimes := make([]string, len(req.Video.mimes))
+					copy(mimes, req.Video.mimes)
+					newImp.Video = &openrtb.Video{
+						MIMEs:          mimes,
+						MinDuration:    req.Video.Minduration,
+						W:              unit.Sizes[0].W,
+						H:              unit.Sizes[0].H,
+						StartDelay:     req.Video.Startdelay,
+						PlaybackMethod: req.Video.PlaybackMethod,
+					}
+				default:
+					// Error - unknown media type
+				}
+				imps[ind] = newImp
+				ind = ind + 1
+			}
+		} else {
+			newImp := openrtb.Imp{
+				ID:     unit.Code,
+				Secure: req.Secure,
+			}
+			for _, mType := range mediatypes {
+				switch mType {
+				case BANNER:
+					newImp.Banner = &openrtb.Banner{
+						W:        unit.Sizes[0].W,
+						H:        unit.Sizes[0].H,
+						Format:   unit.Sizes,
+						TopFrame: unit.TopFrame,
+					}
+				case VIDEO:
+					mimes := make([]string, len(req.Video.mimes))
+					copy(mimes, req.Video.mimes)
+					newImp.Video = &openrtb.Video{
+						MIMEs:          mimes,
+						MinDuration:    req.Video.Minduration,
+						W:              unit.Sizes[0].W,
+						H:              unit.Sizes[0].H,
+						StartDelay:     req.Video.Startdelay,
+						PlaybackMethod: req.Video.PlaybackMethod,
+					}
+				default:
+					// Error - unknown media type
+				}
+			}
+			imps[i] = newImp
 		}
 	}
 

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -21,6 +21,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 	ind := 0
 	for i, unit := range bidder.AdUnits {
 		if len(unit.Sizes) <= 0 {
+			ind = ind + 1
 			continue
 		}
 

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -19,7 +19,8 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 
 	imps := make([]openrtb.Imp, len(bidder.AdUnits)*len(mediatypes))
 	ind := 0
-	for i, unit := range bidder.AdUnits {
+	impsPresent := false
+	for _, unit := range bidder.AdUnits {
 		if len(unit.Sizes) <= 0 {
 			ind = ind + 1
 			continue
@@ -58,8 +59,9 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 						// Error - unknown media type
 					}
 					imps[ind] = newImp
+					ind = ind + 1
+					impsPresent = true
 				}
-				ind = ind + 1
 			}
 		} else {
 			newImp := openrtb.Imp{
@@ -92,14 +94,21 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 					// Error - unknown media type
 				}
 			}
-			imps[i] = newImp
+			imps[ind] = newImp
+			ind = ind + 1
+			impsPresent = true
 		}
+	}
+
+	newImps := imps[:ind]
+	if !impsPresent {
+		newImps = nil
 	}
 
 	if req.App != nil {
 		return openrtb.BidRequest{
 			ID:     req.Tid,
-			Imp:    imps[:ind],
+			Imp:    newImps,
 			App:    req.App,
 			Device: req.Device,
 			User:   req.User,
@@ -113,7 +122,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 
 	return openrtb.BidRequest{
 		ID:  req.Tid,
-		Imp: imps[:ind],
+		Imp: newImps,
 		Site: &openrtb.Site{
 			Domain: req.Domain,
 			Page:   req.Url,

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -34,6 +34,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			Imp:    imps,
 			App:    req.App,
 			Device: req.Device,
+			User:   req.User,
 			Source: &openrtb.Source{
 				TID: req.Tid,
 			},

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -6,6 +6,13 @@ import (
 	"github.com/prebid/openrtb"
 )
 
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
 func mediaTypeInSlice(t pbs.MediaType, list []pbs.MediaType) bool {
 	for _, b := range list {
 		if b == t {
@@ -13,6 +20,18 @@ func mediaTypeInSlice(t pbs.MediaType, list []pbs.MediaType) bool {
 		}
 	}
 	return false
+}
+
+func commonMediaTypes(l1 []pbs.MediaType, l2 []pbs.MediaType) []pbs.MediaType {
+	res := make([]pbs.MediaType, min(len(l1), len(l2)))
+	i := 0
+	for _, b := range l1 {
+		if mediaTypeInSlice(b, l2) {
+			res[i] = b
+			i = i + 1
+		}
+	}
+	return res[:i]
 }
 
 func makeBanner(unit pbs.PBSAdUnit) *openrtb.Banner {
@@ -40,9 +59,9 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	}
 }
 
-func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string, mediatypes []pbs.MediaType, singleMediaTypeImp bool) openrtb.BidRequest {
+func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string, allowedMediatypes []pbs.MediaType, singleMediaTypeImp bool) openrtb.BidRequest {
 
-	imps := make([]openrtb.Imp, len(bidder.AdUnits)*len(mediatypes))
+	imps := make([]openrtb.Imp, len(bidder.AdUnits)*len(allowedMediatypes))
 	ind := 0
 	impsPresent := false
 	for _, unit := range bidder.AdUnits {
@@ -50,46 +69,44 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			ind = ind + 1
 			continue
 		}
+		unitMediaTypes := commonMediaTypes(unit.MediaTypes, allowedMediatypes)
+		if len(unitMediaTypes) == 0 {
+			continue
+		}
 
 		if singleMediaTypeImp {
-			for _, mType := range unit.MediaTypes {
-				var newImp openrtb.Imp
-				if mediaTypeInSlice(mType, mediatypes) {
-					newImp = openrtb.Imp{
-						ID:     unit.Code,
-						Secure: req.Secure,
-					}
-					switch mType {
-					case pbs.MEDIA_TYPE_BANNER:
-						newImp.Banner = makeBanner(unit)
-					case pbs.MEDIA_TYPE_VIDEO:
-						newImp.Video = makeVideo(unit)
-					default:
-						// Error - unknown media type
-						continue
-					}
-					imps[ind] = newImp
-					ind = ind + 1
-					impsPresent = true
+			for _, mType := range unitMediaTypes {
+				newImp := openrtb.Imp{
+					ID:     unit.Code,
+					Secure: req.Secure,
 				}
+				switch mType {
+				case pbs.MEDIA_TYPE_BANNER:
+					newImp.Banner = makeBanner(unit)
+				case pbs.MEDIA_TYPE_VIDEO:
+					newImp.Video = makeVideo(unit)
+				default:
+					// Error - unknown media type
+					continue
+				}
+				imps[ind] = newImp
+				ind = ind + 1
+				impsPresent = true
 			}
 		} else {
 			newImp := openrtb.Imp{
 				ID:     unit.Code,
 				Secure: req.Secure,
 			}
-			for _, mType := range unit.MediaTypes {
-				if mediaTypeInSlice(mType, mediatypes) {
-
-					switch mType {
-					case pbs.MEDIA_TYPE_BANNER:
-						newImp.Banner = makeBanner(unit)
-					case pbs.MEDIA_TYPE_VIDEO:
-						newImp.Video = makeVideo(unit)
-					default:
-						// Error - unknown media type
-						continue
-					}
+			for _, mType := range unitMediaTypes {
+				switch mType {
+				case pbs.MEDIA_TYPE_BANNER:
+					newImp.Banner = makeBanner(unit)
+				case pbs.MEDIA_TYPE_VIDEO:
+					newImp.Video = makeVideo(unit)
+				default:
+					// Error - unknown media type
+					continue
 				}
 			}
 			imps[ind] = newImp

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -34,6 +34,148 @@ func TestOpenRTB(t *testing.T) {
 	assert.EqualValues(t, resp.Imp[0].Banner.H, 12)
 }
 
+func TestOpenRTBVideo(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Video: pbs.PBSVideo {
+					Mimes:          []string{"video/mp4"},
+					Minduration:    15,
+					Maxduration:    30,
+					Startdelay:     5,
+					Skippable:      0,
+					PlaybackMethod: 1,
+			},
+
+		},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
+	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
+	assert.EqualValues(t, resp.Imp[0].Video.StartDelay, 5)
+	assert.EqualValues(t, resp.Imp[0].Video.PlaybackMethod, []int8{1})
+	assert.EqualValues(t, resp.Imp[0].Video.MIMEs, []string{"video/mp4"})
+}
+
+func TestOpenRTBVideoFilteredOut(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Video: pbs.PBSVideo {
+					Mimes:          []string{"video/mp4"},
+					Minduration:    15,
+					Maxduration:    30,
+					Startdelay:     5,
+					Skippable:      0,
+					PlaybackMethod: 1,
+				},
+
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	assert.Equal(t, resp.Imp, []openrtb.Imp(nil))
+}
+
+func TestOpenRTBMultiMediaImp(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Video: pbs.PBSVideo {
+					Mimes:          []string{"video/mp4"},
+					Minduration:    15,
+					Maxduration:    30,
+					Startdelay:     5,
+					Skippable:      0,
+					PlaybackMethod: 1,
+				},
+
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, false)
+	assert.Equal(t, len(resp.Imp), 1)
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
+	assert.EqualValues(t, resp.Imp[0].Video.W, 10)
+	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
+	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
+}
+
+
+func TestOpenRTBSingleMediaImp(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Video: pbs.PBSVideo {
+					Mimes:          []string{"video/mp4"},
+					Minduration:    15,
+					Maxduration:    30,
+					Startdelay:     5,
+					Skippable:      0,
+					PlaybackMethod: 1,
+				},
+
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, true)
+	assert.Equal(t, len(resp.Imp), 2)
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
+	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
+	assert.Equal(t, resp.Imp[1].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[1].Banner.W, 10)
+}
+
+
 func TestOpenRTBNoSize(t *testing.T) {
 
 	pbReq := pbs.PBSRequest{}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -16,7 +16,8 @@ func TestOpenRTB(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -26,7 +27,7 @@ func TestOpenRTB(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
@@ -40,11 +41,12 @@ func TestOpenRTBNoSize(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 	assert.Equal(t, resp.Imp[0].ID, "")
 }
 

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -47,3 +47,60 @@ func TestOpenRTBNoSize(t *testing.T) {
 	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 	assert.Equal(t, resp.Imp[0].ID, "")
 }
+
+func TestOpenRTBMobile(t *testing.T) {
+	pbReq := pbs.PBSRequest{
+		AccountID:     "test_account_id",
+		Tid:           "test_tid",
+		CacheMarkup:   1,
+		SortBids:      1,
+		MaxKeyLength:  20,
+		Secure:        1,
+		TimeoutMillis: 1000,
+		App: &openrtb.App{
+			Bundle: "AppNexus.PrebidMobileDemo",
+			Publisher: &openrtb.Publisher{
+				ID: "1995257847363113",
+			},
+		},
+		Device: &openrtb.Device{
+			UA:    "test_ua",
+			IP:    "test_ip",
+			Make:  "test_make",
+			Model: "test_model",
+			IFA:   "test_ifa",
+		},
+		User: &openrtb.User{
+			BuyerUID: "test_buyeruid",
+		},
+	}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 300,
+						H: 250,
+					},
+				},
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Banner.W, 300)
+	assert.EqualValues(t, resp.Imp[0].Banner.H, 250)
+
+	assert.EqualValues(t, resp.App.Bundle, "AppNexus.PrebidMobileDemo")
+	assert.EqualValues(t, resp.App.Publisher.ID, "1995257847363113")
+	assert.EqualValues(t, resp.User.BuyerUID, "test_buyeruid")
+
+	assert.EqualValues(t, resp.Device.UA, "test_ua")
+	assert.EqualValues(t, resp.Device.IP, "test_ip")
+	assert.EqualValues(t, resp.Device.Make, "test_make")
+	assert.EqualValues(t, resp.Device.Model, "test_model")
+	assert.EqualValues(t, resp.Device.IFA, "test_ifa")
+}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -304,7 +304,8 @@ func TestOpenRTBMobile(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 300,
@@ -314,8 +315,9 @@ func TestOpenRTBMobile(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 
+	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 300)
 	assert.EqualValues(t, resp.Imp[0].Banner.H, 250)

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/prebid/openrtb"
 )
 
+func TestCommonMediaTypes(t *testing.T) {
+	mt1 := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}
+	mt2 := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	common := commonMediaTypes(mt1, mt2)
+	assert.Equal(t, len(common), 1)
+	assert.Equal(t, common[0], pbs.MEDIA_TYPE_BANNER)
+
+	common2 := commonMediaTypes(mt2, mt1)
+	assert.Equal(t, len(common2), 1)
+	assert.Equal(t, common2[0], pbs.MEDIA_TYPE_BANNER)
+
+	mt3 := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	mt4 := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	common3 := commonMediaTypes(mt3, mt4)
+	assert.Equal(t, len(common3), 2)
+
+	mt5 := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}
+	mt6 := []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}
+	common4 := commonMediaTypes(mt5, mt6)
+	assert.Equal(t, len(common4), 0)
+}
+
 func TestOpenRTB(t *testing.T) {
 
 	pbReq := pbs.PBSRequest{}
@@ -68,6 +90,31 @@ func TestOpenRTBVideo(t *testing.T) {
 	assert.EqualValues(t, resp.Imp[0].Video.StartDelay, 5)
 	assert.EqualValues(t, resp.Imp[0].Video.PlaybackMethod, []int8{1})
 	assert.EqualValues(t, resp.Imp[0].Video.MIMEs, []string{"video/mp4"})
+}
+
+func TestOpenRTBVideoNoVideoData(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.Equal(t, resp.Imp[0].Video.MaxDuration, uint64(0x0))
+
 }
 
 func TestOpenRTBVideoFilteredOut(t *testing.T) {

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -49,16 +49,15 @@ func TestOpenRTBVideo(t *testing.T) {
 						H: 12,
 					},
 				},
-				Video: pbs.PBSVideo {
+				Video: pbs.PBSVideo{
 					Mimes:          []string{"video/mp4"},
 					Minduration:    15,
 					Maxduration:    30,
 					Startdelay:     5,
 					Skippable:      0,
 					PlaybackMethod: 1,
+				},
 			},
-
-		},
 		},
 	}
 	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
@@ -86,7 +85,7 @@ func TestOpenRTBVideoFilteredOut(t *testing.T) {
 						H: 12,
 					},
 				},
-				Video: pbs.PBSVideo {
+				Video: pbs.PBSVideo{
 					Mimes:          []string{"video/mp4"},
 					Minduration:    15,
 					Maxduration:    30,
@@ -94,7 +93,6 @@ func TestOpenRTBVideoFilteredOut(t *testing.T) {
 					Skippable:      0,
 					PlaybackMethod: 1,
 				},
-
 			},
 		},
 	}
@@ -117,7 +115,7 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 						H: 12,
 					},
 				},
-				Video: pbs.PBSVideo {
+				Video: pbs.PBSVideo{
 					Mimes:          []string{"video/mp4"},
 					Minduration:    15,
 					Maxduration:    30,
@@ -125,7 +123,6 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 					Skippable:      0,
 					PlaybackMethod: 1,
 				},
-
 			},
 		},
 	}
@@ -138,6 +135,38 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
 }
 
+func TestOpenRTBMultiMediaImpFiltered(t *testing.T) {
+
+	pbReq := pbs.PBSRequest{}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER},
+				Sizes: []openrtb.Format{
+					{
+						W: 10,
+						H: 12,
+					},
+				},
+				Video: pbs.PBSVideo{
+					Mimes:          []string{"video/mp4"},
+					Minduration:    15,
+					Maxduration:    30,
+					Startdelay:     5,
+					Skippable:      0,
+					PlaybackMethod: 1,
+				},
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, false)
+	assert.Equal(t, len(resp.Imp), 1)
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
+	assert.EqualValues(t, resp.Imp[0].Video, (*openrtb.Video)(nil))
+}
 
 func TestOpenRTBSingleMediaImp(t *testing.T) {
 
@@ -154,7 +183,7 @@ func TestOpenRTBSingleMediaImp(t *testing.T) {
 						H: 12,
 					},
 				},
-				Video: pbs.PBSVideo {
+				Video: pbs.PBSVideo{
 					Mimes:          []string{"video/mp4"},
 					Minduration:    15,
 					Maxduration:    30,
@@ -162,7 +191,6 @@ func TestOpenRTBSingleMediaImp(t *testing.T) {
 					Skippable:      0,
 					PlaybackMethod: 1,
 				},
-
 			},
 		},
 	}
@@ -174,7 +202,6 @@ func TestOpenRTBSingleMediaImp(t *testing.T) {
 	assert.Equal(t, resp.Imp[1].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[1].Banner.W, 10)
 }
-
 
 func TestOpenRTBNoSize(t *testing.T) {
 

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -49,8 +49,9 @@ func TestOpenRTB(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 
+	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Banner.H, 12)
@@ -82,7 +83,9 @@ func TestOpenRTBVideo(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+
+	assert.Equal(t, err, nil)
 
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
@@ -110,10 +113,9 @@ func TestOpenRTBVideoNoVideoData(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+	_, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
 
-	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.Equal(t, resp.Imp[0].Video.MaxDuration, uint64(0x0))
+	assert.NotEqual(t, err, nil)
 
 }
 
@@ -143,7 +145,8 @@ func TestOpenRTBVideoFilteredOut(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp, []openrtb.Imp(nil))
 }
 
@@ -173,7 +176,8 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, false)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, false)
+	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
@@ -208,7 +212,8 @@ func TestOpenRTBMultiMediaImpFiltered(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, false)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, false)
+	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
@@ -241,7 +246,8 @@ func TestOpenRTBSingleMediaImp(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, true)
+	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 2)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
@@ -262,8 +268,9 @@ func TestOpenRTBNoSize(t *testing.T) {
 			},
 		},
 	}
-	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 	//	assert.Equal(t, resp.Imp[0].ID, "")
+	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp, []openrtb.Imp(nil))
 }
 

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -47,7 +47,8 @@ func TestOpenRTBNoSize(t *testing.T) {
 		},
 	}
 	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
-	assert.Equal(t, resp.Imp[0].ID, "")
+	//	assert.Equal(t, resp.Imp[0].ID, "")
+	assert.Equal(t, resp.Imp, []openrtb.Imp(nil))
 }
 
 func TestOpenRTBMobile(t *testing.T) {

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -46,7 +46,12 @@ type pubmaticParams struct {
 
 func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	pbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	pbReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+
+	if err != nil {
+		return pbs.PBSBidSlice{}, err
+	}
+
 	for i, unit := range bidder.AdUnits {
 		var params pubmaticParams
 		err := json.Unmarshal(unit.Params, &params)

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -45,7 +45,8 @@ type pubmaticParams struct {
 }
 
 func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	pbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	pbReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
 	for i, unit := range bidder.AdUnits {
 		var params pubmaticParams
 		err := json.Unmarshal(unit.Params, &params)

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -59,7 +59,9 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		if params.AdSlot == "" {
 			return nil, errors.New("Missing adSlot param")
 		}
-		pbReq.Imp[i].Banner.Format = nil // pubmatic doesn't support
+		if pbReq.Imp[i].Banner != nil {
+			pbReq.Imp[i].Banner.Format = nil
+		} // pubmatic doesn't support
 		pbReq.Imp[i].TagID = params.AdSlot
 		if pbReq.Site != nil {
 			pbReq.Site.Publisher = &openrtb.Publisher{ID: params.PublisherId}

--- a/adapters/pubmatic_test.go
+++ b/adapters/pubmatic_test.go
@@ -52,7 +52,8 @@ func TestPubmaticTimeout(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -86,7 +87,8 @@ func TestPubmaticInvalidJson(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -121,7 +123,8 @@ func TestPubmaticInvalidStatusCode(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -156,7 +159,8 @@ func TestPubmaticMissingPublisherId(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -191,7 +195,8 @@ func TestPubmaticMissingAdSlot(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code: "unitCode",
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,
@@ -250,8 +255,9 @@ func TestPubmaticBasicResponse(t *testing.T) {
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
 			{
-				Code:  "unitCode",
-				BidID: "bidid",
+				Code:       "unitCode",
+				BidID:      "bidid",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
 				Sizes: []openrtb.Format{
 					{
 						W: 10,

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -49,7 +49,8 @@ type PulsepointParams struct {
 }
 
 func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	ppReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	ppReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
 	for i, unit := range bidder.AdUnits {
 		var params PulsepointParams
 		err := json.Unmarshal(unit.Params, &params)

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -50,7 +50,12 @@ type PulsepointParams struct {
 
 func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	ppReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	ppReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+
+	if err != nil {
+		return pbs.PBSBidSlice{}, err
+	}
+
 	for i, unit := range bidder.AdUnits {
 		var params PulsepointParams
 		err := json.Unmarshal(unit.Params, &params)

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -213,10 +213,12 @@ func (a *RubiconAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJS
 	return
 }
 
+
 func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	requests := make([]bytes.Buffer, len(bidder.AdUnits))
 	for i, unit := range bidder.AdUnits {
-		rubiReq := makeOpenRTBGeneric(req, bidder, a.FamilyName())
+		rubiReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+		// TODO: Implement special video handling for Rubicon
 
 		// only grab this ad unit
 		rubiReq.Imp = rubiReq.Imp[i : i+1]

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -216,14 +216,17 @@ func (a *RubiconAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJS
 func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	requests := make([]bytes.Buffer, len(bidder.AdUnits))
 	for i, unit := range bidder.AdUnits {
-		rubiReq := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+		rubiReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+		if err != nil {
+			continue
+		}
 		// TODO: Implement special video handling for Rubicon
 
 		// only grab this ad unit
 		rubiReq.Imp = rubiReq.Imp[i : i+1]
 
 		var params rubiconParams
-		err := json.Unmarshal(unit.Params, &params)
+		err = json.Unmarshal(unit.Params, &params)
 		if err != nil {
 			return nil, err
 		}

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -213,7 +213,6 @@ func (a *RubiconAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJS
 	return
 }
 
-
 func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	requests := make([]bytes.Buffer, len(bidder.AdUnits))
 	for i, unit := range bidder.AdUnits {

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -225,7 +225,8 @@ func TestRubiconBasicResponse(t *testing.T) {
 	}
 	for i, tag := range rubidata.tags {
 		pbin.AdUnits[i] = pbs.AdUnit{
-			Code: tag.code,
+			Code:       tag.code,
+			MediaTypes: []string{"BANNER"},
 			Sizes: []openrtb.Format{
 				{
 					W: 300,

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,9 +20,7 @@ type Configuration struct {
 type Cache interface {
 	Close() error
 	Accounts() AccountsService
-	Apps() AppsService
 	Config() ConfigService
-	Domains() DomainsService
 }
 
 type AccountsService interface {
@@ -30,17 +28,7 @@ type AccountsService interface {
 	Set(*Account) error
 }
 
-type AppsService interface {
-	Get(string) (*App, error)
-	Set(*App) error
-}
-
 type ConfigService interface {
 	Get(string) (string, error)
 	Set(string, string) error
-}
-
-type DomainsService interface {
-	Get(string) (*Domain, error)
-	Set(*Domain) error
 }

--- a/cache/dummycache/dummycache.go
+++ b/cache/dummycache/dummycache.go
@@ -9,8 +9,6 @@ import (
 // Cache dummy config that will echo back results
 type Cache struct {
 	accounts *accountService
-	domains  *domainService
-	apps     *appsService
 	config   *configService
 }
 
@@ -18,20 +16,12 @@ type Cache struct {
 func New() (*Cache, error) {
 	return &Cache{
 		accounts: &accountService{},
-		domains:  &domainService{},
-		apps:     &appsService{},
 		config:   &configService{},
 	}, nil
 }
 
 func (c *Cache) Accounts() cache.AccountsService {
 	return c.accounts
-}
-func (c *Cache) Domains() cache.DomainsService {
-	return c.domains
-}
-func (c *Cache) Apps() cache.AppsService {
-	return c.apps
 }
 func (c *Cache) Config() cache.ConfigService {
 	return c.config
@@ -50,38 +40,6 @@ func (s *accountService) Get(id string) (*cache.Account, error) {
 
 // Set will always return nil since this is a dummy service
 func (s *accountService) Set(account *cache.Account) error {
-	return nil
-}
-
-// DomainService handles the domain information
-type domainService struct {
-}
-
-// Get echos back the domain
-func (s *domainService) Get(id string) (*cache.Domain, error) {
-	return &cache.Domain{
-		Domain: id,
-	}, nil
-}
-
-// Set will always return nil since this is a dummy service
-func (s *domainService) Set(domain *cache.Domain) error {
-	return nil
-}
-
-// AppsService handles apps information
-type appsService struct {
-}
-
-// Get echos back the app
-func (s *appsService) Get(id string) (*cache.App, error) {
-	return &cache.App{
-		Bundle: id,
-	}, nil
-}
-
-// Set will always return nil since this is a dummy service
-func (s *appsService) Set(app *cache.App) error {
 	return nil
 }
 

--- a/cache/dummycache/dummycache_test.go
+++ b/cache/dummycache/dummycache_test.go
@@ -6,24 +6,6 @@ func TestDummyCache(t *testing.T) {
 
 	c, _ := New()
 
-	domain, err := c.Domains().Get("one.com")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if domain.Domain != "one.com" {
-		t.Error("Wrong domain returned")
-	}
-
-	app, err := c.Apps().Get("com.app.one")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if app.Bundle != "com.app.one" {
-		t.Error("Wrong app returned")
-	}
-
 	account, err := c.Accounts().Get("account1")
 	if err != nil {
 		t.Fatal(err)

--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -11,8 +11,6 @@ import (
 
 type shared struct {
 	Configs  map[string]string
-	Domains  map[string]bool
-	Apps     map[string]bool
 	Accounts map[string]bool
 }
 
@@ -20,8 +18,6 @@ type shared struct {
 type Cache struct {
 	shared   *shared
 	accounts *accountService
-	domains  *domainService
-	apps     *appsService
 	config   *configService
 }
 
@@ -32,8 +28,6 @@ type fileConfig struct {
 
 type fileCacheFile struct {
 	Configs  []fileConfig `yaml:"configs"`
-	Domains  []string     `yaml:"domains"`
-	Apps     []string     `yaml:"apps"`
 	Accounts []string     `yaml:"accounts"`
 }
 
@@ -69,18 +63,6 @@ func New(filename string) (*Cache, error) {
 	}
 	glog.Infof("Loaded %d configs", len(u.Configs))
 
-	s.Domains = make(map[string]bool, len(u.Domains))
-	for _, domain := range u.Domains {
-		s.Domains[domain] = true
-	}
-	glog.Infof("Loaded %d domains", len(u.Domains))
-
-	s.Apps = make(map[string]bool, len(u.Apps))
-	for _, app := range u.Apps {
-		s.Apps[app] = true
-	}
-	glog.Infof("Loaded %d apps", len(u.Apps))
-
 	s.Accounts = make(map[string]bool, len(u.Accounts))
 	for _, Account := range u.Accounts {
 		s.Accounts[Account] = true
@@ -90,8 +72,6 @@ func New(filename string) (*Cache, error) {
 	return &Cache{
 		shared:   s,
 		accounts: &accountService{s},
-		domains:  &domainService{s},
-		apps:     &appsService{s},
 		config:   &configService{s},
 	}, nil
 }
@@ -104,12 +84,6 @@ func (c *Cache) Close() error {
 
 func (c *Cache) Accounts() cache.AccountsService {
 	return c.accounts
-}
-func (c *Cache) Domains() cache.DomainsService {
-	return c.domains
-}
-func (c *Cache) Apps() cache.AppsService {
-	return c.apps
 }
 func (c *Cache) Config() cache.ConfigService {
 	return c.config
@@ -132,46 +106,6 @@ func (s *accountService) Get(id string) (*cache.Account, error) {
 
 // Set will always return nil since this is a dummy service
 func (s *accountService) Set(account *cache.Account) error {
-	return nil
-}
-
-// DomainService handles the domain information
-type domainService struct {
-	shared *shared
-}
-
-// Get will return back the domain if it exists in memory
-func (s *domainService) Get(id string) (*cache.Domain, error) {
-	if _, ok := s.shared.Domains[id]; !ok {
-		return nil, fmt.Errorf("Not found")
-	}
-	return &cache.Domain{
-		Domain: id,
-	}, nil
-}
-
-// Set will always return nil since this is a dummy service
-func (s *domainService) Set(domain *cache.Domain) error {
-	return nil
-}
-
-// AppsService handles apps information
-type appsService struct {
-	shared *shared
-}
-
-// Get will return the App if it exists
-func (s *appsService) Get(id string) (*cache.App, error) {
-	if _, ok := s.shared.Apps[id]; !ok {
-		return nil, fmt.Errorf("Not found")
-	}
-	return &cache.App{
-		Bundle: id,
-	}, nil
-}
-
-// Set will always return nil since this is a dummy service
-func (s *appsService) Set(app *cache.App) error {
 	return nil
 }
 

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -10,8 +10,6 @@ import (
 
 func TestFileCache(t *testing.T) {
 	fcf := fileCacheFile{
-		Domains:  []string{"one.com", "two.com", "three.com"},
-		Apps:     []string{"com.app.one", "com.app.two", "com.app.three"},
 		Accounts: []string{"account1", "account2", "account3"},
 		Configs: []fileConfig{
 			{
@@ -51,46 +49,18 @@ func TestFileCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := dataCache.Domains().Get("one.com")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if d.Domain != "one.com" {
-		t.Error("fetched invalid domain")
-	}
-
-	d, err = dataCache.Domains().Get("abc123")
-	if err == nil {
-		t.Error("domain should not exist in cache")
-	}
-
-	app, err := dataCache.Apps().Get("com.app.one")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if app.Bundle != "com.app.one" {
-		t.Error("fetched invalid app")
-	}
-
-	app, err = dataCache.Apps().Get("abc123")
-	if err == nil {
-		t.Error("domain should not exist in cache")
-	}
-
 	a, err := dataCache.Accounts().Get("account1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if a.ID != "account1" {
-		t.Error("fetched invalid domain")
+		t.Error("fetched invalid account")
 	}
 
 	a, err = dataCache.Accounts().Get("abc123")
 	if err == nil {
-		t.Error("domain should not exist in cache")
+		t.Error("account should not exist in cache")
 	}
 
 	c, err := dataCache.Config().Get("one")
@@ -99,11 +69,11 @@ func TestFileCache(t *testing.T) {
 	}
 
 	if c != "config1" {
-		t.Error("fetched invalid domain")
+		t.Error("fetched invalid config")
 	}
 
 	c, err = dataCache.Config().Get("abc123")
 	if err == nil {
-		t.Error("domain should not exist in cache")
+		t.Error("config should not exist in cache")
 	}
 }

--- a/cache/postgrescache/postgrescache_test.go
+++ b/cache/postgrescache/postgrescache_test.go
@@ -31,11 +31,8 @@ func TestPostgresConfig(t *testing.T) {
 }
 
 type StubCache struct {
-	shared *shared
-
+	shared   *shared
 	accounts *accountService
-	domains  *domainService
-	apps     *appsService
 	config   *configService
 }
 
@@ -45,8 +42,6 @@ func StubNew(cfg PostgresConfig) *Cache {
 	return &Cache{
 		shared:   shared,
 		accounts: &accountService{shared: shared},
-		domains:  &domainService{shared: shared},
-		apps:     &appsService{shared: shared},
 		config:   &configService{shared: shared},
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 254023165c0bb49bce2dcdc276d754d2dc5fc6592d19e9d40a9358323faf8ba9
-updated: 2017-06-21T17:00:58.66496526-04:00
+updated: 2017-07-17T14:59:27.087179719-04:00
 imports:
 - name: github.com/blang/semver
   version: 4a1e882c79dcf4ec00d2e29fac74b9c8938d5052
@@ -51,9 +51,7 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/rs/cors
-  version: a62a804a8a009876ca59105f7899938a1349f4b3
-- name: github.com/rs/xhandler
-  version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
+  version: 8dd4211afb5d08dbb39a533b9bb9e4b486351df6
 - name: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 - name: github.com/spf13/afero
@@ -93,6 +91,10 @@ imports:
   subpackages:
   - transform
   - unicode/norm
+- name: golang.org/x/tools
+  version: 807424b52bbede51990d57ed6e388f9ccc283770
+  subpackages:
+  - go/gcimporter15/testdata
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
 - name: gopkg.in/yaml.v2

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -40,7 +40,7 @@ type Bids struct {
 type PBSVideo struct {
 	Mimes          []string `json:"mimes,omitempty"`
 	Minduration    uint64   `json:"minduration,omitempty"`
-	Maxduration    int64    `json:"maxduration,omitempty"`
+	Maxduration    uint64   `json:"maxduration,omitempty"`
 	Startdelay     int64    `json:"startdelay,omitempty"`
 	Skippable      int      `json:"skippable,omitempty"`
 	PlaybackMethod int8     `json:"playback_method,omitempty"`

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -16,9 +16,17 @@ import (
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/prebid"
+	"golang.org/x/tools/go/gcimporter15/testdata"
 )
 
 const MAX_BIDDERS = 8
+
+type MediaType byte
+
+const (
+	BANNER MediaType = iota
+	VIDEO
+)
 
 type ConfigCache interface {
 	LoadConfig(string) ([]Bids, error)
@@ -36,7 +44,9 @@ type AdUnit struct {
 	Sizes    []openrtb.Format `json:"sizes"`
 	Bids     []Bids           `json:"bids"`
 	ConfigID string           `json:"config_id"`
+	MediaTypes []string       `json:"media_types"`
 }
+
 
 type PBSAdUnit struct {
 	Sizes    []openrtb.Format
@@ -44,6 +54,16 @@ type PBSAdUnit struct {
 	Code     string
 	BidID    string
 	Params   json.RawMessage
+	MediaTypes []MediaType
+}
+
+func ParseMediaType(s string) (MediaType, error) {
+	mediaTypes := map[string]MediaType {"BANNER":BANNER, "VIDEO":VIDEO}
+	t, ok := mediaTypes[s]
+	if !ok  {
+		return nil, fmt.Errorf("Invalid MediaType %q", s)
+	}
+	return t, nil
 }
 
 type PBSBidder struct {
@@ -193,6 +213,28 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 			glog.Infof("Ad unit %s has %d bidders for %d sizes", unit.Code, len(bidders), len(unit.Sizes))
 		}
 
+		var mtypes []MediaType
+		mtmap := make(map[MediaType]bool)
+
+		if unit.MediaTypes == nil {
+			mtypes = append(mtypes, BANNER)
+		} else {
+			for _, t := range unit.MediaTypes {
+				mt, er := ParseMediaType(t)
+				if er != nil {
+					glog.Infof(er)
+				} else {
+					if !mtmap[mt] {
+						mtypes = append(mtypes, mt)
+						mtmap[mt] = true
+					}
+				}
+			}
+			if len(mtypes) == 0 {
+				mtypes = append(mtypes, BANNER)
+			}
+		}
+
 		for _, b := range bidders {
 			var bidder *PBSBidder
 			// index requires a different request for each ad unit
@@ -220,6 +262,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				Code:     unit.Code,
 				Params:   b.Params,
 				BidID:    b.BidID,
+				MediaTypes: mtypes,
 			}
 
 			bidder.AdUnits = append(bidder.AdUnits, pau)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/prebid"
-	"golang.org/x/tools/go/gcimporter15/testdata"
 )
 
 const MAX_BIDDERS = 8
@@ -24,8 +23,8 @@ const MAX_BIDDERS = 8
 type MediaType byte
 
 const (
-	BANNER MediaType = iota
-	VIDEO
+	MEDIA_TYPE_BANNER MediaType = iota
+	MEDIA_TYPE_VIDEO
 )
 
 type ConfigCache interface {
@@ -40,11 +39,11 @@ type Bids struct {
 
 type PBSVideo struct {
 	Mimes          []string `json:"mimes,omitempty"`
-	Minduration    int      `json:"minduration,omitempty"`
-	Maxduration    int      `json:"maxduration,omitempty"`
-	Startdelay     int      `json:"startdelay,omitempty"`
+	Minduration    uint64      `json:"minduration,omitempty"`
+	Maxduration    int64      `json:"maxduration,omitempty"`
+	Startdelay     int64      `json:"startdelay,omitempty"`
 	Skippable      int      `json:"skippable,omitempty"`
-	PlaybackMethod string   `json:"playback_method,omitempty"`
+	PlaybackMethod int8   `json:"playback_method,omitempty"`
 	Frameworks     []string `json:"frameworks,omitempty"`
 }
 
@@ -68,10 +67,10 @@ type PBSAdUnit struct {
 }
 
 func ParseMediaType(s string) (MediaType, error) {
-	mediaTypes := map[string]MediaType{"BANNER": BANNER, "VIDEO": VIDEO}
+	mediaTypes := map[string]MediaType{"MEDIA_TYPE_BANNER": MEDIA_TYPE_BANNER, "MEDIA_TYPE_VIDEO": MEDIA_TYPE_VIDEO}
 	t, ok := mediaTypes[s]
 	if !ok {
-		return nil, fmt.Errorf("Invalid MediaType %q", s)
+		return 0, fmt.Errorf("Invalid MediaType %s", s)
 	}
 	return t, nil
 }
@@ -227,12 +226,12 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		mtmap := make(map[MediaType]bool)
 
 		if unit.MediaTypes == nil {
-			mtypes = append(mtypes, BANNER)
+			mtypes = append(mtypes, MEDIA_TYPE_BANNER)
 		} else {
 			for _, t := range unit.MediaTypes {
 				mt, er := ParseMediaType(t)
 				if er != nil {
-					glog.Infof(er)
+					glog.Infof("Invalid media type: %s",er)
 				} else {
 					if !mtmap[mt] {
 						mtypes = append(mtypes, mt)
@@ -241,7 +240,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				}
 			}
 			if len(mtypes) == 0 {
-				mtypes = append(mtypes, BANNER)
+				mtypes = append(mtypes, MEDIA_TYPE_BANNER)
 			}
 		}
 

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -81,6 +81,7 @@ type PBSRequest struct {
 	IsDebug       bool            `json:"is_debug"`
 	App           *openrtb.App    `json:"app"`
 	Device        *openrtb.Device `json:"device"`
+	User          *openrtb.User   `json:"user"`
 
 	// internal
 	Bidders []*PBSBidder      `json:"-"`
@@ -125,6 +126,9 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 
 	if pbsReq.Device == nil {
 		pbsReq.Device = &openrtb.Device{}
+	}
+	if pbsReq.User == nil {
+		pbsReq.User = &openrtb.User{}
 	}
 
 	// use client-side data for web requests

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -39,11 +39,11 @@ type Bids struct {
 
 type PBSVideo struct {
 	Mimes          []string `json:"mimes,omitempty"`
-	Minduration    uint64      `json:"minduration,omitempty"`
-	Maxduration    int64      `json:"maxduration,omitempty"`
-	Startdelay     int64      `json:"startdelay,omitempty"`
+	Minduration    uint64   `json:"minduration,omitempty"`
+	Maxduration    int64    `json:"maxduration,omitempty"`
+	Startdelay     int64    `json:"startdelay,omitempty"`
 	Skippable      int      `json:"skippable,omitempty"`
-	PlaybackMethod int8   `json:"playback_method,omitempty"`
+	PlaybackMethod int8     `json:"playback_method,omitempty"`
 	Frameworks     []string `json:"frameworks,omitempty"`
 }
 
@@ -231,7 +231,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 			for _, t := range unit.MediaTypes {
 				mt, er := ParseMediaType(t)
 				if er != nil {
-					glog.Infof("Invalid media type: %s",er)
+					glog.Infof("Invalid media type: %s", er)
 				} else {
 					if !mtmap[mt] {
 						mtypes = append(mtypes, mt)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -162,19 +162,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid URL '%s': %v", url.Host, err)
 		}
-
-		// all domains must be in the whitelist
-		_, err = cache.Domains().Get(pbsReq.Domain)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid URL %s", pbsReq.Domain)
-		}
-	} else {
-
-		_, err = cache.Apps().Get(pbsReq.App.Bundle)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid app bundle %s", pbsReq.App.Bundle)
-		}
-
 	}
 
 	if r.FormValue("debug") == "1" {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -38,29 +38,39 @@ type Bids struct {
 	Params     json.RawMessage `json:"params"`
 }
 
-type AdUnit struct {
-	Code     string           `json:"code"`
-	TopFrame int8             `json:"is_top_frame"`
-	Sizes    []openrtb.Format `json:"sizes"`
-	Bids     []Bids           `json:"bids"`
-	ConfigID string           `json:"config_id"`
-	MediaTypes []string       `json:"media_types"`
+type PBSVideo struct {
+	Mimes          []string `json:"mimes,omitempty"`
+	Minduration    int      `json:"minduration,omitempty"`
+	Maxduration    int      `json:"maxduration,omitempty"`
+	Startdelay     int      `json:"startdelay,omitempty"`
+	Skippable      int      `json:"skippable,omitempty"`
+	PlaybackMethod string   `json:"playback_method,omitempty"`
+	Frameworks     []string `json:"frameworks,omitempty"`
 }
 
+type AdUnit struct {
+	Code       string           `json:"code"`
+	TopFrame   int8             `json:"is_top_frame"`
+	Sizes      []openrtb.Format `json:"sizes"`
+	Bids       []Bids           `json:"bids"`
+	ConfigID   string           `json:"config_id"`
+	MediaTypes []string         `json:"media_types"`
+}
 
 type PBSAdUnit struct {
-	Sizes    []openrtb.Format
-	TopFrame int8
-	Code     string
-	BidID    string
-	Params   json.RawMessage
+	Sizes      []openrtb.Format
+	TopFrame   int8
+	Code       string
+	BidID      string
+	Params     json.RawMessage
+	Video      PBSVideo
 	MediaTypes []MediaType
 }
 
 func ParseMediaType(s string) (MediaType, error) {
-	mediaTypes := map[string]MediaType {"BANNER":BANNER, "VIDEO":VIDEO}
+	mediaTypes := map[string]MediaType{"BANNER": BANNER, "VIDEO": VIDEO}
 	t, ok := mediaTypes[s]
-	if !ok  {
+	if !ok {
 		return nil, fmt.Errorf("Invalid MediaType %q", s)
 	}
 	return t, nil
@@ -257,11 +267,11 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 			}
 
 			pau := PBSAdUnit{
-				Sizes:    unit.Sizes,
-				TopFrame: unit.TopFrame,
-				Code:     unit.Code,
-				Params:   b.Params,
-				BidID:    b.BidID,
+				Sizes:      unit.Sizes,
+				TopFrame:   unit.TopFrame,
+				Code:       unit.Code,
+				Params:     b.Params,
+				BidID:      b.BidID,
 				MediaTypes: mtypes,
 			}
 

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -5,8 +5,27 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/magiconair/properties/assert"
 	"github.com/prebid/prebid-server/cache/dummycache"
 )
+
+func TestParseMediaTypes(t *testing.T) {
+	types1 := []string{"Banner"}
+	t1 := ParseMediaTypes(types1)
+	assert.Equal(t, len(t1), 1)
+	assert.Equal(t, t1[0], MEDIA_TYPE_BANNER)
+
+	types2 := []string{"Banner", "Video"}
+	t2 := ParseMediaTypes(types2)
+	assert.Equal(t, len(t2), 2)
+	assert.Equal(t, t2[0], MEDIA_TYPE_BANNER)
+	assert.Equal(t, t2[1], MEDIA_TYPE_VIDEO)
+
+	types3 := []string{"Banner", "Vo"}
+	t3 := ParseMediaTypes(types3)
+	assert.Equal(t, len(t3), 1)
+	assert.Equal(t, t3[0], MEDIA_TYPE_BANNER)
+}
 
 func TestParseSimpleRequest(t *testing.T) {
 	body := []byte(`{

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -226,3 +226,97 @@ func TestParseConfig(t *testing.T) {
 		t.Errorf("Index bidder should have 1 ad unit")
 	}
 }
+
+func TestParseMobileRequest(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":"F",
+	      "buyeruid":"test_buyeruid",
+	      "yob":2000,
+	      "id":"testid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "config_id":"ad5ffb41-3492-40f3-9c25-ade093eb4e5f",
+	         "code":"5d748364ee9c46a2b112892fc3551b6f"
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.1"
+	   },
+	   "sdk":{
+	      "version":"0.0.1",
+	      "platform":"iOS",
+	      "source":"prebid-mobile"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := ParsePBSRequest(r, d)
+	if err != nil {
+		t.Fatalf("Parse simple request failed: %v", err)
+	}
+	if pbs_req.Tid != "abcd" {
+		t.Errorf("Parse TID failed")
+	}
+	if len(pbs_req.AdUnits) != 1 {
+		t.Errorf("Parse ad units failed")
+	}
+
+	if pbs_req.User.BuyerUID != "test_buyeruid" {
+		t.Errorf("Parse user buyeruid failed")
+	}
+	if pbs_req.User.Gender != "F" {
+		t.Errorf("Parse user gender failed")
+	}
+	if pbs_req.User.Yob != 2000 {
+		t.Errorf("Parse user year of birth failed")
+	}
+	if pbs_req.User.ID != "testid" {
+		t.Errorf("Parse user id failed")
+	}
+	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
+		t.Errorf("Parse app bundle failed")
+	}
+	if pbs_req.App.Ver != "0.0.1" {
+		t.Errorf("Parse app version failed")
+	}
+
+	if pbs_req.Device.IFA != "test_device_ifa" {
+		t.Errorf("Parse device ifa failed")
+	}
+	if pbs_req.Device.OSV != "9.3.5" {
+		t.Errorf("Parse device osv failed")
+	}
+	if pbs_req.Device.OS != "iOS" {
+		t.Errorf("Parse device os failed")
+	}
+	if pbs_req.Device.Make != "Apple" {
+		t.Errorf("Parse device make failed")
+	}
+	if pbs_req.Device.Model != "iPhone6,1" {
+		t.Errorf("Parse device model failed")
+	}
+}

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -16,6 +16,8 @@ type PBSBid struct {
 	// it helps publishers and bidders identify and communicate about malicious or inappropriate ads.
 	// This project simply passes it along with the bid.
 	Creative_id string `json:"creative_id,omitempty"`
+	// CreativeMediaType shows whether the creative is a video or banner.
+	CreativeMediaType MediaType `json:"media_type,omitempty"`
 	// BidderCode is the PBSBidder.BidderCode of the PBSBidder who made this bid.
 	BidderCode string `json:"bidder"`
 	// BidHash is the hash of the bidder's unique bid identifier for blockchain. It should not be sent to browser.

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -245,6 +245,27 @@
                 }
             }
         },
+        "user" : {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Exchange-specific ID for the user.",
+                    "type": "string"
+                },
+                "buyeruid": {
+                    "description": "Buyer-specific ID for the user as mapped by the exchange for the buyer.",
+                    "type": "string"
+                },
+                "yob": {
+                    "description": "Year of birth as a 4-digit integer.",
+                    "type": "integer"
+                },
+                "gender": {
+                    "description": "Gender, where M=male, F=female, O=known to be other, omitted is unknown",
+                    "type": "string"
+                }
+            }
+        },
         "ad_units": {
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
This pull request addresses the issue #76 (Adding video support to the server). To provide the support, the following changes are implemented:
1. Added new structure - pbs.PBSVideo 
2. Added new data type - pbs.MediaType with possible values MEDIA_TYPE_VIDEO and MEDIA_TYPE_BANNER
3. Modified PBSRequest to support Video data
4. Modified OpenRRTB utils to support Video media type. The changes allow filtering imps by media type and production of single- and multi-mediatype imps.
5. Modified adapters to work with the changed OpenRTB utils
6. Modified existing unit tests and added new ones.
