### PR TITLE
Block mock server on context cancel

### DIFF
--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -151,6 +151,7 @@ func TestBidderTimeout(t *testing.T) {
 		numCalls := atomic.AddInt32(&counter, 1)
 		if numCalls == 2 {
 			cancelFunc()
+			<-ctx.Done() // Fixes #369 (hopefully)
 		}
 
 		w.WriteHeader(200)


### PR DESCRIPTION
This fixes #369, I hope.

I'll re-run the Travis builds on this PR a bunch of times to see if any of them fail. Given that this test failure is intermittent, I'm a bit suspicious that there's some lag time between the `cancelFunc()` call and the time when the context is _actually_ cancelled.

If I've guessed the problem correctly, then blocking to wait for the channel to close should solve it.