### PR TITLE
adding missing video property on request.

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prebid/prebid-server/pbs"
 
 	"errors"
+
 	"github.com/mxmCherry/openrtb"
 )
 
@@ -52,7 +53,12 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	mimes := make([]string, len(unit.Video.Mimes))
 	copy(mimes, unit.Video.Mimes)
 	pbm := make([]int8, 1)
+	//this will become int8 soon, so we only care about the first index in the array
 	pbm[0] = unit.Video.PlaybackMethod
+	if pbm[0] == 0 {
+		// slice of [0] = 0 will be considered non empty and sent, even though 0 is invalid per the spec.
+		pbm = append(pbm[:0], pbm[1:]...)
+	}
 	return &openrtb.Video{
 		MIMEs:          mimes,
 		MinDuration:    unit.Video.Minduration,
@@ -61,6 +67,7 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 		H:              unit.Sizes[0].H,
 		StartDelay:     unit.Video.Startdelay,
 		PlaybackMethod: pbm,
+		Protocols:      unit.Video.Protocols,
 	}
 }
 

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -56,8 +56,7 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	//this will become int8 soon, so we only care about the first index in the array
 	pbm[0] = unit.Video.PlaybackMethod
 	if pbm[0] == 0 {
-		// slice of [0] = 0 will be considered non empty and sent, even though 0 is invalid per the spec.
-		pbm = append(pbm[:0], pbm[1:]...)
+		pbm = nil
 	}
 	return &openrtb.Video{
 		MIMEs:          mimes,

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -63,6 +63,19 @@ type PBSVideo struct {
 	// 5 - Initiates on Entering Viewport with Sound On
 	// 6 - Initiates on Entering Viewport with Sound Off by Default
 	PlaybackMethod int8 `json:"playback_method,omitempty"`
+
+	//protocols as specified in ORTB 5.8
+	// 1 VAST 1.0
+	// 2 VAST 2.0
+	// 3 VAST 3.0
+	// 4 VAST 1.0 Wrapper
+	// 5 VAST 2.0 Wrapper
+	// 6 VAST 3.0 Wrapper
+	// 7 VAST 4.0
+	// 8 VAST 4.0 Wrapper
+	// 9 DAAST 1.0
+	// 10 DAAST 1.0 Wrapper
+	Protocols []int8 `json:"protocols,omitempty"`
 }
 
 type AdUnit struct {
@@ -73,6 +86,7 @@ type AdUnit struct {
 	ConfigID   string           `json:"config_id"`
 	MediaTypes []string         `json:"media_types"`
 	Instl      int8             `json:"instl"`
+	Video      PBSVideo         `json:"video"`
 }
 
 type PBSAdUnit struct {
@@ -325,6 +339,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *Hos
 				Params:     b.Params,
 				BidID:      b.BidID,
 				MediaTypes: mtypes,
+				Video:      unit.Video,
 			}
 
 			bidder.AdUnits = append(bidder.AdUnits, pau)

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/prebid/prebid-server/cache/dummycache"
 )
 
+const mimeVideoMp4 = "video/mp4"
+const mimeVideoFlv = "video/x-flv"
+
 func TestParseMediaTypes(t *testing.T) {
 	types1 := []string{"Banner"}
 	t1 := ParseMediaTypes(types1)
@@ -49,7 +52,7 @@ func TestParseSimpleRequest(t *testing.T) {
                 "sizes": [{"w": 728, "h": 90}],
                 "media_types" :["banner", "video"],
 				"video" : {
-					"mimes" : ["video/mp4"]
+					"mimes" : ["video/mp4", "video/x-flv"]
 				},
                 "bids": [
                     {
@@ -114,8 +117,11 @@ func TestParseSimpleRequest(t *testing.T) {
 	if pbs_req.AdUnits[1].MediaTypes[1] != "video" {
 		t.Errorf("Instead of video MediaType received %s", pbs_req.AdUnits[1].MediaTypes[0])
 	}
-	if pbs_req.AdUnits[1].Video.Mimes[0] != "video/mp4" {
+	if pbs_req.AdUnits[1].Video.Mimes[0] != mimeVideoMp4 {
 		t.Errorf("Instead of video/mp4 mimes received %s", pbs_req.AdUnits[1].Video.Mimes)
+	}
+	if pbs_req.AdUnits[1].Video.Mimes[1] != mimeVideoFlv {
+		t.Errorf("Instead of video/flv mimes received %s", pbs_req.AdUnits[1].Video.Mimes)
 	}
 
 }

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -48,6 +48,9 @@ func TestParseSimpleRequest(t *testing.T) {
                 "code": "second",
                 "sizes": [{"w": 728, "h": 90}],
                 "media_types" :["banner", "video"],
+				"video" : {
+					"mimes" : ["video/mp4"]
+				},
                 "bids": [
                     {
                         "bidder": "indexExchange"
@@ -110,6 +113,9 @@ func TestParseSimpleRequest(t *testing.T) {
 	}
 	if pbs_req.AdUnits[1].MediaTypes[1] != "video" {
 		t.Errorf("Instead of video MediaType received %s", pbs_req.AdUnits[1].MediaTypes[0])
+	}
+	if pbs_req.AdUnits[1].Video.Mimes[0] != "video/mp4" {
+		t.Errorf("Instead of video/mp4 mimes received %s", pbs_req.AdUnits[1].Video.Mimes)
 	}
 
 }

--- a/static/pbs_request.json
+++ b/static/pbs_request.json
@@ -245,7 +245,7 @@
                 }
             }
         },
-        "user" : {
+        "user": {
             "type": "object",
             "properties": {
                 "id": {
@@ -276,8 +276,16 @@
                     "code"
                 ],
                 "oneOf": [
-                    {"required": ["bids"]},
-                    {"required": ["config_id"]}
+                    {
+                        "required": [
+                            "bids"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "config_id"
+                        ]
+                    }
                 ],
                 "properties": {
                     "code": {
@@ -305,7 +313,47 @@
                         "description": "Media types accepted by this ad unit",
                         "items": {
                             "type": "string",
-                            "enum": ["banner","video"]
+                            "enum": [
+                                "banner",
+                                "video"
+                            ]
+                        }
+                    },
+                    "video": {
+                        "type": "object",
+                        "description": "Video attributes of this ad Unit",
+                        "properties": {
+                            "mimes": {
+                                "type": "array",
+                                "description": "Mime types as defined by ORTB - ex: video/mp4",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "minduration": {
+                                "type": "integer",
+                                "description": "Minimum video ad duration in seconds."
+                            },
+                            "maxduration": {
+                                "type": "integer",
+                                "description": "Maximum video ad duration in seconds."
+                            },
+                            "startdelay": {
+                                "type": "integer",
+                                "description": "	//Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements."
+                            },
+                            "skippable": {
+                                "type": "integer",
+                                "description": "Indicates if the player will allow the video to be skipped ( 0 = no, 1 = yes)."
+                            },
+                            "playback_method": {
+                                "type": "integer",
+                                "description": "Playback method code as defined by ORTB."
+                            },
+                            "protocols": {
+                                "type": "integer",
+                                "description": "protocols as specified in ORTB 2.5 spec: 5.8"
+                            }
                         }
                     },
                     "bids": {


### PR DESCRIPTION
In case of video request, we expect an `adunit.video` object. 