### PR TITLE
Fixed a bug in the validate script, and then fixed formatting issues.

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1,26 +1,26 @@
 package openrtb2
 
 import (
-	"github.com/julienschmidt/httprouter"
-	"net/http"
-	"github.com/mxmCherry/openrtb"
-	"encoding/json"
-	"github.com/prebid/prebid-server/exchange"
-	"fmt"
 	"context"
+	"encoding/json"
 	"errors"
-	"github.com/prebid/prebid-server/openrtb_ext"
-	"time"
-	"github.com/prebid/prebid-server/prebid"
-	"net/url"
-	"golang.org/x/net/publicsuffix"
+	"fmt"
+	"github.com/buger/jsonparser"
 	"github.com/evanphx/json-patch"
-	"github.com/prebid/prebid-server/stored_requests"
+	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/exchange"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/prebid"
+	"github.com/prebid/prebid-server/stored_requests"
+	"golang.org/x/net/publicsuffix"
 	"io"
 	"io/ioutil"
-	"github.com/buger/jsonparser"
-	"github.com/golang/glog"
+	"net/http"
+	"net/url"
+	"time"
 )
 
 func NewEndpoint(ex exchange.Exchange, validator openrtb_ext.BidderParamValidator, requestsById stored_requests.Fetcher, cfg *config.Configuration) (httprouter.Handle, error) {
@@ -81,7 +81,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 func (deps *endpointDeps) parseRequest(httpRequest *http.Request) (req *openrtb.BidRequest, ctx context.Context, cancel func(), errs []error) {
 	req = &openrtb.BidRequest{}
 	ctx = context.Background()
-	cancel = func() { }
+	cancel = func() {}
 	errs = nil
 
 	// Pull the request body into a buffer, so we have it for later usage.
@@ -108,11 +108,11 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request) (req *openrtb.
 	}
 
 	if req.TMax > 0 {
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TMax) * time.Millisecond)
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TMax)*time.Millisecond)
 	}
 
 	// Process any stored request directives in the impression objects.
-	if errL := deps.processStoredRequests(ctx, req, rawRequest); len(errL)>0 {
+	if errL := deps.processStoredRequests(ctx, req, rawRequest); len(errL) > 0 {
 		errs = errL
 		return
 	}
@@ -309,7 +309,7 @@ func setFieldsImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
 
 // setDeviceImplicitly uses implicit info from httpReq to populate bidReq.Device
 func setDeviceImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
-	setIPImplicitly(httpReq, bidReq) 	// Fixes #230
+	setIPImplicitly(httpReq, bidReq) // Fixes #230
 	setUAImplicitly(httpReq, bidReq)
 }
 
@@ -417,13 +417,12 @@ func (deps *endpointDeps) findStoredRequestIds(imps []openrtb.Imp) ([]string, []
 				errList = append(errList, err)
 				storedReqIds[i] = ""
 			}
-		} else{
+		} else {
 			storedReqIds[i] = ""
 		}
 	}
 	return storedReqIds, shortIds, errList
 }
-
 
 // Process the stored request data for an Imp.
 // Need to modify the Imp object in place as we cannot simply assign one Imp to another (deep copy)

--- a/endpoints/openrtb2/auction_benchmark_test.go
+++ b/endpoints/openrtb2/auction_benchmark_test.go
@@ -1,13 +1,13 @@
 package openrtb2
 
 import (
-	"strings"
-	"testing"
-	"net/http/httptest"
-	"net/http"
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
-	"github.com/prebid/prebid-server/config"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 )
 
 // dummyServer returns the header bidding test ad. This response was scraped from a real appnexus server response.
@@ -51,7 +51,7 @@ func newDummyRequest() *http.Request {
 func BenchmarkOpenrtbEndpoint(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(dummyServer))
 	defer server.Close()
-	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), &config.Configuration{}), &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), &config.Configuration{}), &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1,27 +1,27 @@
 package openrtb2
 
 import (
-	"testing"
-	"github.com/mxmCherry/openrtb"
-	"context"
-	"net/http/httptest"
-	"strings"
-	"net/http"
-	"encoding/json"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"github.com/evanphx/json-patch"
-	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 )
 
 const maxSize = 1024 * 256
 
 // TestGoodRequests makes sure that the auction runs properly-formatted bids correctly.
 func TestGoodRequests(t *testing.T) {
-	endpoint, _ := NewEndpoint(&nobidExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(&nobidExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 
 	for _, requestData := range validRequests {
 		request := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(requestData))
@@ -52,7 +52,7 @@ func TestGoodRequests(t *testing.T) {
 
 // TestBadRequests makes sure we return 400's on bad requests.
 func TestBadRequests(t *testing.T) {
-	endpoint, _ := NewEndpoint(&nobidExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(&nobidExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 	for _, badRequest := range invalidRequests {
 		request := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(badRequest))
 		recorder := httptest.NewRecorder()
@@ -67,7 +67,7 @@ func TestBadRequests(t *testing.T) {
 
 // TestNilExchange makes sure we fail when given nil for the Exchange.
 func TestNilExchange(t *testing.T) {
-	_, err := NewEndpoint(nil, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	_, err := NewEndpoint(nil, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 	if err == nil {
 		t.Errorf("NewEndpoint should return an error when given a nil Exchange.")
 	}
@@ -75,7 +75,7 @@ func TestNilExchange(t *testing.T) {
 
 // TestNilValidator makes sure we fail when given nil for the BidderParamValidator.
 func TestNilValidator(t *testing.T) {
-	_, err := NewEndpoint(&nobidExchange{}, nil, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	_, err := NewEndpoint(&nobidExchange{}, nil, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 	if err == nil {
 		t.Errorf("NewEndpoint should return an error when given a nil BidderParamValidator.")
 	}
@@ -83,7 +83,7 @@ func TestNilValidator(t *testing.T) {
 
 // TestExchangeError makes sure we return a 500 if the exchange auction fails.
 func TestExchangeError(t *testing.T) {
-	endpoint, _ := NewEndpoint(&brokenExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(&brokenExchange{}, &bidderParamValidator{}, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize})
 	request := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequests[0]))
 	recorder := httptest.NewRecorder()
 	endpoint(recorder, request, nil)
@@ -129,7 +129,7 @@ func TestUserAgentOverride(t *testing.T) {
 // TestImplicitIPs prevents #230
 func TestImplicitIPs(t *testing.T) {
 	ex := &nobidExchange{}
-	endpoint, _ := NewEndpoint(ex, &bidderParamValidator{}, &mockStoredReqFetcher{}, &config.Configuration{ MaxRequestSize: maxSize })
+	endpoint, _ := NewEndpoint(ex, &bidderParamValidator{}, &mockStoredReqFetcher{}, &config.Configuration{MaxRequestSize: maxSize})
 	httpReq := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequests[0]))
 	httpReq.Header.Set("X-Forwarded-For", "123.456.78.90")
 	recorder := httptest.NewRecorder()
@@ -162,7 +162,7 @@ func TestRefererParsing(t *testing.T) {
 
 // Test the stored request functionality
 func TestStoredRequests(t *testing.T) {
-	edep := &endpointDeps{&nobidExchange{}, &bidderParamValidator{}, &mockStoredReqFetcher{}, &config.Configuration{ MaxRequestSize: maxSize }}
+	edep := &endpointDeps{&nobidExchange{}, &bidderParamValidator{}, &mockStoredReqFetcher{}, &config.Configuration{MaxRequestSize: maxSize}}
 
 	for i, requestData := range testStoredRequests {
 		Request := openrtb.BidRequest{}
@@ -186,7 +186,7 @@ func TestStoredRequests(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error mashalling bid request: %s", err.Error())
 		}
-		if ! jsonpatch.Equal(requestJson, expectJson) {
+		if !jsonpatch.Equal(requestJson, expectJson) {
 			t.Errorf("Error in processStoredRequests, test %d failed on compare\nFound:\n%s\nExpected:\n%s", i, string(requestJson), string(expectJson))
 		}
 
@@ -200,7 +200,7 @@ func TestOversizedRequest(t *testing.T) {
 		&nobidExchange{},
 		&bidderParamValidator{},
 		&mockStoredReqFetcher{},
-		&config.Configuration{ MaxRequestSize: int64(len(reqBody) - 1) },
+		&config.Configuration{MaxRequestSize: int64(len(reqBody) - 1)},
 	}
 
 	req := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(reqBody))
@@ -247,7 +247,7 @@ func TestNoEncoding(t *testing.T) {
 		&mockExchange{},
 		&bidderParamValidator{},
 		&mockStoredReqFetcher{},
-		&config.Configuration{ MaxRequestSize: maxSize })
+		&config.Configuration{MaxRequestSize: maxSize})
 	request := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequests[0]))
 	recorder := httptest.NewRecorder()
 	endpoint(recorder, request, nil)
@@ -265,9 +265,9 @@ type nobidExchange struct {
 func (e *nobidExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest) (*openrtb.BidResponse, error) {
 	e.gotRequest = bidRequest
 	return &openrtb.BidResponse{
-		ID: bidRequest.ID,
+		ID:    bidRequest.ID,
 		BidID: "test bid id",
-		NBR: openrtb.NoBidReasonCodeUnknownError.Ptr(),
+		NBR:   openrtb.NoBidReasonCodeUnknownError.Ptr(),
 	}, nil
 }
 
@@ -283,7 +283,7 @@ func (validator *bidderParamValidator) Validate(name openrtb_ext.BidderName, ext
 	}
 }
 
-type brokenExchange struct {}
+type brokenExchange struct{}
 
 func (e *brokenExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest) (*openrtb.BidResponse, error) {
 	return nil, errors.New("Critical, unrecoverable error.")
@@ -351,7 +351,6 @@ var validRequests = []string{
 		]
 	}`,
 }
-
 
 var invalidRequests = []string{
 	"5",
@@ -603,7 +602,7 @@ var testStoredRequests = []string{
 }
 
 // The expected requests after stored request processing
-var testFinalRequests = []string {
+var testFinalRequests = []string{
 	`{
 		"id": "ThisID",
 		"imp": [
@@ -676,7 +675,7 @@ func (cf mockStoredReqFetcher) FetchRequests(ctx context.Context, ids []string) 
 	return testStoredRequestData, nil
 }
 
-type mockExchange struct {}
+type mockExchange struct{}
 
 func (*mockExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest) (*openrtb.BidResponse, error) {
 	return &openrtb.BidResponse{

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -2,9 +2,9 @@ package exchange
 
 import (
 	"github.com/prebid/prebid-server/adapters/appnexus"
-	"net/http"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"net/http"
 )
 
 // The newAdapterMap function is segregated to its own file to make it a simple and clean location for each Adapter

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -1,15 +1,15 @@
 package exchange
 
 import (
-	"context"
-	"github.com/mxmCherry/openrtb"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"bytes"
+	"context"
+	"fmt"
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"golang.org/x/net/context/ctxhttp"
 	"io/ioutil"
-	"fmt"
 	"net/http"
-	"github.com/prebid/prebid-server/adapters"
 )
 
 // adaptedBidder defines the contract needed to participate in an Auction within an Exchange.
@@ -42,8 +42,8 @@ type adaptedBidder interface {
 // pbsOrtbBid.Bid.Ext will become "response.seatbid[i].bid.ext.bidder" in the final OpenRTB response.
 // pbsOrtbBid.BidType will become "response.seatbid[i].bid.ext.prebid.type" in the final OpenRTB response.
 type pbsOrtbBid struct {
-	bid *openrtb.Bid
-	bidType openrtb_ext.BidType
+	bid        *openrtb.Bid
+	bidType    openrtb_ext.BidType
 	bidTargets map[string]string
 }
 
@@ -122,8 +122,8 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 				}
 
 				seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
-					bid:  bid.Bid,
-					bidType: bid.BidType,
+					bid:        bid.Bid,
+					bidType:    bid.BidType,
 					bidTargets: targets,
 				})
 			}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -1,16 +1,16 @@
 package exchange
 
 import (
-	"testing"
-	"github.com/mxmCherry/openrtb"
-	"errors"
-	"net/http/httptest"
-	"sync/atomic"
-	"net/http"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"context"
 	"encoding/json"
+	"errors"
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
 )
 
 // TestSingleBidder makes sure that the following things work if the Bidder needs only one request.
@@ -379,20 +379,20 @@ func TestTargetingKeys(t *testing.T) {
 
 	mockBids := []*adapters.TypedBid{
 		{
-			Bid:     &openrtb.Bid{
-				ID: "123456",
-				W: 728,
-				H: 90,
+			Bid: &openrtb.Bid{
+				ID:    "123456",
+				W:     728,
+				H:     90,
 				Price: 1.34,
 				ImpID: "Imp1",
 			},
 			BidType: openrtb_ext.BidTypeBanner,
 		},
 		{
-			Bid:     &openrtb.Bid{
-				ID: "567890",
-				W: 300,
-				H: 250,
+			Bid: &openrtb.Bid{
+				ID:    "567890",
+				W:     300,
+				H:     250,
 				Price: 0.97,
 				ImpID: "Imp2",
 			},
@@ -417,20 +417,20 @@ func TestTargetingKeys(t *testing.T) {
 		Prebid: openrtb_ext.ExtRequestPrebid{
 			Targeting: &openrtb_ext.ExtRequestTargeting{
 				PriceGranularity: openrtb_ext.PriceGranularityMedium,
-				MaxLength: 20,
+				MaxLength:        20,
 			},
 		},
 	}
 	var bidReqExtRaw openrtb.RawJSON
-	bidReqExtRaw ,_ = json.Marshal(bidReqExt)
+	bidReqExtRaw, _ = json.Marshal(bidReqExt)
 	bidRequest := &openrtb.BidRequest{
-		ID: "This Bid",
+		ID:   "This Bid",
 		Test: 0,
-		Ext: bidReqExtRaw,
+		Ext:  bidReqExtRaw,
 	}
 
 	seatBid, errs := bidder.requestBid(context.Background(), bidRequest, &targetData{
-		winningBids: make(map[string]*openrtb.Bid),
+		winningBids:    make(map[string]*openrtb.Bid),
 		winningBidders: make(map[string]openrtb_ext.BidderName),
 	}, "dummy")
 	if len(errs) > 0 {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1,14 +1,14 @@
 package exchange
 
 import (
-	"github.com/mxmCherry/openrtb"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"context"
-	"time"
-	"net/http"
 	"encoding/json"
 	"fmt"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"net/http"
+	"time"
 )
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
@@ -26,13 +26,13 @@ type exchange struct {
 // Container to pass out response ext data from the GetAllBids goroutines back into the main thread
 type seatResponseExtra struct {
 	ResponseTimeMillis int
-	Errors []string
+	Errors             []string
 }
 
 type bidResponseWrapper struct {
-	adapterBids *pbsOrtbSeatBid
+	adapterBids  *pbsOrtbSeatBid
 	adapterExtra *seatResponseExtra
-	bidder openrtb_ext.BidderName
+	bidder       openrtb_ext.BidderName
 }
 
 func NewExchange(client *http.Client, cfg *config.Configuration) Exchange {
@@ -102,9 +102,9 @@ func (e *exchange) getAllBids(ctx context.Context, liveAdapters []openrtb_ext.Bi
 			brw.adapterBids = bids
 			// Structure to record extra tracking data generated during bidding
 			ae := new(seatResponseExtra)
-			ae.ResponseTimeMillis = int(elapsed/time.Millisecond)
+			ae.ResponseTimeMillis = int(elapsed / time.Millisecond)
 			serr := make([]string, len(err))
-			for i :=0; i<len(err); i++ {
+			for i := 0; i < len(err); i++ {
 				serr[i] = err[i].Error()
 			}
 			ae.Errors = serr
@@ -114,7 +114,7 @@ func (e *exchange) getAllBids(ctx context.Context, liveAdapters []openrtb_ext.Bi
 	}
 	// Wait for the bidders to do their thing
 	for i := 0; i < len(liveAdapters); i++ {
-		brw := <- chBids
+		brw := <-chBids
 		adapterExtra[brw.bidder] = brw.adapterExtra
 		adapterBids[brw.bidder] = brw.adapterBids
 	}
@@ -131,7 +131,6 @@ func (e *exchange) buildBidResponse(liveAdapters []openrtb_ext.BidderName, adapt
 		// signal "Invalid Request" if no valid bidders.
 		bidResponse.NBR = openrtb.NoBidReasonCode.Ptr(openrtb.NoBidReasonCodeInvalidRequest)
 	}
-
 
 	// Create the SeatBids. We use a zero sized slice so that we can append non-zero seat bids, and not include seatBid
 	// objects for seatBids without any bids. Preallocate the max possible size to avoid reallocating the array as we go.
@@ -158,7 +157,7 @@ func (e *exchange) buildBidResponse(liveAdapters []openrtb_ext.BidderName, adapt
 // Extract all the data from the SeatBids and build the ExtBidResponse
 func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, test int8, errList []error) *openrtb_ext.ExtBidResponse {
 	bidResponseExt := &openrtb_ext.ExtBidResponse{
-		Errors: make(map[openrtb_ext.BidderName][]string, len(adapterBids)),
+		Errors:             make(map[openrtb_ext.BidderName][]string, len(adapterBids)),
 		ResponseTimeMillis: make(map[openrtb_ext.BidderName]int, len(adapterBids)),
 	}
 	if test == 1 {
@@ -180,7 +179,7 @@ func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pb
 		}
 		if len(errList) > 0 {
 			s := make([]string, len(errList))
-			for i :=0; i<len(errList); i++ {
+			for i := 0; i < len(errList); i++ {
 				s[i] = errList[i].Error()
 			}
 			bidResponseExt.Errors["prebid"] = s
@@ -230,7 +229,7 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, targData *targetData, adapter ope
 			Bidder: thisBid.bid.Ext,
 			Prebid: &openrtb_ext.ExtBidPrebid{
 				Targeting: thisBid.bidTargets,
-				Type: thisBid.bidType,
+				Type:      thisBid.bidType,
 			},
 		}
 
@@ -239,8 +238,8 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, targData *targetData, adapter ope
 			errList = append(errList, fmt.Sprintf("Error writing SeatBid.Bid[%d].Ext: %s", i, err.Error()))
 		} else {
 			bids = append(bids, *thisBid.bid)
-			targData.addBid(adapter, &(bids[len(bids) - 1]))
-			bids[len(bids) - 1].Ext = ext
+			targData.addBid(adapter, &(bids[len(bids)-1]))
+			bids[len(bids)-1].Ext = ext
 		}
 	}
 	return bids, errList

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -90,8 +90,12 @@ func TestHoldAuction(t *testing.T) {
 		dummy3 = -1
 	)
 	for i, sb := range bidResponse.SeatBid {
-		if sb.Seat == "dummy" { dummy1 = i }
-		if sb.Seat == "dummy3" { dummy3 = i }
+		if sb.Seat == "dummy" {
+			dummy1 = i
+		}
+		if sb.Seat == "dummy3" {
+			dummy3 = i
+		}
 	}
 	if len(bidResponse.SeatBid[dummy1].Bid) != 2 {
 		t.Errorf("HoldAuction: Expected 2 bids from dummy bidder, found %d instead", len(bidResponse.SeatBid[dummy1].Bid))
@@ -141,13 +145,13 @@ func TestGetAllBids(t *testing.T) {
 	if len(e.adapterMap[BidderDummy2].(*mockAdapter).errs) != 2 {
 		t.Errorf("GetAllBids, Bidder2 adapter error generation failed. Only seeing %d errors", len(e.adapterMap[BidderDummy2].(*mockAdapter).errs))
 	}
-	if len(adapterExtra[BidderDummy2].Errors) !=2 {
+	if len(adapterExtra[BidderDummy2].Errors) != 2 {
 		t.Errorf("GetAllBids failed to report 2 errors on Bidder2, found %d errors", len(adapterExtra[BidderDummy2].Errors))
 	}
-	if len(adapterExtra[BidderDummy].Errors) !=0 {
+	if len(adapterExtra[BidderDummy].Errors) != 0 {
 		t.Errorf("GetAllBids found errors on Bidder1, found %d errors", len(adapterExtra[BidderDummy2].Errors))
 	}
-	if len(adapterBids[BidderDummy2].bids) !=0 {
+	if len(adapterBids[BidderDummy2].bids) != 0 {
 		t.Errorf("GetAllBids found bids on Bidder2, found %d bids", len(adapterBids[BidderDummy2].bids))
 	}
 
@@ -155,15 +159,13 @@ func TestGetAllBids(t *testing.T) {
 	mockAdapterConfigErr2(e.adapterMap[BidderDummy2].(*mockAdapter))
 	adapterBids, adapterExtra = e.getAllBids(ctx, e.adapters, cleanRequests, nil)
 
-	if len(adapterExtra[BidderDummy2].Errors) !=1 {
+	if len(adapterExtra[BidderDummy2].Errors) != 1 {
 		t.Errorf("GetAllBids failed to report 1 errors on Bidder2, found %d errors", len(adapterExtra[BidderDummy2].Errors))
 	}
-	if len(adapterExtra[BidderDummy].Errors) !=0 {
+	if len(adapterExtra[BidderDummy].Errors) != 0 {
 		t.Errorf("GetAllBids found errors on Bidder1, found %d errors", len(adapterExtra[BidderDummy2].Errors))
 	}
 }
-
-
 
 func TestBuildBidResponse(t *testing.T) {
 	//  BuildBidResponse(liveAdapters []openrtb_ext.BidderName, adapterBids map[openrtb_ext.BidderName]*adapters.pbsOrtbSeatBid, bidRequest *openrtb.BidRequest, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra) *openrtb.BidResponse
@@ -183,16 +185,16 @@ func TestBuildBidResponse(t *testing.T) {
 		Prebid: openrtb_ext.ExtRequestPrebid{
 			Targeting: &openrtb_ext.ExtRequestTargeting{
 				PriceGranularity: openrtb_ext.PriceGranularityMedium,
-				MaxLength: 20,
+				MaxLength:        20,
 			},
 		},
 	}
 	var bidReqExtRaw openrtb.RawJSON
-	bidReqExtRaw ,err := json.Marshal(bidReqExt)
+	bidReqExtRaw, err := json.Marshal(bidReqExt)
 	bidRequest := openrtb.BidRequest{
-		ID: "This Bid",
+		ID:   "This Bid",
 		Test: 0,
-		Ext: bidReqExtRaw,
+		Ext:  bidReqExtRaw,
 	}
 
 	liveAdapters := make([]openrtb_ext.BidderName, 3)
@@ -207,15 +209,15 @@ func TestBuildBidResponse(t *testing.T) {
 	adapterBids[BidderDummy], errs1 = mockDummyBids1("dummy")
 	adapterBids[BidderDummy2], errs2 = mockDummyBids2("dummy2")
 	adapterBids[BidderDummy3], errs3 = mockDummyBids3("dummy3")
-	adapterExtra[BidderDummy] = &seatResponseExtra{ResponseTimeMillis: 131, Errors:convertErr2Str(errs1)}
-	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors:convertErr2Str(errs2)}
-	adapterExtra[BidderDummy3] = &seatResponseExtra{ResponseTimeMillis: 141, Errors:convertErr2Str(errs3)}
+	adapterExtra[BidderDummy] = &seatResponseExtra{ResponseTimeMillis: 131, Errors: convertErr2Str(errs1)}
+	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors: convertErr2Str(errs2)}
+	adapterExtra[BidderDummy3] = &seatResponseExtra{ResponseTimeMillis: 141, Errors: convertErr2Str(errs3)}
 
 	errList := make([]error, 0, 1)
 	targData := &targetData{
 		priceGranularity: openrtb_ext.PriceGranularityMedium,
-		winningBids: make(map[string]*openrtb.Bid),
-		winningBidders: make(map[string]openrtb_ext.BidderName),
+		winningBids:      make(map[string]*openrtb.Bid),
+		winningBidders:   make(map[string]openrtb_ext.BidderName),
 	}
 	bidResponse, err := e.buildBidResponse(liveAdapters, adapterBids, &bidRequest, adapterExtra, targData, errList)
 	if err != nil {
@@ -275,7 +277,7 @@ func TestBuildBidResponse(t *testing.T) {
 	}
 	// Now test with an error condition
 	adapterBids[BidderDummy2], errs2 = mockDummyBidsErr1()
-	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors:convertErr2Str(errs2)}
+	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors: convertErr2Str(errs2)}
 
 	bidResponse, err = e.buildBidResponse(liveAdapters, adapterBids, &bidRequest, adapterExtra, nil, errList)
 	if err != nil {
@@ -294,7 +296,7 @@ func TestBuildBidResponse(t *testing.T) {
 
 	// Test with null bid response error
 	adapterBids[BidderDummy2], errs2 = mockDummyBidsErr2()
-	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors:convertErr2Str(errs2)}
+	adapterExtra[BidderDummy2] = &seatResponseExtra{ResponseTimeMillis: 97, Errors: convertErr2Str(errs2)}
 
 	bidResponse, err = e.buildBidResponse(liveAdapters, adapterBids, &bidRequest, adapterExtra, nil, errList)
 	if err != nil {
@@ -322,7 +324,7 @@ func assertStringValue(t *testing.T, object string, expect string, value string)
 
 type mockAdapter struct {
 	seatBid *pbsOrtbSeatBid
-	errs []error
+	errs    []error
 }
 
 func (a *mockAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, targetData *targetData, name openrtb_ext.BidderName) (*pbsOrtbSeatBid, []error) {
@@ -330,10 +332,11 @@ func (a *mockAdapter) requestBid(ctx context.Context, request *openrtb.BidReques
 }
 
 const (
-	BidderDummy openrtb_ext.BidderName = "dummy"
+	BidderDummy  openrtb_ext.BidderName = "dummy"
 	BidderDummy2 openrtb_ext.BidderName = "dummy2"
 	BidderDummy3 openrtb_ext.BidderName = "dummy3"
 )
+
 // Tester is responsible for filling bid results into the adapters
 func NewDummyExchange(client *http.Client) *exchange {
 	e := new(exchange)
@@ -347,7 +350,7 @@ func NewDummyExchange(client *http.Client) *exchange {
 	c.errs = make([]error, 0, 5)
 
 	e.adapterMap = map[openrtb_ext.BidderName]adaptedBidder{
-		BidderDummy: a,
+		BidderDummy:  a,
 		BidderDummy2: b,
 		BidderDummy3: c,
 	}
@@ -358,7 +361,6 @@ func NewDummyExchange(client *http.Client) *exchange {
 	}
 	return e
 }
-
 
 func mockHandler(statusCode int, getBody string, postBody string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -411,7 +413,7 @@ func mockDummyBids1(adapter string) (*pbsOrtbSeatBid, []error) {
 	sb1.bids[0].bidTargets = targ
 	fmt.Println(string(sb1.bids[0].bid.Ext))
 	if err != nil {
-		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: "+err.Error())
+		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: " + err.Error())
 	}
 	sb1.bids[1].bid.ID = "1234567890"
 	sb1.bids[1].bid.W = 300
@@ -425,7 +427,7 @@ func mockDummyBids1(adapter string) (*pbsOrtbSeatBid, []error) {
 	sb1.bids[1].bidTargets = targ
 	fmt.Println(string(sb1.bids[0].bid.Ext))
 	if err != nil {
-		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: "+err.Error())
+		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: " + err.Error())
 	}
 
 	errs := make([]error, 0, 5)
@@ -453,7 +455,7 @@ func mockDummyBids2(adapter string) (*pbsOrtbSeatBid, []error) {
 	sb1.bids[0].bidTargets = targ
 	fmt.Println(string(sb1.bids[0].bid.Ext))
 	if err != nil {
-		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: "+err.Error())
+		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: " + err.Error())
 	}
 	sb1.bids[1].bid.ID = "1234"
 	sb1.bids[1].bid.W = 300
@@ -467,7 +469,7 @@ func mockDummyBids2(adapter string) (*pbsOrtbSeatBid, []error) {
 	sb1.bids[1].bidTargets = targ
 	fmt.Println(string(sb1.bids[0].bid.Ext))
 	if err != nil {
-		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: "+err.Error())
+		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: " + err.Error())
 	}
 
 	errs := make([]error, 0, 5)
@@ -492,7 +494,7 @@ func mockDummyBids3(adapter string) (*pbsOrtbSeatBid, []error) {
 	sb1.bids[0].bidTargets = targ
 	fmt.Println(string(sb1.bids[0].bid.Ext))
 	if err != nil {
-		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: "+err.Error())
+		fmt.Println("ERROR: Packing ext[0] in mockDummyBids1: " + err.Error())
 	}
 
 	errs := make([]error, 0, 5)
@@ -504,8 +506,8 @@ func mockDummyBidsErr1() (*pbsOrtbSeatBid, []error) {
 	sb1.bids = nil
 
 	errs := make([]error, 0, 5)
-	errs = append(errs, errors.New("This was an error") )
-	errs = append(errs, errors.New("Another error goes here") )
+	errs = append(errs, errors.New("This was an error"))
+	errs = append(errs, errors.New("Another error goes here"))
 
 	return sb1, errs
 }
@@ -513,15 +515,14 @@ func mockDummyBidsErr2() (*pbsOrtbSeatBid, []error) {
 	var sb1 *pbsOrtbSeatBid = nil
 
 	errs := make([]error, 0, 5)
-	errs = append(errs, errors.New("This was a FATAL error") )
+	errs = append(errs, errors.New("This was a FATAL error"))
 
 	return sb1, errs
 }
 
-
 func convertErr2Str(e []error) []string {
 	s := make([]string, len(e))
-	for i :=0; i<len(e); i++ {
+	for i := 0; i < len(e); i++ {
 		s[i] = e[i].Error()
 	}
 	return s

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -1,9 +1,9 @@
 package exchange
 
 import (
-	"github.com/prebid/prebid-server/openrtb_ext"
-	"github.com/mxmCherry/openrtb"
 	"encoding/json"
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs/buckets"
 	"strconv"
 )
@@ -56,8 +56,8 @@ func (t *targetData) makePrebidTargets(name openrtb_ext.BidderName, bid *openrtb
 	hbCacheIdBidderKey := openrtb_ext.HbCacheIdConstantKey.BidderKey(name, t.lengthMax)
 
 	pbs_kvs := map[string]string{
-		hbPbBidderKey:      roundedCpm,
-		hbBidderBidderKey:  string(name),
+		hbPbBidderKey:     roundedCpm,
+		hbBidderBidderKey: string(name),
 	}
 
 	if hbSize != "" {

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -1,10 +1,10 @@
 package exchange
 
 import (
-	"testing"
-	"github.com/mxmCherry/openrtb"
 	"encoding/json"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"testing"
 )
 
 func TestRandomizeList(t *testing.T) {
@@ -31,7 +31,7 @@ func TestRandomizeList(t *testing.T) {
 func TestCleanOpenRTBRequests(t *testing.T) {
 	// Very simple Bid request. The dummy bidders know what to do.
 	bidRequest := openrtb.BidRequest{
-		ID: "This Bid",
+		ID:  "This Bid",
 		Imp: make([]openrtb.Imp, 2),
 	}
 	// Need extensions for all the bidders so we know to hold auctions for them.
@@ -58,7 +58,7 @@ func TestCleanOpenRTBRequests(t *testing.T) {
 	adapters[1] = openrtb_ext.BidderName("dummy2")
 	adapters[2] = openrtb_ext.BidderName("dummy3")
 
-	cleanRequests, errList := cleanOpenRTBRequests( &bidRequest, adapters)
+	cleanRequests, errList := cleanOpenRTBRequests(&bidRequest, adapters)
 
 	if len(errList) > 0 {
 		for _, e := range errList {
@@ -75,7 +75,7 @@ func TestCleanOpenRTBRequests(t *testing.T) {
 		t.Errorf("CleanOpenRTBRequests: %s", err.Error())
 	}
 	dummymap, ok := cleanImpExt["bidder"]
-	if ! ok {
+	if !ok {
 		t.Error("CleanOpenRTBRequests: dummy adapter did not get proper bidder extension")
 	}
 	if dummymap["placementId"] != "5554444" {
@@ -90,7 +90,7 @@ func TestCleanOpenRTBRequests(t *testing.T) {
 		t.Errorf("CleanOpenRTBRequests: %s", err.Error())
 	}
 	dummymap, ok = cleanImpExt["bidder"]
-	if ! ok {
+	if !ok {
 		t.Error("CleanOpenRTBRequests: dummy3 adapter did not get proper bidder extension")
 	}
 	if dummymap["placementId"] != "1234567" {
@@ -98,4 +98,3 @@ func TestCleanOpenRTBRequests(t *testing.T) {
 	}
 
 }
-

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -10,9 +10,9 @@ type ExtBid struct {
 
 // ExtBidPrebid defines the contract for bidresponse.seatbid.bid[i].ext.prebid
 type ExtBidPrebid struct {
-	Cache              *ExtResponseCache `json:"cache,omitempty"`
-	Targeting          map[string]string `json:"targeting,omitempty"`
-	Type               BidType           `json:"type"`
+	Cache     *ExtResponseCache `json:"cache,omitempty"`
+	Targeting map[string]string `json:"targeting,omitempty"`
+	Type      BidType           `json:"type"`
 }
 
 // ExtResponseCache defines the contract for  bidresponse.seatbid.bid[i].ext.prebid.cache
@@ -36,14 +36,14 @@ const (
 type TargetingKey string
 
 const (
-	HbpbConstantKey TargetingKey = "hb_pb"
-	HbBidderConstantKey TargetingKey = "hb_bidder"
-	HbSizeConstantKey TargetingKey = "hb_size"
+	HbpbConstantKey                 TargetingKey = "hb_pb"
+	HbBidderConstantKey             TargetingKey = "hb_bidder"
+	HbSizeConstantKey               TargetingKey = "hb_size"
 	HbCreativeLoadMethodConstantKey TargetingKey = "hb_creative_loadtype"
-	HbCacheIdConstantKey TargetingKey = "hb_cache_id"
-	HbDealIdConstantKey TargetingKey = "hb_deal"
+	HbCacheIdConstantKey            TargetingKey = "hb_cache_id"
+	HbDealIdConstantKey             TargetingKey = "hb_deal"
 	// These are not keys, but values used by hbCreativeLoadMethodConstantKey
-	HbCreativeLoadMethodHTML string = "html"
+	HbCreativeLoadMethodHTML      string = "html"
 	HbCreativeLoadMethodDemandSDK string = "demand_sdk"
 )
 

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -1,14 +1,14 @@
 package openrtb_ext
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"github.com/mxmCherry/openrtb"
 	"github.com/xeipuuv/gojsonschema"
 	"io/ioutil"
-	"strings"
-	"fmt"
 	"net/http"
-	"bytes"
-	"errors"
+	"strings"
 )
 
 const schemaDirectory = "static/bidder-params"
@@ -16,24 +16,24 @@ const schemaDirectory = "static/bidder-params"
 type BidderName string
 
 const (
-	BidderAppnexus BidderName   = "appnexus"
-	BidderFacebook BidderName   = "facebook"
-	BidderIndex BidderName      = "index"
+	BidderAppnexus   BidderName = "appnexus"
+	BidderFacebook   BidderName = "facebook"
+	BidderIndex      BidderName = "index"
 	BidderLifestreet BidderName = "lifestreet"
-	BidderPubmatic BidderName   = "pubmatic"
+	BidderPubmatic   BidderName = "pubmatic"
 	BidderPulsepoint BidderName = "pulsepoint"
-	BidderRubicon BidderName    = "rubicon"
+	BidderRubicon    BidderName = "rubicon"
 	BidderConversant BidderName = "conversant"
 )
 
-var bidderMap = map[string]BidderName {
-	"appnexus": BidderAppnexus,
-	"facebook": BidderFacebook,
-	"index": BidderIndex,
+var bidderMap = map[string]BidderName{
+	"appnexus":   BidderAppnexus,
+	"facebook":   BidderFacebook,
+	"index":      BidderIndex,
 	"lifestreet": BidderLifestreet,
-	"pubmatic": BidderPubmatic,
+	"pubmatic":   BidderPubmatic,
 	"pulsepoint": BidderPulsepoint,
-	"rubicon": BidderRubicon,
+	"rubicon":    BidderRubicon,
 	"conversant": BidderConversant,
 }
 
@@ -99,13 +99,13 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 
 	return &bidderParamValidator{
 		schemaContents: schemaContents,
-		parsedSchemas: schemas,
+		parsedSchemas:  schemas,
 	}, nil
 }
 
 type bidderParamValidator struct {
 	schemaContents map[BidderName]string
-	parsedSchemas map[BidderName]*gojsonschema.Schema
+	parsedSchemas  map[BidderName]*gojsonschema.Schema
 }
 
 func (validator *bidderParamValidator) Validate(name BidderName, ext openrtb.RawJSON) error {

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -1,10 +1,10 @@
 package openrtb_ext
 
 import (
-	"testing"
+	"github.com/mxmCherry/openrtb"
 	"github.com/xeipuuv/gojsonschema"
 	"os"
-	"github.com/mxmCherry/openrtb"
+	"testing"
 )
 
 // TestMain does the expensive setup so we don't keep re-reading the files in static/bidder-params for each test.
@@ -16,6 +16,7 @@ func TestMain(m *testing.M) {
 	validator = bidderParams
 	os.Exit(m.Run())
 }
+
 var validator BidderParamValidator
 
 // TestGetBidderName makes sure the GetBidderNames method works properly.

--- a/openrtb_ext/doc.go
+++ b/openrtb_ext/doc.go
@@ -1,4 +1,3 @@
-
 /*
 Package openrtb_ext defines all the input validation for Prebid Server's extensions to the OpenRTB 2.5 spec.
 

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -9,7 +9,7 @@ type ExtRequest struct {
 
 // ExtRequestPrebid defines the contract for bidrequest.ext.prebid
 type ExtRequestPrebid struct {
-	Targeting *ExtRequestTargeting`json:"targeting"`
+	Targeting *ExtRequestTargeting `json:"targeting"`
 }
 
 // ExtRequestTargeting defines the contract for bidrequest.ext.prebid.targeting

--- a/openrtb_ext/request_test.go
+++ b/openrtb_ext/request_test.go
@@ -1,8 +1,8 @@
 package openrtb_ext
 
 import (
-	"testing"
 	"encoding/json"
+	"testing"
 )
 
 // Test the unmashalling of the prebid extensions and setting default Price Granularity

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -4,7 +4,7 @@ package openrtb_ext
 type ExtBidResponse struct {
 	Debug *ExtResponseDebug `json:"debug,omitempty"`
 	// ExtResponseErrors defines the contract for bidresponse.ext.errors
- 	Errors map[BidderName][]string `json:"errors,omitempty"`
+	Errors map[BidderName][]string `json:"errors,omitempty"`
 	// ExtResponseTimeMillis defines the contract for bidresponse.ext.responsetimemillis
 	ResponseTimeMillis map[BidderName]int `json:"responsetimemillis,omitempty"`
 	// ExtResponseUserSync defines the contract for bidresponse.ext.usersync

--- a/stored_requests/backends/db_fetcher/fetcher.go
+++ b/stored_requests/backends/db_fetcher/fetcher.go
@@ -1,16 +1,16 @@
 package db_fetcher
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"context"
 	"github.com/golang/glog"
 )
 
 // dbFetcher fetches Stored Requests from a database. This should be instantiated through the NewPostgres() function.
 type dbFetcher struct {
-	db *sql.DB
+	db         *sql.DB
 	queryMaker func(int) (string, error)
 }
 

--- a/stored_requests/backends/db_fetcher/postgres.go
+++ b/stored_requests/backends/db_fetcher/postgres.go
@@ -1,10 +1,10 @@
 package db_fetcher
 
 import (
+	"bytes"
+	"database/sql"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/stored_requests"
-	"database/sql"
-	"bytes"
 	"strconv"
 )
 
@@ -15,7 +15,7 @@ func NewPostgres(cfg *config.PostgresConfig) (stored_requests.Fetcher, error) {
 	}
 
 	return &dbFetcher{
-		db: db,
+		db:         db,
 		queryMaker: cfg.MakeQuery,
 	}, nil
 }

--- a/stored_requests/backends/db_fetcher/postgres_test.go
+++ b/stored_requests/backends/db_fetcher/postgres_test.go
@@ -1,10 +1,10 @@
 package db_fetcher
 
 import (
-	"testing"
 	"github.com/prebid/prebid-server/config"
-	"strings"
 	"strconv"
+	"strings"
+	"testing"
 )
 
 // TestDSNCreation makes sure we turn the config into a string expected by the Postgres driver library.
@@ -54,6 +54,6 @@ func assertHasValue(t *testing.T, m map[string]string, key string, val string) {
 		t.Errorf("Map missing required key: %s", key)
 	}
 	if val != realVal {
-		t.Errorf("Unexpected value at key %s. Expected %s, Got %s", val, realVal)
+		t.Errorf("Unexpected value at key %s. Expected %s, Got %s", key, val, realVal)
 	}
 }

--- a/stored_requests/backends/empty_fetcher/fetcher.go
+++ b/stored_requests/backends/empty_fetcher/fetcher.go
@@ -1,10 +1,10 @@
 package empty_fetcher
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/prebid/prebid-server/stored_requests"
-	"context"
 )
 
 // EmptyFetcher is a nil-object which has no Stored Requests.
@@ -13,7 +13,7 @@ func EmptyFetcher() stored_requests.Fetcher {
 	return &instance
 }
 
-type emptyFetcher struct {}
+type emptyFetcher struct{}
 
 func (fetcher *emptyFetcher) FetchRequests(ctx context.Context, ids []string) (map[string]json.RawMessage, []error) {
 	errs := make([]error, 0, len(ids))

--- a/stored_requests/backends/empty_fetcher/fetcher_test.go
+++ b/stored_requests/backends/empty_fetcher/fetcher_test.go
@@ -1,8 +1,8 @@
 package empty_fetcher
 
 import (
-	"testing"
 	"context"
+	"testing"
 )
 
 func TestErrorLength(t *testing.T) {

--- a/stored_requests/backends/file_fetcher/fetcher.go
+++ b/stored_requests/backends/file_fetcher/fetcher.go
@@ -1,12 +1,12 @@
 package file_fetcher
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/prebid/prebid-server/stored_requests"
 	"io/ioutil"
 	"strings"
-	"github.com/prebid/prebid-server/stored_requests"
-	"context"
 )
 
 // NewFileFetcher _immediately_ loads stored request data from local files.

--- a/stored_requests/backends/file_fetcher/fetcher_test.go
+++ b/stored_requests/backends/file_fetcher/fetcher_test.go
@@ -1,9 +1,9 @@
 package file_fetcher
 
 import (
-	"testing"
-	"encoding/json"
 	"context"
+	"encoding/json"
+	"testing"
 )
 
 func TestFileFetcher(t *testing.T) {
@@ -26,7 +26,7 @@ func TestFileFetcher(t *testing.T) {
 		t.Errorf("Failed to unmarshal 1: %v", err)
 	}
 	if len(req1Val) != 1 {
-		t.Errorf("Unexpected req1Val length. Expected %v, Got %s", 1, len(req1Val))
+		t.Errorf("Unexpected req1Val length. Expected %d, Got %d", 1, len(req1Val))
 	}
 	data, hadKey := req1Val["test"]
 	if !hadKey {

--- a/stored_requests/fetcher.go
+++ b/stored_requests/fetcher.go
@@ -1,8 +1,8 @@
 package stored_requests
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 )
 
 // Fetcher knows how to fetch Stored Request data by id.

--- a/validate.sh
+++ b/validate.sh
@@ -18,8 +18,8 @@ done
 die() { echo -e "$@" 1>&2 ; exit 1;  }
 
 # check there are no formatting issues
-GOFMT_LINES=`gofmt -l *.go pbs adapters | wc -l | xargs`
 GOGLOB="*.go adapters cache config endpoints exchange openrtb_ext pbs prebid prebid_cache_client"
+GOFMT_LINES=`gofmt -l $GOGLOB | wc -l | xargs`
 
 if $AUTOFMT; then
   # if there are files with formatting issues, they will be automatically corrected using the gofmt -w <file> command

--- a/validate.sh
+++ b/validate.sh
@@ -17,10 +17,15 @@ done
 
 die() { echo -e "$@" 1>&2 ; exit 1;  }
 
-# check there are no formatting issues
-GOGLOB="*.go adapters cache config endpoints exchange openrtb_ext pbs prebid prebid_cache_client"
-GOFMT_LINES=`gofmt -l $GOGLOB | wc -l | xargs`
+# Build a list of all the top-level directories in the project.
+GOGLOB="*.go"
+for DIRECTORY in */ ; do
+  GOGLOB="$GOGLOB ${DIRECTORY%/}"
+done
+GOGLOB="${GOGLOB/vendor/}"
 
+# Check that there are no formatting issues
+GOFMT_LINES=`gofmt -l $GOGLOB | wc -l | xargs`
 if $AUTOFMT; then
   # if there are files with formatting issues, they will be automatically corrected using the gofmt -w <file> command
   if [[ $GOFMT_LINES -ne 0 ]]; then

--- a/validate.sh
+++ b/validate.sh
@@ -22,7 +22,8 @@ GOGLOB="*.go"
 for DIRECTORY in */ ; do
   GOGLOB="$GOGLOB ${DIRECTORY%/}"
 done
-GOGLOB="${GOGLOB/vendor/}"
+GOGLOB="${GOGLOB/ docs/}"
+GOGLOB="${GOGLOB/ vendor/}"
 
 # Check that there are no formatting issues
 GOFMT_LINES=`gofmt -l $GOGLOB | wc -l | xargs`


### PR DESCRIPTION
I've seen a bunch of PRs lately indicating that `gofmt` is happening unreliably.

This fixes at least one bug in the `./validate.sh` script, and contains the `gofmt` fixes for all the files.