### PR TITLE
Remove domain/app whitelisting

### DIFF
--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -168,13 +168,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid URL %s", pbsReq.Domain)
 		}
-	} else {
-
-		_, err = cache.Apps().Get(pbsReq.App.Bundle)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid app bundle %s", pbsReq.App.Bundle)
-		}
-
 	}
 
 	if r.FormValue("debug") == "1" {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -162,12 +162,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid URL '%s': %v", url.Host, err)
 		}
-
-		// all domains must be in the whitelist
-		_, err = cache.Domains().Get(pbsReq.Domain)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid URL %s", pbsReq.Domain)
-		}
 	}
 
 	if r.FormValue("debug") == "1" {


### PR DESCRIPTION
This PR removes the code that checks whether app bundle/bundle exists in the database, going forward PBS will forward all the app bundles/domains to bidders.