### PR TITLE
Amp usability improvements

### DIFF
--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -8,8 +8,8 @@ For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-p
 The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests), with a few caveats:
 
 - The `imp` array must contain one, and only one, object
-- `ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)
-- `ext.prebid.cache.bids` _must_ be defined to be an empty object
+- `request.ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)
+- `request.ext.prebid.cache.bids` _must_ be defined to be an empty object
 
 Otherwise, the Stored BidRequest payload supports all the same OpenRTB properties as [/openrtb2/auction](./auction.md) does.
 

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -1,31 +1,22 @@
 # Prebid Server AMP Endpoint
 
-This document describes the behavior of the Prebid Server amp endpoint, including:
+This document describes the behavior of the Prebid Server AMP endpoint in detail.
+For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html)
 
-- Request/response formats
+## `GET /openrtb2/amp?tag_id={ID}`
 
-## AMP RTC
-The AMP endpoint uses the OpenRTB enpoint code behind the scenes. This document will only describe 
-the changes from OpenRTB2 support, please refer to that documentation for anything not specified here.
+The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests), with a few caveats:
 
-## `GET /openrtb2/amp?tag_id=<ID>`
+- The `imp` array must contain one, and only one, object
+- `ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)
+- `ext.prebid.cache.bids` _must_ be defined to be an empty object
 
-This endpoint runs an auction with the OpenRTB 2.5 bid request refernced by the given `tag_id`.
-The `tag_id` refernces a stored request that is a full OpenRTB2 request. Obviously there needs to be a
-unique `tag_id` for every unique OpenRTB request configuration desired. Once the request is recieved
-by prebid server, the stored request is recalled, and processing is passed on to the OpenRTB2 code
-to conduct an auction as normal.
+Otherwise, the Stored BidRequest payload supports all the same OpenRTB properties as [/openrtb2/auction](./auction.md) does.
 
-## Sample response
+### Response
 
-The response contains only the targeting key/value pairs produced in the auction. See 
-[Prebid documentation](http://prebid.org/adops.html) for more detail on the targeting keys and
-how they are used in Prebid. This includes the
-key/values for cached ads. The creative delivered in response to the prebid demand must be able to
-refernce the cache in order to pull the ad, as AMP/RTC does not allow for transmitting the ad to
-the creative through the RTC response. A sample RTC response is shown below:
+A sample response payload looks like this:
 
-```
 {
 	"targeting": {
 		"hb_pb": 1.30
@@ -34,7 +25,6 @@ the creative through the RTC response. A sample RTC response is shown below:
 		"hb_uuid": "6768-FB78-9890-7878"
 	}
 }
-```
 
-The key/values are pulled from all the bids in the OpenRTB2 response that have a `cache_id` associated
-with them. An uncached ad can never be delivered of course.
+In [the typical AMP setup](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html),
+these targeting params will be sent to DFP.

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -17,6 +17,7 @@ Otherwise, the Stored BidRequest payload supports all the same OpenRTB propertie
 
 A sample response payload looks like this:
 
+```
 {
 	"targeting": {
 		"hb_pb": 1.30
@@ -25,6 +26,7 @@ A sample response payload looks like this:
 		"hb_uuid": "6768-FB78-9890-7878"
 	}
 }
+```
 
 In [the typical AMP setup](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html),
 these targeting params will be sent to DFP.

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -5,13 +5,14 @@ For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-p
 
 ## `GET /openrtb2/amp?tag_id={ID}`
 
-The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests), with a few caveats:
+The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests).
+For a thorough description of BidRequest JSON, see the [/openrtb2/auction](./auction.md) docs.
 
-- The `imp` array must contain one, and only one, object
+For AMP, there are only a few additional caveats:
+
+- The `imp` array must contain one, and only one, impression object
 - `request.ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)
 - `request.ext.prebid.cache.bids` _must_ be defined to be an empty object
-
-Otherwise, the Stored BidRequest payload supports all the same OpenRTB properties as [/openrtb2/auction](./auction.md) does.
 
 ### Response
 

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -8,11 +8,7 @@ For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-p
 The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests).
 For a thorough description of BidRequest JSON, see the [/openrtb2/auction](./auction.md) docs.
 
-Stored BidRequests for AMP have a few additional caveats:
-
-- The `imp` array must contain one, and only one, impression object
-- `request.ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)
-- `request.ext.prebid.cache.bids` _must_ be defined to be an empty object
+The only caveat is that AMP BidRequests must contain an `imp` array with one, and only one, impression object.
 
 ### Response
 

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -8,7 +8,7 @@ For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-p
 The `tag_id` ID must reference a [Stored BidRequest](../../developers/stored-requests.md#stored-bidrequests).
 For a thorough description of BidRequest JSON, see the [/openrtb2/auction](./auction.md) docs.
 
-For AMP, there are only a few additional caveats:
+Stored BidRequests for AMP have a few additional caveats:
 
 - The `imp` array must contain one, and only one, impression object
 - `request.ext.prebid.targeting` _must_ be defined (`ext.prebid.targeting.pricegranularity` is still optional)

--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -1,7 +1,7 @@
 # Prebid Server AMP Endpoint
 
 This document describes the behavior of the Prebid Server AMP endpoint in detail.
-For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html)
+For a User's Guide, see the [AMP feature docs](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html).
 
 ## `GET /openrtb2/amp?tag_id={ID}`
 

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -23,7 +23,15 @@ import (
 // TestGoodRequests makes sure that the auction runs properly-formatted stored bids correctly.
 func TestGoodAmpRequests(t *testing.T) {
 	goodRequests := map[string]json.RawMessage{
-		"10": json.RawMessage(validRequest(t, "site.json")),
+		"1": json.RawMessage(validRequest(t, "aliased-buyeruids.json")),
+		"2": json.RawMessage(validRequest(t, "aliases.json")),
+		"3": json.RawMessage(validRequest(t, "app.json")),
+		"4": json.RawMessage(validRequest(t, "digitrust.json")),
+		"5": json.RawMessage(validRequest(t, "gdpr-no-consentstring.json")),
+		"6": json.RawMessage(validRequest(t, "gdpr.json")),
+		"7": json.RawMessage(validRequest(t, "site.json")),
+		"8": json.RawMessage(validRequest(t, "timeout.json")),
+		"9": json.RawMessage(validRequest(t, "user.json")),
 	}
 
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
@@ -56,12 +64,8 @@ func TestGoodAmpRequests(t *testing.T) {
 
 // TestBadRequests makes sure we return 400's on bad requests.
 func TestAmpBadRequests(t *testing.T) {
-	badRequests := map[string]json.RawMessage{
-		"11": json.RawMessage(validRequest(t, "app.json")),
-		"12": json.RawMessage(validRequest(t, "timeout.json")),
-	}
-
 	files := fetchFiles(t, "sample-requests/invalid-whole")
+	badRequests := make(map[string]json.RawMessage, len(files))
 	for index, file := range files {
 		badRequests[strconv.Itoa(100+index)] = readFile(t, "sample-requests/invalid-whole/"+file.Name())
 	}


### PR DESCRIPTION
This is part of my attempt to address mass confusion surrounding AMP.

Functionally, this sets defaults for `request.ext.prebid.cache` and `request.ext.prebid.targeting`, which should make AMP easier to use.

I also updated the docs to make it clearer what's expected and what's not, remove AMP implementation details, and link to more thorough documentation.

I will also be looking for ways to improve the `/openrtb2/auction.md` file... but I think that's better left for another PR.