### PR TITLE
Adding per-bidder TTLs

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -43,6 +43,8 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		}
 	}
 
+	buyerUID, _, _ := req.Cookie.GetUID(bidderFamily)
+	id, _, _ := req.Cookie.GetUID("adnxs")
 	return openrtb.BidRequest{
 		ID:  req.Tid,
 		Imp: imps,
@@ -52,8 +54,8 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		},
 		Device: req.Device,
 		User: &openrtb.User{
-			BuyerUID: req.GetUserID(bidderFamily),
-			ID:       req.GetUserID("adnxs"),
+			BuyerUID: buyerUID,
+			ID:       id,
 		},
 		Source: &openrtb.Source{
 			FD:  1, // upstream, aka header

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -79,12 +79,13 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		bidder.Debug = append(bidder.Debug, debug)
 	}
 
+	userId, _, _ := req.Cookie.GetUID(a.FamilyName())
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")
 	httpReq.AddCookie(&http.Cookie{
 		Name:  "KADUSERCOOKIE",
-		Value: req.GetUserID(a.FamilyName()),
+		Value: userId,
 	})
 
 	pbResp, err := ctxhttp.Do(ctx, a.http.Client, httpReq)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -158,7 +158,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if anid, err := r.Cookie("uuid2"); err == nil {
 			pbsReq.Cookie.TrySync("adnxs", anid.Value)
 		}
-		pbsReq.User.ID = pbsReq.GetUserID("adnxs")
+		pbsReq.User.ID, _, _ = pbsReq.Cookie.GetUID("adnxs")
 
 		pbsReq.Device.UA = r.Header.Get("User-Agent")
 		pbsReq.Device.IP = prebid.GetIP(r)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -251,11 +251,6 @@ func (req PBSRequest) Elapsed() int {
 	return int(time.Since(req.Start) / 1000000)
 }
 
-func (req *PBSRequest) GetUserID(BidderCode string) string {
-	uid, _ := req.Cookie.GetUID(BidderCode)
-	return uid
-}
-
 func (p PBSRequest) String() string {
 	b, _ := json.MarshalIndent(p, "", "    ")
 	return string(b)

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -23,6 +23,7 @@ const COOKIE_NAME = "uids"
 
 // DEFAULT_TTL is the default amount of time which a cookie is considered valid.
 const DEFAULT_TTL = 14 * 24 * time.Hour
+
 // customBidderTTLs stores rules about how long a particular UID sync is valid for each bidder.
 // If a bidder does a cookie sync *without* listing a rule here, then the DEFAULT_TTL will be used.
 var customBidderTTLs = map[string]time.Duration{}

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -151,14 +151,14 @@ func (cookie *PBSCookie) Unsync(familyName string) {
 	delete(cookie.uids, familyName)
 }
 
-// HasSync returns true if we have an active UID for the given family, and false otherwise.
-func (cookie *PBSCookie) HasSync(familyName string) bool {
+// HasLiveSync returns true if we have an active UID for the given family, and false otherwise.
+func (cookie *PBSCookie) HasLiveSync(familyName string) bool {
 	_, _, isLive := cookie.GetUID(familyName)
 	return isLive
 }
 
-// SyncCount returns the number of families which have active UIDs for this user.
-func (cookie *PBSCookie) SyncCount() int {
+// LiveSyncCount returns the number of families which have active UIDs for this user.
+func (cookie *PBSCookie) LiveSyncCount() int {
 	now := time.Now()
 	numSyncs := 0
 	if cookie != nil {

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -227,6 +227,10 @@ func (cookie *PBSCookie) UnmarshalJSON(b []byte) error {
 		} else {
 			cookie.uids = cookieContract.UIDs
 
+			if cookie.uids == nil {
+				cookie.uids = make(map[string]temporaryUid, len(cookieContract.LegacyUIDs))
+			}
+
 			// Interpret "legacy" UIDs as having been expired already.
 			// This should cause us to re-sync, since it would be time for a new one.
 			for bidder, uid := range cookieContract.LegacyUIDs {

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -23,6 +23,7 @@ const COOKIE_NAME = "uids"
 
 // customBidderTTLs stores rules about how long a particular UID sync is valid for each bidder.
 // If a bidder does a cookie sync *without* listing a rule here, then the UID's TTL will be 7 days.
+const DEFAULT_TTL = 14 * 24 * time.Hour
 var customBidderTTLs = map[string]time.Duration{}
 
 const (
@@ -372,7 +373,7 @@ func (deps *UserSyncDeps) OptOut(w http.ResponseWriter, r *http.Request, _ httpr
 
 // getExpiry gets an expiry date for the cookie, assuming it was generated right now.
 func getExpiry(familyName string) time.Time {
-	ttl := 14 * 24 * time.Hour
+	ttl := DEFAULT_TTL
 	if customTTL, ok := customBidderTTLs[familyName]; ok {
 		ttl = customTTL
 	}

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -21,9 +21,10 @@ import (
 const RECAPTCHA_URL = "https://www.google.com/recaptcha/api/siteverify"
 const COOKIE_NAME = "uids"
 
-// customBidderTTLs stores rules about how long a particular UID sync is valid for each bidder.
-// If a bidder does a cookie sync *without* listing a rule here, then the UID's TTL will be 7 days.
+// DEFAULT_TTL is the default amount of time which a cookie is considered valid.
 const DEFAULT_TTL = 14 * 24 * time.Hour
+// customBidderTTLs stores rules about how long a particular UID sync is valid for each bidder.
+// If a bidder does a cookie sync *without* listing a rule here, then the DEFAULT_TTL will be used.
 var customBidderTTLs = map[string]time.Duration{}
 
 const (

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -372,7 +372,7 @@ func (deps *UserSyncDeps) OptOut(w http.ResponseWriter, r *http.Request, _ httpr
 
 // getExpiry gets an expiry date for the cookie, assuming it was generated right now.
 func getExpiry(familyName string) time.Time {
-	ttl := 7 * 24 * time.Hour
+	ttl := 14 * 24 * time.Hour
 	if customTTL, ok := customBidderTTLs[familyName]; ok {
 		ttl = customTTL
 	}

--- a/pbs/usersync_test.go
+++ b/pbs/usersync_test.go
@@ -2,6 +2,7 @@ package pbs
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -152,6 +153,32 @@ func TestCookieReadWrite(t *testing.T) {
 	}
 	if received.SyncCount() != 2 {
 		t.Errorf("Expected 2 user syncs. Got %d", received.SyncCount())
+	}
+}
+
+func TestPopulatedLegacyCookieRead(t *testing.T) {
+	legacyJson := `{"uids":{"adnxs":"123","audienceNetwork":"456"},"bday":"2017-08-03T21:04:52.629198911Z"}`
+	var cookie PBSCookie
+	json.Unmarshal([]byte(legacyJson), &cookie)
+
+	if cookie.SyncCount() != 0 {
+		t.Errorf("Expected 0 user syncs. Got %d", cookie.SyncCount())
+	}
+	if cookie.HasSync("adnxs") {
+		t.Errorf("Received cookie should act like it has no ID for adnxs.")
+	}
+	if cookie.HasSync("audienceNetwork") {
+		t.Errorf("Received cookie should act like it has no ID for audienceNetwork.")
+	}
+}
+
+func TestEmptyLegacyCookieRead(t *testing.T) {
+	legacyJson := `{"bday":"2017-08-29T18:54:18.393925772Z"}`
+	var cookie PBSCookie
+	json.Unmarshal([]byte(legacyJson), &cookie)
+
+	if cookie.SyncCount() != 0 {
+		t.Errorf("Expected 0 user syncs. Got %d", cookie.SyncCount())
 	}
 }
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -194,7 +194,7 @@ func cookieSync(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		UUID:         csReq.UUID,
 		BidderStatus: make([]*pbs.PBSBidder, 0, len(csReq.Bidders)),
 	}
-	if _, err := r.Cookie("uuid2"); (requireUUID2 && err != nil) || userSyncCookie.SyncCount() == 0 {
+	if _, err := r.Cookie("uuid2"); (requireUUID2 && err != nil) || userSyncCookie.LiveSyncCount() == 0 {
 		csResp.Status = "no_cookie"
 	} else {
 		csResp.Status = "ok"
@@ -202,7 +202,7 @@ func cookieSync(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	for _, bidder := range csReq.Bidders {
 		if ex, ok := exchanges[bidder]; ok {
-			if !userSyncCookie.HasSync(ex.FamilyName()) {
+			if !userSyncCookie.HasLiveSync(ex.FamilyName()) {
 				b := pbs.PBSBidder{
 					BidderCode:   bidder,
 					NoCookie:     true,
@@ -245,7 +245,7 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	status := "OK"
 	if pbs_req.App != nil {
 		mAppRequestMeter.Mark(1)
-	} else if pbs_req.Cookie.SyncCount() == 0 {
+	} else if pbs_req.Cookie.LiveSyncCount() == 0 {
 		mNoCookieMeter.Mark(1)
 		if isSafari {
 			mSafariNoCookieMeter.Mark(1)

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -295,8 +295,8 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 			ametrics.RequestMeter.Mark(1)
 			accountAdapterMetric.RequestMeter.Mark(1)
 			if pbs_req.App == nil {
-				_, _, isLive := pbs_req.Cookie.GetUID(ex.FamilyName())
-				if !isLive {
+				uid, _, _ := pbs_req.Cookie.GetUID(ex.FamilyName())
+				if uid == "" {
 					bidder.NoCookie = true
 					bidder.UsersyncInfo = ex.GetUsersyncInfo()
 					ametrics.NoCookieMeter.Mark(1)

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -282,13 +282,16 @@ func auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 			accountAdapterMetric := am.AdapterMetrics[bidder.BidderCode]
 			ametrics.RequestMeter.Mark(1)
 			accountAdapterMetric.RequestMeter.Mark(1)
-			if pbs_req.App == nil && pbs_req.GetUserID(ex.FamilyName()) == "" {
-				bidder.NoCookie = true
-				bidder.UsersyncInfo = ex.GetUsersyncInfo()
-				ametrics.NoCookieMeter.Mark(1)
-				accountAdapterMetric.NoCookieMeter.Mark(1)
-				if ex.SkipNoCookies() {
-					continue
+			if pbs_req.App == nil {
+				_, _, isLive := pbs_req.Cookie.GetUID(ex.FamilyName())
+				if !isLive {
+					bidder.NoCookie = true
+					bidder.UsersyncInfo = ex.GetUsersyncInfo()
+					ametrics.NoCookieMeter.Mark(1)
+					accountAdapterMetric.NoCookieMeter.Mark(1)
+					if ex.SkipNoCookies() {
+						continue
+					}
 				}
 			}
 			sentBids++


### PR DESCRIPTION
This replaces #91, but incorporates the changes from #106.

When a PBS cookie gets parsed from legacy JSON into a PBSCookie, all UIDs will be considered expired.
When a PBSCookie is asked if a UID exists, it answers "no" if that date has expired.
When a PBSCookie gets written to JSON, it includes the expiration date.

Over time, the legacy cookie JSON will be replaced with the new format, which includes per-bidder TTLs. After 6 months, it'll be safe to delete the logic which reads legacy cookies.