### PR TITLE
Adding some developer-focused docs

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Development
+
+During development, run the unit tests with:
+
+```bash
+./validate.sh
+```
+New submissions *must* include unit tests. Bugfixes should include a test which prevents that bug from being re-introduced in the future.
+
+## Pull Requests
+
+When your changes are complete, run the tests with code coverage and strict format checking:
+
+```bash
+./validate.sh --nofmt --cov
+```
+
+All pull requests must have 90% coverage. View your coverage report with:
+
+```bash
+./scripts/coverage.sh --html
+```
+
+When you're ready, [submit a Pull Request](https://help.github.com/articles/creating-a-pull-request/) against
+[our GitHub repository](https://github.com/prebid/prebid-server/compare).
+These same tests will be run with [Travis CI](https://travis-ci.com/).
+
+If the tests pass locally, but fail on your PR, make sure to `git pull` the latest code from `master`.
+
+**Note**: We also have some [known intermittent failures](https://github.com/prebid/prebid-server/issues/103).
+          If the tests still fail after pulling `master`, don't worry about it. We'll re-run them when we review your PR.

--- a/docs/developers/deployment.md
+++ b/docs/developers/deployment.md
@@ -15,7 +15,7 @@ docker build -t prebid-server .
 Test locally with:
 
 ```bash
-docker run -p 8000:8000 -t prebid-cache
+docker run -p 8000:8000 -t prebid-server
 ```
 
 The server can be reached at `http://localhost:8000`.

--- a/docs/developers/deployment.md
+++ b/docs/developers/deployment.md
@@ -1,0 +1,21 @@
+# Deployment
+
+## Packaging
+
+Prebid Server is [packaged with Docker](https://www.docker.com/what-docker) and
+optimized to create [lightweight containers](https://blog.codeship.com/building-minimal-docker-containers-for-go-applications/).
+
+[Install Docker](https://www.docker.com/community-edition#/download) and build a container:
+
+```bash
+CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' .
+docker build -t prebid-server .
+```
+
+Test locally with:
+
+```bash
+docker run -p 8000:8000 -t prebid-cache
+```
+
+The server can be reached at `http://localhost:8000`.


### PR DESCRIPTION
Adding some contribution guidelines and info of how to package the app using docker. The latter is slated to be removed from the `README` in #165.