### PR TITLE
Fixing some race conditions

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -302,18 +302,20 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 		imp.BidFloor = appnexusExt.Reserve // This will be broken for non-USD currency.
 	}
 	if imp.Banner != nil {
+		bannerCopy := *imp.Banner
 		if appnexusExt.Position == "above" {
-			imp.Banner.Pos = openrtb.AdPositionAboveTheFold.Ptr()
+			bannerCopy.Pos = openrtb.AdPositionAboveTheFold.Ptr()
 		} else if appnexusExt.Position == "below" {
-			imp.Banner.Pos = openrtb.AdPositionBelowTheFold.Ptr()
+			bannerCopy.Pos = openrtb.AdPositionBelowTheFold.Ptr()
 		}
 
 		// Fixes #307
-		if imp.Banner.W == nil && imp.Banner.H == nil && len(imp.Banner.Format) > 0 {
-			firstFormat := imp.Banner.Format[0]
-			imp.Banner.W = &(firstFormat.W)
-			imp.Banner.H = &(firstFormat.H)
+		if bannerCopy.W == nil && bannerCopy.H == nil && len(bannerCopy.Format) > 0 {
+			firstFormat := bannerCopy.Format[0]
+			bannerCopy.W = &(firstFormat.W)
+			bannerCopy.H = &(firstFormat.H)
 		}
+		imp.Banner = &bannerCopy
 	}
 
 	impExt := appnexusImpExt{Appnexus: appnexusImpExtAppnexus{

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -572,11 +572,13 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.
 				continue
 			}
 			bannerExt := rubiconBannerExt{RP: rubiconBannerExtRP{SizeID: primarySizeID, AltSizeIDs: altSizeIDs, MIME: "text/html"}}
-			thisImp.Banner.Ext, err = json.Marshal(&bannerExt)
+			bannerCopy := *thisImp.Banner
+			bannerCopy.Ext, err = json.Marshal(&bannerExt)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
+			thisImp.Banner = &bannerCopy
 		}
 
 		siteExt := rubiconSiteExt{RP: rubiconSiteExtRP{SiteID: rubiconExt.SiteId}}

--- a/endpoints/openrtb2/race_test.go
+++ b/endpoints/openrtb2/race_test.go
@@ -1,0 +1,106 @@
+package openrtb2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/exchange"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
+	metrics "github.com/rcrowley/go-metrics"
+)
+
+func TestRequestConcurrently(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(nobidServer))
+	defer server.Close()
+
+	cfg := &config.Configuration{}
+
+	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), exchange.AdapterList())
+	ex := exchange.NewExchange(server.Client(), &mockCache{}, cfg, theMetrics)
+	paramsValidator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("failed to load params validators: %v", err)
+	}
+
+	endpoint, _ := NewEndpoint(ex, paramsValidator, empty_fetcher.EmptyFetcher(), &config.Configuration{MaxRequestSize: maxSize}, theMetrics)
+
+	req := `
+	{
+		"id": "some-request-id",
+		"site": {
+			"page": "test.somepage.com"
+		},
+		"imp": [
+			{
+				"id": "my-imp-id",
+				"banner": {
+					"format": [
+						{
+							"w": 300,
+							"h": 600
+						}
+					]
+				},
+				"pmp": {
+					"deals": [
+						{
+							"id": "some-deal-id"
+						}
+					]
+				},
+				"ext": {
+					"appnexus": {
+						"placementId": 10433394
+					},
+					"rubicon": {
+						"accountId": 1001,
+						"siteId": 113932,
+						"zoneId": 535510
+					}
+				}
+			}
+		],
+		"ext": {
+			"prebid": {
+				"targeting": {
+					"pricegranularity": "low"
+				},
+				"cache": {
+					"bids": {}
+				}
+			}
+		}
+	}
+	`
+	httpReq, err := http.NewRequest("POST", "pbs.com/openrtb2/auction", strings.NewReader(req))
+	if err != nil {
+		t.Fatalf("Failed to make HTTP request: %v", err)
+	}
+	r := httptest.NewRecorder()
+	endpoint(r, httpReq, nil)
+	if r.Code != http.StatusOK {
+		t.Errorf("Got response status: %d. Expected %d", r.Code, http.StatusOK)
+	}
+}
+
+func nobidServer(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(204)
+}
+
+type mockCache struct{}
+
+func (c *mockCache) PutJson(ctx context.Context, values []json.RawMessage) (ids []string) {
+	ids = make([]string, len(values))
+	for i := 0; i < len(values); i++ {
+		ids[i] = strconv.Itoa(i)
+	}
+	return
+}


### PR DESCRIPTION
High priority changes to fix some race conditions which are crashing us in prod.

Don't pay much attention to `race_test.go`; I'm going to be rewriting it very shortly, building it such that it won't be overlooked by new adapter submissions. I'm including it because it proves that this fixes some real race conditions.

You can verify with `go test -race github.com/prebid/prebid-server/endpoints/openrtb2 -run ^TestRequestConcurrently$ -count 100`. On `master`, it shows a bunch of race conditions. On this branch, it passes cleanly.