### PR TITLE
Fixing a debugging info bug

### DIFF
--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -16,20 +16,22 @@ func newAuction(seatBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, numImps int
 	winningBidsByBidder := make(map[string]map[openrtb_ext.BidderName]*pbsOrtbBid, numImps)
 
 	for bidderName, seatBid := range seatBids {
-		for _, bid := range seatBid.bids {
-			cpm := bid.bid.Price
-			wbid, ok := winningBids[bid.bid.ImpID]
-			if !ok || cpm > wbid.bid.Price {
-				winningBids[bid.bid.ImpID] = bid
-			}
-			if bidMap, ok := winningBidsByBidder[bid.bid.ImpID]; ok {
-				bestSoFar, ok := bidMap[bidderName]
-				if !ok || cpm > bestSoFar.bid.Price {
-					bidMap[bidderName] = bid
+		if seatBid != nil {
+			for _, bid := range seatBid.bids {
+				cpm := bid.bid.Price
+				wbid, ok := winningBids[bid.bid.ImpID]
+				if !ok || cpm > wbid.bid.Price {
+					winningBids[bid.bid.ImpID] = bid
 				}
-			} else {
-				winningBidsByBidder[bid.bid.ImpID] = make(map[openrtb_ext.BidderName]*pbsOrtbBid)
-				winningBidsByBidder[bid.bid.ImpID][bidderName] = bid
+				if bidMap, ok := winningBidsByBidder[bid.bid.ImpID]; ok {
+					bestSoFar, ok := bidMap[bidderName]
+					if !ok || cpm > bestSoFar.bid.Price {
+						bidMap[bidderName] = bid
+					}
+				} else {
+					winningBidsByBidder[bid.bid.ImpID] = make(map[openrtb_ext.BidderName]*pbsOrtbBid)
+					winningBidsByBidder[bid.bid.ImpID][bidderName] = bid
+				}
 			}
 		}
 	}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -174,9 +174,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 	// Wait for the bidders to do their thing
 	for i := 0; i < len(cleanRequests); i++ {
 		brw := <-chBids
-		if brw.adapterBids != nil && len(brw.adapterBids.bids) > 0 {
-			adapterBids[brw.bidder] = brw.adapterBids
-		}
+		adapterBids[brw.bidder] = brw.adapterBids
 		adapterExtra[brw.bidder] = brw.adapterExtra
 	}
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -249,8 +249,8 @@ func TestGetAllBids(t *testing.T) {
 	if len(adapterExtra[BidderDummy].Errors) != 0 {
 		t.Errorf("GetAllBids found errors on Bidder1, found %d errors", len(adapterExtra[BidderDummy2].Errors))
 	}
-	if bid, bidExists := adapterBids[BidderDummy2]; bidExists {
-		t.Errorf("GetAllBids found bids on Bidder2, found %d bids", len(bid.bids))
+	if len(adapterBids[BidderDummy2].bids) != 0 {
+		t.Errorf("GetAllBids found bids on Bidder2, found %d bids", len(adapterBids[BidderDummy2].bids))
 	}
 
 	// Test with null pointer for bid response


### PR DESCRIPTION
This partially reverts #380.

I thought I could guard against `nil` values and filter them out sooner than was actually safe... but apparently it wasn't safe. There just seem to be no unit tests checking to make sure that `ext.debug.httpcalls` is populated properly.

We should beef up the unit tests in `exchange`, because _something_ should have failed as a result of this bug, but... this at least fixes it for now.