### PR TITLE
Fixed #315

### DIFF
--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -25,8 +25,6 @@ if [ "$?" = "0" ]; then
 
 # Fixes #315. If it has errors, print those and exit with an error code
 else
-  while read -r LINE; do
-    echo -e "$LINE"
-  done <<< "$OUTPUT"
+  echo -e "$OUTPUT"
   exit 1
 fi

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -25,6 +25,8 @@ if [ "$?" = "0" ]; then
 
 # Fixes #315. If it has errors, print those and exit with an error code
 else
-  echo $OUTPUT
+  while read -r LINE; do
+    echo -e "$LINE"
+  done <<< "$OUTPUT"
   exit 1
 fi

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+
+COV_MIN=30
+
 #cleanup
 finish() {
+
   if [ -d ".cover" ]; then
     rm -rf .cover
   fi
@@ -9,22 +13,16 @@ finish() {
 
 trap finish EXIT ERR INT TERM
 
-# If the coverage script runs without errors, then make sure that it meets the min code coverage
+#start script logic
 OUTPUT=`./scripts/coverage.sh`
-if [ "$?" = "0" ]; then
-  while read -r LINE; do
-    echo -e "$LINE"
-    if [[ $LINE =~ "%" ]]; then
-      PERCENT=$(echo "$LINE"|cut -d: -f2-|cut -d% -f1|cut -d. -f1|tr -d ' ')
-      if [[ $PERCENT -lt 30 ]]; then
-        echo "Package has less than 30% code coverage. Run ./scripts/coverage.sh --html to see a detailed coverage report, and add tests to improve your coverage"
-        exit 1
-      fi
-    fi
-  done <<< "$OUTPUT"
 
-# Fixes #315. If it has errors, print those and exit with an error code
-else
-  echo -e "$OUTPUT"
-  exit 1
-fi
+while IFS= read -r LINE; do
+  echo -e "$LINE"
+  if [[ $LINE =~ "%" ]]; then
+    PERCENT=$(echo "$LINE"|cut -d: -f2-|cut -d% -f1|cut -d. -f1|tr -d ' ')
+    if [[ $PERCENT -lt $COV_MIN ]]; then
+      echo "Package has less than $COV_MIN% code coverage. Run ./scripts/coverage.sh --html to see a detailed coverage report, and add tests to improve your coverage"
+      exit 1
+    fi
+  fi
+done <<< "$OUTPUT"

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -21,7 +21,7 @@ while IFS= read -r LINE; do
   if [[ $LINE =~ "%" ]]; then
     PERCENT=$(echo "$LINE"|cut -d: -f2-|cut -d% -f1|cut -d. -f1|tr -d ' ')
     if [[ $PERCENT -lt $COV_MIN ]]; then
-      echo "Package has less than $COV_MIN% code coverage. Run ./scripts/coverage.sh --html to see a detailed coverage report, and add tests to improve your coverage"
+      echo "Package has less than ${COV_MIN}% code coverage. Run ./scripts/coverage.sh --html to see a detailed coverage report, and add tests to improve your coverage"
       exit 1
     fi
   fi


### PR DESCRIPTION
This fixes #315

Looks like this was caused by two things:

- `set -e`: makes the script exit immediately if any line errors
- `OUTPUT=./scripts/coverage.sh`: Saves `stdout` of `coverage.sh` to `OUTPUT` (rather than printing it to the terminal). If `coverage.sh` fails, then this line fails too... which triggers `set -e` so that the script exits without printing anything.

I basically just removed `set -e`, and checked the return from `coverage.sh` explicitly.