### PR TITLE
Add instl on the Ad Unit to be passed to ortb bidders

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -84,6 +84,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 				newImp := openrtb.Imp{
 					ID:     unit.Code,
 					Secure: &req.Secure,
+					Instl:  unit.Instl,
 				}
 				switch mType {
 				case pbs.MEDIA_TYPE_BANNER:
@@ -106,6 +107,7 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			newImp := openrtb.Imp{
 				ID:     unit.Code,
 				Secure: &req.Secure,
+				Instl:  unit.Instl,
 			}
 			for _, mType := range unitMediaTypes {
 				switch mType {

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -46,6 +46,7 @@ func TestOpenRTB(t *testing.T) {
 						H: 12,
 					},
 				},
+				Instl: 1,
 			},
 		},
 	}
@@ -55,6 +56,7 @@ func TestOpenRTB(t *testing.T) {
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Banner.H, 12)
+	assert.EqualValues(t, resp.Imp[0].Instl, 1)
 }
 
 func TestOpenRTBVideo(t *testing.T) {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -71,6 +71,7 @@ type AdUnit struct {
 	Bids       []Bids           `json:"bids"`
 	ConfigID   string           `json:"config_id"`
 	MediaTypes []string         `json:"media_types"`
+	Instl      int8             `json:"instl"`
 }
 
 type PBSAdUnit struct {
@@ -81,6 +82,7 @@ type PBSAdUnit struct {
 	Params     json.RawMessage
 	Video      PBSVideo
 	MediaTypes []MediaType
+	Instl      int8
 }
 
 func ParseMediaType(s string) (MediaType, error) {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -310,6 +310,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				Sizes:      unit.Sizes,
 				TopFrame:   unit.TopFrame,
 				Code:       unit.Code,
+				Instl:    	unit.Instl,
 				Params:     b.Params,
 				BidID:      b.BidID,
 				MediaTypes: mtypes,

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -310,7 +310,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 				Sizes:      unit.Sizes,
 				TopFrame:   unit.TopFrame,
 				Code:       unit.Code,
-				Instl:    	unit.Instl,
+				Instl:      unit.Instl,
 				Params:     b.Params,
 				BidID:      b.BidID,
 				MediaTypes: mtypes,

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -450,3 +450,74 @@ func TestParseMobileRequest(t *testing.T) {
 		t.Errorf("Parse sdk platform failed")
 	}
 }
+
+func TestParseRequestWithInstl(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":"F",
+	      "buyeruid":"test_buyeruid",
+	      "yob":2000,
+	      "id":"testid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "bids": [
+                    {
+                        "bidder": "indexExchange"
+                    },
+                    {
+                        "bidder": "appnexus"
+                    }
+                ],
+	         "code":"5d748364ee9c46a2b112892fc3551b6f",
+	         "instl": 1
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.2"
+	   },
+	   "sdk":{
+	      "version":"0.0.2",
+	      "platform":"iOS",
+	      "source":"prebid-mobile"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := ParsePBSRequest(r, d)
+	if err != nil {
+		t.Fatalf("Parse simple request failed: %v", err)
+	}
+	if len(pbs_req.Bidders) != 2 {
+		t.Errorf("Should have 2 bidders. ")
+	}
+	if pbs_req.Bidders[0].AdUnits[0].Instl != 1 {
+		t.Errorf("Parse instl failed.")
+	}
+	if pbs_req.Bidders[1].AdUnits[0].Instl != 1 {
+		t.Errorf("Parse instl failed.")
+	}
+
+}

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -346,6 +346,12 @@
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 1
+                    },
+                    "instl":{
+                        "description": "1 = the ad is interstitial or full screen, 0 = not interstitial",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1
                     }
                 }
             }


### PR DESCRIPTION
This PR includes adding a field "instl" on the ad unit, which will be parsed and sent to bidders.
Example of using the field is as the following:
`{  
   "max_key_length":20,
   "prebid_version":"0.21.0-pre",
   "sort_bids":1,
   "ad_units":[  
      {  
         "sizes":[  
            {  
               "w":300,
               "h":250
            }
         ],
        "config_id": "3qviqn8hy78bbbubb78y",
         "code":"test code",
         "instl":1
      }
   ],
   "cache_markup":1,
   "..."
}`