### PR TITLE
Add hb_creative_load_method keyword to winning bid.AdServerTargeting in PBSResponse

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -372,61 +372,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	}
 
 	if pbs_req.SortBids == 1 {
-		priceGranularitySetting := account.PriceGranularity
-		if priceGranularitySetting == "" {
-			priceGranularitySetting = DEFAULT_PRICE_GRANULARITY
-		}
-
-		// record bids by ad unit code for sorting
-		code_bids := make(map[string]pbs.PBSBidSlice, len(pbs_resp.Bids))
-		for _, bid := range pbs_resp.Bids {
-			code_bids[bid.AdUnitCode] = append(code_bids[bid.AdUnitCode], bid)
-		}
-
-		// loop through ad units to find top bid
-		for _, unit := range pbs_req.AdUnits {
-			bar := code_bids[unit.Code]
-
-			if len(bar) == 0 {
-				if glog.V(1) {
-					glog.Infof("No bids for ad unit '%s'", unit.Code)
-				}
-				continue
-			}
-			sort.Sort(bar)
-
-			// after sorting we need to add the ad targeting keywords
-			for i, bid := range bar {
-				priceBucketStringMap := pbs.GetPriceBucketString(bid.Price)
-				roundedCpm := priceBucketStringMap[priceGranularitySetting]
-
-				hbPbBidderKey := "hb_pb_" + bid.BidderCode
-				hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
-				hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
-				if pbs_req.MaxKeyLength != 0 {
-					hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
-					hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
-					hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), int(pbs_req.MaxKeyLength))]
-				}
-				pbs_kvs := map[string]string{
-					hbPbBidderKey:      roundedCpm,
-					hbBidderBidderKey:  bid.BidderCode,
-					hbCacheIdBidderKey: bid.CacheID,
-				}
-				// For the top bid, we want to add the following additional keys
-				if i == 0 {
-					pbs_kvs["hb_pb"] = roundedCpm
-					pbs_kvs["hb_bidder"] = bid.BidderCode
-					pbs_kvs["hb_cache_id"] = bid.CacheID
-					if bid.BidderCode == "audienceNetwork" {
-						pbs_kvs["hb_creative_load_method"] = "demand_sdk"
-					} else {
-						pbs_kvs["hb_creative_load_method"] = "html"
-					}
-				}
-				bid.AdServerTargeting = pbs_kvs
-			}
-		}
+		sortBidsAddKeywordsMobile(pbs_resp.Bids, pbs_req, account.PriceGranularity)
 	}
 
 	if glog.V(1) {
@@ -465,6 +411,63 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	//enc.SetIndent("", "  ")
 	enc.Encode(pbs_resp)
 	mRequestTimer.UpdateSince(pbs_req.Start)
+}
+
+func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, priceGranularitySetting string) {
+	if priceGranularitySetting == "" {
+		priceGranularitySetting = DEFAULT_PRICE_GRANULARITY
+	}
+
+	// record bids by ad unit code for sorting
+	code_bids := make(map[string]pbs.PBSBidSlice, len(bids))
+	for _, bid := range bids {
+		code_bids[bid.AdUnitCode] = append(code_bids[bid.AdUnitCode], bid)
+	}
+
+	// loop through ad units to find top bid
+	for _, unit := range pbs_req.AdUnits {
+		bar := code_bids[unit.Code]
+
+		if len(bar) == 0 {
+			if glog.V(1) {
+				glog.Infof("No bids for ad unit '%s'", unit.Code)
+			}
+			continue
+		}
+		sort.Sort(bar)
+
+		// after sorting we need to add the ad targeting keywords
+		for i, bid := range bar {
+			priceBucketStringMap := pbs.GetPriceBucketString(bid.Price)
+			roundedCpm := priceBucketStringMap[priceGranularitySetting]
+
+			hbPbBidderKey := "hb_pb_" + bid.BidderCode
+			hbBidderBidderKey := "hb_bidder_" + bid.BidderCode
+			hbCacheIdBidderKey := "hb_cache_id_" + bid.BidderCode
+			if pbs_req.MaxKeyLength != 0 {
+				hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
+				hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
+				hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), int(pbs_req.MaxKeyLength))]
+			}
+			pbs_kvs := map[string]string{
+				hbPbBidderKey:      roundedCpm,
+				hbBidderBidderKey:  bid.BidderCode,
+				hbCacheIdBidderKey: bid.CacheID,
+			}
+			// For the top bid, we want to add the following additional keys
+			if i == 0 {
+				pbs_kvs["hb_pb"] = roundedCpm
+				pbs_kvs["hb_bidder"] = bid.BidderCode
+				pbs_kvs["hb_cache_id"] = bid.CacheID
+				if bid.BidderCode == "audienceNetwork" {
+					pbs_kvs["hb_creative_load_method"] = "demand_sdk"
+				} else {
+					pbs_kvs["hb_creative_load_method"] = "html"
+				}
+			}
+			bid.AdServerTargeting = pbs_kvs
+		}
+	}
 }
 
 func status(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -98,12 +98,17 @@ type bidResult struct {
 
 const defaultPriceGranularity = "med"
 
-const hbCreativeLoadMethodDemandSDK = "demand_sdk"
-const hbCreativeLoadMethodHTML = "html"
+// Constant keys for ad server targeting for responses to Prebid Mobile
 const hbpbConstantKey = "hb_pb"
 const hbCreativeLoadMethodConstantKey = "hb_creative_load_method"
 const hbBidderConstantKey = "hb_bidder"
 const hbCacheIdConstantKey = "hb_cache_id"
+
+// hb_creative_load_method key can be one of `demand_sdk` or `html`
+// default is `html` where the creative is loaded in the primary ad server's webview through AppNexus hosted JS
+// `demand_sdk` is for bidders who insist on their creatives being loaded in their own SDK's webview
+const hbCreativeLoadMethodHTML = "html"
+const hbCreativeLoadMethodDemandSDK = "demand_sdk"
 
 func min(x, y int) int {
 	if x < y {

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -418,6 +418,11 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 					pbs_kvs["hb_pb"] = roundedCpm
 					pbs_kvs["hb_bidder"] = bid.BidderCode
 					pbs_kvs["hb_cache_id"] = bid.CacheID
+					if bid.BidderCode == "audienceNetwork" {
+						pbs_kvs["hb_creative_load_method"] = "demand_sdk"
+					} else {
+						pbs_kvs["hb_creative_load_method"] = "html"
+					}
 				}
 				bid.AdServerTargeting = pbs_kvs
 			}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"github.com/julienschmidt/httprouter"
+	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbs"
 	"net/http"
@@ -108,5 +109,96 @@ func TestCookieSyncHasCookies(t *testing.T) {
 
 	if len(csresp.BidderStatus) != 0 {
 		t.Errorf("Expected 0 bidder status rows; got %d", len(csresp.BidderStatus))
+	}
+}
+
+func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":"F",
+	      "buyeruid":"test_buyeruid",
+	      "yob":2000,
+	      "id":"testid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "config_id":"ad5ffb41-3492-40f3-9c25-ade093eb4e5f",
+	         "code":"test_adunitcode"
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.1"
+	   },
+	   "sdk":{
+	      "version":"0.0.1",
+	      "platform":"iOS",
+	      "source":"prebid-mobile"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := pbs.ParsePBSRequest(r, d)
+	if err != nil {
+		t.Errorf("Unexpected error on parsing %v", err)
+	}
+
+	bids := make(pbs.PBSBidSlice, 0)
+
+	fb_bid := pbs.PBSBid{
+		BidID:      "test_bidid",
+		AdUnitCode: "test_adunitcode",
+		BidderCode: "audienceNetwork",
+		Price:      1.05,
+		Adm:        "test_adm",
+		Width:      300,
+		Height:     250,
+	}
+	bids = append(bids, &fb_bid)
+	an_bid := pbs.PBSBid{
+		BidID:      "test_bidid2",
+		AdUnitCode: "test_adunitcode",
+		BidderCode: "appnexus",
+		Price:      1.00,
+		Adm:        "test_adm",
+		Width:      300,
+		Height:     250,
+	}
+	bids = append(bids, &an_bid)
+	pbs_resp := pbs.PBSResponse{
+		Bids: bids,
+	}
+	sortBidsAddKeywordsMobile(pbs_resp.Bids, pbs_req, "")
+
+	for _, bid := range bids {
+		if bid.AdServerTargeting == nil {
+			t.Errorf("Ad server targeting should not be nil")
+		}
+		if bid.BidderCode == "audienceNetwork" {
+			if bid.AdServerTargeting["hb_creative_load_method"] != "demand_sdk" {
+				t.Errorf("Facebook bid should have demand_sdk as hb_creative_load_method in ad server targeting")
+			}
+		}
 	}
 }


### PR DESCRIPTION
We need a new ad server targeting keyword `hb_creative_load_method` to be returned for the winning bid for Prebid Mobile. This keyword will tell us how we need to load the creative, either in html or in native code by the demand SDK. Needed specifically for Facebook demand right now.

Also abstracted out sortBidsAddKeywords functionality to make it easier to unit test and to make the code cleaner.