### PR TITLE
Added an error if audience network is misconfigured

### DIFF
--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -275,6 +275,7 @@ func NewAdapterFromFacebook(config *adapters.HTTPAdapterConfig, partnerID string
 
 func NewFacebookAdapter(config *adapters.HTTPAdapterConfig, partnerID string) *FacebookAdapter {
 	a := adapters.NewHTTPAdapter(config)
+
 	return &FacebookAdapter{
 		http: a,
 		URI:  "https://an.facebook.com/placementbid.ortb",

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -261,13 +261,20 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	return bids, nil
 }
 
-func NewFacebookAdapter(config *adapters.HTTPAdapterConfig, partnerID string) *FacebookAdapter {
-	a := adapters.NewHTTPAdapter(config)
-
+func NewAdapterFromFacebook(config *adapters.HTTPAdapterConfig, partnerID string) adapters.Adapter {
 	if partnerID == "" {
 		glog.Errorf("No facebook partnerID specified. Calls to the Audience Network will fail. Did you set adapters.facebook.platform_id in the app config?")
+		return &adapters.MisconfiguredAdapter{
+			TheName:       "audienceNetwork",
+			TheFamilyName: "audienceNetwork",
+			Err:           errors.New("Audience Network is not configured properly on this Prebid Server deploy. If you believe this should work, contact the company hosting the service."),
+		}
 	}
+	return NewFacebookAdapter(config, partnerID)
+}
 
+func NewFacebookAdapter(config *adapters.HTTPAdapterConfig, partnerID string) *FacebookAdapter {
+	a := adapters.NewHTTPAdapter(config)
 	return &FacebookAdapter{
 		http: a,
 		URI:  "https://an.facebook.com/placementbid.ortb",

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -267,7 +267,7 @@ func NewAdapterFromFacebook(config *adapters.HTTPAdapterConfig, partnerID string
 		return &adapters.MisconfiguredAdapter{
 			TheName:       "audienceNetwork",
 			TheFamilyName: "audienceNetwork",
-			Err:           errors.New("Audience Network is not configured properly on this Prebid Server deploy. If you believe this should work, contact the company hosting the service."),
+			Err:           errors.New("Audience Network is not configured properly on this Prebid Server deploy. If you believe this should work, contact the company hosting the service and tell them to check their configuration."),
 		}
 	}
 	return NewFacebookAdapter(config, partnerID)

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/pbs"
@@ -262,6 +263,10 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 
 func NewFacebookAdapter(config *adapters.HTTPAdapterConfig, partnerID string) *FacebookAdapter {
 	a := adapters.NewHTTPAdapter(config)
+
+	if partnerID == "" {
+		glog.Errorf("No facebook partnerID specified. Calls to the Audience Network will fail. Did you set adapters.facebook.platform_id in the app config?")
+	}
 
 	return &FacebookAdapter{
 		http: a,

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -2,9 +2,10 @@ package adapters
 
 import (
 	"encoding/base64"
+	"net/http"
+
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
-	"net/http"
 )
 
 // Bidder describes how to connect to external demand.

--- a/adapters/legacy.go
+++ b/adapters/legacy.go
@@ -79,3 +79,24 @@ type CallOneResult struct {
 	Bid          *pbs.PBSBid
 	Error        error
 }
+
+type MisconfiguredAdapter struct {
+	TheName       string
+	TheFamilyName string
+	Err           error
+}
+
+func (b *MisconfiguredAdapter) Name() string {
+	return b.TheName
+}
+
+func (b *MisconfiguredAdapter) FamilyName() string {
+	return b.TheFamilyName
+}
+func (b *MisconfiguredAdapter) SkipNoCookies() bool {
+	return false
+}
+
+func (b *MisconfiguredAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
+	return nil, b.Err
+}

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -25,7 +25,7 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_e
 		// TODO #267: Upgrade the Conversant adapter
 		openrtb_ext.BidderConversant: adaptLegacyAdapter(conversant.NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["conversant"].Endpoint)),
 		// TODO #211: Upgrade the Facebook adapter
-		openrtb_ext.BidderFacebook: adaptLegacyAdapter(audienceNetwork.NewFacebookAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID)),
+		openrtb_ext.BidderFacebook: adaptLegacyAdapter(audienceNetwork.NewAdapterFromFacebook(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID)),
 		// TODO #212: Upgrade the Index adapter
 		openrtb_ext.BidderIndex: adaptLegacyAdapter(indexExchange.NewIndexAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["indexexchange"].Endpoint)),
 		// TODO #213: Upgrade the Lifestreet adapter

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -756,7 +756,7 @@ func newExchangeMap(cfg *config.Configuration) map[string]adapters.Adapter {
 		"pulsepoint":    pulsepoint.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["pulsepoint"].Endpoint),
 		"rubicon": rubicon.NewRubiconAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["rubicon"].Endpoint,
 			cfg.Adapters["rubicon"].XAPI.Username, cfg.Adapters["rubicon"].XAPI.Password, cfg.Adapters["rubicon"].XAPI.Tracker),
-		"audienceNetwork": audienceNetwork.NewFacebookAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID),
+		"audienceNetwork": audienceNetwork.NewAdapterFromFacebook(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID),
 		"lifestreet":      lifestreet.NewLifestreetAdapter(adapters.DefaultHTTPAdapterConfig),
 		"conversant":      conversant.NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["conversant"].Endpoint),
 	}


### PR DESCRIPTION
@anwzhang was missing a config option and got obtuse errors from the facebook adapter. Whenever she tried to run an auction, the response was:

```
{
    "id": "blahblah",
    "ext": {
        "errors": {
            "audienceNetwork": [
                "json: error calling MarshalJSON for type openrtb.RawJSON: invalid character '}' looking for beginning of value"
            ]
        },
        "responsetimemillis": {
            "audienceNetwork": 0
        }
    }
}
```

The root problem is that facebook's adapter requires a `partnerID`, which is set in your app config. During development, it's easy to skip this in your app config... and this is the behavior you'll see. 

I don't think we can assume that every PBS host (and every developer) can has a `partnerID` with facebook... so we can't just `glog.Fatal` and crash the process on bad config. As a next best thing, this improves the error message so the next person can figure out what's happening faster.