### PR TITLE
Fixed a bug in Targeting + Legacy Adapters

### DIFF
--- a/exchange/legacy.go
+++ b/exchange/legacy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
@@ -303,7 +304,7 @@ func transformBid(legacyBid *pbs.PBSBid, bidderTarg *targetData, name openrtb_ex
 	}
 
 	targets, err := bidderTarg.makePrebidTargets(name, newBid)
-	if targets != nil {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Another but which @anwzhang surfaced...

Requests sent to a Legacy bidder which include Targeting were not working properly. The root cause was this line, which seems like a simple logic bug.

Regression test included to make sure this doesn't happen again later.