### PR TITLE
Refactor OpenRTB User object in for non-mobile

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -43,7 +43,6 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		}
 	}
 	if req.User != nil {
-		req.User.ID = req.GetUserID("adnxs")
 		req.User.BuyerUID = req.GetUserID(bidderFamily)
 	}
 

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -42,6 +42,10 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			TMax: req.TimeoutMillis,
 		}
 	}
+	if req.User != nil {
+		req.User.ID = req.GetUserID("adnxs")
+		req.User.BuyerUID = req.GetUserID(bidderFamily)
+	}
 
 	return openrtb.BidRequest{
 		ID:  req.Tid,
@@ -51,10 +55,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			Page:   req.Url,
 		},
 		Device: req.Device,
-		User: &openrtb.User{
-			BuyerUID: req.GetUserID(bidderFamily),
-			ID:       req.GetUserID("adnxs"),
-		},
+		User:   req.User,
 		Source: &openrtb.Source{
 			FD:  1, // upstream, aka header
 			TID: req.Tid,

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -104,3 +104,40 @@ func TestOpenRTBMobile(t *testing.T) {
 	assert.EqualValues(t, resp.Device.Model, "test_model")
 	assert.EqualValues(t, resp.Device.IFA, "test_ifa")
 }
+
+func TestOpenRTBEmptyUser(t *testing.T) {
+	pbReq := pbs.PBSRequest{
+		User: &openrtb.User{},
+	}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+			},
+		},
+	}
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+
+	assert.EqualValues(t, resp.User, &openrtb.User{})
+}
+
+func TestOpenRTBUserWithCookie(t *testing.T) {
+	pbsCookie := pbs.NewPBSCookie()
+	pbsCookie.TrySync("test", "abcde")
+	pbReq := pbs.PBSRequest{
+		User: &openrtb.User{},
+	}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code: "unitCode",
+			},
+		},
+	}
+	pbReq.Cookie = pbsCookie
+	resp := makeOpenRTBGeneric(&pbReq, &pbBidder, "test")
+
+	assert.EqualValues(t, resp.User.BuyerUID, "abcde")
+}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -158,6 +158,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if anid, err := r.Cookie("uuid2"); err == nil {
 			pbsReq.Cookie.TrySync("adnxs", anid.Value)
 		}
+		pbsReq.User.ID = pbsReq.GetUserID("adnxs")
 
 		pbsReq.Device.UA = r.Header.Get("User-Agent")
 		pbsReq.Device.IP = prebid.GetIP(r)


### PR DESCRIPTION
This PR addresses the follow up @dbemiller and I discussed [here](https://github.com/prebid/prebid-server/pull/101). Added unit testing to confirm that the new logic works.

I think it still makes the most sense to populate the User BuyerUID for non mobile in `openrtb_util.go` because we're passing the bidderFamily through there, but we can set the User.ID field in parsePBSRequest in `pbsrequest.go`.