### PR TITLE
Fixed a bug in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 MAINTAINER Brian O'Kelley <bokelley@appnexus.com>
 ADD prebid-server prebid-server
-ADD static/* static/
+COPY static static/
 EXPOSE 8000
 ENTRYPOINT ["/prebid-server"]
 CMD ["-v", "1", "-logtostderr"]


### PR DESCRIPTION
Found this issue while updating the docs...

In #147, I added a directory to `static`. I tested it locally with the binary... but didn't think to test it inside the docker container. So now, the app immediately crashes because it can't read those files.

This fixes it. According to Docker, `COPY` is preferred over `ADD` anyway: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy