### PR TITLE
Added missing setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ For more information, see:
 
 ## Installation
 
-First install [Go 1.9.1](https://golang.org/doc/install) and [Glide](https://github.com/Masterminds/glide#install).
+First install [Go 1.9.1](https://golang.org/doc/install) and [Glide](https://github.com/Masterminds/glide#install). Note that Glide requires an explicit GOPATH to be set.
+
+```bash
+export GOPATH=$(go env GOPATH)
+mkdir -p $GOPATH
+```
 
 Then download and prepare Prebid Server:
 


### PR DESCRIPTION
For a first time setup, Glide fails unless GOPATH is set explicitly.

```bash
enel@enel:~/go/src/github.com/prebid/prebid-server$ glide install
[ERROR]	$GOPATH is not set.
```