### PR TITLE
Rubicon Project server-initiated targeting

### DIFF
--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -45,6 +45,14 @@ type anBidInfo struct {
 	delay     time.Duration
 }
 
+type rpExtensionTargetingObject struct {
+	rp rpTargetingObject
+}
+
+type rpTargetingObject struct {
+	targeting []string
+}
+
 var andata anBidInfo
 
 func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -45,14 +45,6 @@ type anBidInfo struct {
 	delay     time.Duration
 }
 
-type rpExtensionTargetingObject struct {
-	rp rpTargetingObject
-}
-
-type rpTargetingObject struct {
-	targeting []string
-}
-
 var andata anBidInfo
 
 func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -83,6 +83,19 @@ type rubiconBannerExt struct {
 	RP rubiconBannerExtRP `json:"rp"`
 }
 
+type rubiconTargetingExt struct {
+	RP rubiconTargetingExtRP `json:"rp"`
+}
+
+type rubiconTargetingExtRP struct {
+	Targeting []rubiconTargetingObj `json:"targeting"`
+}
+
+type rubiconTargetingObj struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
+}
+
 type rubiSize struct {
 	w uint16
 	h uint16
@@ -210,6 +223,22 @@ func (a *RubiconAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJS
 		Height:      bid.H,
 		DealId:      bid.DealID,
 	}
+
+	// Pull out any server-side determined targeting
+	var rpExtTrg rubiconTargetingExt
+
+	if err := json.Unmarshal([]byte(bid.Ext), &rpExtTrg); err == nil {
+		// Converting string => array(string) to string => string
+		targeting := make(map[string]string)
+
+		// Only pick off the first for now
+		for _, target := range rpExtTrg.RP.Targeting {
+			targeting[target.Key] = target.Values[0]
+		}
+
+		result.bid.AdServerTargeting = targeting
+	}
+
 	return
 }
 

--- a/adapters/rubicon_test.go
+++ b/adapters/rubicon_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -24,10 +25,11 @@ type rubiAppendTrackerUrlTestScenario struct {
 }
 
 type rubiTagInfo struct {
-	code    string
-	zoneID  int
-	bid     float64
-	content string
+	code              string
+	zoneID            int
+	bid               float64
+	content           string
+	adServerTargeting map[string]string
 }
 
 type rubiBidInfo struct {
@@ -122,11 +124,15 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	targeting := "{\"rp\":{\"targeting\":[{\"key\":\"key1\",\"values\":[\"value1\"]},{\"key\":\"key2\",\"values\":[\"value2\"]}]}}"
+	rawTargeting := openrtb.RawJSON(targeting)
+
 	resp.SeatBid[0].Bid[0] = openrtb.Bid{
 		ID:    "random-id",
 		ImpID: imp.ID,
 		Price: rubidata.tags[ix].bid,
 		AdM:   rubidata.tags[ix].content,
+		Ext:   rawTargeting,
 	}
 
 	if breq.Site == nil {
@@ -205,15 +211,22 @@ func TestRubiconBasicResponse(t *testing.T) {
 		deviceUA:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30",
 		buyerUID:  "need-an-actual-fb-id",
 	}
+
+	targeting := make(map[string]string, 2)
+	targeting["key1"] = "value1"
+	targeting["key2"] = "value2"
+
 	rubidata.tags[0] = rubiTagInfo{
-		code:   "first-tag",
-		zoneID: 8394,
-		bid:    1.67,
+		code:              "first-tag",
+		zoneID:            8394,
+		bid:               1.67,
+		adServerTargeting: targeting,
 	}
 	rubidata.tags[1] = rubiTagInfo{
-		code:   "second-tag",
-		zoneID: 8395,
-		bid:    3.22,
+		code:              "second-tag",
+		zoneID:            8395,
+		bid:               3.22,
+		adServerTargeting: targeting,
 	}
 
 	conf := *DefaultHTTPAdapterConfig
@@ -298,6 +311,9 @@ func TestRubiconBasicResponse(t *testing.T) {
 				}
 				if bid.Adm != tag.content {
 					t.Errorf("Incorrect bid markup '%s' expected '%s'", bid.Adm, tag.content)
+				}
+				if !reflect.DeepEqual(bid.AdServerTargeting, tag.adServerTargeting) {
+					t.Errorf("Incorrect targeting '%+v' expected '%+v'", bid.AdServerTargeting, tag.adServerTargeting)
 				}
 			}
 		}


### PR DESCRIPTION
Allow Rubicon Project bidder to respond with KVPs to be passed through to Prebid.js and onto ad server of record.