### PR TITLE
Fb coin flip

### DIFF
--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"strings"
+
+	"net/url"
 
 	"github.com/prebid/openrtb"
 	"github.com/prebid/prebid-server/pbs"
@@ -49,7 +52,23 @@ type facebookParams struct {
 	PlacementId string `json:"placementId"`
 }
 
+func coinFlip() bool {
+	random := rand.Intn(2)
+	if random == 0 {
+		return false
+	}
+	return true
+}
+
 func (a *FacebookAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result callOneResult, err error) {
+	fmt.Println(a.URI)
+	if coinFlip() {
+		url, _ := url.Parse(a.URI)
+		//50% of traffic to non-secure endpoint
+		url.Scheme = "http"
+		a.URI = url.String()
+	}
+
 	httpReq, _ := http.NewRequest("POST", a.URI, &reqJSON)
 	httpReq.Header.Add("Content-Type", "application/json")
 	httpReq.Header.Add("Accept", "application/json")

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -52,11 +52,7 @@ type facebookParams struct {
 }
 
 func coinFlip() bool {
-	random := rand.Intn(2)
-	if random == 0 {
-		return false
-	}
-	return true
+	return rand.Intn(2) != 0
 }
 
 func (a *FacebookAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result callOneResult, err error) {

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -61,14 +61,12 @@ func coinFlip() bool {
 }
 
 func (a *FacebookAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result callOneResult, err error) {
-	fmt.Println(a.URI)
 	if coinFlip() {
 		url, _ := url.Parse(a.URI)
 		//50% of traffic to non-secure endpoint
 		url.Scheme = "http"
 		a.URI = url.String()
 	}
-
 	httpReq, _ := http.NewRequest("POST", a.URI, &reqJSON)
 	httpReq.Header.Add("Content-Type", "application/json")
 	httpReq.Header.Add("Accept", "application/json")

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -176,6 +176,7 @@ func TestFacebookBasicResponse(t *testing.T) {
 	conf := *DefaultHTTPAdapterConfig
 	an := NewFacebookAdapter(&conf, fmt.Sprintf("%d", fbdata.partnerID), "localhost")
 	an.URI = server.URL
+	an.nonSecureUri = server.URL
 
 	pbin := pbs.PBSRequest{
 		AdUnits: make([]pbs.AdUnit, 2),


### PR DESCRIPTION
This PR moves ~50% of the traffic to non-secure endpoint per FB request. 