### PR TITLE
Added Lifestreet adapter (3)

### DIFF
--- a/adapters/lifestreet.go
+++ b/adapters/lifestreet.go
@@ -1,0 +1,216 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/pbs"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+type LifestreetAdapter struct {
+	http         *HTTPAdapter
+	URI          string
+	usersyncInfo *pbs.UsersyncInfo
+}
+
+/* Name - export adapter name */
+func (a *LifestreetAdapter) Name() string {
+	return "Lifestreet"
+}
+
+// used for cookies and such
+func (a *LifestreetAdapter) FamilyName() string {
+	return "lifestreet"
+}
+
+func (a *LifestreetAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+	return a.usersyncInfo
+}
+
+func (a *LifestreetAdapter) SkipNoCookies() bool {
+	return false
+}
+
+// parameters for Lifestreet adapter.
+type lifestreetParams struct {
+	SlotTag string `json:"slot_tag"`
+}
+
+func (a *LifestreetAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, reqJSON bytes.Buffer) (result callOneResult, err error) {
+	httpReq, err := http.NewRequest("POST", a.URI, &reqJSON)
+	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
+	httpReq.Header.Add("Accept", "application/json")
+
+	lsmResp, e := ctxhttp.Do(ctx, a.http.Client, httpReq)
+	if e != nil {
+		err = e
+		return
+	}
+
+	defer lsmResp.Body.Close()
+	body, _ := ioutil.ReadAll(lsmResp.Body)
+	result.responseBody = string(body)
+
+	result.statusCode = lsmResp.StatusCode
+
+	if lsmResp.StatusCode == 204 {
+		return
+	}
+
+	if lsmResp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP status %d; body: %s", lsmResp.StatusCode, result.responseBody)
+		return
+	}
+
+	var bidResp openrtb.BidResponse
+	err = json.Unmarshal(body, &bidResp)
+	if err != nil {
+		return
+	}
+	if len(bidResp.SeatBid) == 0 || len(bidResp.SeatBid[0].Bid) == 0 {
+		return
+	}
+	bid := bidResp.SeatBid[0].Bid[0]
+
+	result.bid = &pbs.PBSBid{
+		AdUnitCode:  bid.ImpID,
+		Price:       bid.Price,
+		Adm:         bid.AdM,
+		Creative_id: bid.CrID,
+		Width:       bid.W,
+		Height:      bid.H,
+		DealId:      bid.DealID,
+		NURL:        bid.NURL,
+	}
+	return
+}
+
+func (a *LifestreetAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, slotTag string, mtype pbs.MediaType, unitInd int) (openrtb.BidRequest, error) {
+	lsReq, err := makeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{mtype}, true)
+
+	if err != nil {
+		return openrtb.BidRequest{}, err
+	}
+
+	if lsReq.Imp != nil && len(lsReq.Imp) > 0 {
+		lsReq.Imp = lsReq.Imp[unitInd : unitInd+1]
+
+		lsReq.Imp[0].Banner.Format = nil
+		lsReq.Imp[0].TagID = slotTag
+
+		return lsReq, nil
+	} else {
+		return lsReq, errors.New("No supported impressions")
+	}
+}
+
+func (a *LifestreetAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	requests := make([]bytes.Buffer, len(bidder.AdUnits)*2)
+	reqIndex := 0
+	for i, unit := range bidder.AdUnits {
+		var params lifestreetParams
+		err := json.Unmarshal(unit.Params, &params)
+		if err != nil {
+			return nil, err
+		}
+		if params.SlotTag == "" {
+			return nil, errors.New("Missing slot_tag param")
+		}
+		s := strings.Split(params.SlotTag, ".")
+		if len(s) != 2 {
+			return nil, fmt.Errorf("Invalid slot_tag param '%s'", params.SlotTag)
+		}
+
+		// BANNER
+		lsReqB, err := a.MakeOpenRtbBidRequest(req, bidder, params.SlotTag, pbs.MEDIA_TYPE_BANNER, i)
+		if err == nil {
+			err = json.NewEncoder(&requests[reqIndex]).Encode(lsReqB)
+			reqIndex = reqIndex + 1
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// VIDEO
+		lsReqV, err := a.MakeOpenRtbBidRequest(req, bidder, params.SlotTag, pbs.MEDIA_TYPE_VIDEO, i)
+		if err == nil {
+			err = json.NewEncoder(&requests[reqIndex]).Encode(lsReqV)
+			reqIndex = reqIndex + 1
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	ch := make(chan callOneResult)
+	for i, _ := range bidder.AdUnits {
+		go func(bidder *pbs.PBSBidder, reqJSON bytes.Buffer) {
+			result, err := a.callOne(ctx, req, reqJSON)
+			result.Error = err
+			if result.bid != nil {
+				result.bid.BidderCode = bidder.BidderCode
+				result.bid.BidID = bidder.LookupBidID(result.bid.AdUnitCode)
+				if result.bid.BidID == "" {
+					result.Error = fmt.Errorf("Unknown ad unit code '%s'", result.bid.AdUnitCode)
+					result.bid = nil
+				}
+			}
+			ch <- result
+		}(bidder, requests[i])
+	}
+
+	var err error
+
+	bids := make(pbs.PBSBidSlice, 0)
+	for i := 0; i < len(bidder.AdUnits); i++ {
+		result := <-ch
+		if result.bid != nil {
+			bids = append(bids, result.bid)
+		}
+		if req.IsDebug {
+			debug := &pbs.BidderDebug{
+				RequestURI:   a.URI,
+				RequestBody:  requests[i].String(),
+				StatusCode:   result.statusCode,
+				ResponseBody: result.responseBody,
+			}
+			bidder.Debug = append(bidder.Debug, debug)
+		}
+		if result.Error != nil {
+			err = result.Error
+		}
+	}
+
+	if len(bids) == 0 {
+		return nil, err
+	}
+	return bids, nil
+}
+
+func NewLifestreetAdapter(config *HTTPAdapterConfig, externalURL string) *LifestreetAdapter {
+	a := NewHTTPAdapter(config)
+
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=lifestreet&uid=$$visitor_cookie$$", externalURL)
+	usersyncURL := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl="
+
+	info := &pbs.UsersyncInfo{
+		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		Type:        "redirect",
+		SupportCORS: false,
+	}
+
+	return &LifestreetAdapter{
+		http:         a,
+		URI:          "https://prebid.s2s.lfstmedia.com/adrequest",
+		usersyncInfo: info,
+	}
+}

--- a/adapters/lifestreet_test.go
+++ b/adapters/lifestreet_test.go
@@ -1,0 +1,298 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/pbs"
+
+	"fmt"
+
+	"github.com/mxmCherry/openrtb"
+)
+
+type lsTagInfo struct {
+	code    string
+	slotTag string
+	bid     float64
+	content string
+}
+
+type lsBidInfo struct {
+	appBundle            string
+	deviceIP             string
+	deviceUA             string
+	deviceMake           string
+	deviceModel          string
+	deviceConnectiontype int8
+	deviceIfa            string
+	tags                 []lsTagInfo
+	referrer             string
+	width                uint64
+	height               uint64
+	delay                time.Duration
+}
+
+var lsdata lsBidInfo
+
+func DummyLifestreetServer(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var breq openrtb.BidRequest
+	err = json.Unmarshal(body, &breq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if breq.App == nil {
+		http.Error(w, fmt.Sprintf("No app object sent"), http.StatusInternalServerError)
+		return
+	}
+	if breq.App.Bundle != lsdata.appBundle {
+		http.Error(w, fmt.Sprintf("Bundle '%s' doesn't match '%s", breq.App.Bundle, lsdata.appBundle), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.UA != lsdata.deviceUA {
+		http.Error(w, fmt.Sprintf("UA '%s' doesn't match '%s", breq.Device.UA, lsdata.deviceUA), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.IP != lsdata.deviceIP {
+		http.Error(w, fmt.Sprintf("IP '%s' doesn't match '%s", breq.Device.IP, lsdata.deviceIP), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.Make != lsdata.deviceMake {
+		http.Error(w, fmt.Sprintf("Make '%s' doesn't match '%s", breq.Device.Make, lsdata.deviceMake), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.Model != lsdata.deviceModel {
+		http.Error(w, fmt.Sprintf("Model '%s' doesn't match '%s", breq.Device.Model, lsdata.deviceModel), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.Connectiontype != lsdata.deviceConnectiontype {
+		http.Error(w, fmt.Sprintf("Connectiontype '%s' doesn't match '%s", breq.Device.Connectiontype, lsdata.deviceConnectiontype), http.StatusInternalServerError)
+		return
+	}
+	if breq.Device.IFA != lsdata.deviceIfa {
+		http.Error(w, fmt.Sprintf("IFA '%s' doesn't match '%s", breq.Device.IFA, lsdata.deviceIfa), http.StatusInternalServerError)
+		return
+	}
+	if len(breq.Imp) != 1 {
+		http.Error(w, fmt.Sprintf("Wrong number of imp objects sent: %d", len(breq.Imp)), http.StatusInternalServerError)
+		return
+	}
+	var bid *openrtb.Bid
+	for _, tag := range lsdata.tags {
+		if breq.Imp[0].Banner == nil {
+			http.Error(w, fmt.Sprintf("No banner object sent"), http.StatusInternalServerError)
+			return
+		}
+		if breq.Imp[0].Banner.W != lsdata.width || breq.Imp[0].Banner.H != lsdata.height {
+			http.Error(w, fmt.Sprintf("Size '%dx%d' doesn't match '%dx%d", breq.Imp[0].Banner.W, breq.Imp[0].Banner.H, lsdata.width, lsdata.height), http.StatusInternalServerError)
+			return
+		}
+		if breq.Imp[0].TagID == tag.slotTag {
+			bid = &openrtb.Bid{
+				ID:    "random-id",
+				ImpID: breq.Imp[0].ID,
+				Price: tag.bid,
+				AdM:   tag.content,
+				W:     lsdata.width,
+				H:     lsdata.height,
+			}
+		}
+	}
+	if bid == nil {
+		http.Error(w, fmt.Sprintf("Slot tag '%s' not found", breq.Imp[0].TagID), http.StatusInternalServerError)
+		return
+	}
+
+	resp := openrtb.BidResponse{
+		ID:    "2345676337",
+		BidID: "975537589956",
+		Cur:   "USD",
+		SeatBid: []openrtb.SeatBid{
+			{
+				Seat: "LSM",
+				Bid:  []openrtb.Bid{*bid},
+			},
+		},
+	}
+
+	if lsdata.delay > 0 {
+		<-time.After(lsdata.delay)
+	}
+
+	js, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+func TestLifestreetBasicResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(DummyLifestreetServer))
+	defer server.Close()
+
+	lsdata = lsBidInfo{
+		appBundle:            "AppNexus.PrebidMobileDemo",
+		deviceIP:             "111.111.111.111",
+		deviceUA:             "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E8301",
+		deviceMake:           "Apple",
+		deviceModel:          "x86_64",
+		deviceConnectiontype: 1,
+		deviceIfa:            "6F3EA622-C2EE-4449-A97A-AE986D080C08",
+		tags:                 make([]lsTagInfo, 2),
+		referrer:             "http://test.com",
+		width:                320,
+		height:               480,
+	}
+	lsdata.tags[0] = lsTagInfo{
+		code:    "first-tag",
+		slotTag: "slot123.123",
+		bid:     2.44,
+	}
+	lsdata.tags[1] = lsTagInfo{
+		code:    "second-tag",
+		slotTag: "slot122.122",
+		bid:     1.11,
+	}
+
+	conf := *DefaultHTTPAdapterConfig
+	an := NewLifestreetAdapter(&conf, server.URL)
+	an.URI = server.URL
+
+	pbin := pbs.PBSRequest{
+		AdUnits: make([]pbs.AdUnit, 2),
+		App: &openrtb.App{
+			Bundle: lsdata.appBundle,
+		},
+		Device: &openrtb.Device{
+			UA:             lsdata.deviceUA,
+			IP:             lsdata.deviceIP,
+			Make:           lsdata.deviceMake,
+			Model:          lsdata.deviceModel,
+			Connectiontype: lsdata.deviceConnectiontype,
+			IFA:            lsdata.deviceIfa,
+		},
+	}
+	for i, tag := range lsdata.tags {
+		pbin.AdUnits[i] = pbs.AdUnit{
+			Code: tag.code,
+			Sizes: []openrtb.Format{
+				{
+					W: lsdata.width,
+					H: lsdata.height,
+				},
+			},
+			Bids: []pbs.Bids{
+				pbs.Bids{
+					BidderCode: "lifestreet",
+					BidID:      fmt.Sprintf("random-id-from-pbjs-%d", i),
+					Params:     json.RawMessage(fmt.Sprintf("{\"slot_tag\": \"%s\"}", tag.slotTag)),
+				},
+			},
+		}
+	}
+
+	body := new(bytes.Buffer)
+	err := json.NewEncoder(body).Encode(pbin)
+	if err != nil {
+		t.Fatalf("Json encoding failed: %v", err)
+	}
+
+	fmt.Println("body", body)
+
+	req := httptest.NewRequest("POST", server.URL, body)
+	req.Header.Add("User-Agent", lsdata.deviceUA)
+	req.Header.Add("Referer", lsdata.referrer)
+	req.Header.Add("X-Real-IP", lsdata.deviceIP)
+
+	pc := pbs.ParsePBSCookieFromRequest(req)
+	fakewriter := httptest.NewRecorder()
+	pc.SetCookieOnResponse(fakewriter, "")
+	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
+
+	cacheClient, _ := dummycache.New()
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient)
+	if err != nil {
+		t.Fatalf("ParsePBSRequest failed: %v", err)
+	}
+	if len(pbReq.Bidders) != 1 {
+		t.Fatalf("ParsePBSRequest returned %d bidders instead of 1", len(pbReq.Bidders))
+	}
+	if pbReq.Bidders[0].BidderCode != "lifestreet" {
+		t.Fatalf("ParsePBSRequest returned invalid bidder")
+	}
+
+	ctx := context.TODO()
+	bids, err := an.Call(ctx, pbReq, pbReq.Bidders[0])
+	if err != nil {
+		t.Fatalf("Should not have gotten an error: %v", err)
+	}
+	if len(bids) != 2 {
+		t.Fatalf("Received %d bids instead of 2", len(bids))
+	}
+	for _, bid := range bids {
+		matched := false
+		for _, tag := range lsdata.tags {
+			if bid.AdUnitCode == tag.code {
+				matched = true
+				if bid.BidderCode != "lifestreet" {
+					t.Errorf("Incorrect BidderCode '%s'", bid.BidderCode)
+				}
+				if bid.Price != tag.bid {
+					t.Errorf("Incorrect bid price '%.2f' expected '%.2f'", bid.Price, tag.bid)
+				}
+				if bid.Width != lsdata.width || bid.Height != lsdata.height {
+					t.Errorf("Incorrect bid size %dx%d, expected %dx%d", bid.Width, bid.Height, lsdata.width, lsdata.height)
+				}
+				if bid.Adm != tag.content {
+					t.Errorf("Incorrect bid markup '%s' expected '%s'", bid.Adm, tag.content)
+				}
+			}
+		}
+		if !matched {
+			t.Errorf("Received bid for unknown ad unit '%s'", bid.AdUnitCode)
+		}
+	}
+
+	// same test but with request timing out
+	lsdata.delay = 5 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	bids, err = an.Call(ctx, pbReq, pbReq.Bidders[0])
+	if err == nil {
+		t.Fatalf("Should have gotten a timeout error: %v", err)
+	}
+}
+
+func TestLifestreetUserSyncInfo(t *testing.T) {
+	url := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl=localhost%2Fsetuid%3Fbidder%3Dlifestreet%26uid%3D%24%24visitor_cookie%24%24"
+
+	an := NewLifestreetAdapter(DefaultHTTPAdapterConfig, "localhost")
+	if an.usersyncInfo.URL != url {
+		t.Fatalf("User Sync Info URL '%s' doesn't match '%s'", an.usersyncInfo.URL, url)
+	}
+	if an.usersyncInfo.Type != "redirect" {
+		t.Fatalf("should be redirect")
+	}
+	if an.usersyncInfo.SupportCORS != false {
+		t.Fatalf("should have been false")
+	}
+}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -637,6 +637,7 @@ func setupExchanges(cfg *config.Configuration) {
 		"rubicon": adapters.NewRubiconAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["rubicon"].Endpoint,
 			cfg.Adapters["rubicon"].XAPI.Username, cfg.Adapters["rubicon"].XAPI.Password, cfg.Adapters["rubicon"].XAPI.Tracker, cfg.Adapters["rubicon"].UserSyncURL),
 		"audienceNetwork": adapters.NewFacebookAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID, cfg.Adapters["facebook"].UserSyncURL),
+		"lifestreet":      adapters.NewLifestreetAdapter(adapters.DefaultHTTPAdapterConfig, cfg.ExternalURL),
 	}
 
 	metricsRegistry = metrics.NewPrefixedRegistry("prebidserver.")


### PR DESCRIPTION
A Lifestreet adapter for Prebid Server.
Test parameters:
[ { "bidder": "lifestreet", "params": { "slot_tag": "slot178682.159" } } ]

See previous pull requests for more info #125 and #100 