### PR TITLE
Parse ip address from mobile requests to send to bidders

### DIFF
--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -206,6 +206,8 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	if pbsReq.Device == nil {
 		pbsReq.Device = &openrtb.Device{}
 	}
+	pbsReq.Device.IP = prebid.GetIP(r)
+
 	if pbsReq.SDK == nil {
 		pbsReq.SDK = &SDK{}
 	}
@@ -231,7 +233,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		}
 
 		pbsReq.Device.UA = r.Header.Get("User-Agent")
-		pbsReq.Device.IP = prebid.GetIP(r)
 
 		pbsReq.Url = r.Header.Get("Referer") // must be specified in the header
 		// TODO: this should explicitly put us in test mode

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -449,4 +449,7 @@ func TestParseMobileRequest(t *testing.T) {
 	if pbs_req.SDK.Platform != "iOS" {
 		t.Errorf("Parse sdk platform failed")
 	}
+	if pbs_req.Device.IP == "" {
+		t.Errorf("Parse device ip failed %s", pbs_req.Device.IP)
+	}
 }


### PR DESCRIPTION
Prebid server was only parsing the ip address from non app requests. We also want to parse the ip address for mobile.