### PR TITLE
Checked response code of test in --cov mode.

### DIFF
--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -15,6 +15,10 @@ trap finish EXIT ERR INT TERM
 
 #start script logic
 OUTPUT=`./scripts/coverage.sh`
+if [[ "$?" -ne "0" ]]; then
+  echo -e "$OUTPUT"
+  exit 1
+fi
 
 while IFS= read -r LINE; do
   echo -e "$LINE"


### PR DESCRIPTION
Must have introduced this during that last-minute rewrite in #315. Without `set -e`, we need to check this return code explicitly.