### PR TITLE
Quick fix for some segfaults in legacy code

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -88,6 +88,10 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			return nil, errors.New("No placement or member+invcode provided")
 		}
 
+		// Fixes some segfaults. Since this is legacy code, I'm not looking into it too deeply
+		if len(anReq.Imp) <= i {
+			break
+		}
 		if params.InvCode != "" {
 			anReq.Imp[i].TagID = params.InvCode
 			if params.Member != "" {


### PR DESCRIPTION
Stack trace from the problem is here:

```
panic: runtime error: index out of range
 goroutine 119248 [running]:
github.com/prebid/prebid-server/adapters/appnexus.(*AppNexusAdapter).Call(0xc45a04a2c0, 0xd1c520, 0xc4a6395860, 0xc4a6634700, 0xc4a6642780, 0x0, 0x0, 0x0, 0x0, 0x0)
    /some/path/prebid-server/adapters/appnexus/appnexus.go:102 +0x1e1d
main.(*auctionDeps).auction.func1(0xd1b020, 0xc45a04a2c0, 0xd1c520, 0xc4a6395860, 0xc4a6634700, 0xc420124700, 0xc4a68b6c80, 0xc4a6577d00, 0xc4a68d7620, 0xc4a6642780)
    /some/path/prebid-server/pbs_light.go:370 +0xa2
created by main.(*auctionDeps).auction
    /some/path/prebid-server/pbs_light.go:368 +0x62a
```