### PR TITLE
Documenting the code review process

### DIFF
--- a/docs/developers/code-reviews.md
+++ b/docs/developers/code-reviews.md
@@ -36,6 +36,7 @@ Code reviews should focus on things which cannot be validated by machines.
 Some examples include:
 
 - Can we improve the user's experience in any way?
+- Do the changes contain any required docs updates?
 - Do you believe that the code works by looking at the unit tests? If not, suggest more tests until you do!
 - Is the motivation behind these changes clear? If not, there must be [an issue](https://github.com/prebid/prebid-server/issues) explaining it. Are there better ways to achieve those goals?
 - Does the code use any global, mutable state? [Inject dependencies](https://en.wikipedia.org/wiki/Dependency_injection) instead!

--- a/docs/developers/code-reviews.md
+++ b/docs/developers/code-reviews.md
@@ -36,7 +36,7 @@ Code reviews should focus on things which cannot be validated by machines.
 Some examples include:
 
 - Can we improve the user's experience in any way?
-- Have the docs been updated appropriately? If not, add the `needs docs` label.
+- Have the relevant [docs](..) been added or updated? If not, add the `needs docs` label.
 - Do you believe that the code works by looking at the unit tests? If not, suggest more tests until you do!
 - Is the motivation behind these changes clear? If not, there must be [an issue](https://github.com/prebid/prebid-server/issues) explaining it. Are there better ways to achieve those goals?
 - Does the code use any global, mutable state? [Inject dependencies](https://en.wikipedia.org/wiki/Dependency_injection) instead!

--- a/docs/developers/code-reviews.md
+++ b/docs/developers/code-reviews.md
@@ -1,0 +1,43 @@
+# Code Reviews
+
+## Standards
+Anyone is free to review and comment on any [open pull requests](https://github.com/prebid/prebid-server/pulls).
+
+All pull requests must be reviewed and approved by at least one [core member](https://github.com/orgs/prebid/teams/core/members) before merge.
+
+Very small pull requests may be merged with just one review if they:
+
+1. Do not change the public API.
+2. Have low risk of bugs, in the opinion of the reviewer.
+3. Introduce no new features, or impact the code architecture.
+
+Larger pull requests must meet at least one of the following two additional requirements.
+
+1. Have a second approval from a core member
+2. Be open for 5 business days with no new changes requested.
+
+## Process
+
+New pull requests should be [assigned](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) to a core member for review within 3 business days of being opened.
+That person should either approve the changes or request changes within 4 business days of being assigned.
+If they're too busy, they should assign it to someone else who can review it within that timeframe.
+
+If the changes are small, that member can merge the PR once the changes are complete. Otherwise, they should
+assign the pull request to another member for a second review.
+
+The pull request can then be merged whenever the second reviewer approves, or if 5 business days pass with no farther
+changes requested by anybody, whichever comes first.
+
+
+## Priorities
+
+Code reviews should focus on things which cannot be validated by machines.
+
+Some examples include:
+
+- Can we improve the user's experience in any way?
+- Do you believe that the code works by looking at the unit tests? If not, suggest more tests until you do!
+- Is the motivation behind these changes clear? If not, there must be [an issue](https://github.com/prebid/prebid-server/issues) explaining it. Are there better ways to achieve those goals?
+- Does the code use any global, mutable state? [Inject dependencies](https://en.wikipedia.org/wiki/Dependency_injection) instead!
+- Can the code be organized into smaller, more modular pieces?
+- Is there dead code which can be deleted? Or TODO comments which should be resolved?

--- a/docs/developers/code-reviews.md
+++ b/docs/developers/code-reviews.md
@@ -36,7 +36,7 @@ Code reviews should focus on things which cannot be validated by machines.
 Some examples include:
 
 - Can we improve the user's experience in any way?
-- Do the changes contain any required docs updates?
+- Have the docs been updated appropriately? If not, add the `needs docs` label.
 - Do you believe that the code works by looking at the unit tests? If not, suggest more tests until you do!
 - Is the motivation behind these changes clear? If not, there must be [an issue](https://github.com/prebid/prebid-server/issues) explaining it. Are there better ways to achieve those goals?
 - Does the code use any global, mutable state? [Inject dependencies](https://en.wikipedia.org/wiki/Dependency_injection) instead!

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -27,6 +27,14 @@ All pull requests must have 90% coverage in the changed code. Check the code cov
 
 Bugfixes should include a regression test which prevents that bug from being re-introduced in the future.
 
+## Update Documentation
+
+Documentation for the project is stored in the [docs](..) directory. If your feature requires docs updates,
+those updates must be submitted in the same Pull Request as the code changes.
+
+- [docs/endpoints](../endpoints) describes the Prebid Server API. For example, the endpoint `host:port/openrtb2/auction` is described by [docs/endpoints/openrtb2/auction.md](../endpoints/openrtb2/auction.md)
+- [docs/developers](../developers) contains docs intended for Developers. These assume that the reader is technical, and describe the mechanics of features.
+
 ## Open a Pull Request
 
 When you're ready, [submit a Pull Request](https://help.github.com/articles/creating-a-pull-request/)

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,33 +1,45 @@
 # Contributing
 
-## Development
+## Create an issue
 
-During development, run the unit tests with:
+[Create an issue](https://github.com/prebid/prebid-server/issues/new) describing the motivation for your changes.
+Are you fixing a bug? Improving documentation? Optimizing some slow code?
+
+Pull Requests without associated Issues may still be accepted, if the motivation is obvious.
+However, this will help speed up code review if there's any uncertainty.
+
+## Change the code
+
+[Create a fork](https://help.github.com/articles/working-with-forks/) and make your code changes.
+Fix code formatting and run the unit tests with:
 
 ```bash
 ./validate.sh
 ```
-New submissions *must* include unit tests. Bugfixes should include a test which prevents that bug from being re-introduced in the future.
 
-## Pull Requests
+## Add tests
 
-When your changes are complete, run the tests with code coverage and strict format checking:
-
-```bash
-./validate.sh --nofmt --cov
-```
-
-All pull requests must have 90% coverage. View your coverage report with:
+All pull requests must have 90% coverage in the changed code. Check the code coverage with:
 
 ```bash
 ./scripts/coverage.sh --html
 ```
 
-When you're ready, [submit a Pull Request](https://help.github.com/articles/creating-a-pull-request/) against
-[our GitHub repository](https://github.com/prebid/prebid-server/compare).
-These same tests will be run with [Travis CI](https://travis-ci.com/).
+Bugfixes should include a regression test which prevents that bug from being re-introduced in the future.
 
-If the tests pass locally, but fail on your PR, make sure to `git pull` the latest code from `master`.
+## Open a Pull Request
+
+When you're ready, [submit a Pull Request](https://help.github.com/articles/creating-a-pull-request/)
+against the `master` branch of [our GitHub repository](https://github.com/prebid/prebid-server/compare).
+
+Pull Requests will be vetted through [Travis CI](https://travis-ci.com/).
+To reproduce these same tests locally, do:
+
+```bash
+./validate.sh --nofmt --cov
+```
+
+If the tests pass locally, but fail on your PR, [update your fork](https://help.github.com/articles/syncing-a-fork/) with the latest code from `master`.
 
 **Note**: We also have some [known intermittent failures](https://github.com/prebid/prebid-server/issues/103).
           If the tests still fail after pulling `master`, don't worry about it. We'll re-run them when we review your PR.


### PR DESCRIPTION
Just to formalize things a bit.

I suspect we'll want to change these pretty aggressively once we start trying to follow them. Tough to tell what works without trying it, though.

From what I've seen in Prebid.js so far, that second reviewer tends to cost more than they add in value. And since this is not a client-side library, we can fix critical bugs and release updates much more quickly and easily than in that project.

So I chose here to make that second reviewer optional, introducing a waiting period instead. This idea was cherry-picked from [the Node.js standards](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951), because I think it's a good one.