### PR TITLE
Updated the index endpoint

### DIFF
--- a/adapters/index.go
+++ b/adapters/index.go
@@ -146,7 +146,7 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 
 func NewIndexAdapter(config *HTTPAdapterConfig, uri string, externalURL string) *IndexAdapter {
 	a := NewHTTPAdapter(config)
-	redirect_uri := fmt.Sprintf("%s/setuid?bidder=indexExchange&uid=__UID__", externalURL)
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=indexExchange&uid=", externalURL)
 	usersyncURI := "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb="
 
 	info := &pbs.UsersyncInfo{

--- a/adapters/index_test.go
+++ b/adapters/index_test.go
@@ -238,7 +238,7 @@ func TestIndexBasicResponse(t *testing.T) {
 func TestIndexUserSyncInfo(t *testing.T) {
 
 	an := NewIndexAdapter(DefaultHTTPAdapterConfig, "http://appnexus-eu.lb.indexww.com/bidder?p=184932", "localhost")
-	if an.usersyncInfo.URL != "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D__UID__" {
+	if an.usersyncInfo.URL != "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D" {
 		t.Fatalf("should have matched")
 	}
 	if an.usersyncInfo.Type != "redirect" {


### PR DESCRIPTION
Per note from @mjacobsonny, Index doesn't expect the `__UID__` macro to be on the end of the redirect link we send them.