### PR TITLE
Gender backwards compatibility bug

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/prebid/prebid-server
 import:
+- package: github.com/blang/semver
 - package: github.com/golang/glog
 - package: github.com/golang/protobuf
   subpackages:

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -211,7 +212,8 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	}
 
 	// only parse user object for SDK version 0.0.2 and up
-	if pbsReq.SDK.Version !=nil && pbsReq.SDK.Version != "0.0.1" {
+	if CompareVersions(pbsReq.SDK.Version, "0.0.2") >= 0 {
+		// if pbsReq.SDK.Version != "0.0.1" {
 		if pbsReq.PBSUser != nil {
 			err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
 			if err != nil {
@@ -219,6 +221,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 			}
 		}
 	}
+
 	if pbsReq.User == nil {
 		pbsReq.User = &openrtb.User{}
 	}
@@ -329,4 +332,73 @@ func (req PBSRequest) Elapsed() int {
 func (p PBSRequest) String() string {
 	b, _ := json.MarshalIndent(p, "", "    ")
 	return string(b)
+}
+
+func CompareVersions(v1, v2 string) int {
+	var x, r, l int = 0, 0, 0
+	v1Digits := strings.Split(v1, ".")
+	v2Digits := strings.Split(v2, ".")
+	len1, len2 := len(v1Digits), len(v2Digits)
+
+	if len1 > len2 {
+		x = len1
+	} else {
+		x = len2
+	}
+
+	for i := 0; i < x; i++ {
+		if i < len1 && i < len2 {
+			if v1Digits[i] == v2Digits[i] {
+				continue
+			}
+		}
+
+		r = 0
+		if i < len1 {
+			r = NumVersion(v1Digits[i])
+		}
+
+		l = 0
+		if i < len2 {
+			l = NumVersion(v2Digits[i])
+		}
+
+		if r < l {
+			return -1
+		} else if r > l {
+			return 1
+		}
+	}
+
+	return 0
+
+}
+
+var specialForms = map[string]int{
+	"dev":   -6,
+	"alpha": -5,
+	"a":     -5,
+	"beta":  -4,
+	"b":     -4,
+	"RC":    -3,
+	"rc":    -3,
+	"#":     -2,
+	"p":     1,
+	"pl":    1,
+}
+
+func NumVersion(value string) int {
+	if value == "" {
+		return 0
+	}
+
+	if number, err := strconv.Atoi(value); err == nil {
+		return number
+	}
+
+	if special, ok := specialForms[value]; ok {
+		return special
+	}
+
+	return -7
 }

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -209,7 +209,9 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	if pbsReq.SDK == nil {
 		pbsReq.SDK = &SDK{}
 	}
-	if pbsReq.SDK.Version != "0.0.1" {
+
+	// only parse user object for SDK version 0.0.2 and up
+	if pbsReq.SDK.Version !=nil && pbsReq.SDK.Version != "0.0.1" {
 		if pbsReq.PBSUser != nil {
 			err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
 			if err != nil {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -211,7 +211,9 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		pbsReq.SDK = &SDK{}
 	}
 
-	// only parse user object for SDK version 0.0.2 and up
+	// Early versions of prebid mobile are sending requests with gender indicated by numbers,
+	// those traffic can't be parsed by latest Prebid Server after the change of gender to use string so clients using early versions can't be monetized.
+	// To handle those traffic, adding a check here to ignore the sent gender for versions lower than 0.0.2.
 	v1, err := semver.Make(pbsReq.SDK.Version)
 	v2, err := semver.Make("0.0.2")
 	if v1.Compare(v2) >= 0 {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -213,7 +213,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 
 	// only parse user object for SDK version 0.0.2 and up
 	if CompareVersions(pbsReq.SDK.Version, "0.0.2") >= 0 {
-		// if pbsReq.SDK.Version != "0.0.1" {
 		if pbsReq.PBSUser != nil {
 			err = json.Unmarshal([]byte(pbsReq.PBSUser), &pbsReq.User)
 			if err != nil {

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -547,15 +547,15 @@ func TestCompareVersions(t *testing.T) {
 
 	res = CompareVersions("0.0.3", "0.0.2")
 	if res != 1 {
-		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+		t.Errorf("Wrong comparison of versions, 0.0.3 should be greater than 0.0.2")
 	}
 
 	res = CompareVersions("0.0.2", "0.0.2")
 	if res != 0 {
-		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+		t.Errorf("Wrong comparison of versions, 0.0.2 should equal 0.0.2")
 	}
 	res = CompareVersions("", "0.0.2")
 	if res != -1 {
-		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+		t.Errorf("Wrong comparison of versions, zero value should be smaller than 0.0.2")
 	}
 }

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -450,3 +450,112 @@ func TestParseMobileRequest(t *testing.T) {
 		t.Errorf("Parse sdk platform failed")
 	}
 }
+
+func TestParseMalformedMobileRequest(t *testing.T) {
+	body := []byte(`{
+	   "max_key_length":20,
+	   "user":{
+	      "gender":0,
+	      "buyeruid":"test_buyeruid"
+	   },
+	   "prebid_version":"0.21.0-pre",
+	   "sort_bids":1,
+	   "ad_units":[
+	      {
+	         "sizes":[
+	            {
+	               "w":300,
+	               "h":250
+	            }
+	         ],
+	         "config_id":"ad5ffb41-3492-40f3-9c25-ade093eb4e5f",
+	         "code":"5d748364ee9c46a2b112892fc3551b6f"
+	      }
+	   ],
+	   "cache_markup":1,
+	   "app":{
+	      "bundle":"AppNexus.PrebidMobileDemo",
+	      "ver":"0.0.1"
+	   },
+	   "device":{
+	      "ifa":"test_device_ifa",
+	      "osv":"9.3.5",
+	      "os":"iOS",
+	      "make":"Apple",
+	      "model":"iPhone6,1"
+	   },
+	   "tid":"abcd",
+	   "account_id":"aecd6ef7-b992-4e99-9bb8-65e2d984e1dd"
+	}
+    `)
+	r := httptest.NewRequest("POST", "/auction", bytes.NewBuffer(body))
+	d, _ := dummycache.New()
+
+	pbs_req, err := ParsePBSRequest(r, d)
+	if err != nil {
+		t.Fatalf("Parse simple request failed: %v", err)
+	}
+	if pbs_req.Tid != "abcd" {
+		t.Errorf("Parse TID failed")
+	}
+	if len(pbs_req.AdUnits) != 1 {
+		t.Errorf("Parse ad units failed")
+	}
+	// We are expecting all user fields to be nil. Since no SDK version is passed in
+	if pbs_req.User.BuyerUID != "" {
+		t.Errorf("Parse user buyeruid failed %s", pbs_req.User.BuyerUID)
+	}
+	if pbs_req.User.Gender != "" {
+		t.Errorf("Parse user gender failed %s", pbs_req.User.Gender)
+	}
+	if pbs_req.User.Yob != 0 {
+		t.Errorf("Parse user year of birth failed %d", pbs_req.User.Yob)
+	}
+	if pbs_req.User.ID != "" {
+		t.Errorf("Parse user id failed %s", pbs_req.User.ID)
+	}
+
+	if pbs_req.App.Bundle != "AppNexus.PrebidMobileDemo" {
+		t.Errorf("Parse app bundle failed")
+	}
+	if pbs_req.App.Ver != "0.0.1" {
+		t.Errorf("Parse app version failed")
+	}
+
+	if pbs_req.Device.IFA != "test_device_ifa" {
+		t.Errorf("Parse device ifa failed")
+	}
+	if pbs_req.Device.OSV != "9.3.5" {
+		t.Errorf("Parse device osv failed")
+	}
+	if pbs_req.Device.OS != "iOS" {
+		t.Errorf("Parse device os failed")
+	}
+	if pbs_req.Device.Make != "Apple" {
+		t.Errorf("Parse device make failed")
+	}
+	if pbs_req.Device.Model != "iPhone6,1" {
+		t.Errorf("Parse device model failed")
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	res := CompareVersions("0.0.1", "0.0.2")
+	if res != -1 {
+		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+	}
+
+	res = CompareVersions("0.0.3", "0.0.2")
+	if res != 1 {
+		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+	}
+
+	res = CompareVersions("0.0.2", "0.0.2")
+	if res != 0 {
+		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+	}
+	res = CompareVersions("", "0.0.2")
+	if res != -1 {
+		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
+	}
+}

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -538,24 +538,3 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 		t.Errorf("Parse device model failed")
 	}
 }
-
-func TestCompareVersions(t *testing.T) {
-	res := CompareVersions("0.0.1", "0.0.2")
-	if res != -1 {
-		t.Errorf("Wrong comparison of versions, 0.0.1 should be smaller than 0.0.2")
-	}
-
-	res = CompareVersions("0.0.3", "0.0.2")
-	if res != 1 {
-		t.Errorf("Wrong comparison of versions, 0.0.3 should be greater than 0.0.2")
-	}
-
-	res = CompareVersions("0.0.2", "0.0.2")
-	if res != 0 {
-		t.Errorf("Wrong comparison of versions, 0.0.2 should equal 0.0.2")
-	}
-	res = CompareVersions("", "0.0.2")
-	if res != -1 {
-		t.Errorf("Wrong comparison of versions, zero value should be smaller than 0.0.2")
-	}
-}


### PR DESCRIPTION
This PR include a fix for a bug that when no SDK value passes in or version 0.0.0 passes in, User object parsing should not be handled. 