### PR TITLE
Added some docs for special adapter rules

### DIFF
--- a/docs/bidders/audienceNetwork.md
+++ b/docs/bidders/audienceNetwork.md
@@ -1,0 +1,6 @@
+# Audience Network Bidder
+
+## Mobile Bids
+
+Audience Network will not bid on requests made from device simulators.
+When testingfor Mobile bids, you must make bid requests using a real device.

--- a/docs/bidders/rubicon.md
+++ b/docs/bidders/rubicon.md
@@ -1,0 +1,6 @@
+# Rubicon Bidder
+
+## User syncs
+
+Prebid Server host companies must contact Rubicon directly if they want to sync cookies.
+Email [the Bidder's maintainer](../../adapters/rubicon/info.yaml) to arrange this.


### PR DESCRIPTION
This documents some special cases we found while testing the audience network adapter recently.

Also fixes #272, because it's easy.