### PR TITLE
Delete Adapter.Name()

### DIFF
--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -58,7 +58,7 @@ func NewAdformAdapter(config *adapters.HTTPAdapterConfig, endpointURL string) *A
 }
 
 // used for cookies and such
-func (a *AdformAdapter) FamilyName() string {
+func (a *AdformAdapter) Name() string {
 	return "adform"
 }
 
@@ -141,7 +141,7 @@ func pbsRequestToAdformRequest(a *AdformAdapter, request *pbs.PBSRequest, bidder
 		adUnits = append(adUnits, &adformAdUnit)
 	}
 
-	userId, _, _ := request.Cookie.GetUID(a.FamilyName())
+	userId, _, _ := request.Cookie.GetUID(a.Name())
 
 	return &adformRequest{
 		adUnits:    adUnits,

--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -57,11 +57,6 @@ func NewAdformAdapter(config *adapters.HTTPAdapterConfig, endpointURL string) *A
 	return NewAdformBidder(adapters.NewHTTPAdapter(config).Client, endpointURL)
 }
 
-/* Name - export adapter name */
-func (a *AdformAdapter) Name() string {
-	return "Adform"
-}
-
 // used for cookies and such
 func (a *AdformAdapter) FamilyName() string {
 	return "adform"

--- a/adapters/adform/adform_test.go
+++ b/adapters/adform/adform_test.go
@@ -433,9 +433,6 @@ func TestAdformProperties(t *testing.T) {
 	if adapter.SkipNoCookies() != false {
 		t.Fatalf("should have been false")
 	}
-	if adapter.Name() != "Adform" {
-		t.Fatalf("should have been Adform")
-	}
 }
 
 // helpers

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -27,7 +27,7 @@ type AppNexusAdapter struct {
 }
 
 // used for cookies and such
-func (a *AppNexusAdapter) FamilyName() string {
+func (a *AppNexusAdapter) Name() string {
 	return "adnxs"
 }
 
@@ -70,7 +70,7 @@ type appnexusImpExt struct {
 
 func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	anReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), supportedMediaTypes, true)
+	anReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes, true)
 
 	if err != nil {
 		return nil, err

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -26,11 +26,6 @@ type AppNexusAdapter struct {
 	URI  string
 }
 
-/* Name - export adapter name */
-func (a *AppNexusAdapter) Name() string {
-	return "AppNexus"
-}
-
 // used for cookies and such
 func (a *AppNexusAdapter) FamilyName() string {
 	return "adnxs"

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -32,11 +32,6 @@ var supportedHeight = map[uint64]bool{
 	250: true,
 }
 
-/* Name - export adapter name */
-func (a *FacebookAdapter) Name() string {
-	return "audienceNetwork"
-}
-
 // used for cookies and such
 func (a *FacebookAdapter) FamilyName() string {
 	return "audienceNetwork"

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -33,7 +33,7 @@ var supportedHeight = map[uint64]bool{
 }
 
 // used for cookies and such
-func (a *FacebookAdapter) FamilyName() string {
+func (a *FacebookAdapter) Name() string {
 	return "audienceNetwork"
 }
 
@@ -109,7 +109,7 @@ func (a *FacebookAdapter) callOne(ctx context.Context, reqJSON bytes.Buffer) (re
 
 func (a *FacebookAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, placementId string, mtype pbs.MediaType, pubId string, unitInd int) (openrtb.BidRequest, error) {
 	// this method creates imps for all ad units for the bidder with a single media type
-	fbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{mtype}, true)
+	fbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype}, true)
 
 	if err != nil {
 		return openrtb.BidRequest{}, err
@@ -261,9 +261,8 @@ func NewAdapterFromFacebook(config *adapters.HTTPAdapterConfig, partnerID string
 	if partnerID == "" {
 		glog.Errorf("No facebook partnerID specified. Calls to the Audience Network will fail. Did you set adapters.facebook.platform_id in the app config?")
 		return &adapters.MisconfiguredAdapter{
-			TheName:       "audienceNetwork",
-			TheFamilyName: "audienceNetwork",
-			Err:           errors.New("Audience Network is not configured properly on this Prebid Server deploy. If you believe this should work, contact the company hosting the service and tell them to check their configuration."),
+			TheName: "audienceNetwork",
+			Err:     errors.New("Audience Network is not configured properly on this Prebid Server deploy. If you believe this should work, contact the company hosting the service and tell them to check their configuration."),
 		}
 	}
 	return NewFacebookAdapter(config, partnerID)

--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -20,7 +20,7 @@ type ConversantAdapter struct {
 }
 
 // Corresponds to the bidder name in cookies and requests
-func (a *ConversantAdapter) FamilyName() string {
+func (a *ConversantAdapter) Name() string {
 	return "conversant"
 }
 
@@ -44,7 +44,7 @@ type conversantParams struct {
 
 func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	cnvrReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	cnvrReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
 
 	if err != nil {
 		return nil, err

--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -19,11 +19,6 @@ type ConversantAdapter struct {
 	URI  string
 }
 
-// Name - export adapter name
-func (a *ConversantAdapter) Name() string {
-	return "conversant"
-}
-
 // Corresponds to the bidder name in cookies and requests
 func (a *ConversantAdapter) FamilyName() string {
 	return "conversant"

--- a/adapters/conversant/conversant_test.go
+++ b/adapters/conversant/conversant_test.go
@@ -36,7 +36,6 @@ const DefaultParam = `{"site_id": "12345"}`
 func TestConversantProperties(t *testing.T) {
 	an := NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, "someUrl")
 
-	assertNotEqual(t, an.Name(), "", "Missing name")
 	assertNotEqual(t, an.FamilyName(), "", "Missing family name")
 	assertTrue(t, an.SkipNoCookies(), "SkipNoCookies should be true")
 }
@@ -389,7 +388,7 @@ func TestConversantVideoRequestWithParams(t *testing.T) {
 	param := `{ "site_id": "12345",
 		   "tag_id": "bottom left",
 		   "position": 3,
-		   "bidfloor": 1.01, 
+		   "bidfloor": 1.01,
 		   "mimes": ["video/x-ms-wmv"],
 		   "protocols": [1, 2],
 		   "api": [1, 2],

--- a/adapters/conversant/conversant_test.go
+++ b/adapters/conversant/conversant_test.go
@@ -36,7 +36,7 @@ const DefaultParam = `{"site_id": "12345"}`
 func TestConversantProperties(t *testing.T) {
 	an := NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, "someUrl")
 
-	assertNotEqual(t, an.FamilyName(), "", "Missing family name")
+	assertNotEqual(t, an.Name(), "", "Missing family name")
 	assertTrue(t, an.SkipNoCookies(), "SkipNoCookies should be true")
 }
 

--- a/adapters/indexExchange/index.go
+++ b/adapters/indexExchange/index.go
@@ -23,7 +23,7 @@ type IndexAdapter struct {
 }
 
 // used for cookies and such
-func (a *IndexAdapter) FamilyName() string {
+func (a *IndexAdapter) Name() string {
 	return "indexExchange"
 }
 
@@ -40,7 +40,7 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 		return nil, fmt.Errorf("Index doesn't support apps")
 	}
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	indexReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	indexReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
 
 	if err != nil {
 		return nil, err

--- a/adapters/indexExchange/index.go
+++ b/adapters/indexExchange/index.go
@@ -22,11 +22,6 @@ type IndexAdapter struct {
 	URI  string
 }
 
-/* Name - export adapter name */
-func (a *IndexAdapter) Name() string {
-	return "indexExchange"
-}
-
 // used for cookies and such
 func (a *IndexAdapter) FamilyName() string {
 	return "indexExchange"

--- a/adapters/indexExchange/index_test.go
+++ b/adapters/indexExchange/index_test.go
@@ -20,10 +20,6 @@ func TestIndexInvalidCall(t *testing.T) {
 
 	an := NewIndexAdapter(adapters.DefaultHTTPAdapterConfig, "http://appnexus-eu.lb.indexww.com/bidder?p=184932")
 	an.URI = "blah"
-	s := an.Name()
-	if s == "" {
-		t.Fatal("Missing name")
-	}
 
 	ctx := context.TODO()
 	pbReq := pbs.PBSRequest{}

--- a/adapters/legacy.go
+++ b/adapters/legacy.go
@@ -19,8 +19,8 @@ import (
 // PBS is currently being rewritten to use Bidder, and this will be removed after.
 // Their primary purpose is to produce bids in response to Auction requests.
 type Adapter interface {
-	// FamilyName must be identical to the BidderName.
-	FamilyName() string
+	// Name must be identical to the BidderName.
+	Name() string
 	// Determines whether this adapter should get callouts if there is not a synched user ID.
 	SkipNoCookies() bool
 	// Call produces bids which should be considered, given the auction params.
@@ -77,17 +77,12 @@ type CallOneResult struct {
 }
 
 type MisconfiguredAdapter struct {
-	TheName       string
-	TheFamilyName string
-	Err           error
+	TheName string
+	Err     error
 }
 
 func (b *MisconfiguredAdapter) Name() string {
 	return b.TheName
-}
-
-func (b *MisconfiguredAdapter) FamilyName() string {
-	return b.TheFamilyName
 }
 func (b *MisconfiguredAdapter) SkipNoCookies() bool {
 	return false

--- a/adapters/legacy.go
+++ b/adapters/legacy.go
@@ -21,7 +21,7 @@ import (
 type Adapter interface {
 	// FamilyName must be identical to the BidderName.
 	FamilyName() string
-	// This must return false.
+	// Determines whether this adapter should get callouts if there is not a synched user ID.
 	SkipNoCookies() bool
 	// Call produces bids which should be considered, given the auction params.
 	//

--- a/adapters/legacy.go
+++ b/adapters/legacy.go
@@ -19,13 +19,9 @@ import (
 // PBS is currently being rewritten to use Bidder, and this will be removed after.
 // Their primary purpose is to produce bids in response to Auction requests.
 type Adapter interface {
-	// Name uniquely identifies this adapter. This must be identical to the code in Prebid.js,
-	// but cannot overlap with any other adapters in prebid-server.
-	Name() string
-	// FamilyName identifies the space of cookies which this adapter accesses. For example, an adapter
-	// using the adnxs.com cookie space should return "adnxs".
+	// FamilyName must be identical to the BidderName.
 	FamilyName() string
-	// Determines whether this adapter should get callouts if there is not a synched user ID
+	// This must return false.
 	SkipNoCookies() bool
 	// Call produces bids which should be considered, given the auction params.
 	//

--- a/adapters/lifestreet/lifestreet.go
+++ b/adapters/lifestreet/lifestreet.go
@@ -21,11 +21,6 @@ type LifestreetAdapter struct {
 	URI  string
 }
 
-/* Name - export adapter name */
-func (a *LifestreetAdapter) Name() string {
-	return "Lifestreet"
-}
-
 // used for cookies and such
 func (a *LifestreetAdapter) FamilyName() string {
 	return "lifestreet"

--- a/adapters/lifestreet/lifestreet.go
+++ b/adapters/lifestreet/lifestreet.go
@@ -22,7 +22,7 @@ type LifestreetAdapter struct {
 }
 
 // used for cookies and such
-func (a *LifestreetAdapter) FamilyName() string {
+func (a *LifestreetAdapter) Name() string {
 	return "lifestreet"
 }
 
@@ -85,7 +85,7 @@ func (a *LifestreetAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, re
 }
 
 func (a *LifestreetAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, slotTag string, mtype pbs.MediaType, unitInd int) (openrtb.BidRequest, error) {
-	lsReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), []pbs.MediaType{mtype}, true)
+	lsReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype}, true)
 
 	if err != nil {
 		return openrtb.BidRequest{}, err

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -26,7 +26,7 @@ type PubmaticAdapter struct {
 }
 
 // used for cookies and such
-func (a *PubmaticAdapter) FamilyName() string {
+func (a *PubmaticAdapter) Name() string {
 	return "pubmatic"
 }
 
@@ -46,7 +46,7 @@ func PrepareLogMessage(tID, pubId, adUnitId, bidID, details string, args ...inte
 
 func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	pbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	pbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
 
 	if err != nil {
 		glog.Warningf("[PUBMATIC] Failed to make ortb request for request id [%s] \n", pbReq.ID)
@@ -147,7 +147,7 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		bidder.Debug = append(bidder.Debug, debug)
 	}
 
-	userId, _, _ := req.Cookie.GetUID(a.FamilyName())
+	userId, _, _ := req.Cookie.GetUID(a.Name())
 	httpReq, err := http.NewRequest("POST", a.URI, bytes.NewBuffer(reqJSON))
 	httpReq.Header.Add("Content-Type", "application/json;charset=utf-8")
 	httpReq.Header.Add("Accept", "application/json")

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -25,11 +25,6 @@ type PubmaticAdapter struct {
 	URI  string
 }
 
-/* Name - export adapter name */
-func (a *PubmaticAdapter) Name() string {
-	return "Pubmatic"
-}
-
 // used for cookies and such
 func (a *PubmaticAdapter) FamilyName() string {
 	return "pubmatic"

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -82,11 +82,6 @@ func TestPubmaticInvalidCall(t *testing.T) {
 
 	an := NewPubmaticAdapter(adapters.DefaultHTTPAdapterConfig, "blah")
 
-	s := an.Name()
-	if s == "" {
-		t.Fatal("Missing name")
-	}
-
 	ctx := context.Background()
 	pbReq := pbs.PBSRequest{}
 	pbBidder := pbs.PBSBidder{}

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -22,11 +22,6 @@ type PulsePointAdapter struct {
 	URI  string
 }
 
-// adapter name
-func (a *PulsePointAdapter) Name() string {
-	return "pulsepoint"
-}
-
 // used for cookies and such
 func (a *PulsePointAdapter) FamilyName() string {
 	return "pulsepoint"

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -23,7 +23,7 @@ type PulsePointAdapter struct {
 }
 
 // used for cookies and such
-func (a *PulsePointAdapter) FamilyName() string {
+func (a *PulsePointAdapter) Name() string {
 	return "pulsepoint"
 }
 
@@ -40,7 +40,7 @@ type PulsepointParams struct {
 
 func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	ppReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), mediaTypes, true)
+	ppReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
 
 	if err != nil {
 		return nil, err

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -32,7 +32,7 @@ type PulsePointOrtbMockService struct {
  */
 func TestPulsePointAdapterNames(t *testing.T) {
 	adapter := NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, "http://localhost/bid")
-	VerifyStringValue(adapter.FamilyName(), "pulsepoint", t)
+	VerifyStringValue(adapter.Name(), "pulsepoint", t)
 }
 
 /**

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -32,7 +32,6 @@ type PulsePointOrtbMockService struct {
  */
 func TestPulsePointAdapterNames(t *testing.T) {
 	adapter := NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, "http://localhost/bid")
-	VerifyStringValue(adapter.Name(), "pulsepoint", t)
 	VerifyStringValue(adapter.FamilyName(), "pulsepoint", t)
 }
 

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -26,11 +26,6 @@ type RubiconAdapter struct {
 	XAPIPassword string
 }
 
-/* Name - export adapter name */
-func (a *RubiconAdapter) Name() string {
-	return "Rubicon"
-}
-
 // used for cookies and such
 func (a *RubiconAdapter) FamilyName() string {
 	return "rubicon"

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -27,7 +27,7 @@ type RubiconAdapter struct {
 }
 
 // used for cookies and such
-func (a *RubiconAdapter) FamilyName() string {
+func (a *RubiconAdapter) Name() string {
 	return "rubicon"
 }
 
@@ -300,7 +300,7 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 	callOneObjects := make([]callOneObject, 0, len(bidder.AdUnits))
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
 
-	rubiReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.FamilyName(), supportedMediaTypes, true)
+	rubiReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes, true)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -316,9 +316,9 @@ func TestRubiconBasicResponse(t *testing.T) {
 func TestRubiconUserSyncInfo(t *testing.T) {
 	an := NewRubiconAdapter(adapters.DefaultHTTPAdapterConfig, "uri", "xuser", "xpass", "pbs-test-tracker")
 
-	familyName := an.FamilyName()
-	if familyName != "rubicon" {
-		t.Errorf("FamilyName '%s' != 'rubicon'", familyName)
+	adapterName := an.Name()
+	if adapterName != "rubicon" {
+		t.Errorf("Name '%s' != 'rubicon'", adapterName)
 	}
 
 	skipNoCookies := an.SkipNoCookies()

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -316,11 +316,6 @@ func TestRubiconBasicResponse(t *testing.T) {
 func TestRubiconUserSyncInfo(t *testing.T) {
 	an := NewRubiconAdapter(adapters.DefaultHTTPAdapterConfig, "uri", "xuser", "xpass", "pbs-test-tracker")
 
-	name := an.Name()
-	if name != "Rubicon" {
-		t.Errorf("Name '%s' != 'Rubicon'", name)
-	}
-
 	familyName := an.FamilyName()
 	if familyName != "rubicon" {
 		t.Errorf("FamilyName '%s' != 'rubicon'", familyName)

--- a/exchange/legacy.go
+++ b/exchange/legacy.go
@@ -97,7 +97,7 @@ func (bidder *adaptedAdapter) toLegacyRequest(req *openrtb.BidRequest) (*pbs.PBS
 	cookie := pbs.NewPBSCookie()
 	if req.User != nil {
 		if req.User.BuyerUID != "" {
-			cookie.TrySync(bidder.adapter.FamilyName(), req.User.BuyerUID)
+			cookie.TrySync(bidder.adapter.Name(), req.User.BuyerUID)
 		}
 
 		// This shouldn't be appnexus-specific... but this line does correctly invert the

--- a/exchange/legacy_test.go
+++ b/exchange/legacy_test.go
@@ -477,10 +477,6 @@ type mockLegacyAdapter struct {
 }
 
 func (a *mockLegacyAdapter) Name() string {
-	return "someBidder"
-}
-
-func (a *mockLegacyAdapter) FamilyName() string {
 	return "someFamily"
 }
 

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -17,7 +17,10 @@ const schemaDirectory = "static/bidder-params"
 // BidderName may refer to a bidder ID, or an Alias which is defined in the request.
 type BidderName string
 
+// These names _must_ coincide with the bidder code in Prebid.js, if an adapter also exists in that project.
+// Please keep these (and the BidderMap) alphabetized to minimize merge conflicts among adapter submissions.
 const (
+	BidderAdform     BidderName = "adform"
 	BidderAppnexus   BidderName = "appnexus"
 	BidderConversant BidderName = "conversant"
 	BidderFacebook   BidderName = "audienceNetwork"
@@ -26,11 +29,11 @@ const (
 	BidderPubmatic   BidderName = "pubmatic"
 	BidderPulsepoint BidderName = "pulsepoint"
 	BidderRubicon    BidderName = "rubicon"
-	BidderAdform     BidderName = "adform"
 )
 
 // BidderMap stores all the valid OpenRTB 2.x Bidders in the project. This map *must not* be mutated.
 var BidderMap = map[string]BidderName{
+	"adform":          BidderAdform,
 	"appnexus":        BidderAppnexus,
 	"audienceNetwork": BidderFacebook,
 	"conversant":      BidderConversant,
@@ -39,7 +42,6 @@ var BidderMap = map[string]BidderName{
 	"pubmatic":        BidderPubmatic,
 	"pulsepoint":      BidderPulsepoint,
 	"rubicon":         BidderRubicon,
-	"adform":          BidderAdform,
 }
 
 func (name BidderName) MarshalJSON() ([]byte, error) {

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-server/config"
@@ -36,7 +37,7 @@ const (
 	USERSYNC_SUCCESS     = "usersync.%s.sets"
 )
 
-// bidderToFamilyNames maps the BidderName to Adapter.FamilyName() for the early adapters.
+// bidderToFamilyNames maps the BidderName to Adapter.Name() for the early adapters.
 // If a mapping isn't listed here, then we assume that the two are the same.
 var bidderToFamilyNames = map[openrtb_ext.BidderName]string{
 	openrtb_ext.BidderAppnexus: "adnxs",

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -768,6 +768,7 @@ func setupExchanges(cfg *config.Configuration) {
 }
 
 func newExchangeMap(cfg *config.Configuration) map[string]adapters.Adapter {
+	// These keys _must_ coincide with the bidder code in Prebid.js, if the adapter exists in both projects
 	return map[string]adapters.Adapter{
 		"appnexus":      appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig),
 		"districtm":     appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig),


### PR DESCRIPTION
I just noticed that no code actually calls these functions, or reads these values, so... they're dead code and shouldn't exist.

The BidderName and `exchange` map keys are the real source of truth... so I added some comments to make that clear. 