### PR TITLE
making small change to lifestreet adapater

### DIFF
--- a/adapters/lifestreet.go
+++ b/adapters/lifestreet.go
@@ -104,7 +104,9 @@ func (a *LifestreetAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *p
 	if lsReq.Imp != nil && len(lsReq.Imp) > 0 {
 		lsReq.Imp = lsReq.Imp[unitInd : unitInd+1]
 
-		lsReq.Imp[0].Banner.Format = nil
+		if lsReq.Imp[0].Banner != nil {
+			lsReq.Imp[0].Banner.Format = nil
+		}
 		lsReq.Imp[0].TagID = slotTag
 
 		return lsReq, nil


### PR DESCRIPTION
Inserting a small change within the LifeStreet adapter to detect if the Imp.Banner object exists before it attempts to nil out the Imp.Banner.Format object.  This is to avoid segfault error when their adapter calls for video adunit.  See RAD-1924