### PR TITLE
Implement Code Coverage check logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.cover/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
     - glide install
 
 script:
-    - ./validate.sh --nofmt
+    - ./validate.sh --nofmt --cov

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -31,6 +31,6 @@ while read -r LINE; do
 done < scripts/results.tmp
 
 if $CHECKCOV; then
-  echo "Detected at least one package had less than 80% code coverage.  Please review results below or from your terminal run ./scripts/coverage.sh --html for more detailed results"
+  echo "Detected at least one package had less than 20% code coverage.  Please review results below or from your terminal run ./scripts/coverage.sh --html for more detailed results"
   exit 1
 fi

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -18,13 +18,14 @@ trap finish EXIT ERR INT TERM
 OUTPUT=`./scripts/coverage.sh`
 
 while read -r LINE; do
+  echo -e "$LINE"
   if [[ $LINE =~ "%" ]]; then
     PERCENT=$(echo "$LINE"|cut -d: -f2-|cut -d% -f1|cut -d. -f1|tr -d ' ')
     if [[ $PERCENT -lt 20 ]]; then
       CHECKCOV=true
     fi
   fi
-done < "$OUTPUT"
+done <<< "$OUTPUT"
 
 if $CHECKCOV; then
   echo "Detected at least one package had less than 20% code coverage.  Please review results below or from your terminal run ./scripts/coverage.sh --html for more detailed results"

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -6,10 +6,6 @@ CHECKCOV=false
 
 #cleanup
 finish() {
-  cat scripts/results.tmp
-  if [ -e "scripts/results.tmp" ]; then
-    rm scripts/results.tmp
-  fi
 
   if [ -d ".cover" ]; then
     rm -rf .cover
@@ -19,16 +15,16 @@ finish() {
 trap finish EXIT ERR INT TERM
 
 #start script logic
-./scripts/coverage.sh > scripts/results.tmp
+OUTPUT=`./scripts/coverage.sh`
 
 while read -r LINE; do
   if [[ $LINE =~ "%" ]]; then
-    PERCENT=$(echo "$LINE"|cut -d: -f2- |cut -d% -f1| cut -d. -f1|tr -d ' ')
+    PERCENT=$(echo "$LINE"|cut -d: -f2-|cut -d% -f1|cut -d. -f1|tr -d ' ')
     if [[ $PERCENT -lt 20 ]]; then
       CHECKCOV=true
     fi
   fi
-done < scripts/results.tmp
+done < "$OUTPUT"
 
 if $CHECKCOV; then
   echo "Detected at least one package had less than 20% code coverage.  Please review results below or from your terminal run ./scripts/coverage.sh --html for more detailed results"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -4,10 +4,9 @@
 # Works around the fact that `go test -coverprofile` currently does not work
 # with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
 #
-# Usage: script/coverage [--html|--coveralls]
+# Usage: script/coverage.sh [--html]
 #
 #     --html      Additionally create HTML report and open it in browser
-#     --coveralls Push coverage statistics to coveralls.io
 #
 
 set -e
@@ -33,11 +32,6 @@ show_cover_report() {
     go tool cover -${1}="$profile"
 }
 
-push_to_coveralls() {
-    echo "Pushing coverage statistics to coveralls.io"
-    goveralls -coverprofile="$profile"
-}
-
 generate_cover_data $(go list ./... | grep -v /vendor/)
 #show_cover_report func
 case "$1" in
@@ -45,8 +39,6 @@ case "$1" in
     ;;
 --html)
     show_cover_report html ;;
---coveralls)
-    push_to_coveralls ;;
 *)
     echo >&2 "error: invalid option: $1"; exit 1 ;;
 esac

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Generate test coverage statistics for Go packages.
+# 
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: script/coverage [--html|--coveralls]
+#
+#     --html      Additionally create HTML report and open it in browser
+#     --coveralls Push coverage statistics to coveralls.io
+#
+
+set -e
+
+workdir=.cover
+profile="$workdir/cover.out"
+mode=count
+
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    for pkg in "$@"; do
+        f="$workdir/$(echo $pkg | tr / -).cover"
+        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" >"$profile"
+    grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+}
+
+show_cover_report() {
+    go tool cover -${1}="$profile"
+}
+
+push_to_coveralls() {
+    echo "Pushing coverage statistics to coveralls.io"
+    goveralls -coverprofile="$profile"
+}
+
+generate_cover_data $(go list ./... | grep -v /vendor/)
+#show_cover_report func
+case "$1" in
+"")
+    ;;
+--html)
+    show_cover_report html ;;
+--coveralls)
+    push_to_coveralls ;;
+*)
+    echo >&2 "error: invalid option: $1"; exit 1 ;;
+esac

--- a/validate.sh
+++ b/validate.sh
@@ -3,10 +3,12 @@
 set -e
 
 AUTOFMT=true
+COVERAGE=false
 
 while true; do
   case "$1" in
      --nofmt ) AUTOFMT=false; shift ;;
+     --cov ) COVERAGE=true; shift ;;
      * ) break ;;
   esac
 done
@@ -29,5 +31,8 @@ else
   test $GOFMT_LINES -eq 0 || die "gofmt needs to be run, ${GOFMT_LINES} files have issues.  Below is a list of files to review:\n`gofmt -l *.go pbs adapters`"
 fi
 
-#go test $(go list ./... | grep -v /vendor/)
-./scripts/check_coverage.sh
+if $COVERAGE; then
+  ./scripts/check_coverage.sh
+else
+  go test $(go list ./... | grep -v /vendor/)
+fi

--- a/validate.sh
+++ b/validate.sh
@@ -29,4 +29,5 @@ else
   test $GOFMT_LINES -eq 0 || die "gofmt needs to be run, ${GOFMT_LINES} files have issues.  Below is a list of files to review:\n`gofmt -l *.go pbs adapters`"
 fi
 
-go test $(go list ./... | grep -v /vendor/)
+#go test $(go list ./... | grep -v /vendor/)
+./scripts/check_coverage.sh


### PR DESCRIPTION
Added two scripts and a change to the validate.sh script to setup an automatic coverage check on the packages within the PBS framework.  

The coverage.sh file performs the actual coverage check process for each package and then collates the data together into one coverage file.  From the terminal, this script can be ran separately with the --html flag to produce a more detailed coverage report (eg $ ./scripts/coverage.sh --html).

The check_coverage.sh file calls the coverage.sh file and reads through the (coverage) results for each package to detect if any area is below a certain threshold percentage.  Currently this percentage is 20 (to get this implemented and allow for the chance for more unit tests to be written); later, this threshold would ideally be at 80%.

The validate.sh script is now configured to use these new scripts instead of the basic go test command, so that if a code coverage check falls below the threshold the code change will be blocked.