### PR TITLE
Go version 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-    - 1.8.3
+    - 1.9
     - master
 
 install:


### PR DESCRIPTION
has been released, and we've been running with it in prod for a little while now.

Updating the `.travis` file so that our CI uses it.