### PR TITLE
Prevent Rubicon bidder from crashing the app on requests with no format array

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -208,6 +208,11 @@ func lookupSize(s openrtb.Format) (int, error) {
 }
 
 func parseRubiconSizes(sizes []openrtb.Format) (primary int, alt []int, err error) {
+	// Fixes #317
+	if len(sizes) < 1 {
+		err = errors.New("rubicon imps must have at least one imp.format element")
+		return
+	}
 	alt = make([]int, 0, len(sizes)-1)
 	for _, size := range sizes {
 		rs, lerr := lookupSize(size)

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -11,16 +11,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/pbs"
 
 	"fmt"
 
+	"strings"
+
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-	"strings"
 )
 
 type rubiAppendTrackerUrlTestScenario struct {
@@ -1106,4 +1108,8 @@ func TestOpenRTBStandardResponse(t *testing.T) {
 	if theBid.ID != "1234567890" {
 		t.Errorf("Bad bid ID. Expected %s, got %s", "1234567890", theBid.ID)
 	}
+}
+
+func TestJsonSamples(t *testing.T) {
+	adapterstest.RunJSONBidderTest(t, "rubicontest", NewRubiconBidder(http.DefaultClient, "uri", "xuser", "xpass", "pbs-test-tracker", "usersync-url"))
 }

--- a/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
+++ b/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
@@ -1,4 +1,5 @@
 {
+  "//": "Prevents #317",
   "mockBidRequest": {
     "id": "e8f0d8a3-f360-43c2-af08-34aa265108b0",
     "site": {

--- a/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
+++ b/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
@@ -1,0 +1,23 @@
+{
+  "mockBidRequest": {
+    "id": "e8f0d8a3-f360-43c2-af08-34aa265108b0",
+    "site": {
+      "page": "mysite.com"
+    },
+    "imp": [
+      {
+        "id":"/19968336/header-bid-tag-0",
+        "banner": {},
+        "ext": {
+          "bidder": {
+            "accountId": 1001,
+            "siteId":113932,
+            "zoneId":535510
+          }
+        }
+      }
+    ]
+  },
+
+  "expectedMakeRequestsErrors": ["rubicon imps must have at least one imp.format element"]
+}


### PR DESCRIPTION
Fixes #317.

There's probably a better way to do this.  Pubs can also define dimensions in `imp.banner.w` and `imp.banner.h`, while leaving the `format` array empty, but... my goal here is just to stabilize the code so that it can be run safely in prod.