### PR TITLE
Making host cookie space inspection configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,18 +6,21 @@ import (
 
 // Configuration
 type Configuration struct {
-	CookieDomain    string             `mapstructure:"cookie_domain"`
-	ExternalURL     string             `mapstructure:"external_url"`
-	Host            string             `mapstructure:"host"`
-	Port            int                `mapstructure:"port"`
-	AdminPort       int                `mapstructure:"admin_port"`
-	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheURL        string             `mapstructure:"prebid_cache_url"`
-	RequireUUID2    bool               `mapstructure:"require_uuid2"`
-	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
-	Metrics         Metrics            `mapstructure:"metrics"`
-	DataCache       DataCache          `mapstructure:"datacache"`
-	Adapters        map[string]Adapter `mapstructure:"adapters"`
+	HostCookieDomain string             `mapstructure:"host_cookie_domain"`
+	HostCookieFamily string             `mapstructure:"host_cookie_family"`
+	HostCookieName   string             `mapstructure:"host_cookie_name"`
+	HostOptOutURL	 string             `mapstructure:"host_opt_out_url"`
+	HostOptInURL     string             `mapstructure:"host_opt_in_url"`
+	ExternalURL      string             `mapstructure:"external_url"`
+	Host             string             `mapstructure:"host"`
+	Port             int                `mapstructure:"port"`
+	AdminPort        int                `mapstructure:"admin_port"`
+	DefaultTimeout   uint64             `mapstructure:"default_timeout_ms"`
+	CacheURL         string             `mapstructure:"prebid_cache_url"`
+	RecaptchaSecret  string             `mapstructure:"recaptcha_secret"`
+	Metrics          Metrics            `mapstructure:"metrics"`
+	DataCache        DataCache          `mapstructure:"datacache"`
+	Adapters         map[string]Adapter `mapstructure:"adapters"`
 }
 
 type Adapter struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,14 +54,17 @@ func TestDefaults(t *testing.T) {
 
 }
 
-var fullConfig = []byte(`cookie_domain: ".adnxs.com"
-external_url: http://prebid.adnxs.com/
+var fullConfig = []byte(`host_cookie_domain: ".prebid.org"
+host_cookie_name: userid
+host_cookie_family: prebid
+host_opt_out_url: http://prebid.org/optout
+host_opt_in_url: http://prebid.org/optin
+external_url: http://prebid-server.prebid.org/
 host: prebid.adnxs.com
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
 prebid_cache_url: http://prebidcache.net/test/a1?qs=something
-require_uuid2: true
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -111,8 +114,12 @@ func TestFullConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	cmpStrings(t, "cookie domain", cfg.CookieDomain, ".adnxs.com")
-	cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid.adnxs.com/")
+	cmpStrings(t, "cookie domain", cfg.HostCookieDomain, ".prebid.org")
+	cmpStrings(t, "cookie name", cfg.HostCookieName, "userid")
+	cmpStrings(t, "cookie family", cfg.HostCookieFamily, "prebid")
+	cmpStrings(t, "opt out", cfg.HostOptOutURL, "http://prebid.org/optout")
+	cmpStrings(t, "opt in", cfg.HostOptInURL, "http://prebid.org/optin")
+	cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid-server.prebid.org/")
 	cmpStrings(t, "host", cfg.Host, "prebid.adnxs.com")
 	cmpInts(t, "port", cfg.Port, 1234)
 	cmpInts(t, "admin_port", cfg.AdminPort, 5678)
@@ -120,9 +127,6 @@ func TestFullConfig(t *testing.T) {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
 	cmpStrings(t, "prebid_cache_url", cfg.CacheURL, "http://prebidcache.net/test/a1?qs=something")
-	if cfg.RequireUUID2 != true {
-		t.Errorf("RequireUUID2 was false")
-	}
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -136,11 +136,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		pc := ParseUIDCookie(r)
 		pbsReq.UserIDs = pc.UIDs
 
-		// this would be for the shared adnxs.com domain
-		if anid, err := r.Cookie("uuid2"); err == nil {
-			pbsReq.UserIDs["adnxs"] = anid.Value
-		}
-
 		pbsReq.Device.UA = r.Header.Get("User-Agent")
 		pbsReq.Device.IP = prebid.GetIP(r)
 
@@ -238,6 +233,10 @@ func (req PBSRequest) GetUserID(BidderCode string) string {
 		return uid
 	}
 	return ""
+}
+
+func (req PBSRequest) SetUserID(BidderCode string, UserID string) {
+	req.UserIDs[BidderCode] = UserID
 }
 
 func (p PBSRequest) String() string {

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -17,6 +17,8 @@ import (
 )
 
 var cookie_domain string
+var optout_url string
+var optin_url string
 var external_url string
 var recaptcha_secret string
 
@@ -172,16 +174,18 @@ func OptOut(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	SetUIDCookie(w, pc)
 	if optout == "" {
-		http.Redirect(w, r, "https://ib.adnxs.com/optin", 301)
+		http.Redirect(w, r, optin_url, 301)
 	} else {
-		http.Redirect(w, r, "https://ib.adnxs.com/optout", 301)
+		http.Redirect(w, r, optout_url, 301)
 	}
 }
 
 // split this for testability
-func InitUsersyncHandlers(router *httprouter.Router, metricsRegistry metrics.Registry, cdomain string,
+func InitUsersyncHandlers(router *httprouter.Router, metricsRegistry metrics.Registry, cdomain string, optout string, optin string,
 	xternal_url string, captcha_secret string) {
 	cookie_domain = cdomain
+	optout_url = optout
+	optin_url = optin
 	external_url = xternal_url
 	recaptcha_secret = captcha_secret
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -76,8 +76,11 @@ var (
 	accountMetrics        map[string]*AccountMetrics // FIXME -- this seems like an unbounded queue
 	accountMetricsRWMutex sync.RWMutex
 
-	requireUUID2 bool
-	cookieDomain string
+	hostCookieDomain string
+	hostCookieFamily string
+	hostCookieName   string
+	hostOptOutURL    string
+	hostOptInURL     string
 )
 
 var exchanges map[string]adapters.Adapter
@@ -180,7 +183,7 @@ func cookieSync(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		UUID:         csReq.UUID,
 		BidderStatus: make([]*pbs.PBSBidder, 0, len(csReq.Bidders)),
 	}
-	if _, err := r.Cookie("uuid2"); (requireUUID2 && err != nil) || len(cookies.UIDs) == 0 {
+	if len(cookies.UIDs) == 0 {
 		csResp.Status = "no_cookie"
 	} else {
 		csResp.Status = "ok"
@@ -226,6 +229,13 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		return
 	}
 
+	// Host company has right to leverage private cookie store for user ID
+	if pbs_req.GetUserID(hostCookieFamily) == "" && hostCookieFamily != "" && hostCookieName != "" {
+		if hostCookie, err := r.Cookie(hostCookieName); err == nil {
+			pbs_req.SetUserID(hostCookieFamily, hostCookie.Value)
+		}
+	}
+
 	status := "OK"
 	if pbs_req.App != nil {
 		mAppRequestMeter.Mark(1)
@@ -235,17 +245,6 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 			mSafariNoCookieMeter.Mark(1)
 		}
 		status = "no_cookie"
-		if requireUUID2 {
-			uuid2 := fmt.Sprintf("%d", rand.Int63())
-			c := http.Cookie{
-				Name:    "uuid2",
-				Value:   uuid2,
-				Domain:  cookieDomain,
-				Expires: time.Now().Add(180 * 24 * time.Hour),
-			}
-			http.SetCookie(w, &c)
-			pbs_req.UserIDs["adnxs"] = uuid2
-		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(pbs_req.TimeoutMillis))
@@ -615,8 +614,12 @@ func main() {
 		glog.Errorf("Viper was unable to read configurations: %v", err)
 	}
 	// we need to set this global variable so it can be used by other methods
-	requireUUID2 = cfg.RequireUUID2
-	cookieDomain = cfg.CookieDomain
+	hostCookieDomain = cfg.HostCookieDomain
+	hostCookieFamily = cfg.HostCookieFamily
+	hostCookieName = cfg.HostCookieName
+	hostOptOutURL = cfg.HostOptOutURL
+	hostOptInURL = cfg.HostOptInURL
+
 	if err := serve(cfg); err != nil {
 		glog.Fatalf("PreBid Server encountered an error: %v", err)
 	}
@@ -716,7 +719,7 @@ func serve(cfg *config.Configuration) error {
 	router.GET("/ip", getIP)
 	router.ServeFiles("/static/*filepath", http.Dir("static"))
 
-	pbs.InitUsersyncHandlers(router, metricsRegistry, cfg.CookieDomain, cfg.ExternalURL, cfg.RecaptchaSecret)
+	pbs.InitUsersyncHandlers(router, metricsRegistry, hostCookieDomain, hostOptOutURL, hostOptInURL, cfg.ExternalURL, cfg.RecaptchaSecret)
 
 	pbc.InitPrebidCache(cfg.CacheURL)
 

--- a/static/index.html
+++ b/static/index.html
@@ -3,8 +3,8 @@
         <title>Prebid Server</title>
     </head>
     <body>
-        Prebid Server is a free server-to-server proxy for <a href="http://prebid.org">Prebid.js</a> users provided by AppNexus.
-        AppNexus is not responsible for the content or advertising delivered through this proxy. For more information, 
-        please contact prebid-support -at- appnexus.com.
+        Prebid Server is a server-to-server proxy for <a href="http://prebid.org">Prebid.js</a> users.
+        The host is not responsible for the content or advertising delivered through this proxy. For more information, 
+        please contact prebid-server - at - prebid.org.
     </body>
 </html>

--- a/validate.sh
+++ b/validate.sh
@@ -19,7 +19,7 @@ GOFMT_LINES=`gofmt -l *.go pbs adapters | wc -l | xargs`
 if $AUTOFMT; then
   # if there are files with formatting issues, they will be automatically corrected using the gofmt -w <file> command
   if [[ $GOFMT_LINES -ne 0 ]]; then
-    FMT_FILES=`gofmt -l *.go pbs adapters | xargs`
+    FMT_FILES=`gofmt -l *.go pbs adapters prebid config | xargs`
     for FILE in $FMT_FILES; do
         echo "Running: gofmt -w $FILE"
         `gofmt -w $FILE`


### PR DESCRIPTION
- Separate task required to make the /auction method more testable
- Potential structural improvement downstream to pull Host* configuration into struct. Separating form from function for now.
- Removing some specific hard coded references to AppNexus