### PR TITLE
Fix some race conditions

### DIFF
--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -118,10 +118,14 @@ func (a *FacebookAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs
 		fbReq.Imp = fbReq.Imp[unitInd : unitInd+1]
 
 		if fbReq.Site != nil {
-			fbReq.Site.Publisher = &openrtb.Publisher{ID: pubId}
+			siteCopy := *fbReq.Site
+			siteCopy.Publisher = &openrtb.Publisher{ID: pubId}
+			fbReq.Site = &siteCopy
 		}
 		if fbReq.App != nil {
-			fbReq.App.Publisher = &openrtb.Publisher{ID: pubId}
+			appCopy := *fbReq.App
+			appCopy.Publisher = &openrtb.Publisher{ID: pubId}
+			fbReq.App = &appCopy
 		}
 		fbReq.Imp[0].TagID = placementId
 

--- a/adapters/index.go
+++ b/adapters/index.go
@@ -69,7 +69,9 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 		// Index spec says "adunit path representing ad server inventory" but we don't have this
 		// ext is DFP div ID and KV pairs if avail
 		//indexReq.Imp[i].Ext = openrtb.RawJSON("{}")
-		indexReq.Site.Publisher = &openrtb.Publisher{ID: fmt.Sprintf("%d", params.SiteID)}
+		siteCopy := *indexReq.Site
+		siteCopy.Publisher = &openrtb.Publisher{ID: fmt.Sprintf("%d", params.SiteID)}
+		indexReq.Site = &siteCopy
 	}
 	// spec also asks for publisher id if set
 	// ext object on request for prefetch

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -132,10 +132,13 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 	}
 
 	if req.App != nil {
+		appCopy := *req.App
+		appCopy.Ext = make([]byte, len(req.App.Ext))
+		copy(appCopy.Ext, req.App.Ext)
 		return openrtb.BidRequest{
 			ID:     req.Tid,
 			Imp:    newImps,
-			App:    req.App,
+			App:    &appCopy,
 			Device: req.Device,
 			User:   req.User,
 			Source: &openrtb.Source{

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -39,7 +39,7 @@ func makeBanner(unit pbs.PBSAdUnit) *openrtb.Banner {
 	return &openrtb.Banner{
 		W:        unit.Sizes[0].W,
 		H:        unit.Sizes[0].H,
-		Format:   unit.Sizes, // TODO: Copy, if the bidder is shared at all
+		Format:   copyFormats(unit.Sizes), // defensive copy because adapters may mutate Imps, and this is shared data
 		TopFrame: unit.TopFrame,
 	}
 }
@@ -171,4 +171,13 @@ func makeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		AT:   1,
 		TMax: req.TimeoutMillis,
 	}, nil
+}
+
+func copyFormats(sizes []openrtb.Format) []openrtb.Format {
+	sizesCopy := make([]openrtb.Format, len(sizes))
+	for i := 0; i < len(sizes); i++ {
+		sizesCopy[i] = sizes[i]
+		sizesCopy[i].Ext = append([]byte(nil), sizes[i].Ext...)
+	}
+	return sizesCopy
 }

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -368,3 +368,34 @@ func TestOpenRTBUserWithCookie(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.EqualValues(t, resp.User.BuyerUID, "abcde")
 }
+
+func TestSizesCopy(t *testing.T) {
+	formats := []openrtb.Format{
+		{
+			W: 10,
+		},
+		{
+			Ext: []byte{0x5},
+		},
+	}
+	clone := copyFormats(formats)
+
+	if len(clone) != 2 {
+		t.Error("The copy should have 2 elements")
+	}
+	if clone[0].W != 10 {
+		t.Error("The Format's width should be preserved.")
+	}
+	if len(clone[1].Ext) != 1 || clone[1].Ext[0] != 0x5 {
+		t.Error("The Format's Ext should be preserved.")
+	}
+	if &formats[0] == &clone[0] || &formats[1] == &clone[1] {
+		t.Error("The Format elements should not point to the same instance")
+	}
+	if &formats[0] == &clone[0] || &formats[1] == &clone[1] {
+		t.Error("The Format elements should not point to the same instance")
+	}
+	if &formats[1].Ext[0] == &clone[1].Ext[0] {
+		t.Error("The Format.Ext property should point to two different instances")
+	}
+}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -1,13 +1,10 @@
 package adapters
 
 import (
-	"github.com/prebid/prebid-server/pbs"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"bytes"
 	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/pbs"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestCommonMediaTypes(t *testing.T) {
@@ -370,65 +367,4 @@ func TestOpenRTBUserWithCookie(t *testing.T) {
 	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 	assert.Equal(t, err, nil)
 	assert.EqualValues(t, resp.User.BuyerUID, "abcde")
-}
-
-func TestAppCopy(t *testing.T) {
-	pbReq := pbs.PBSRequest{
-		AccountID:     "test_account_id",
-		Tid:           "test_tid",
-		CacheMarkup:   1,
-		SortBids:      1,
-		MaxKeyLength:  20,
-		Secure:        1,
-		TimeoutMillis: 1000,
-		App: &openrtb.App{
-			Bundle: "AppNexus.PrebidMobileDemo",
-			Publisher: &openrtb.Publisher{
-				ID: "1995257847363113",
-			},
-			Ext: openrtb.RawJSON([]byte{0x15, 0x16}),
-		},
-		Device: &openrtb.Device{
-			UA:    "test_ua",
-			IP:    "test_ip",
-			Make:  "test_make",
-			Model: "test_model",
-			IFA:   "test_ifa",
-			Ext:   openrtb.RawJSON([]byte{0x17}),
-		},
-		User: &openrtb.User{
-			BuyerUID: "test_buyeruid",
-		},
-	}
-	pbBidder := pbs.PBSBidder{
-		BidderCode: "bannerCode",
-		AdUnits: []pbs.PBSAdUnit{
-			{
-				Code:       "unitCode",
-				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
-				Sizes: []openrtb.Format{
-					{
-						W: 300,
-						H: 250,
-					},
-				},
-			},
-		},
-	}
-	req, _ := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
-	if req.App.Bundle != pbReq.App.Bundle {
-		t.Errorf("Bundles not equal")
-	}
-	if req.App.Publisher.ID != pbReq.App.Publisher.ID {
-		t.Errorf("PubIDs not equal")
-	}
-	if !bytes.Equal(req.App.Ext, pbReq.App.Ext) {
-		t.Errorf("Ext values not equal")
-	}
-	if req.App == pbReq.App {
-		t.Errorf("App struct was not copied")
-	}
-	if &req.App.Ext[0] == &pbReq.App.Ext[0] {
-		t.Errorf("Ext bytes were not copied")
-	}
 }

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"bytes"
 	"github.com/mxmCherry/openrtb"
 )
 
@@ -369,4 +370,65 @@ func TestOpenRTBUserWithCookie(t *testing.T) {
 	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 	assert.Equal(t, err, nil)
 	assert.EqualValues(t, resp.User.BuyerUID, "abcde")
+}
+
+func TestAppCopy(t *testing.T) {
+	pbReq := pbs.PBSRequest{
+		AccountID:     "test_account_id",
+		Tid:           "test_tid",
+		CacheMarkup:   1,
+		SortBids:      1,
+		MaxKeyLength:  20,
+		Secure:        1,
+		TimeoutMillis: 1000,
+		App: &openrtb.App{
+			Bundle: "AppNexus.PrebidMobileDemo",
+			Publisher: &openrtb.Publisher{
+				ID: "1995257847363113",
+			},
+			Ext: openrtb.RawJSON([]byte{0x15, 0x16}),
+		},
+		Device: &openrtb.Device{
+			UA:    "test_ua",
+			IP:    "test_ip",
+			Make:  "test_make",
+			Model: "test_model",
+			IFA:   "test_ifa",
+			Ext:   openrtb.RawJSON([]byte{0x17}),
+		},
+		User: &openrtb.User{
+			BuyerUID: "test_buyeruid",
+		},
+	}
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			{
+				Code:       "unitCode",
+				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_BANNER},
+				Sizes: []openrtb.Format{
+					{
+						W: 300,
+						H: 250,
+					},
+				},
+			},
+		},
+	}
+	req, _ := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	if req.App.Bundle != pbReq.App.Bundle {
+		t.Errorf("Bundles not equal")
+	}
+	if req.App.Publisher.ID != pbReq.App.Publisher.ID {
+		t.Errorf("PubIDs not equal")
+	}
+	if !bytes.Equal(req.App.Ext, pbReq.App.Ext) {
+		t.Errorf("Ext values not equal")
+	}
+	if req.App == pbReq.App {
+		t.Errorf("App struct was not copied")
+	}
+	if &req.App.Ext[0] == &pbReq.App.Ext[0] {
+		t.Errorf("Ext bytes were not copied")
+	}
 }

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -69,10 +69,14 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		} // pubmatic doesn't support
 		pbReq.Imp[i].TagID = params.AdSlot
 		if pbReq.Site != nil {
-			pbReq.Site.Publisher = &openrtb.Publisher{ID: params.PublisherId}
+			siteCopy := *pbReq.Site
+			siteCopy.Publisher = &openrtb.Publisher{ID: params.PublisherId}
+			pbReq.Site = &siteCopy
 		}
 		if pbReq.App != nil {
-			pbReq.App.Publisher = &openrtb.Publisher{ID: params.PublisherId}
+			appCopy := *pbReq.App
+			appCopy.Publisher = &openrtb.Publisher{ID: params.PublisherId}
+			pbReq.App = &appCopy
 		}
 	}
 

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -74,9 +74,13 @@ func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 		ppReq.Imp[i].TagID = strconv.Itoa(params.TagId)
 		publisher := &openrtb.Publisher{ID: strconv.Itoa(params.PublisherId)}
 		if ppReq.Site != nil {
-			ppReq.Site.Publisher = publisher
+			siteCopy := *ppReq.Site
+			siteCopy.Publisher = publisher
+			ppReq.Site = &siteCopy
 		} else {
-			ppReq.App.Publisher = publisher
+			appCopy := *ppReq.App
+			appCopy.Publisher = publisher
+			ppReq.App = &appCopy
 		}
 		if ppReq.Imp[i].Banner != nil {
 			var size = strings.Split(strings.ToLower(params.AdSize), "x")

--- a/adapters/rubicon.go
+++ b/adapters/rubicon.go
@@ -279,14 +279,18 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 		siteExt := rubiconSiteExt{RP: rubiconSiteExtRP{SiteID: params.SiteId}}
 		pubExt := rubiconPubExt{RP: rubiconPubExtRP{AccountID: params.AccountId}}
 		if rubiReq.Site != nil {
-			rubiReq.Site.Ext, err = json.Marshal(&siteExt)
-			rubiReq.Site.Publisher = &openrtb.Publisher{}
-			rubiReq.Site.Publisher.Ext, err = json.Marshal(&pubExt)
+			siteCopy := *rubiReq.Site
+			siteCopy.Ext, err = json.Marshal(&siteExt)
+			siteCopy.Publisher = &openrtb.Publisher{}
+			siteCopy.Publisher.Ext, err = json.Marshal(&pubExt)
+			rubiReq.Site = &siteCopy
 		}
 		if rubiReq.App != nil {
-			rubiReq.App.Ext, err = json.Marshal(&siteExt)
-			rubiReq.App.Publisher = &openrtb.Publisher{}
-			rubiReq.App.Publisher.Ext, err = json.Marshal(&pubExt)
+			appCopy := *rubiReq.App
+			appCopy.Ext, err = json.Marshal(&siteExt)
+			appCopy.Publisher = &openrtb.Publisher{}
+			appCopy.Publisher.Ext, err = json.Marshal(&pubExt)
+			rubiReq.App = &appCopy
 		}
 
 		err = json.NewEncoder(&requests[i]).Encode(rubiReq)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -191,7 +191,7 @@ func ParseMediaTypes(types []string) []MediaType {
 func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	defer r.Body.Close()
 
-	pbsReq := &PBSRequest{}
+	var pbsReq PBSRequest
 	err := json.NewDecoder(r.Body).Decode(&pbsReq)
 	if err != nil {
 		return nil, err
@@ -329,7 +329,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		}
 	}
 
-	return pbsReq, nil
+	return &pbsReq, nil
 }
 
 func (req PBSRequest) Elapsed() int {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -191,7 +191,7 @@ func ParseMediaTypes(types []string) []MediaType {
 func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 	defer r.Body.Close()
 
-	var pbsReq PBSRequest
+	pbsReq := &PBSRequest{}
 	err := json.NewDecoder(r.Body).Decode(&pbsReq)
 	if err != nil {
 		return nil, err
@@ -329,7 +329,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		}
 	}
 
-	return &pbsReq, nil
+	return pbsReq, nil
 }
 
 func (req PBSRequest) Elapsed() int {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -266,6 +266,10 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid URL '%s': %v", url.Host, err)
 		}
+	} else {
+		appExt := make([]byte, len(pbsReq.App.Ext))
+		copy(appExt, pbsReq.App.Ext)
+		pbsReq.App.Ext = appExt
 	}
 
 	if r.FormValue("debug") == "1" {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -266,10 +266,6 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache) (*PBSRequest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid URL '%s': %v", url.Host, err)
 		}
-	} else {
-		appExt := make([]byte, len(pbsReq.App.Ext))
-		copy(appExt, pbsReq.App.Ext)
-		pbsReq.App.Ext = appExt
 	}
 
 	if r.FormValue("debug") == "1" {


### PR DESCRIPTION
We've been seeing more segfaults due to race conditions. [This gist](https://gist.github.com/dbemiller/032abda28d9a577f303da3b3cac0eaef) is a simplified version of the `/auction` code flow. Run it with `go run -race main.go` to see the race condition, and then re-run it after uncommenting the "copy" lines to show it fixed

I _think_ I got all the mutations, and documented which ones are "allowed" on `makeOpenRTBGeneric`... but of course there's no way to be certain.

I do think we need more general improvements so that these race conditions are less likely... but I'll log a separate issue for it shortly.