### PR TITLE
Closes #185: Add mobile support to Rubicon adapter

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -52,9 +52,15 @@ type rubiconParams struct {
 	Visitor   json.RawMessage `json:"visitor"`
 }
 
+type rubiconImpExtRPTrack struct {
+	Mint        string `json:"mint"`
+	MintVersion string `json:"mint_version"`
+}
+
 type rubiconImpExtRP struct {
-	ZoneID int             `json:"zone_id"`
-	Target json.RawMessage `json:"target"`
+	ZoneID int                  `json:"zone_id"`
+	Target json.RawMessage      `json:"target"`
+	Track  rubiconImpExtRPTrack `json:"track"`
 }
 
 type rubiconImpExt struct {
@@ -106,6 +112,18 @@ type rubiconTargetingExtRP struct {
 type rubiconTargetingObj struct {
 	Key    string   `json:"key"`
 	Values []string `json:"values"`
+}
+
+type rubiconDeviceExtRP struct {
+	PixelRatio float64 `json:"pixelratio"`
+}
+
+type rubiconDeviceExt struct {
+	RP rubiconDeviceExtRP `json:"rp"`
+}
+
+type rubiconUser struct {
+	Language string `json:"language"`
 }
 
 type rubiSize struct {
@@ -281,9 +299,15 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 			return nil, errors.New("Missing zoneId param")
 		}
 
+		var mint, mintVersion string
+		mint = "prebid"
+		mintVersion = req.SDK.Source + "_" + req.SDK.Platform + "_" + req.SDK.Version
+		track := rubiconImpExtRPTrack{Mint: mint, MintVersion: mintVersion}
+
 		impExt := rubiconImpExt{RP: rubiconImpExtRP{
 			ZoneID: params.ZoneId,
 			Target: params.Inventory,
+			Track:  track,
 		}}
 		rubiReq.Imp[0].Ext, err = json.Marshal(&impExt)
 
@@ -294,6 +318,11 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 		userCopy.Ext, err = json.Marshal(&userExt)
 		// Assign back our copy
 		rubiReq.User = &userCopy
+
+		deviceCopy := *rubiReq.Device
+		deviceExt := rubiconDeviceExt{RP: rubiconDeviceExtRP{PixelRatio: rubiReq.Device.PxRatio}}
+		deviceCopy.Ext, err = json.Marshal(&deviceExt)
+		rubiReq.Device = &deviceCopy
 
 		primarySizeID, altSizeIDs, err := parseRubiconSizes(unit.Sizes)
 		if err != nil {
@@ -310,6 +339,13 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 			siteCopy.Publisher = &openrtb.Publisher{}
 			siteCopy.Publisher.Ext, err = json.Marshal(&pubExt)
 			rubiReq.Site = &siteCopy
+		} else {
+			var rubiconUser rubiconUser
+			err = json.Unmarshal(req.PBSUser, &rubiconUser)
+			site := &openrtb.Site{}
+			site.Content = &openrtb.Content{}
+			site.Content.Language = rubiconUser.Language
+			rubiReq.Site = site
 		}
 		if rubiReq.App != nil {
 			appCopy := *rubiReq.App

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -48,6 +48,10 @@ type rubiBidInfo struct {
 	delay              time.Duration
 	visitorTargeting   string
 	inventoryTargeting string
+	sdkVersion         string
+	sdkPlatform        string
+	sdkSource          string
+	devicePxRatio      float64
 }
 
 var rubidata rubiBidInfo
@@ -83,6 +87,15 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 	impTargetingString, _ := json.Marshal(&rix.RP.Target)
 	if string(impTargetingString) != rubidata.inventoryTargeting {
 		http.Error(w, fmt.Sprintf("Inventory FPD targeting '%s' doesn't match '%s'", string(impTargetingString), rubidata.inventoryTargeting), http.StatusInternalServerError)
+		return
+	}
+	if rix.RP.Track.Mint != "prebid" {
+		http.Error(w, fmt.Sprintf("Track mint '%s' doesn't match '%s'", rix.RP.Track.Mint, "prebid"), http.StatusInternalServerError)
+		return
+	}
+	mintVersionString := rubidata.sdkSource + "_" + rubidata.sdkPlatform + "_" + rubidata.sdkVersion
+	if rix.RP.Track.MintVersion != mintVersionString {
+		http.Error(w, fmt.Sprintf("Track mint version '%s' doesn't match '%s'", rix.RP.Track.MintVersion, mintVersionString), http.StatusInternalServerError)
 		return
 	}
 
@@ -188,6 +201,10 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("IP '%s' doesn't match '%s'", breq.Device.IP, rubidata.deviceIP), http.StatusInternalServerError)
 		return
 	}
+	if breq.Device.PxRatio != rubidata.devicePxRatio {
+		http.Error(w, fmt.Sprintf("Pixel ratio '%f' doesn't match '%f'", breq.Device.PxRatio, rubidata.devicePxRatio), http.StatusInternalServerError)
+		return
+	}
 	if breq.User.BuyerUID != rubidata.buyerUID {
 		http.Error(w, fmt.Sprintf("User ID '%s' doesn't match '%s'", breq.User.BuyerUID, rubidata.buyerUID), http.StatusInternalServerError)
 		return
@@ -233,6 +250,10 @@ func TestRubiconBasicResponse(t *testing.T) {
 		buyerUID:           "need-an-actual-rp-id",
 		visitorTargeting:   "[\"v1\",\"v2\"]",
 		inventoryTargeting: "[\"i1\",\"i2\"]",
+		sdkVersion:         "2.0.0",
+		sdkPlatform:        "iOS",
+		sdkSource:          "some-sdk",
+		devicePxRatio:      4.0,
 	}
 
 	targeting := make(map[string]string, 2)
@@ -258,6 +279,8 @@ func TestRubiconBasicResponse(t *testing.T) {
 
 	pbin := pbs.PBSRequest{
 		AdUnits: make([]pbs.AdUnit, 2),
+		Device:  &openrtb.Device{PxRatio: rubidata.devicePxRatio},
+		SDK:     &pbs.SDK{Source: rubidata.sdkSource, Platform: rubidata.sdkPlatform, Version: rubidata.sdkVersion},
 	}
 	for i, tag := range rubidata.tags {
 		pbin.AdUnits[i] = pbs.AdUnit{


### PR DESCRIPTION
Updated rubicon adapter to support sdk version, device pixel ratio, and user language. Initial commit to support mobile.