### PR TITLE
Removing request.ext.prebid.targeting.lengthmax

### DIFF
--- a/docs/developers/stored-requests.md
+++ b/docs/developers/stored-requests.md
@@ -135,7 +135,6 @@ For example, assume the following `stored_requests/data/by_id/stored-request.jso
       "prebid": {
         "targeting": {
           "pricegraularity": "low",
-          "lengthmax": 20
         }
       }
     }
@@ -173,7 +172,6 @@ will produce the same auction as if the HTTP request had been:
     "prebid": {
       "targeting": {
         "pricegraularity": "low",
-        "lengthmax": 20
       }
     }
   }

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -123,7 +123,6 @@ to set these params on the response at `response.seatbid[i].bid[j].ext.prebid.ta
 ```
 {
   "pricegraularity": "One of ['low', 'med', 'high', 'auto', 'dense']", // Required property.
-  "lengthmax": 20 // Max characters allowed in a targeting value. If omitted, there is no max.
 }
 ```
 
@@ -139,6 +138,9 @@ to set these params on the response at `response.seatbid[i].bid[j].ext.prebid.ta
 
 The winning bid for each `request.imp[i]` will also contain `hb_bidder`, `hb_size`, and `hb_pb`
 (with _no_ {bidderName} suffix).
+
+**NOTE**: Targeting keys are limited to 20 characters. If {bidderName} is too long, the returned key
+will be truncated to only include the first 20 characters.
 
 #### Improving Performance
 

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -5,6 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/evanphx/json-patch"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/config"
@@ -13,12 +20,6 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
 	"github.com/rcrowley/go-metrics"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
 )
 
 const maxSize = 1024 * 256
@@ -602,8 +603,7 @@ var validRequests = []string{
 		"ext": {
 			"prebid": {
 				"targeting": {
-					"pricegranularity": "low",
-					"lengthmax": 20
+					"pricegranularity": "low"
 				},
 				"cache": {
 					"bids": {}
@@ -926,7 +926,6 @@ var testStoredRequests = []string{
 					"markup": 1
 				},
 				"targeting": {
-					"lengthmax": 20
 				}
 			}
 		}
@@ -957,7 +956,6 @@ var testStoredRequests = []string{
 					"markup": 1
 				},
 				"targeting": {
-					"lengthmax": 20
 				}
 			}
 		}
@@ -1014,7 +1012,6 @@ var testStoredRequests = []string{
 					"markup": 1
 				},
 				"targeting": {
-					"lengthmax": 20
 				}
 			}
 		}
@@ -1051,7 +1048,6 @@ var testFinalRequests = []string{
 					"markup": 1
 				},
 				"targeting": {
-					"lengthmax": 20
 				}
 			}
 		}
@@ -1081,7 +1077,6 @@ var testFinalRequests = []string{
 					"markup": 1
 				},
 				"targeting": {
-					"lengthmax": 20
 				}
 			}
 		}
@@ -1160,7 +1155,6 @@ var testFinalRequests = []string{
 				"markup": 1
 			},
 			"targeting": {
-				"lengthmax": 20
 			}
 		}
 	}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/mxmCherry/openrtb"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
 // TestSingleBidder makes sure that the following things work if the Bidder needs only one request.
@@ -417,7 +418,6 @@ func TestTargetingKeys(t *testing.T) {
 		Prebid: openrtb_ext.ExtRequestPrebid{
 			Targeting: &openrtb_ext.ExtRequestTargeting{
 				PriceGranularity: openrtb_ext.PriceGranularityMedium,
-				MaxLength:        20,
 			},
 		},
 	}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -87,7 +87,6 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 
 		if requestExt.Prebid.Targeting != nil {
 			targData = &targetData{
-				lengthMax:        requestExt.Prebid.Targeting.MaxLength,
 				priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
 			}
 			if shouldCacheBids {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -189,7 +189,6 @@ func TestBuildBidResponse(t *testing.T) {
 		Prebid: openrtb_ext.ExtRequestPrebid{
 			Targeting: &openrtb_ext.ExtRequestTargeting{
 				PriceGranularity: openrtb_ext.PriceGranularityMedium,
-				MaxLength:        20,
 			},
 		},
 	}

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -2,11 +2,14 @@ package exchange
 
 import (
 	"encoding/json"
+	"strconv"
+
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs/buckets"
-	"strconv"
 )
+
+const maxKeyLength = 20
 
 // targetData tracks information about the winning Bid in each Imp.
 //
@@ -16,7 +19,6 @@ import (
 // All functions on this struct are all nil-safe.
 // If the value is nil, then no targeting data will be tracked.
 type targetData struct {
-	lengthMax        int
 	priceGranularity openrtb_ext.PriceGranularity
 	includeCache     bool
 }
@@ -46,10 +48,10 @@ func (t *targetData) makePrebidTargets(name openrtb_ext.BidderName, bid *openrtb
 		hbSize = w + "x" + h
 	}
 
-	hbPbBidderKey := openrtb_ext.HbpbConstantKey.BidderKey(name, t.lengthMax)
-	hbBidderBidderKey := openrtb_ext.HbBidderConstantKey.BidderKey(name, t.lengthMax)
-	hbSizeBidderKey := openrtb_ext.HbSizeConstantKey.BidderKey(name, t.lengthMax)
-	hbDealIdBidderKey := openrtb_ext.HbDealIdConstantKey.BidderKey(name, t.lengthMax)
+	hbPbBidderKey := openrtb_ext.HbpbConstantKey.BidderKey(name, maxKeyLength)
+	hbBidderBidderKey := openrtb_ext.HbBidderConstantKey.BidderKey(name, maxKeyLength)
+	hbSizeBidderKey := openrtb_ext.HbSizeConstantKey.BidderKey(name, maxKeyLength)
+	hbDealIdBidderKey := openrtb_ext.HbDealIdConstantKey.BidderKey(name, maxKeyLength)
 
 	pbs_kvs := map[string]string{
 		hbPbBidderKey:     roundedCpm,
@@ -82,10 +84,10 @@ func (t *targetData) addTargetsToCompletedAuction(auction *auction) {
 		if err1 == nil && overallWinner && bidExt.Prebid.Targeting != nil {
 			cacheId, hasCacheId := auction.cacheId(bid)
 			if overallWinner {
-				hbPbBidderKey := openrtb_ext.HbpbConstantKey.BidderKey(bidderName, t.lengthMax)
-				hbBidderBidderKey := openrtb_ext.HbBidderConstantKey.BidderKey(bidderName, t.lengthMax)
-				hbSizeBidderKey := openrtb_ext.HbSizeConstantKey.BidderKey(bidderName, t.lengthMax)
-				hbDealIdBidderKey := openrtb_ext.HbDealIdConstantKey.BidderKey(bidderName, t.lengthMax)
+				hbPbBidderKey := openrtb_ext.HbpbConstantKey.BidderKey(bidderName, maxKeyLength)
+				hbBidderBidderKey := openrtb_ext.HbBidderConstantKey.BidderKey(bidderName, maxKeyLength)
+				hbSizeBidderKey := openrtb_ext.HbSizeConstantKey.BidderKey(bidderName, maxKeyLength)
+				hbDealIdBidderKey := openrtb_ext.HbDealIdConstantKey.BidderKey(bidderName, maxKeyLength)
 
 				bidExt.Prebid.Targeting[string(openrtb_ext.HbpbConstantKey)] = bidExt.Prebid.Targeting[hbPbBidderKey]
 				bidExt.Prebid.Targeting[string(openrtb_ext.HbBidderConstantKey)] = bidExt.Prebid.Targeting[hbBidderBidderKey]
@@ -106,7 +108,7 @@ func (t *targetData) addTargetsToCompletedAuction(auction *auction) {
 			}
 
 			if hasCacheId {
-				bidExt.Prebid.Targeting[openrtb_ext.HbCacheKey.BidderKey(bidderName, t.lengthMax)] = cacheId
+				bidExt.Prebid.Targeting[openrtb_ext.HbCacheKey.BidderKey(bidderName, maxKeyLength)] = cacheId
 			}
 
 			bid.Ext, err1 = json.Marshal(bidExt)

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -44,7 +44,6 @@ type ExtRequestPrebidCacheBids struct{}
 // ExtRequestTargeting defines the contract for bidrequest.ext.prebid.targeting
 type ExtRequestTargeting struct {
 	PriceGranularity PriceGranularity `json:"pricegranularity"`
-	MaxLength        int              `json:"lengthmax"`
 }
 
 // ExtRequestTargeting without Unmashall override to prevent infinite loops
@@ -61,7 +60,6 @@ func (ert *ExtRequestTargeting) UnmarshalJSON(b []byte) error {
 	ertRaw := &ExtRequestTargetingPlain{}
 	err := json.Unmarshal(b, ertRaw)
 	ert.PriceGranularity = ertRaw.PriceGranularity
-	ert.MaxLength = ertRaw.MaxLength
 	if err == nil {
 		// set default value
 		if ert.PriceGranularity == "" {

--- a/openrtb_ext/request_test.go
+++ b/openrtb_ext/request_test.go
@@ -53,8 +53,7 @@ const ext1 = `{
 const ext2 = `{
 	"prebid": {
 		"targeting": {
-			"pricegranularity": "dense",
-			"lengthmax": 20
+			"pricegranularity": "dense"
 		}
 	}
 }`


### PR DESCRIPTION
Fixes #321.

I thought Prebid.js supported this... but apparently I was wrong. Best to leave this out until there are real use-cases for it.