### PR TITLE
Ensure backwards compatibility with Prebid Mobile v0.0.1 for User field

### DIFF
--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -139,7 +139,12 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		pbsReq.SDK = &SDK{}
 	}
 	if pbsReq.SDK.Version != "0.0.1" {
-		err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
+		if pbsReq.PBSUser != nil {
+			err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	if pbsReq.User == nil {
 		pbsReq.User = &openrtb.User{}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -46,6 +46,12 @@ type PBSAdUnit struct {
 	Params   json.RawMessage
 }
 
+type SDK struct {
+	Version  string `json:"version"`
+	Source   string `json:"source"`
+	Platform string `json:"platform"`
+}
+
 type PBSBidder struct {
 	BidderCode   string         `json:"bidder"`
 	AdUnitCode   string         `json:"ad_unit,omitempty"` // for index to dedup responses
@@ -81,7 +87,9 @@ type PBSRequest struct {
 	IsDebug       bool            `json:"is_debug"`
 	App           *openrtb.App    `json:"app"`
 	Device        *openrtb.Device `json:"device"`
-	User          *openrtb.User   `json:"user"`
+	User          *openrtb.User   `json:"openrtb_user"`
+	PBSUser       json.RawMessage `json:"user"`
+	SDK           *SDK            `json:"sdk"`
 
 	// internal
 	Bidders []*PBSBidder      `json:"-"`
@@ -126,6 +134,12 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 
 	if pbsReq.Device == nil {
 		pbsReq.Device = &openrtb.Device{}
+	}
+	if pbsReq.SDK == nil {
+		pbsReq.SDK = &SDK{}
+	}
+	if pbsReq.SDK.Version != "0.0.1" {
+		err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
 	}
 	if pbsReq.User == nil {
 		pbsReq.User = &openrtb.User{}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -87,12 +87,12 @@ type PBSRequest struct {
 	IsDebug       bool            `json:"is_debug"`
 	App           *openrtb.App    `json:"app"`
 	Device        *openrtb.Device `json:"device"`
-	User          *openrtb.User   `json:"openrtb_user"`
 	PBSUser       json.RawMessage `json:"user"`
 	SDK           *SDK            `json:"sdk"`
 
 	// internal
 	Bidders []*PBSBidder      `json:"-"`
+	User    *openrtb.User     `json:"-"`
 	UserIDs map[string]string `json:"-"`
 	Url     string            `json:"-"`
 	Domain  string            `json:"-"`

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -227,6 +227,99 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+func TestParseMobileRequestFirstVersion(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":0,
+	      "buyeruid":"test_buyeruid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "config_id":"ad5ffb41-3492-40f3-9c25-ade093eb4e5f",
+	         "code":"5d748364ee9c46a2b112892fc3551b6f"
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.1"
+	   },
+	   "sdk":{
+	      "version":"0.0.2",
+	      "platform":"iOS",
+	      "source":"prebid-mobile"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := ParsePBSRequest(r, d)
+	if err != nil {
+		t.Fatalf("Parse simple request failed: %v", err)
+	}
+	if pbs_req.Tid != "abcd" {
+		t.Errorf("Parse TID failed")
+	}
+	if len(pbs_req.AdUnits) != 1 {
+		t.Errorf("Parse ad units failed")
+	}
+	// We are expecting all user fields to be nil. We don't parse user on v0.0.1 of prebid mobile
+	if pbs_req.User.BuyerUID != "" {
+		t.Errorf("Parse user buyeruid failed %s", pbs_req.User.BuyerUID)
+	}
+	if pbs_req.User.Gender != "" {
+		t.Errorf("Parse user gender failed %s", pbs_req.User.Gender)
+	}
+	if pbs_req.User.Yob != 0 {
+		t.Errorf("Parse user year of birth failed %d", pbs_req.User.Yob)
+	}
+	if pbs_req.User.ID != "" {
+		t.Errorf("Parse user id failed %s", pbs_req.User.ID)
+	}
+
+	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
+		t.Errorf("Parse app bundle failed")
+	}
+	if pbs_req.App.Ver != "0.0.1" {
+		t.Errorf("Parse app version failed")
+	}
+
+	if pbs_req.Device.IFA != "test_device_ifa" {
+		t.Errorf("Parse device ifa failed")
+	}
+	if pbs_req.Device.OSV != "9.3.5" {
+		t.Errorf("Parse device osv failed")
+	}
+	if pbs_req.Device.OS != "iOS" {
+		t.Errorf("Parse device os failed")
+	}
+	if pbs_req.Device.Make != "Apple" {
+		t.Errorf("Parse device make failed")
+	}
+	if pbs_req.Device.Model != "iPhone6,1" {
+		t.Errorf("Parse device model failed")
+	}
+}
+
 func TestParseMobileRequest(t *testing.T) {
 	body := []byte(`{
 	   "max_key_length":20,
@@ -256,7 +349,7 @@ func TestParseMobileRequest(t *testing.T) {
 	      "ver":"0.0.1"
 	   },
 	   "sdk":{
-	      "version":"0.0.1",
+	      "version":"0.0.2",
 	      "platform":"iOS",
 	      "source":"prebid-mobile"
 	   },

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -254,7 +254,7 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	      "ver":"0.0.1"
 	   },
 	   "sdk":{
-	      "version":"0.0.2",
+	      "version":"0.0.1",
 	      "platform":"iOS",
 	      "source":"prebid-mobile"
 	   },
@@ -346,7 +346,7 @@ func TestParseMobileRequest(t *testing.T) {
 	   "cache_markup":1,
 	   "app":{
 	      "bundle":"AppNexus.PrebidMobileDemo",
-	      "ver":"0.0.1"
+	      "ver":"0.0.2"
 	   },
 	   "sdk":{
 	      "version":"0.0.2",
@@ -393,7 +393,7 @@ func TestParseMobileRequest(t *testing.T) {
 	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
 		t.Errorf("Parse app bundle failed")
 	}
-	if pbs_req.App.Ver != "0.0.1" {
+	if pbs_req.App.Ver != "0.0.2" {
 		t.Errorf("Parse app version failed")
 	}
 
@@ -411,5 +411,14 @@ func TestParseMobileRequest(t *testing.T) {
 	}
 	if pbs_req.Device.Model != "iPhone6,1" {
 		t.Errorf("Parse device model failed")
+	}
+	if pbs_req.SDK.Version != "0.0.2" {
+		t.Errorf("Parse sdk version failed")
+	}
+	if pbs_req.SDK.Source != "prebid-mobile" {
+		t.Errorf("Parse sdk source failed")
+	}
+	if pbs_req.SDK.Platform != "iOS" {
+		t.Errorf("Parse sdk platform failed")
 	}
 }


### PR DESCRIPTION
In Prebid Mobile v0.0.1 on both iOS and Android user gender is passed as an integer. We recently found out that clients are using v0.0.1 and need to ensure backwards compatibility with that version.

This PR makes the "user" param of PBSRequest a rawJSONParameter so gender can be passed through as a string or integer without throwing an error. If we are not using v0.0.1 of the SDK, we then parse the User object into the openrtb.User object. 

I'm not changing the static pbs_request.json here because we still want the user object to be passed in according to OpenRTB standards. 