### PR TITLE
Add OpenRTB User object for Open RTB mobile requests

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -34,6 +34,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			Imp:    imps,
 			App:    req.App,
 			Device: req.Device,
+			User:   req.User,
 			Source: &openrtb.Source{
 				TID: req.Tid,
 			},

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -47,3 +47,60 @@ func TestOpenRTBNoSize(t *testing.T) {
 	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
 	assert.Equal(t, resp.Imp[0].ID, "")
 }
+
+func TestOpenRTBMobile(t *testing.T) {
+	pbReq := pbs.PBSRequest{
+		AccountID:     "test_account_id",
+		Tid:           "test_tid",
+		CacheMarkup:   1,
+		SortBids:      1,
+		MaxKeyLength:  20,
+		Secure:        1,
+		TimeoutMillis: 1000,
+		App: &openrtb.App{
+			Bundle: "AppNexus.PrebidMobileDemo",
+			Publisher: &openrtb.Publisher{
+				ID: "1995257847363113",
+			},
+		},
+		Device: &openrtb.Device{
+			UA:    "test_ua",
+			IP:    "test_ip",
+			Make:  "test_make",
+			Model: "test_model",
+			IFA:   "test_ifa",
+		},
+		User: &openrtb.User{
+			BuyerUID: "test_buyeruid",
+		},
+	}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+				Sizes: []openrtb.Format{
+					{
+						W: 300,
+						H: 250,
+					},
+				},
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+
+	assert.Equal(t, resp.Imp[0].ID, "unitCode")
+	assert.EqualValues(t, resp.Imp[0].Banner.W, 300)
+	assert.EqualValues(t, resp.Imp[0].Banner.H, 250)
+
+	assert.EqualValues(t, resp.App.Bundle, "AppNexus.PrebidMobileDemo")
+	assert.EqualValues(t, resp.App.Publisher.ID, "1995257847363113")
+	assert.EqualValues(t, resp.User.BuyerUID, "test_buyeruid")
+
+	assert.EqualValues(t, resp.Device.UA, "test_ua")
+	assert.EqualValues(t, resp.Device.IP, "test_ip")
+	assert.EqualValues(t, resp.Device.Make, "test_make")
+	assert.EqualValues(t, resp.Device.Model, "test_model")
+	assert.EqualValues(t, resp.Device.IFA, "test_ifa")
+}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -81,6 +81,7 @@ type PBSRequest struct {
 	IsDebug       bool            `json:"is_debug"`
 	App           *openrtb.App    `json:"app"`
 	Device        *openrtb.Device `json:"device"`
+	User          *openrtb.User   `json:"user"`
 
 	// internal
 	Bidders []*PBSBidder      `json:"-"`
@@ -125,6 +126,9 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 
 	if pbsReq.Device == nil {
 		pbsReq.Device = &openrtb.Device{}
+	}
+	if pbsReq.User == nil {
+		pbsReq.User = &openrtb.User{}
 	}
 
 	// use client-side data for web requests

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -232,7 +232,9 @@ func TestParseMobileRequest(t *testing.T) {
 	   "max_key_length":20,
 	   "user":{
 	      "gender":"F",
-	      "buyeruid":"test_buyeruid"
+	      "buyeruid":"test_buyeruid",
+	      "yob":2000,
+	      "id":"testid"
 	   },
 	   "prebid_version":"0.21.0-pre",
 	   "sort_bids":1,
@@ -288,6 +290,12 @@ func TestParseMobileRequest(t *testing.T) {
 	}
 	if pbs_req.User.Gender != "F" {
 		t.Errorf("Parse user gender failed")
+	}
+	if pbs_req.User.Yob != 2000 {
+		t.Errorf("Parse user year of birth failed")
+	}
+	if pbs_req.User.ID != "testid" {
+		t.Errorf("Parse user id failed")
 	}
 	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
 		t.Errorf("Parse app bundle failed")

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -226,3 +226,89 @@ func TestParseConfig(t *testing.T) {
 		t.Errorf("Index bidder should have 1 ad unit")
 	}
 }
+
+func TestParseMobileRequest(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":"F",
+	      "buyeruid":"test_buyeruid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "config_id":"ad5ffb41-3492-40f3-9c25-ade093eb4e5f",
+	         "code":"5d748364ee9c46a2b112892fc3551b6f"
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.1"
+	   },
+	   "sdk":{
+	      "version":"0.0.1",
+	      "platform":"iOS",
+	      "source":"prebid-mobile"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := ParsePBSRequest(r, d)
+	if err != nil {
+		t.Fatalf("Parse simple request failed: %v", err)
+	}
+	if pbs_req.Tid != "abcd" {
+		t.Errorf("Parse TID failed")
+	}
+	if len(pbs_req.AdUnits) != 1 {
+		t.Errorf("Parse ad units failed")
+	}
+
+	if pbs_req.User.BuyerUID != "test_buyeruid" {
+		t.Errorf("Parse user buyeruid failed")
+	}
+	if pbs_req.User.Gender != "F" {
+		t.Errorf("Parse user gender failed")
+	}
+	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
+		t.Errorf("Parse app bundle failed")
+	}
+	if pbs_req.App.Ver != "0.0.1" {
+		t.Errorf("Parse app version failed")
+	}
+
+	if pbs_req.Device.IFA != "test_device_ifa" {
+		t.Errorf("Parse device ifa failed")
+	}
+	if pbs_req.Device.OSV != "9.3.5" {
+		t.Errorf("Parse device osv failed")
+	}
+	if pbs_req.Device.OS != "iOS" {
+		t.Errorf("Parse device os failed")
+	}
+	if pbs_req.Device.Make != "Apple" {
+		t.Errorf("Parse device make failed")
+	}
+	if pbs_req.Device.Model != "iPhone6,1" {
+		t.Errorf("Parse device model failed")
+	}
+}

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -261,7 +261,7 @@
                     "type": "integer"
                 },
                 "gender": {
-                    "description": "Gender, where M=male, F=female, 0=known to be other, omitted is unknown",
+                    "description": "Gender, where M=male, F=female, O=known to be other, omitted is unknown",
                     "type": "string"
                 }
             }

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -245,6 +245,27 @@
                 }
             }
         },
+        "user" : {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Exchange-specific ID for the user.",
+                    "type": "string"
+                },
+                "buyeruid": {
+                    "description": "Buyer-specific ID for the user as mapped by the exchange for the buyer.",
+                    "type": "string"
+                },
+                "yob": {
+                    "description": "Year of birth as a 4-digit integer.",
+                    "type": "integer"
+                },
+                "gender": {
+                    "description": "Gender, where M=male, F=female, 0=known to be other, omitted is unknown",
+                    "type": "string"
+                }
+            }
+        },
         "ad_units": {
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
Needed to request for FB demand. From Prebid Mobile we will pass user object with `buyeruid` field in order to send the bidder token for the FB request.