### PR TITLE
Add hb_size key for prebid mobile ad server targeting

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -452,9 +452,12 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 			priceBucketStringMap := pbs.GetPriceBucketString(bid.Price)
 			roundedCpm := priceBucketStringMap[priceGranularitySetting]
 
-			width := strconv.FormatUint(bid.Width, 10)
-			height := strconv.FormatUint(bid.Height, 10)
-			hbSize := width + "x" + height
+			hbSize := ""
+			if bid.Width != 0 && bid.Height != 0 {
+				width := strconv.FormatUint(bid.Width, 10)
+				height := strconv.FormatUint(bid.Height, 10)
+				hbSize = width + "x" + height
+			}
 
 			hbPbBidderKey := hbpbConstantKey + "_" + bid.BidderCode
 			hbBidderBidderKey := hbBidderConstantKey + "_" + bid.BidderCode
@@ -470,14 +473,18 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				hbPbBidderKey:      roundedCpm,
 				hbBidderBidderKey:  bid.BidderCode,
 				hbCacheIdBidderKey: bid.CacheID,
-				hbSizeBidderKey:    hbSize,
+			}
+			if hbSize != "" {
+				pbs_kvs[hbSizeBidderKey] = hbSize
 			}
 			// For the top bid, we want to add the following additional keys
 			if i == 0 {
 				pbs_kvs[hbpbConstantKey] = roundedCpm
 				pbs_kvs[hbBidderConstantKey] = bid.BidderCode
 				pbs_kvs[hbCacheIdConstantKey] = bid.CacheID
-				pbs_kvs[hbSizeConstantKey] = hbSize
+				if hbSize != "" {
+					pbs_kvs[hbSizeConstantKey] = hbSize
+				}
 				if bid.BidderCode == "audienceNetwork" {
 					pbs_kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodDemandSDK
 				} else {

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -170,10 +170,11 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 		BidID:      "test_bidid",
 		AdUnitCode: "test_adunitcode",
 		BidderCode: "audienceNetwork",
-		Price:      1.05,
+		Price:      2.00,
 		Adm:        "test_adm",
 		Width:      300,
 		Height:     250,
+		CacheID:    "test_cache_id1",
 	}
 	bids = append(bids, &fb_bid)
 	an_bid := pbs.PBSBid{
@@ -182,8 +183,9 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 		BidderCode: "appnexus",
 		Price:      1.00,
 		Adm:        "test_adm",
-		Width:      300,
-		Height:     250,
+		Width:      320,
+		Height:     50,
+		CacheID:    "test_cache_id2",
 	}
 	bids = append(bids, &an_bid)
 	pbs_resp := pbs.PBSResponse{
@@ -198,6 +200,35 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 		if bid.BidderCode == "audienceNetwork" {
 			if bid.AdServerTargeting["hb_creative_loadtype"] != "demand_sdk" {
 				t.Errorf("Facebook bid should have demand_sdk as hb_creative_loadtype in ad server targeting")
+			}
+			if bid.AdServerTargeting["hb_size"] != "300x250" {
+				t.Errorf("hb_size key was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_pb"] != "2.00" {
+				t.Errorf("hb_pb key was not parsed correctly ", bid.AdServerTargeting["hb_pb"])
+			}
+			if bid.AdServerTargeting["hb_cache_id"] != "test_cache_id1" {
+				t.Errorf("hb_cache_id key was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_bidder"] != "audienceNetwork" {
+				t.Errorf("hb_bidder key was not parsed correctly")
+			}
+		}
+		if bid.BidderCode == "appnexus" {
+			if bid.AdServerTargeting["hb_size_appnexus"] != "320x50" {
+				t.Errorf("hb_size key for appnexus bidder was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_cache_id_appnexus"] != "test_cache_id2" {
+				t.Errorf("hb_cache_id key for appnexus bidder was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_bidder_appnexus"] != "appnexus" {
+				t.Errorf("hb_bidder key for appnexus bidder was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_pb_appnexus"] != "1.00" {
+				t.Errorf("hb_pb key for appnexus bidder was not parsed correctly")
+			}
+			if bid.AdServerTargeting["hb_pb"] != "" {
+				t.Errorf("hb_pb key was parsed for two bidders")
 			}
 		}
 	}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -188,6 +188,15 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 		CacheID:    "test_cache_id2",
 	}
 	bids = append(bids, &an_bid)
+	nosize_bid := pbs.PBSBid{
+		BidID:      "test_bidid2",
+		AdUnitCode: "test_adunitcode",
+		BidderCode: "nosizebidder",
+		Price:      1.00,
+		Adm:        "test_adm",
+		CacheID:    "test_cache_id2",
+	}
+	bids = append(bids, &nosize_bid)
 	pbs_resp := pbs.PBSResponse{
 		Bids: bids,
 	}
@@ -229,6 +238,11 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			}
 			if bid.AdServerTargeting["hb_pb"] != "" {
 				t.Errorf("hb_pb key was parsed for two bidders")
+			}
+		}
+		if bid.BidderCode == "nosizebidder" {
+			if _, exists := bid.AdServerTargeting["hb_size_nosizebidder"]; exists {
+				t.Errorf("hb_size key for nosize bidder was not parsed correctly", bid.AdServerTargeting)
 			}
 		}
 	}


### PR DESCRIPTION
Some publishers want to target hb_size in their line items for custom creative templates that they're using to render the ads.