### PR TITLE
add creative type on facebook adapter

### DIFF
--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -229,7 +229,6 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 					result.Bid = nil
 				}
 			}
-			}
 			ch <- result
 		}(bidder, requests[i])
 	}

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -103,9 +103,10 @@ func (a *FacebookAdapter) callOne(ctx context.Context, reqJSON bytes.Buffer) (re
 	bid := bidResp.SeatBid[0].Bid[0]
 
 	result.Bid = &pbs.PBSBid{
-		AdUnitCode: bid.ImpID,
-		Price:      bid.Price,
-		Adm:        bid.AdM,
+		AdUnitCode:        bid.ImpID,
+		Price:             bid.Price,
+		Adm:               bid.AdM,
+		CreativeMediaType: "banner", //  hard code this, because that's all facebook supports now, can potentially update it dynamically from "template" field in the "adm"
 	}
 	return
 }
@@ -227,6 +228,7 @@ func (a *FacebookAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 					result.Error = fmt.Errorf("Unknown ad unit code '%s'", result.Bid.AdUnitCode)
 					result.Bid = nil
 				}
+			}
 			}
 			ch <- result
 		}(bidder, requests[i])


### PR DESCRIPTION
Facebook returns bids however showing the following error:
```"errors": {
            "audienceNetwork": [
                "invalid BidType: "
            ]
        }
```
The reason is that adapter communicates with FB using ortb but internally transforms it to a PBSBid object during which no creative type is set on the PBSBid, since FB doesn't return any from server.
