### PR TITLE
Update to use openrtb v9.0.0

### DIFF
--- a/adapters/appnexus.go
+++ b/adapters/appnexus.go
@@ -99,9 +99,9 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		}
 		if anReq.Imp[i].Banner != nil && params.Position != "" {
 			if params.Position == "above" {
-				anReq.Imp[i].Banner.Pos = 1
+				anReq.Imp[i].Banner.Pos = openrtb.AdPositionAboveTheFold.Ptr()
 			} else if params.Position == "below" {
-				anReq.Imp[i].Banner.Pos = 3
+				anReq.Imp[i].Banner.Pos = openrtb.AdPositionBelowTheFold.Ptr()
 			}
 		}
 

--- a/adapters/appnexus_test.go
+++ b/adapters/appnexus_test.go
@@ -145,11 +145,11 @@ func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, fmt.Sprintf("Empty imp.banner.format array"), http.StatusInternalServerError)
 				return
 			}
-			if andata.tags[i].position == "above" && imp.Banner.Pos != 1 {
+			if andata.tags[i].position == "above" && *imp.Banner.Pos != openrtb.AdPosition(1) {
 				http.Error(w, fmt.Sprintf("Mismatch in position - expected 1 for atf"), http.StatusInternalServerError)
 				return
 			}
-			if andata.tags[i].position == "below" && imp.Banner.Pos != 3 {
+			if andata.tags[i].position == "below" && *imp.Banner.Pos != openrtb.AdPosition(3) {
 				http.Error(w, fmt.Sprintf("Mismatch in position - expected 3 for btf"), http.StatusInternalServerError)
 				return
 			}
@@ -180,7 +180,7 @@ func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if imp.Video != nil {
-			resBid.Attr = []int8{6}
+			resBid.Attr = []openrtb.CreativeAttribute{openrtb.CreativeAttribute(6)}
 		}
 		resp.SeatBid[0].Bid = append(resp.SeatBid[0].Bid, resBid)
 	}

--- a/adapters/facebook.go
+++ b/adapters/facebook.go
@@ -137,17 +137,17 @@ func (a *FacebookAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs
 
 		// if instl = 1 sent in, pass size (0,0) to facebook
 		if fbReq.Imp[0].Instl == 1 && fbReq.Imp[0].Banner != nil {
-			fbReq.Imp[0].Banner.W = 0
-			fbReq.Imp[0].Banner.H = 0
+			fbReq.Imp[0].Banner.W = openrtb.Uint64Ptr(0)
+			fbReq.Imp[0].Banner.H = openrtb.Uint64Ptr(0)
 		}
 		// if instl = 0 and type is banner, do not send non supported size
 		if fbReq.Imp[0].Instl == 0 && fbReq.Imp[0].Banner != nil {
-			if !supportedHeight[fbReq.Imp[0].Banner.H] {
+			if !supportedHeight[*fbReq.Imp[0].Banner.H] {
 				return fbReq, errors.New("Facebook do not support banner height other than 50, 90 and 250")
 			}
 			// do not send legacy 320x50 size to facebook, instead use 0x50
-			if fbReq.Imp[0].Banner.W == 320 && fbReq.Imp[0].Banner.H == 50 {
-				fbReq.Imp[0].Banner.W = 0
+			if *fbReq.Imp[0].Banner.W == 320 && *fbReq.Imp[0].Banner.H == 50 {
+				fbReq.Imp[0].Banner.W = openrtb.Uint64Ptr(0)
 			}
 		}
 		return fbReq, nil

--- a/adapters/facebook_test.go
+++ b/adapters/facebook_test.go
@@ -115,12 +115,12 @@ func DummyFacebookServer(w http.ResponseWriter, r *http.Request) {
 				90:  true,
 				250: true,
 			}
-			if !supportedHeight[breq.Imp[0].Banner.H] {
+			if !supportedHeight[*breq.Imp[0].Banner.H] {
 				http.Error(w, fmt.Sprintf("Height '%d' not supported", breq.Imp[0].Banner.H), http.StatusBadRequest)
 				return
 			}
 		} else if breq.Imp[0].Instl == 1 {
-			if breq.Imp[0].Banner.H != 0 || breq.Imp[0].Banner.W != 0 {
+			if *breq.Imp[0].Banner.H != 0 || *breq.Imp[0].Banner.W != 0 {
 				http.Error(w, fmt.Sprintf("Width and height should be 0, 0 for instl type"), http.StatusBadRequest)
 				return
 			}
@@ -532,11 +532,11 @@ func TestGenerateRequestsForFacebook(t *testing.T) {
 	if len(openrtbRequests[1].Imp) != 1 {
 		t.Fatalf("Should only generate 1 imp per ad unit")
 	}
-	if openrtbRequests[0].Imp[0].Banner.W != 0 || openrtbRequests[0].Imp[0].Banner.H != 0 {
+	if *openrtbRequests[0].Imp[0].Banner.W != 0 || *openrtbRequests[0].Imp[0].Banner.H != 0 {
 		t.Fatalf("Should be generating 0x0 for interstitial type")
 	}
 
-	if openrtbRequests[1].Imp[0].Banner.W != 0 {
+	if *openrtbRequests[1].Imp[0].Banner.W != 0 {
 		t.Fatalf("Should be passing width 0 for size 320x50")
 	}
 

--- a/adapters/lifestreet_test.go
+++ b/adapters/lifestreet_test.go
@@ -81,8 +81,8 @@ func DummyLifestreetServer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Model '%s' doesn't match '%s", breq.Device.Model, lsdata.deviceModel), http.StatusInternalServerError)
 		return
 	}
-	if breq.Device.Connectiontype != lsdata.deviceConnectiontype {
-		http.Error(w, fmt.Sprintf("Connectiontype '%s' doesn't match '%s", breq.Device.Connectiontype, lsdata.deviceConnectiontype), http.StatusInternalServerError)
+	if *breq.Device.ConnectionType != openrtb.ConnectionType(lsdata.deviceConnectiontype) {
+		http.Error(w, fmt.Sprintf("Connectiontype '%s' doesn't match '%s", breq.Device.ConnectionType, lsdata.deviceConnectiontype), http.StatusInternalServerError)
 		return
 	}
 	if breq.Device.IFA != lsdata.deviceIfa {
@@ -99,7 +99,7 @@ func DummyLifestreetServer(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("No banner object sent"), http.StatusInternalServerError)
 			return
 		}
-		if breq.Imp[0].Banner.W != lsdata.width || breq.Imp[0].Banner.H != lsdata.height {
+		if *breq.Imp[0].Banner.W != lsdata.width || *breq.Imp[0].Banner.H != lsdata.height {
 			http.Error(w, fmt.Sprintf("Size '%dx%d' doesn't match '%dx%d", breq.Imp[0].Banner.W, breq.Imp[0].Banner.H, lsdata.width, lsdata.height), http.StatusInternalServerError)
 			return
 		}
@@ -186,7 +186,7 @@ func TestLifestreetBasicResponse(t *testing.T) {
 			IP:             lsdata.deviceIP,
 			Make:           lsdata.deviceMake,
 			Model:          lsdata.deviceModel,
-			Connectiontype: lsdata.deviceConnectiontype,
+			ConnectionType: openrtb.ConnectionType(lsdata.deviceConnectiontype).Ptr(),
 			IFA:            lsdata.deviceIfa,
 		},
 	}

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -38,8 +38,8 @@ func commonMediaTypes(l1 []pbs.MediaType, l2 []pbs.MediaType) []pbs.MediaType {
 
 func makeBanner(unit pbs.PBSAdUnit) *openrtb.Banner {
 	return &openrtb.Banner{
-		W:        unit.Sizes[0].W,
-		H:        unit.Sizes[0].H,
+		W:        openrtb.Uint64Ptr(unit.Sizes[0].W),
+		H:        openrtb.Uint64Ptr(unit.Sizes[0].H),
 		Format:   copyFormats(unit.Sizes), // defensive copy because adapters may mutate Imps, and this is shared data
 		TopFrame: unit.TopFrame,
 	}
@@ -52,11 +52,13 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	}
 	mimes := make([]string, len(unit.Video.Mimes))
 	copy(mimes, unit.Video.Mimes)
-	pbm := make([]int8, 1)
+	pbm := make([]openrtb.PlaybackMethod, 1)
 	//this will become int8 soon, so we only care about the first index in the array
-	pbm[0] = unit.Video.PlaybackMethod
-	if pbm[0] == 0 {
-		pbm = nil
+	pbm[0] = openrtb.PlaybackMethod(unit.Video.PlaybackMethod)
+
+	protocols := make([]openrtb.Protocol, len(unit.Video.Protocols))
+	for _, protocol := range unit.Video.Protocols {
+		protocols = append(protocols, openrtb.Protocol(protocol))
 	}
 	return &openrtb.Video{
 		MIMEs:          mimes,
@@ -64,9 +66,9 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 		MaxDuration:    unit.Video.Maxduration,
 		W:              unit.Sizes[0].W,
 		H:              unit.Sizes[0].H,
-		StartDelay:     unit.Video.Startdelay,
+		StartDelay:     openrtb.StartDelay(unit.Video.Startdelay).Ptr(),
 		PlaybackMethod: pbm,
-		Protocols:      unit.Video.Protocols,
+		Protocols:      protocols,
 	}
 }
 

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -56,7 +56,7 @@ func makeVideo(unit pbs.PBSAdUnit) *openrtb.Video {
 	//this will become int8 soon, so we only care about the first index in the array
 	pbm[0] = openrtb.PlaybackMethod(unit.Video.PlaybackMethod)
 
-	protocols := make([]openrtb.Protocol, len(unit.Video.Protocols))
+	protocols := make([]openrtb.Protocol, 0, len(unit.Video.Protocols))
 	for _, protocol := range unit.Video.Protocols {
 		protocols = append(protocols, openrtb.Protocol(protocol))
 	}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -52,8 +52,8 @@ func TestOpenRTB(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
-	assert.EqualValues(t, resp.Imp[0].Banner.H, 12)
+	assert.EqualValues(t, *resp.Imp[0].Banner.W, 10)
+	assert.EqualValues(t, *resp.Imp[0].Banner.H, 12)
 	assert.EqualValues(t, resp.Imp[0].Instl, 1)
 }
 
@@ -89,8 +89,8 @@ func TestOpenRTBVideo(t *testing.T) {
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
 	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
-	assert.EqualValues(t, resp.Imp[0].Video.StartDelay, 5)
-	assert.EqualValues(t, resp.Imp[0].Video.PlaybackMethod, []int8{1})
+	assert.EqualValues(t, *resp.Imp[0].Video.StartDelay, openrtb.StartDelay(5))
+	assert.EqualValues(t, resp.Imp[0].Video.PlaybackMethod, []openrtb.PlaybackMethod{openrtb.PlaybackMethod(1)})
 	assert.EqualValues(t, resp.Imp[0].Video.MIMEs, []string{"video/mp4"})
 }
 
@@ -193,7 +193,7 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
+	assert.EqualValues(t, *resp.Imp[0].Banner.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Video.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
 	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
@@ -229,7 +229,7 @@ func TestOpenRTBMultiMediaImpFiltered(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[0].Banner.W, 10)
+	assert.EqualValues(t, *resp.Imp[0].Banner.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Video, (*openrtb.Video)(nil))
 }
 
@@ -266,7 +266,7 @@ func TestOpenRTBSingleMediaImp(t *testing.T) {
 	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
 	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
 	assert.Equal(t, resp.Imp[1].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[1].Banner.W, 10)
+	assert.EqualValues(t, *resp.Imp[1].Banner.W, 10)
 }
 
 func TestOpenRTBNoSize(t *testing.T) {
@@ -331,8 +331,8 @@ func TestOpenRTBMobile(t *testing.T) {
 	resp, err := makeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[0].Banner.W, 300)
-	assert.EqualValues(t, resp.Imp[0].Banner.H, 250)
+	assert.EqualValues(t, *resp.Imp[0].Banner.W, 300)
+	assert.EqualValues(t, *resp.Imp[0].Banner.H, 250)
 
 	assert.EqualValues(t, resp.App.Bundle, "AppNexus.PrebidMobileDemo")
 	assert.EqualValues(t, resp.App.Publisher.ID, "1995257847363113")

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -426,3 +426,31 @@ func TestSizesCopy(t *testing.T) {
 		t.Error("The Format.Ext property should point to two different instances")
 	}
 }
+
+func TestMakeVideo(t *testing.T) {
+	adUnit := pbs.PBSAdUnit{
+		Code:       "unitCode",
+		MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO},
+		Sizes: []openrtb.Format{
+			{
+				W: 10,
+				H: 12,
+			},
+		},
+		Video: pbs.PBSVideo{
+			Mimes:          []string{"video/mp4"},
+			Minduration:    15,
+			Maxduration:    30,
+			Startdelay:     5,
+			Skippable:      0,
+			PlaybackMethod: 1,
+			Protocols:      []int8{1, 2, 5, 6},
+		},
+	}
+	video := makeVideo(adUnit)
+	assert.EqualValues(t, video.MinDuration, 15)
+	assert.EqualValues(t, video.MaxDuration, 30)
+	assert.EqualValues(t, *video.StartDelay, openrtb.StartDelay(5))
+	assert.EqualValues(t, len(video.PlaybackMethod), 1)
+	assert.EqualValues(t, len(video.Protocols), 4)
+}

--- a/adapters/pubmatic.go
+++ b/adapters/pubmatic.go
@@ -115,8 +115,8 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 					}
 
 					pbReq.Imp[i].TagID = strings.TrimSpace(adSlot[0])
-					pbReq.Imp[i].Banner.H = uint64(height)
-					pbReq.Imp[i].Banner.W = uint64(width)
+					pbReq.Imp[i].Banner.H = openrtb.Uint64Ptr(uint64(height))
+					pbReq.Imp[i].Banner.W = openrtb.Uint64Ptr(uint64(width))
 					adSlotFlag = true
 				} else {
 					glog.Warningf(PrepareLogMessage(pbReq.ID, params.PublisherId, unit.Code, unit.BidID,

--- a/adapters/pubmatic_test.go
+++ b/adapters/pubmatic_test.go
@@ -60,8 +60,8 @@ func DummyPubMaticServer(w http.ResponseWriter, r *http.Request) {
 			AdID:   fmt.Sprintf("adID-%d", i),
 			AdM:    "AdContent",
 			CrID:   fmt.Sprintf("creative-%d", i),
-			W:      imp.Banner.W,
-			H:      imp.Banner.H,
+			W:      *imp.Banner.W,
+			H:      *imp.Banner.H,
 			DealID: fmt.Sprintf("DealID_%d", i),
 		})
 	}

--- a/adapters/pulsepoint.go
+++ b/adapters/pulsepoint.go
@@ -87,13 +87,13 @@ func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 			if len(size) == 2 {
 				width, err := strconv.Atoi(size[0])
 				if err == nil {
-					ppReq.Imp[i].Banner.W = uint64(width)
+					ppReq.Imp[i].Banner.W = openrtb.Uint64Ptr(uint64(width))
 				} else {
 					return nil, fmt.Errorf("Invalid Width param %s", size[0])
 				}
 				height, err := strconv.Atoi(size[1])
 				if err == nil {
-					ppReq.Imp[i].Banner.H = uint64(height)
+					ppReq.Imp[i].Banner.H = openrtb.Uint64Ptr(uint64(height))
 				} else {
 					return nil, fmt.Errorf("Invalid Height param %s", size[1])
 				}

--- a/adapters/pulsepoint_test.go
+++ b/adapters/pulsepoint_test.go
@@ -92,8 +92,8 @@ func TestPulsePointOpenRTBRequest(t *testing.T) {
 	VerifyIntValue(len(service.LastBidRequest.Imp), 1, t)
 	VerifyStringValue(service.LastBidRequest.Imp[0].TagID, "1001", t)
 	VerifyStringValue(service.LastBidRequest.Site.Publisher.ID, "2001", t)
-	VerifyIntValue(int(service.LastBidRequest.Imp[0].Banner.W), 728, t)
-	VerifyIntValue(int(service.LastBidRequest.Imp[0].Banner.H), 90, t)
+	VerifyIntValue(int(*service.LastBidRequest.Imp[0].Banner.W), 728, t)
+	VerifyIntValue(int(*service.LastBidRequest.Imp[0].Banner.H), 90, t)
 }
 
 /**
@@ -304,7 +304,7 @@ func CreateService(tagsToBid map[string]bool) PulsePointOrtbMockService {
 		var bids []openrtb.Bid
 		for i, imp := range breq.Imp {
 			if tagsToBid[imp.TagID] {
-				bids = append(bids, SampleBid(int(imp.Banner.W), int(imp.Banner.H), imp.ID, i+1))
+				bids = append(bids, SampleBid(int(*imp.Banner.W), int(*imp.Banner.H), imp.ID, i+1))
 			}
 		}
 		// no bids were produced, pulsepoint service returns 204

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bbcb2501de5b89169fcba133707aaa1ece150de1f4ffade394e628fbe7fdf6f2
-updated: 2017-10-06T09:04:36.014507258-04:00
+hash: feca4c103cd7b2467d1af455bd9f78334868740d70da29b48023f0d55db80808
+updated: 2017-10-19T15:37:35.714422661-04:00
 imports:
 - name: github.com/blang/semver
   version: 4a1e882c79dcf4ec00d2e29fac74b9c8938d5052
@@ -45,7 +45,7 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: cc8532a8e9a55ea36402aa21efdf403a60d34096
 - name: github.com/mxmCherry/openrtb
-  version: af5bbec3623c8140b3f381af8ddcb1fce268d7d2
+  version: 53a357476a774def318ed6c4d8d4105787d3bd90
 - name: github.com/pelletier/go-buffruneio
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/julienschmidt/httprouter
   version: ~1.1.0
 - package: github.com/mxmCherry/openrtb
-  version: ~6.0.0
+  version: ~9.0.0
 - package: github.com/rcrowley/go-metrics
 - package: github.com/spf13/viper
 - package: github.com/vrischmann/go-metrics-influxdb


### PR DESCRIPTION
This updates to use openrtb v9.0.0 where Banner W,H are now *uint64 instead of uint64. This change is required for us to pass through 0 values for width and height for FB demand for Prebid Mobile.

List of other changes since v6.0.0 are [here](https://github.com/mxmCherry/openrtb/releases)