### PR TITLE
Made the config accessible for adapter construction.

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -406,3 +406,22 @@ func NewAppNexusAdapter(config *adapters.HTTPAdapterConfig, externalURL string) 
 		usersyncInfo: info,
 	}
 }
+
+func NewAppNexusBidder(client *http.Client, externalURL string) *AppNexusAdapter {
+	a := &adapters.HTTPAdapter{Client: client}
+
+	redirect_uri := fmt.Sprintf("%s/setuid?bidder=adnxs&uid=$UID", externalURL)
+	usersyncURL := "//ib.adnxs.com/getuid?"
+
+	info := &pbs.UsersyncInfo{
+		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
+		Type:        "redirect",
+		SupportCORS: false,
+	}
+
+	return &AppNexusAdapter{
+		http:         a,
+		URI:          uri,
+		usersyncInfo: info,
+	}
+}

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -389,22 +389,7 @@ func getMediaTypeForImp(impId string, imps []openrtb.Imp) openrtb_ext.BidType {
 }
 
 func NewAppNexusAdapter(config *adapters.HTTPAdapterConfig, externalURL string) *AppNexusAdapter {
-	a := adapters.NewHTTPAdapter(config)
-
-	redirect_uri := fmt.Sprintf("%s/setuid?bidder=adnxs&uid=$UID", externalURL)
-	usersyncURL := "//ib.adnxs.com/getuid?"
-
-	info := &pbs.UsersyncInfo{
-		URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
-		Type:        "redirect",
-		SupportCORS: false,
-	}
-
-	return &AppNexusAdapter{
-		http:         a,
-		URI:          uri,
-		usersyncInfo: info,
-	}
+	return NewAppNexusBidder(adapters.NewHTTPAdapter(config).Client, externalURL)
 }
 
 func NewAppNexusBidder(client *http.Client, externalURL string) *AppNexusAdapter {

--- a/adapters/legacy.go
+++ b/adapters/legacy.go
@@ -47,8 +47,7 @@ type HTTPAdapterConfig struct {
 }
 
 type HTTPAdapter struct {
-	Transport *http.Transport
-	Client    *http.Client
+	Client *http.Client
 }
 
 // DefaultHTTPAdapterConfig is an HTTPAdapterConfig that chooses sensible default values.
@@ -69,7 +68,6 @@ func NewHTTPAdapter(c *HTTPAdapterConfig) *HTTPAdapter {
 	}
 
 	return &HTTPAdapter{
-		Transport: ts,
 		Client: &http.Client{
 			Transport: ts,
 		},

--- a/endpoints/openrtb2/auction_benchmark_test.go
+++ b/endpoints/openrtb2/auction_benchmark_test.go
@@ -51,7 +51,7 @@ func newDummyRequest() *http.Request {
 func BenchmarkOpenrtbEndpoint(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(dummyServer))
 	defer server.Close()
-	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client()), &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), &config.Configuration{}), &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -12,6 +12,6 @@ import (
 
 func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_ext.BidderName]adaptedBidder {
 	return map[openrtb_ext.BidderName]adaptedBidder{
-		openrtb_ext.BidderAppnexus: adaptBidder(new(appnexus.AppNexusAdapter), client),
+		openrtb_ext.BidderAppnexus: adaptBidder(appnexus.NewAppNexusBidder(client, cfg.ExternalURL), client),
 	}
 }

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -4,12 +4,13 @@ import (
 	"github.com/prebid/prebid-server/adapters/appnexus"
 	"net/http"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/config"
 )
 
 // The newAdapterMap function is segregated to its own file to make it a simple and clean location for each Adapter
 // to register itself. No wading through Exchange code to find it.
 
-func newAdapterMap(client *http.Client) map[openrtb_ext.BidderName]adaptedBidder {
+func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_ext.BidderName]adaptedBidder {
 	return map[openrtb_ext.BidderName]adaptedBidder{
 		openrtb_ext.BidderAppnexus: adaptBidder(new(appnexus.AppNexusAdapter), client),
 	}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"encoding/json"
 	"fmt"
+	"github.com/prebid/prebid-server/config"
 )
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
@@ -34,10 +35,10 @@ type bidResponseWrapper struct {
 	bidder openrtb_ext.BidderName
 }
 
-func NewExchange(client *http.Client) Exchange {
+func NewExchange(client *http.Client, cfg *config.Configuration) Exchange {
 	e := new(exchange)
 
-	e.adapterMap = newAdapterMap(client)
+	e.adapterMap = newAdapterMap(client, cfg)
 	e.adapters = make([]openrtb_ext.BidderName, 0, len(e.adapterMap))
 	for a, _ := range e.adapterMap {
 		e.adapters = append(e.adapters, a)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"encoding/json"
 	"errors"
+	"github.com/prebid/prebid-server/config"
 )
 
 func TestNewExchange(t *testing.T) {
@@ -19,7 +20,7 @@ func TestNewExchange(t *testing.T) {
 	defer server.Close()
 
 	// Just match the counts
-	e := NewExchange(server.Client()).(*exchange)
+	e := NewExchange(server.Client(), &config.Configuration{}).(*exchange)
 	if len(e.adapters) != len(e.adapterMap) {
 		t.Errorf("Exchange initialized, but adapter list doesn't match adapter map (%d - %d)", len(e.adapters), len(e.adapterMap))
 	}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -840,7 +840,8 @@ func serve(cfg *config.Configuration) error {
 				IdleConnTimeout:     60 * time.Second,
 				TLSClientConfig:     &tls.Config{RootCAs: ssl.GetRootCAPool()},
 			},
-		})
+		},
+		cfg)
 
 	byId, err := NewFetcher(&(cfg.StoredRequests))
 	if err != nil {


### PR DESCRIPTION
Fixes #246. Config options are now accessible in `adapter_map`, which is where OpenRTB Bidders are constructed.