### PR TITLE
Updating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # Prebid Server
 
 Prebid Server is an open source implementation of Server-Side Header Bidding.
+It is managed by [Prebid.org](http://prebid.org/overview/what-is-prebid-org.html),
+and upholds the principles from the [Prebid Code of Conduct](http://prebid.org/wrapper_code_of_conduct.html).
+
 For more information, see:
 
 - [A Beginner's Guide to Header Bidding](http://adprofs.co/beginners-guide-to-header-bidding/)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For more information, see:
 - [A Beginner's Guide to Header Bidding](http://adprofs.co/beginners-guide-to-header-bidding/)
 - [Server-side Header Bidding Explained](http://www.adopsinsider.com/header-bidding/server-side-header-bidding/)
 
+If you're familiar with [Prebid.JS](https://github.com/prebid/Prebid.js), see the [getting started guide](http://prebid.org/dev-docs/get-started-with-prebid-server.html).
+
 ## Installation
 
 First install [Go 1.9.1](https://golang.org/doc/install) and [Glide](https://github.com/Masterminds/glide#install).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ and upholds the principles from the [Prebid Code of Conduct](http://prebid.org/w
 
 For more information, see:
 
-- [A Beginner's Guide to Header Bidding](http://adprofs.co/beginners-guide-to-header-bidding/)
-- [Server-side Header Bidding Explained](http://www.adopsinsider.com/header-bidding/server-side-header-bidding/)
-
-If you're familiar with [Prebid.JS](https://github.com/prebid/Prebid.js), see the [getting started guide](http://prebid.org/dev-docs/get-started-with-prebid-server.html).
+- [What is Prebid?](http://prebid.org/overview/intro.html)
+- [Getting started with Prebid Server](http://prebid.org/dev-docs/get-started-with-prebid-server.html)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,114 +1,48 @@
 [![Build Status](https://travis-ci.org/prebid/prebid-server.svg?branch=master)](https://travis-ci.org/prebid/prebid-server)
 
-# prebid-server
-Server side component to offload prebid processing to the cloud
+# Prebid Server
 
-# Discussion group for development / adapter testing
-http://redditadops.slack.com channel headerbidding-dev
+Prebid Server is an open source implementation of Server-Side Header Bidding.
+For more information, see:
 
-# Current Status of Adapters (Sep 20, 2017)
-Working on live sites:
-- AppNexus Web
-- Audience Network (Facebook) Web
-- Rubicon Web
-- Index Exchange Web
+- [A Beginner's Guide to Header Bidding](http://adprofs.co/beginners-guide-to-header-bidding/)
+- [Server-side Header Bidding Explained](http://www.adopsinsider.com/header-bidding/server-side-header-bidding/)
 
-In testing:
-- Pubmatic web
+## Installation
 
-Under development/ testing
-- PulsePoint Web
+First install [Go 1.9.1](https://golang.org/doc/install) and [Glide](https://github.com/Masterminds/glide#install).
 
-# How it works
-The client (typically prebid.js) sends a JSON request to Prebid Server at `/auction`. See static/pbs_request.json for the format.
-Prebid Server forms OpenRTB requests, sends them to the appropriate adapters, concatenates the responses, and returns them
-to the client.
+Then download and prepare Prebid Server:
 
-A few key points:
- * No ranking or decisioning is performed by Prebid Server. It just proxies requests.
- * No ad quality management (malware, viruses, deceptive creatives) is performed by Prebid Server
- * Prebid Server does no fraud scanning and does nothing to prevent bad traffic.
-
-# User synching
-Prebid Server provides a `/setuid` endpoint that allows adapters to push in their user IDs. These are stored in a cookie named,
-creatively, `uids`. To see stored cookies, call `/getuids`. To set an optout cookie, call `/optout`. When an adapter doesn't
-have a synched cookie, a `no_cookie` response is returned with a usersync URL that the client should call via asynchronous pixel
-or equivalent. If Prebid Server doesn't have a cookie set, a preemptive `no_cookie` response is returned to allow the client
-to ask for user consent and drop a cookie.
-
-# Logging
-Prebid Server does no server-side logging. It can stream metrics to an InfluxDB endpoint, which are aggregated as a time series.
-Prebid Server has no user profiling or user-data collection capabilities.
-
-# Usage
-## Without Docker
-### Prerequisites
-* [Go](https://www.golang.org)
-* [Glide](https://glide.sh/)
-
-# Hosted version
-AppNexus is hosting a version (generally bleeding-edge of this repo including some in-flight pull requests) at https://prebid.adnxs.com.
-
-### Getting
-1. Install glide: https://github.com/Masterminds/glide#install
-2. `cd $GOPATH`
-3. `git clone https://github.com/prebid/prebid-server src/github.com/prebid/prebid-server`
-4. `cd src/github.com/prebid/prebid-server`
-5. `glide install`
-6. `./validate.sh`
-
-### Running
-To compile a binary and run locally:
-```
-$ make build
-$ ./prebid-server -v 1 -logtostderr
+```bash
+cd $GOPATH
+git clone https://github.com/prebid/prebid-server src/github.com/prebid/prebid-server
+cd src/github.com/prebid/prebid-server
+glide install
 ```
 
-## With Docker
-### Prerequisites
-* [Docker](https://www.docker.com)
+Build the project and run the automated tests:
 
-### Compiling an alpine binary
-The Dockerfile for prebid-server copies the binary in the root directory to the
-docker container, and must be specifically be compiled for the target
-architecture (alpine).
-
-```
-$ docker run --rm -v "$PWD":/go/src/github.com/prebid/prebid-server \
--w /go/src/github.com/prebid/prebid-server \
-billyteves/alpine-golang-glide:1.2.0 \
-/bin/bash -c 'glide install; go build -v'
+```bash
+./validate.sh
 ```
 
-The above command will run a container with the necessary dependencies (alpine,
-go 1.8, glide) and compile an alpine compatible binary.
+Or just run the server locally:
 
-### Build prebid-server docker container
-```
-# make image
-```
-
-### Run container
-This command will run a prebid-server container in interactive mode and map the
-`8000` port to your machine's `8000` port so that you can visit `http://localhost:8000`
-and see prebid-server's index page.
-
-```
-$ docker run --rm -it -p 8000:8000 prebid-server
+```bash
+go build .
+./prebid-server
 ```
 
-# Data integration
-Prebid Server has three primary data objects that it needs to manage:
- * Accounts represent publishers, and are used for metrics aggregation and terms of service adherence. Requests without an
- active account will be rejected.
- * Domains are compared to the HTTP Referer header; all unknown/unapproved domains will be rejected.
- * Bundles are compared to the `app.bundle` value; all unknown/unapproved bundles will be rejected.
- * Configs are used for server-side configuration of adapters, primarily for use with mobile apps where managing configs
- client-side is ineffective.
+Load the landing page in your browser at `http://localhost:8000/`.
+For the full API reference, see [docs/endpoints](docs/endpoints)
 
-# Up Next
- * Limit adapters to one bid per ad unit
- * NURL support
- * Think through how deals work
- * Video
- * Native
+
+## Contributing
+
+Want to add an adapter? Found a bug? Great! This project is in its infancy, and many things
+can be improved.
+
+Report bugs, feature requests, and suggest improvements [on Github](https://github.com/prebid/prebid-server/issues).
+
+Or better yet, [open a pull request](https://github.com/prebid/prebid-server/compare) with the changes you'd like to see.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd src/github.com/prebid/prebid-server
 glide install
 ```
 
-Build the project and run the automated tests:
+Run the automated tests:
 
 ```bash
 ./validate.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ For the full API reference, see [docs/endpoints](docs/endpoints)
 Want to add an adapter? Found a bug? Great! This project is in its infancy, and many things
 can be improved.
 
-Report bugs, feature requests, and suggest improvements [on Github](https://github.com/prebid/prebid-server/issues).
+Report bugs, request features, and suggest improvements [on Github](https://github.com/prebid/prebid-server/issues).
 
 Or better yet, [open a pull request](https://github.com/prebid/prebid-server/compare) with the changes you'd like to see.

--- a/docs/endpoints/bidders/params.md
+++ b/docs/endpoints/bidders/params.md
@@ -1,6 +1,6 @@
 ## GET /bidders/params
 
-This endpoint gets informatoin about all the custom bidders params that Prebid Server supports.
+This endpoint gets information about all the custom bidders params that Prebid Server supports.
 
 ### Returns
 


### PR DESCRIPTION
Streamlining the README to be more "normal", and culling lots of scary details that don't need to be the _first_ thing you see.

The link to the `docs/endpoints` directory may be a little premature... but ideally I'd like to add `.md` files in it for every public endpoint. So for example `/bidders/params` is currently documented by `/bidders/params.md`. In the future, `/getuids` would be documented by `docs/endpoints/getuids.md`, etc.