### PR TITLE
Various Targeting-Related Changes

### DIFF
--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -47,27 +47,23 @@ type ExtRequestTargeting struct {
 	MaxLength        int              `json:"lengthmax"`
 }
 
-// ExtRequestTargeting without Unmashall override to prevent infinite loops
-type ExtRequestTargetingPlain struct {
-	PriceGranularity PriceGranularity `json:"pricegranularity"`
-	MaxLength        int              `json:"lengthmax"`
-}
-
-// Make an unmashaller that will set a default PriceGranularity
+// Make an unmarshaller that will set a default PriceGranularity
 func (ert *ExtRequestTargeting) UnmarshalJSON(b []byte) error {
 	if string(b) == "null" {
 		return nil
 	}
-	ertRaw := &ExtRequestTargetingPlain{}
-	err := json.Unmarshal(b, ertRaw)
-	ert.PriceGranularity = ertRaw.PriceGranularity
-	ert.MaxLength = ertRaw.MaxLength
-	if err == nil {
-		// set default value
-		if ert.PriceGranularity == "" {
-			ert.PriceGranularity = PriceGranularityMedium
-		}
+
+	// define seperate type to prevent infinite recursive calls to UnmarshalJSON
+	type extRequestTargetingDefaults ExtRequestTargeting
+	defaults := &extRequestTargetingDefaults{
+		PriceGranularity: PriceGranularityMedium,
 	}
+
+	err := json.Unmarshal(b, defaults)
+	if err == nil {
+		*ert = ExtRequestTargeting(*defaults)
+	}
+
 	return err
 }
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -505,11 +505,13 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				hbDealIdBidderKey = hbDealIdBidderKey[:min(len(hbDealIdBidderKey), int(pbs_req.MaxKeyLength))]
 				hbSizeBidderKey = hbSizeBidderKey[:min(len(hbSizeBidderKey), int(pbs_req.MaxKeyLength))]
 			}
+
 			pbs_kvs := map[string]string{
 				hbPbBidderKey:      roundedCpm,
 				hbBidderBidderKey:  bid.BidderCode,
 				hbCacheIdBidderKey: bid.CacheID,
 			}
+
 			if hbSize != "" {
 				pbs_kvs[hbSizeBidderKey] = hbSize
 			}
@@ -533,7 +535,13 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 					pbs_kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodHTML
 				}
 			}
-			bid.AdServerTargeting = pbs_kvs
+			if bid.AdServerTargeting == nil {
+				bid.AdServerTargeting = pbs_kvs
+			} else {
+				for k, v := range pbs_kvs {
+					bid.AdServerTargeting[k] = v
+				}
+			}
 		}
 	}
 }

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -506,11 +506,15 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				hbSizeBidderKey = hbSizeBidderKey[:min(len(hbSizeBidderKey), int(pbs_req.MaxKeyLength))]
 			}
 
-			pbs_kvs := map[string]string{
-				hbPbBidderKey:      roundedCpm,
-				hbBidderBidderKey:  bid.BidderCode,
-				hbCacheIdBidderKey: bid.CacheID,
+			// fixes #288 where map was being overwritten instead of updated
+			if bid.AdServerTargeting == nil {
+				bid.AdServerTargeting = make(map[string]string)
 			}
+			pbs_kvs := bid.AdServerTargeting
+
+			pbs_kvs[hbPbBidderKey] = roundedCpm
+			pbs_kvs[hbBidderBidderKey] = bid.BidderCode
+			pbs_kvs[hbCacheIdBidderKey] = bid.CacheID
 
 			if hbSize != "" {
 				pbs_kvs[hbSizeBidderKey] = hbSize
@@ -533,13 +537,6 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 					pbs_kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodDemandSDK
 				} else {
 					pbs_kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodHTML
-				}
-			}
-			if bid.AdServerTargeting == nil {
-				bid.AdServerTargeting = pbs_kvs
-			} else {
-				for k, v := range pbs_kvs {
-					bid.AdServerTargeting[k] = v
 				}
 			}
 		}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -195,6 +195,21 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 		DealId:     "1234",
 	}
 	bids = append(bids, &an_bid)
+	rb_bid := pbs.PBSBid{
+		BidID:      "test_bidid2",
+		AdUnitCode: "test_adunitcode",
+		BidderCode: "rubicon",
+		Price:      1.00,
+		Adm:        "test_adm",
+		Width:      300,
+		Height:     250,
+		CacheID:    "test_cache_id2",
+		DealId:     "7890",
+	}
+	rb_bid.AdServerTargeting = map[string]string{
+		"rpfl_1001": "15_tier0100",
+	}
+	bids = append(bids, &rb_bid)
 	nosize_bid := pbs.PBSBid{
 		BidID:      "test_bidid2",
 		AdUnitCode: "test_adunitcode",
@@ -261,6 +276,11 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			}
 			if bid.AdServerTargeting["hb_deal_appnexus"] != "1234" {
 				t.Errorf("hb_deal_id_appnexus was not parsed correctly %v", bid.AdServerTargeting["hb_deal_id_appnexus"])
+			}
+		}
+		if bid.BidderCode == "rubicon" {
+			if bid.AdServerTargeting["rpfl_1001"] != "15_tier0100" {
+				t.Error("custom ad_server_targeting KVPs from adapter were not preserved")
 			}
 		}
 		if bid.BidderCode == "nosizebidder" {


### PR DESCRIPTION
1. Fix #288: `"sort_bids": 1` in the request would call `sortBidsAddKeywordsMobile` which would overwrite any existing KVPs in `"ad_server_targeting"`.
2. Cleanup extraneous `ExtRequestTargetingPlain` type and instead use a type alias.