### PR TITLE
Bidder panic recovery

### DIFF
--- a/adapters/decorators/panicProof.go
+++ b/adapters/decorators/panicProof.go
@@ -1,10 +1,10 @@
 package decorators
 
 import (
-	"github.com/prebid/prebid-server/pbs"
 	"context"
 	"fmt"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/pbs"
 )
 
 func PreventPanics(delegate adapters.Adapter) adapters.Adapter {
@@ -13,7 +13,7 @@ func PreventPanics(delegate adapters.Adapter) adapters.Adapter {
 	}
 }
 
-type panicProofAdapter struct{
+type panicProofAdapter struct {
 	delegate adapters.Adapter
 }
 

--- a/adapters/decorators/panicProof.go
+++ b/adapters/decorators/panicProof.go
@@ -1,0 +1,45 @@
+package decorators
+
+import (
+	"github.com/prebid/prebid-server/pbs"
+	"context"
+	"fmt"
+	"github.com/prebid/prebid-server/adapters"
+)
+
+func PreventPanics(delegate adapters.Adapter) adapters.Adapter {
+	return &panicProofAdapter{
+		delegate: delegate,
+	}
+}
+
+type panicProofAdapter struct{
+	delegate adapters.Adapter
+}
+
+func (a *panicProofAdapter) Name() string {
+	return a.delegate.Name()
+}
+
+// used for cookies and such
+func (a *panicProofAdapter) FamilyName() string {
+	return a.delegate.FamilyName()
+}
+
+func (a *panicProofAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+	return a.delegate.GetUsersyncInfo()
+}
+
+func (a *panicProofAdapter) SkipNoCookies() bool {
+	return a.delegate.SkipNoCookies()
+}
+
+func (a *panicProofAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (bids pbs.PBSBidSlice, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			bids = nil
+			err = fmt.Errorf("Panic from bidder %s. %v", a.Name(), r)
+		}
+	}()
+	return a.delegate.Call(ctx, req, bidder)
+}

--- a/adapters/decorators/panicProof_test.go
+++ b/adapters/decorators/panicProof_test.go
@@ -1,0 +1,76 @@
+package decorators
+
+import (
+	"testing"
+	"github.com/prebid/prebid-server/pbs"
+	"context"
+)
+
+type brokenAdapter struct{}
+
+func (a *brokenAdapter) Name() string {
+	return "test"
+}
+
+// used for cookies and such
+func (a *brokenAdapter) FamilyName() string {
+	return "testFamily"
+}
+
+func (a *brokenAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+	return nil
+}
+
+func (a *brokenAdapter) SkipNoCookies() bool {
+	return false
+}
+
+func (a *brokenAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (bids pbs.PBSBidSlice, err error) {
+	panic("Fail!")
+}
+
+type workingAdapter struct{}
+
+func (a *workingAdapter) Name() string {
+	return "test"
+}
+
+// used for cookies and such
+func (a *workingAdapter) FamilyName() string {
+	return "testFamily"
+}
+
+func (a *workingAdapter) GetUsersyncInfo() *pbs.UsersyncInfo {
+	return nil
+}
+
+func (a *workingAdapter) SkipNoCookies() bool {
+	return false
+}
+
+func (a *workingAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (bids pbs.PBSBidSlice, err error) {
+	bid := pbs.PBSBid{}
+	return pbs.PBSBidSlice([]*pbs.PBSBid{&bid}), nil
+}
+
+func TestBrokenAdapter(t *testing.T) {
+	safe := PreventPanics(&brokenAdapter{})
+	bids, err := safe.Call(context.Background(), nil, nil)
+	if bids != nil {
+		t.Errorf("The wrapped adapter should return empty bids.")
+	}
+	if err == nil {
+		t.Errorf("The wrapped adapter should return a non-nil error.")
+	}
+}
+
+func TestWorkingAdapter(t *testing.T) {
+	safe := PreventPanics(&workingAdapter{})
+	bids, err := safe.Call(context.Background(), nil, nil)
+	if len(bids) != 1 {
+		t.Errorf("Working adapters should keep their bids.")
+	}
+	if err != nil {
+		t.Errorf("Working adapters should still return a non-nil error.")
+	}
+}

--- a/adapters/decorators/panicProof_test.go
+++ b/adapters/decorators/panicProof_test.go
@@ -1,9 +1,9 @@
 package decorators
 
 import (
-	"testing"
-	"github.com/prebid/prebid-server/pbs"
 	"context"
+	"github.com/prebid/prebid-server/pbs"
+	"testing"
 )
 
 type brokenAdapter struct{}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -34,10 +34,8 @@ import (
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
-	"log"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 )
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -25,6 +25,7 @@ import (
 	"github.com/xojoc/useragent"
 
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/adapters/decorators"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/cache/filecache"
@@ -33,12 +34,11 @@ import (
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
+	"log"
 	"os"
 	"os/signal"
-	"syscall"
-	"log"
 	"runtime"
-	"github.com/prebid/prebid-server/adapters/decorators"
+	"syscall"
 )
 
 type DomainMetrics struct {
@@ -623,8 +623,8 @@ func main() {
 
 func setupExchanges(cfg *config.Configuration) {
 	exchanges = map[string]adapters.Adapter{
-		"appnexus":      decorators.PreventPanics(adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.ExternalURL)),
-		"districtm":     decorators.PreventPanics(adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.ExternalURL)),
+		"appnexus":  decorators.PreventPanics(adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.ExternalURL)),
+		"districtm": decorators.PreventPanics(adapters.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.ExternalURL)),
 		"indexExchange": decorators.PreventPanics(adapters.NewIndexAdapter(
 			adapters.DefaultHTTPAdapterConfig,
 			cfg.Adapters["indexexchange"].Endpoint,


### PR DESCRIPTION
Go's Server recovers from panics so that an error on a single request doesn't bring down the whole process.

But... we run adapters in a goroutine which we spawn ourselves. So any panics which occur there _will_ bring down the whole process.

This middleware prevents bad bidder behavior from crashing the process.