### PR TITLE
Improve appnexus multiformat auctions

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -67,6 +67,14 @@ type appnexusImpExtAppnexus struct {
 	TrafficSourceCode string `json:"traffic_source_code,omitempty"`
 }
 
+type appnexusBidExt struct {
+	Appnexus appnexusBidExtAppnexus `json:"appnexus"`
+}
+
+type appnexusBidExtAppnexus struct {
+	BidType int `json:"bid_ad_type"`
+}
+
 type appnexusImpExt struct {
 	Appnexus appnexusImpExtAppnexus `json:"appnexus"`
 }
@@ -183,11 +191,8 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 
 	bids := make(pbs.PBSBidSlice, 0)
 
-	numBids := 0
 	for _, sb := range bidResp.SeatBid {
 		for _, bid := range sb.Bid {
-			numBids++
-
 			bidID := bidder.LookupBidID(bid.ImpID)
 			if bidID == "" {
 				return nil, fmt.Errorf("Unknown ad unit code '%s'", bid.ImpID)
@@ -206,9 +211,10 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 				NURL:        bid.NURL,
 			}
 
-			mediaType := getMediaTypeForImp(bid.ImpID, anReq.Imp)
-			pbid.CreativeMediaType = string(mediaType)
-			bids = append(bids, &pbid)
+			if mediaType, err := getMediaTypeForBid(&bid); err == nil {
+				pbid.CreativeMediaType = string(mediaType)
+				bids = append(bids, &pbid)
+			}
 		}
 	}
 
@@ -286,7 +292,6 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 	if imp.Native != nil || imp.Audio != nil {
 		return "", fmt.Errorf("Appnexus doesn't support audio or native Imps. Ignoring Imp ID=%s", imp.ID)
 	}
-
 	var bidderExt adapters.ExtImpBidder
 	if err := json.Unmarshal(imp.Ext, &bidderExt); err != nil {
 		return "", err
@@ -366,33 +371,40 @@ func (a *AppNexusAdapter) MakeBids(internalRequest *openrtb.BidRequest, external
 
 	bids := make([]*adapters.TypedBid, 0, 5)
 
+	var errs []error
 	for _, sb := range bidResp.SeatBid {
 		for _, bid := range sb.Bid {
-			bids = append(bids, &adapters.TypedBid{
-				Bid:     &bid,
-				BidType: getMediaTypeForImp(bid.ImpID, internalRequest.Imp),
-			})
+			if bidType, err := getMediaTypeForBid(&bid); err == nil {
+				bids = append(bids, &adapters.TypedBid{
+					Bid:     &bid,
+					BidType: bidType,
+				})
+			} else {
+				errs = append(errs, err)
+			}
 		}
 	}
-	return bids, nil
+	return bids, errs
 }
 
-// getMediaTypeForImp figures out which media type this bid is for.
-//
-// This is only safe for multi-type impressions because the AN server prioritizes video over banner,
-// and we duplicate that logic here. A ticket exists to return the media type in the bid response,
-// at which point we can delete this.
-func getMediaTypeForImp(impId string, imps []openrtb.Imp) openrtb_ext.BidType {
-	mediaType := openrtb_ext.BidTypeBanner
-	for _, imp := range imps {
-		if imp.ID == impId {
-			if imp.Video != nil {
-				mediaType = openrtb_ext.BidTypeVideo
-			}
-			return mediaType
-		}
+// getMediaTypeForBid determines which type of bid.
+func getMediaTypeForBid(bid *openrtb.Bid) (openrtb_ext.BidType, error) {
+	var impExt appnexusBidExt
+	if err := json.Unmarshal(bid.Ext, &impExt); err != nil {
+		return "", err
 	}
-	return mediaType
+	switch impExt.Appnexus.BidType {
+	case 0:
+		return openrtb_ext.BidTypeBanner, nil
+	case 1:
+		return openrtb_ext.BidTypeVideo, nil
+	case 2:
+		return openrtb_ext.BidTypeAudio, nil
+	case 3:
+		return openrtb_ext.BidTypeNative, nil
+	default:
+		return "", fmt.Errorf("Unrecognized bid_ad_type in response from appnexus: %d", impExt.Appnexus.BidType)
+	}
 }
 
 func NewAppNexusAdapter(config *adapters.HTTPAdapterConfig, externalURL string) *AppNexusAdapter {

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -188,6 +188,7 @@ func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {
 			ImpID: imp.ID,
 			Price: andata.tags[i].bid,
 			AdM:   andata.tags[i].content,
+			Ext:   openrtb.RawJSON(fmt.Sprintf(`{"appnexus":{"bid_ad_type":%d}}`, bidTypeToInt(andata.tags[i].mediaType))),
 		}
 
 		if imp.Video != nil {
@@ -235,6 +236,20 @@ func DummyAppNexusServer(w http.ResponseWriter, r *http.Request) {
 	w.Write(js)
 }
 
+func bidTypeToInt(bidType string) int {
+	switch bidType {
+	case "banner":
+		return 0
+	case "video":
+		return 1
+	case "audio":
+		return 2
+	case "native":
+		return 3
+	default:
+		return -1
+	}
+}
 func TestAppNexusBasicResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(DummyAppNexusServer))
 	defer server.Close()
@@ -371,7 +386,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 			if bid.AdUnitCode == tag.code {
 				matched = true
 				if bid.CreativeMediaType != tag.mediaType {
-					t.Errorf("Incorrect Creative MediaType '%s'", bid.CreativeMediaType)
+					t.Errorf("Incorrect Creative MediaType '%s'. Expected '%s'", bid.CreativeMediaType, tag.mediaType)
 				}
 				if bid.BidderCode != "appnexus" {
 					t.Errorf("Incorrect BidderCode '%s'", bid.BidderCode)

--- a/adapters/appnexus/appnexustest/exemplary/simple-banner.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-banner.json
@@ -80,6 +80,7 @@
                   "appnexus": {
                     "brand_id": 1,
                     "auction_id": 8189378542222915032,
+                    "bid_ad_type": 0,
                     "bidder_id": 2,
                     "ranking_price": 0.000000
                   }
@@ -112,6 +113,7 @@
           "appnexus": {
             "brand_id": 1,
             "auction_id": 8189378542222915032,
+            "bid_ad_type": 0,
             "bidder_id": 2,
             "ranking_price": 0.000000
           }


### PR DESCRIPTION
This fixes a long-standing hack in the appnexus adapter, for both legacy & OpenRTB endpoints.

Previously, there was some logic which basically assumed that the bid was video if possible, and banner otherwise. This is super fragile, because it used insider knowledge of impbus to "guess" which type of response it was. If impbus changed their bidding strategy, this code could easily assign the wrong type to the bid.

I asked impbus to return the bid type in their response `ext`, which they've now finished. This should be more reliable, which I count as a precondition for supporting Native.