### PR TITLE
Update references of prebid/openrtb to use mxmCherry/openrtb

### DIFF
--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -15,7 +15,7 @@ import (
 
 	"golang.org/x/net/context/ctxhttp"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type AppNexusAdapter struct {

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -15,7 +15,7 @@ import (
 
 	"fmt"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type anTagInfo struct {

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
 )

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -15,7 +15,7 @@ import (
 
 	"fmt"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type tagInfo struct {

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/net/context/ctxhttp"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type IndexAdapter struct {

--- a/adapters/index_test.go
+++ b/adapters/index_test.go
@@ -12,7 +12,7 @@ import (
 
 	"fmt"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 func TestIndexInvalidCall(t *testing.T) {

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -3,7 +3,7 @@ package adapters
 import (
 	"github.com/prebid/prebid-server/pbs"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily string) openrtb.BidRequest {
@@ -22,7 +22,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 				Format:   unit.Sizes,
 				TopFrame: unit.TopFrame,
 			},
-			Secure: req.Secure,
+			Secure: &req.Secure,
 			// pmp
 			// ext
 		}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 func TestOpenRTB(t *testing.T) {

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
 )

--- a/adapters/pubmatic_test.go
+++ b/adapters/pubmatic_test.go
@@ -12,7 +12,7 @@ import (
 
 	"fmt"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 func TestPubmaticInvalidCall(t *testing.T) {

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
 )

--- a/adapters/pulsepoint_test.go
+++ b/adapters/pulsepoint_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/pbs"
 )

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/net/context/ctxhttp"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type RubiconAdapter struct {

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -15,7 +15,7 @@ import (
 
 	"fmt"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 )
 
 type rubiAppendTrackerUrlTestScenario struct {

--- a/glide.lock
+++ b/glide.lock
@@ -46,8 +46,8 @@ imports:
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
   version: 685a1f1cb7a66b9cadbe8f1ac49d9f8f567d6a9d
-- name: github.com/prebid/openrtb
-  version: 4abcf757715a1a5e13211dd6c67c8e21c73b4668
+- name: github.com/mxmCherry/openrtb
+  version: af5bbec3623c8140b3f381af8ddcb1fce268d7d2
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/rs/cors

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,8 @@ import:
   - proto
 - package: github.com/julienschmidt/httprouter
   version: ~1.1.0
-- package: github.com/prebid/openrtb
-  version: ~3.0.3
+- package: github.com/mxmCherry/openrtb
+  version: ~6.0.0
 - package: github.com/rcrowley/go-metrics
 - package: github.com/spf13/viper
 - package: github.com/vrischmann/go-metrics-influxdb

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/net/publicsuffix"
 
-	"github.com/prebid/openrtb"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/prebid"
 )
@@ -82,7 +82,7 @@ type PBSRequest struct {
 	SortBids      int8            `json:"sort_bids"`
 	MaxKeyLength  int8            `json:"max_key_length"`
 	Secure        int8            `json:"secure"`
-	TimeoutMillis uint64          `json:"timeout_millis"`
+	TimeoutMillis int64           `json:"timeout_millis"`
 	AdUnits       []AdUnit        `json:"ad_units"`
 	IsDebug       bool            `json:"is_debug"`
 	App           *openrtb.App    `json:"app"`
@@ -129,7 +129,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	}
 
 	if pbsReq.TimeoutMillis == 0 || pbsReq.TimeoutMillis > 2000 {
-		pbsReq.TimeoutMillis = uint64(viper.GetInt("default_timeout_ms"))
+		pbsReq.TimeoutMillis = int64(viper.GetInt("default_timeout_ms"))
 	}
 
 	if pbsReq.Device == nil {


### PR DESCRIPTION
Now that https://github.com/mxmCherry/openrtb is formerly running OpenRTB 2.5, I've updated the various files in prebid-server to import the formal repo instead of the previously created custom fork (prebid/openrtb).  

In addition to the import changes, there were a few var type changes required to use the updated framework; these changes have also been included.