### PR TITLE
Set secure=1 on AMP requests

### DIFF
--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -10,6 +10,8 @@ For a thorough description of BidRequest JSON, see the [/openrtb2/auction](./auc
 
 The only caveat is that AMP BidRequests must contain an `imp` array with one, and only one, impression object.
 
+All AMP content must be secure, so this endpoint will enforce that request.imp[0].secure = 1. Saves on publishers forgetting to set this.
+
 ### Response
 
 A sample response payload looks like this:

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -211,6 +211,15 @@ func (deps *endpointDeps) loadRequestJSONForAmp(httpRequest *http.Request) (req 
 		errs = []error{fmt.Errorf("data for tag_id '%s' includes %d imp elements. Only one is allowed", ampId, len(req.Imp))}
 		return
 	}
+
+	// Force HTTPS as AMP requires it, but pubs can forget to set it.
+	if req.Imp[0].Secure == nil {
+		secure := int8(1)
+		req.Imp[0].Secure = &secure
+	} else {
+		*req.Imp[0].Secure = 1
+	}
+
 	return
 }
 


### PR DESCRIPTION
fixes #402 , AMP spec requires secure content URLs, so no use cases for insecure ads.