### PR TITLE
Built scalable structure for cache in config and moved cache url formation to config module

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Configuration struct {
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
 	CacheHost       string             `mapstructure:"prebid_cache_host"`
-	CacheMacro		string             `mapstructure:"prebid_cache_macros"`
+	CacheMacro      string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheUrl        Cache              `mapstructure:"cache"`
+	CacheURL        Cache              `mapstructure:"cache"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`
@@ -72,10 +72,10 @@ func New() (*Configuration, error) {
 	return &c, nil
 }
 
-func (cfg *Configuration) GetCacheUrl(uuid string) string {
+func (cfg *Configuration) GetCacheURL(uuid string) string {
 	var buffer bytes.Buffer
-	buffer.WriteString(cfg.CacheUrl.Host)
+	buffer.WriteString(cfg.CacheURL.Host)
 	buffer.WriteString("/cache?")
-	buffer.WriteString(strings.Replace(cfg.CacheUrl.Query, "%PBS_CACHE_UUID%", uuid, 1))
+	buffer.WriteString(strings.Replace(cfg.CacheURL.Query, "%PBS_CACHE_UUID%", uuid, 1))
 	return buffer.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,8 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheURL        string             `mapstructure:"prebid_cache_url"`
+	CacheHost       string             `mapstructure:"prebid_cache_host"`
+	CacheMacro		string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,8 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheHost       string             `mapstructure:"prebid_cache_host"`
-	CacheMacro      string             `mapstructure:"prebid_cache_macros"`
+	CacheUrl        string             `mapstructure:"prebid_cache_url"`
+	Macros          string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 // Configuration
@@ -11,8 +13,7 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheUrl        string             `mapstructure:"prebid_cache_url"`
-	Macros          string             `mapstructure:"macros"`
+	CacheUrl        Cache              `mapstructure:"cache"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`
@@ -57,6 +58,11 @@ type DataCache struct {
 	TTLSeconds int    `mapstructure:"ttl_seconds"`
 }
 
+type Cache struct {
+	Host  string `mapstructure:"host"`
+	Query string `mapstructure:"query"`
+}
+
 // New uses viper to get our server configurations
 func New() (*Configuration, error) {
 	var c Configuration
@@ -64,4 +70,12 @@ func New() (*Configuration, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (cfg *Configuration) GetCacheUrl(uuid string) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(cfg.CacheUrl.Host)
+	buffer.WriteString("/cache?")
+	buffer.WriteString(strings.Replace(cfg.CacheUrl.Query, "%PBS_CACHE_UUID%", uuid, 1))
+	return buffer.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"github.com/spf13/viper"
 	"strings"
+	"fmt"
 )
 
 // Configuration
@@ -59,6 +60,7 @@ type DataCache struct {
 }
 
 type Cache struct {
+	Scheme string `mapstructure:"scheme"`
 	Host  string `mapstructure:"host"`
 	Query string `mapstructure:"query"`
 }
@@ -74,8 +76,6 @@ func New() (*Configuration, error) {
 
 func (cfg *Configuration) GetCacheURL(uuid string) string {
 	var buffer bytes.Buffer
-	buffer.WriteString(cfg.CacheURL.Host)
-	buffer.WriteString("/cache?")
-	buffer.WriteString(strings.Replace(cfg.CacheURL.Query, "%PBS_CACHE_UUID%", uuid, 1))
+	fmt.Fprintf(&buffer, "%s://%s/cache?%s", cfg.CacheURL.Scheme,cfg.CacheURL.Host, strings.Replace(cfg.CacheURL.Query, "%PBS_CACHE_UUID%", uuid, 1))
 	return buffer.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Configuration struct {
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
 	CacheUrl        string             `mapstructure:"prebid_cache_url"`
-	Macros          string             `mapstructure:"prebid_cache_macros"`
+	Macros          string             `mapstructure:"macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,8 +66,9 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_url: http://prebidcache.net
-macros: uuid=%PBS_CACHE_UUID%
+cache:
+  host: http://prebidcache.net
+  query: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -129,8 +130,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
-	cmpStrings(t, "macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "cache.host", cfg.CacheUrl.Host, "http://prebidcache.net")
+	cmpStrings(t, "cache.query", cfg.CacheUrl.Query, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,8 +130,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "cache.host", cfg.CacheUrl.Host, "http://prebidcache.net")
-	cmpStrings(t, "cache.query", cfg.CacheUrl.Query, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "http://prebidcache.net")
+	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,7 +66,7 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_host: http://prebidcache.net
+prebid_cache_url: http://prebidcache.net
 prebid_cache_macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
@@ -129,8 +129,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_host", cfg.CacheHost, "http://prebidcache.net")
-	cmpStrings(t, "prebid_cache_macros", cfg.CacheMacro, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
+	cmpStrings(t, "prebid_cache_macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,7 +66,8 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_url: http://prebidcache.net/test/a1?qs=something
+prebid_cache_host: http://prebidcache.net
+prebid_cache_macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -128,7 +129,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_url", cfg.CacheURL, "http://prebidcache.net/test/a1?qs=something")
+	cmpStrings(t, "prebid_cache_host", cfg.CacheHost, "http://prebidcache.net")
+	cmpStrings(t, "prebid_cache_macros", cfg.CacheMacro, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,7 +67,7 @@ port: 1234
 admin_port: 5678
 default_timeout_ms: 123
 prebid_cache_url: http://prebidcache.net
-prebid_cache_macros: uuid=%PBS_CACHE_UUID%
+macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -130,7 +130,7 @@ func TestFullConfig(t *testing.T) {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
 	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
-	cmpStrings(t, "prebid_cache_macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,7 +67,8 @@ port: 1234
 admin_port: 5678
 default_timeout_ms: 123
 cache:
-  host: http://prebidcache.net
+  scheme: http
+  host: prebidcache.net
   query: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
@@ -130,7 +131,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "http://prebidcache.net")
+	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")
+	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "prebidcache.net")
 	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -43,7 +43,7 @@ type PBSBid struct {
 	CacheID string `json:"cache_id,omitempty"`
 	// Complete cache url returned from the prebid-cache.
 	// more flexible than a design that assumes the UUID is always appended to the end of the URL.
-	CacheUrl string `json:"cache_url,omitempty"`
+	CacheURL string `json:"cache_url,omitempty"`
 	// ResponseTime is the number of milliseconds it took for the adapter to return a bid.
 	ResponseTime      int               `json:"response_time_ms,omitempty"`
 	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -41,6 +41,9 @@ type PBSBid struct {
 	// CacheId is an ID in prebid-cache which can be used to fetch this ad's content.
 	// This supports prebid-mobile, which requires that the content be available from a URL.
 	CacheID string `json:"cache_id,omitempty"`
+	// Complete cache url returned from the prebid-cache.
+	// more flexible than a design that assumes the UUID is always appended to the end of the URL.
+	CacheUrl string `json:"cache_url,omitempty"`
 	// ResponseTime is the number of milliseconds it took for the adapter to return a bid.
 	ResponseTime      int               `json:"response_time_ms,omitempty"`
 	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -313,7 +313,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.CacheHost + "/cache?" + strings.Replace(deps.cfg.CacheMacro, "%PBS_CACHE_UUID%", bid.CacheID, 1);
+			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1);
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -714,7 +714,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheHost)
+	pbc.InitPrebidCache(cfg.CacheUrl)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -312,7 +312,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.GetCacheUrl(bid.CacheID)
+			bid.CacheURL = deps.cfg.GetCacheURL(bid.CacheID)
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -713,7 +713,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheUrl.Host)
+	pbc.InitPrebidCache(cfg.CacheURL.Host)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -713,7 +713,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheURL.Host)
+	pbc.InitPrebidCache(cfg.CacheURL)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -313,7 +313,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1);
+			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1)
 			bid.NURL = ""
 			bid.Adm = ""
 		}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
-	"strings"
 )
 
 var hostCookieSettings pbs.HostCookieSettings
@@ -313,7 +312,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1)
+			bid.CacheUrl = deps.cfg.GetCacheUrl(bid.CacheID)
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -714,7 +713,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheUrl)
+	pbc.InitPrebidCache(cfg.CacheUrl.Host)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
+	"strings"
 )
 
 var hostCookieSettings pbs.HostCookieSettings
@@ -154,7 +155,8 @@ func (deps *cookieSyncDeps) cookieSync(w http.ResponseWriter, r *http.Request, _
 }
 
 type auctionDeps struct {
-	m *pbsmetrics.Metrics
+	m   *pbsmetrics.Metrics
+	cfg *config.Configuration
 }
 
 func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -311,6 +313,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
+			bid.CacheUrl = deps.cfg.CacheHost + "/cache?" + strings.Replace(deps.cfg.CacheMacro, "%PBS_CACHE_UUID%", bid.CacheID, 1);
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -682,7 +685,7 @@ func serve(cfg *config.Configuration) error {
 	})()
 
 	router := httprouter.New()
-	router.POST("/auction", (&auctionDeps{m}).auction)
+	router.POST("/auction", (&auctionDeps{m, cfg}).auction)
 	router.GET("/bidders/params", NewJsonDirectoryServer(schemaDirectory))
 	router.POST("/cookie_sync", (&cookieSyncDeps{m}).cookieSync)
 	router.POST("/validate", validate)
@@ -711,7 +714,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheURL)
+	pbc.InitPrebidCache(cfg.CacheHost)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/prebid_cache_client/prebid_cache.go
+++ b/prebid_cache_client/prebid_cache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/prebid/prebid-server/config"
 	"golang.org/x/net/context/ctxhttp"
 )
 
@@ -24,7 +25,7 @@ type BidCache struct {
 
 // internal protocol objects
 type putObject struct {
-	Type  string  `json:"type"`
+	Type  string    `json:"type"`
 	Value *BidCache `json:"value"`
 }
 
@@ -40,15 +41,13 @@ type response struct {
 }
 
 var (
-	client  *http.Client
-	baseURL string
-	putURL  string
+	client *http.Client
+	putURL string
 )
 
 // InitPrebidCache setup the global prebid cache
-func InitPrebidCache(baseurl string) {
-	baseURL = baseurl
-	putURL = fmt.Sprintf("%s/cache", baseURL)
+func InitPrebidCache(cacheURL config.Cache) {
+	putURL = fmt.Sprintf("%s://%s/cache", cacheURL.Scheme, cacheURL.Host)
 
 	ts := &http.Transport{
 		MaxIdleConns:    10,

--- a/prebid_cache_client/prebid_cache_test.go
+++ b/prebid_cache_client/prebid_cache_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"fmt"
+	"strings"
+	"github.com/prebid/prebid-server/config"
 )
 
 var delay time.Duration
@@ -109,7 +111,12 @@ func TestPrebidClient(t *testing.T) {
 				},
 	}
 
-	InitPrebidCache(server.URL)
+	var serverURL = strings.Split(server.URL, "://")
+	var cache = config.Cache{
+		serverURL[0],
+		serverURL[1],
+		""}
+	InitPrebidCache(cache)
 
 	ctx := context.TODO()
 	err := Put(ctx, cobj)


### PR DESCRIPTION
Addressed the following requested changes:

1. consolidate the "cache configs" in a struct to help keep the config organized, and we'll have a scalable structure if people want to add config options for the scheme, port, etc, later.
2. String concatenation could be very inefficient, since each string concatenation makes a new string & copies the old one - so used bytes.buffer to optimize.
3. Move cache url formation into a function in config module.


