### PR TITLE
[Proposal] Rework stored request caches to allow propagation of invalidation/updates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ func (cfg *Configuration) validate() error {
 	if cfg.MaxRequestSize < 0 {
 		return fmt.Errorf("cfg.max_request_size must be a positive number. Got  %d", cfg.MaxRequestSize)
 	}
-	return nil
+	return cfg.StoredRequests.validate()
 }
 
 type Analytics struct {

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -32,14 +32,6 @@ type HTTPFetcherConfig struct {
 }
 
 func (cfg *StoredRequests) validate() error {
-	if cfg.Files && cfg.Postgres != nil {
-		return errors.New("stored request backend is ambiguous. If stored_requests.postgres is defined, then stored_requests.filesystem must be false")
-	}
-
-	if cfg.InMemoryCache != nil && !cfg.Files && cfg.Postgres == nil {
-		return errors.New("in_memory_cache requires at least one of filesystem or postgres must be configured")
-	}
-
 	if cfg.CacheEventsAPI && cfg.InMemoryCache == nil {
 		return errors.New("cache_events_api requires a configured in_memory_cache")
 	}

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -18,11 +19,32 @@ type StoredRequests struct {
 	HTTP *HTTPFetcherConfig `mapstructure:"http"`
 	// Cache should be non-nil if an in-memory cache should be used to store Stored Requests locally.
 	InMemoryCache *InMemoryCache `mapstructure:"in_memory_cache"`
+	// CacheEventsAPI should be non-nil if a API endpoints to invalidate/update the caches should be exposed.
+	// This is intended to be a useful development tool and not recommended for a production environment.
+	// It should not be exposed to public networks without authentication.
+	CacheEventsAPI bool `mapstructure:"cache_events_api"`
 }
 
+// HTTPFetcherConfig configures an HTTP stored requests fetcher
 type HTTPFetcherConfig struct {
 	Endpoint    string `mapstructure:"endpoint"`
 	AmpEndpoint string `mapstructure:"amp_endpoint"`
+}
+
+func (cfg *StoredRequests) validate() error {
+	if cfg.Files && cfg.Postgres != nil {
+		return errors.New("stored request backend is ambiguous. If stored_requests.postgres is defined, then stored_requests.filesystem must be false")
+	}
+
+	if cfg.InMemoryCache != nil && !cfg.Files && cfg.Postgres == nil {
+		return errors.New("in_memory_cache requires at least one of filesystem or postgres must be configured")
+	}
+
+	if cfg.CacheEventsAPI && cfg.InMemoryCache == nil {
+		return errors.New("cache_events_api requires a configured in_memory_cache")
+	}
+
+	return nil
 }
 
 // PostgresConfig configures the Postgres connection for Stored Requests

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -1017,11 +1017,15 @@ func NewFetchers(cfg *config.StoredRequests, db *sql.DB, eventProducers []events
 		byAmpId = stored_requests.WithCache(byAmpId, byAmpIdCache)
 
 		for _, ep := range eventProducers {
-			listeners = append(listeners, events.Listen(byIdCache, ep))
+			listener := events.SimpleEventListener()
+			go listener.Listen(byIdCache, ep)
+			listeners = append(listeners, listener)
 		}
 
 		for _, ep := range ampEventProducers {
-			listeners = append(listeners, events.Listen(byAmpIdCache, ep))
+			listener := events.SimpleEventListener()
+			go listener.Listen(byAmpIdCache, ep)
+			listeners = append(listeners, listener)
 		}
 	}
 	return

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -896,10 +896,10 @@ func serve(cfg *config.Configuration) error {
 	router.ServeFiles("/static/*filepath", http.Dir("static"))
 
 	if cfg.StoredRequests.CacheEventsAPI {
-		router.POST("/storedrequests/openrtb2/:id", handleStoredRequests)
-		router.DELETE("/storedrequests/openrtb2/:id", handleStoredRequests)
-		router.POST("/storedrequests/amp/:id", handleAmpStoredRequests)
-		router.DELETE("/storedrequests/amp/:id", handleAmpStoredRequests)
+		router.POST("/storedrequests/openrtb2", handleStoredRequests)
+		router.DELETE("/storedrequests/openrtb2", handleStoredRequests)
+		router.POST("/storedrequests/amp", handleAmpStoredRequests)
+		router.DELETE("/storedrequests/amp", handleAmpStoredRequests)
 	}
 
 	hostCookieSettings = pbs.HostCookieSettings{

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -970,7 +970,7 @@ const requestConfigPath = "./stored_requests/data/by_id"
 // If it can't generate both of those from the given config, then an error will be returned.
 //
 // This function assumes that the argument config has been validated.
-func NewFetchers(cfg *config.StoredRequests, db *sql.DB, eventProducers []events.EventProducer, ampEventProducers []events.EventProducer) (byId stored_requests.Fetcher, byAmpId stored_requests.Fetcher, listeners []events.EventListener, err error) {
+func NewFetchers(cfg *config.StoredRequests, db *sql.DB, eventProducers []events.EventProducer, ampEventProducers []events.EventProducer) (byId stored_requests.Fetcher, byAmpId stored_requests.Fetcher, listeners []*events.EventListener, err error) {
 	idList := make(stored_requests.MultiFetcher, 0, 3)
 	ampIdList := make(stored_requests.MultiFetcher, 0, 3)
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -62,6 +62,8 @@ import (
 	"github.com/prebid/prebid-server/stored_requests/backends/file_fetcher"
 	"github.com/prebid/prebid-server/stored_requests/backends/http_fetcher"
 	"github.com/prebid/prebid-server/stored_requests/caches/in_memory"
+	"github.com/prebid/prebid-server/stored_requests/events"
+	apiEvents "github.com/prebid/prebid-server/stored_requests/events/api"
 	usersyncers "github.com/prebid/prebid-server/usersync"
 )
 
@@ -730,6 +732,7 @@ func init() {
 	// no metrics configured by default (metrics{host|database|username|password})
 
 	viper.SetDefault("stored_requests.filesystem", "true")
+	viper.SetDefault("stored_requests.cache_events_api", false)
 
 	// This Appnexus endpoint works for most purposes. Docs can be found at https://wiki.appnexus.com/display/supply/Incoming+Bid+Request+from+SSPs
 	viper.SetDefault("adapters.appnexus.endpoint", "http://ib.adnxs.com/openrtb2")
@@ -848,10 +851,24 @@ func serve(cfg *config.Configuration) error {
 	}
 	theExchange := exchange.NewExchange(theClient, pbc.NewClient(&cfg.CacheURL), cfg, metricsEngine)
 
-	byId, byAmpId, err := NewFetchers(&(cfg.StoredRequests), db)
+	var handleStoredRequests, handleAmpStoredRequests httprouter.Handle
+	var eventProducers, ampEventProducers []events.EventProducer
+	if cfg.StoredRequests.CacheEventsAPI {
+		var apiEventProducer, ampApiEventProducer events.EventProducer
+		apiEventProducer, handleStoredRequests = apiEvents.NewEventsAPI()
+		eventProducers = append(eventProducers, apiEventProducer)
+		ampApiEventProducer, handleAmpStoredRequests = apiEvents.NewEventsAPI()
+		ampEventProducers = append(ampEventProducers, ampApiEventProducer)
+	}
+	byId, byAmpId, listeners, err := NewFetchers(&(cfg.StoredRequests), db, eventProducers, ampEventProducers)
 	if err != nil {
 		glog.Fatalf("Failed to initialize config backends. %v", err)
 	}
+	defer func() {
+		for _, l := range listeners {
+			l.Stop()
+		}
+	}()
 
 	openrtbEndpoint, err := openrtb2.NewEndpoint(theExchange, paramsValidator, byId, cfg, metricsEngine, pbsAnalytics)
 	if err != nil {
@@ -877,6 +894,13 @@ func serve(cfg *config.Configuration) error {
 	router.GET("/status", status)
 	router.GET("/", serveIndex)
 	router.ServeFiles("/static/*filepath", http.Dir("static"))
+
+	if cfg.StoredRequests.CacheEventsAPI {
+		router.POST("/storedrequests/openrtb2/:id", handleStoredRequests)
+		router.DELETE("/storedrequests/openrtb2/:id", handleStoredRequests)
+		router.POST("/storedrequests/amp/:id", handleAmpStoredRequests)
+		router.DELETE("/storedrequests/amp/:id", handleAmpStoredRequests)
+	}
 
 	hostCookieSettings = pbs.HostCookieSettings{
 		Domain:       cfg.HostCookie.Domain,
@@ -946,9 +970,10 @@ const requestConfigPath = "./stored_requests/data/by_id"
 // If it can't generate both of those from the given config, then an error will be returned.
 //
 // This function assumes that the argument config has been validated.
-func NewFetchers(cfg *config.StoredRequests, db *sql.DB) (byId stored_requests.Fetcher, byAmpId stored_requests.Fetcher, err error) {
+func NewFetchers(cfg *config.StoredRequests, db *sql.DB, eventProducers []events.EventProducer, ampEventProducers []events.EventProducer) (byId stored_requests.Fetcher, byAmpId stored_requests.Fetcher, listeners []events.EventListener, err error) {
 	idList := make(stored_requests.MultiFetcher, 0, 3)
 	ampIdList := make(stored_requests.MultiFetcher, 0, 3)
+
 	if cfg.Files {
 		glog.Infof("Loading Stored Requests from filesystem at path %s", requestConfigPath)
 		byId, err = file_fetcher.NewFileFetcher(requestConfigPath)
@@ -985,8 +1010,19 @@ func NewFetchers(cfg *config.StoredRequests, db *sql.DB) (byId stored_requests.F
 
 	if cfg.InMemoryCache != nil {
 		glog.Infof("Using a Stored Request in-memory cache. Max size for StoredRequests: %d bytes. Max size for Stored Imps: %d bytes. TTL: %d seconds.", cfg.InMemoryCache.RequestCacheSize, cfg.InMemoryCache.ImpCacheSize, cfg.InMemoryCache.TTL)
-		byId = stored_requests.WithCache(byId, in_memory.NewLRUCache(cfg.InMemoryCache))
-		byAmpId = stored_requests.WithCache(byAmpId, in_memory.NewLRUCache(cfg.InMemoryCache))
+		byIdCache := in_memory.NewLRUCache(cfg.InMemoryCache)
+		byAmpIdCache := in_memory.NewLRUCache(cfg.InMemoryCache)
+
+		byId = stored_requests.WithCache(byId, byIdCache)
+		byAmpId = stored_requests.WithCache(byAmpId, byAmpIdCache)
+
+		for _, ep := range eventProducers {
+			listeners = append(listeners, events.Listen(byIdCache, ep))
+		}
+
+		for _, ep := range ampEventProducers {
+			listeners = append(listeners, events.Listen(byAmpIdCache, ep))
+		}
 	}
 	return
 }

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -2,20 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/mxmCherry/openrtb"
-
-	"context"
-	"io/ioutil"
-	"os"
-	"time"
-
-	"fmt"
+	"github.com/spf13/viper"
 
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/cache/dummycache"
@@ -25,7 +24,6 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	usersyncers "github.com/prebid/prebid-server/usersync"
-	"github.com/spf13/viper"
 )
 
 const adapterDirectory = "adapters"
@@ -742,9 +740,9 @@ func ensureHasKey(t *testing.T, data map[string]json.RawMessage, key string) {
 }
 
 func TestNewFilesFetcher(t *testing.T) {
-	fetcher, _, err := NewFetchers(&config.StoredRequests{
+	fetcher, _, _, err := NewFetchers(&config.StoredRequests{
 		Files: true,
-	}, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Error constructing file backends. %v", err)
 	}
@@ -754,7 +752,7 @@ func TestNewFilesFetcher(t *testing.T) {
 }
 
 func TestNewEmptyFetcher(t *testing.T) {
-	fetcher, _, err := NewFetchers(&config.StoredRequests{}, nil)
+	fetcher, _, _, err := NewFetchers(&config.StoredRequests{}, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Error constructing backends. %v", err)
 	}

--- a/stored_requests/caches/in_memory/lru.go
+++ b/stored_requests/caches/in_memory/lru.go
@@ -30,15 +30,10 @@ type cache struct {
 	ttlSeconds       int
 }
 
-func (c *cache) GetRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
+func (c *cache) Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
 	requestData = doGet(c.requestDataCache, requestIDs)
 	impData = doGet(c.impDataCache, impIDs)
 	return
-}
-
-func (c *cache) SaveRequests(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage) {
-	c.doSave(c.requestDataCache, storedRequests)
-	c.doSave(c.impDataCache, storedImps)
 }
 
 func doGet(cache *freecache.Cache, ids []string) (data map[string]json.RawMessage) {
@@ -53,10 +48,46 @@ func doGet(cache *freecache.Cache, ids []string) (data map[string]json.RawMessag
 	return
 }
 
+func (c *cache) Save(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage) {
+	c.doSave(c.requestDataCache, storedRequests)
+	c.doSave(c.impDataCache, storedImps)
+}
+
 func (c *cache) doSave(cache *freecache.Cache, values map[string]json.RawMessage) {
 	for id, data := range values {
 		if err := cache.Set([]byte(id), data, c.ttlSeconds); err != nil {
 			glog.Errorf("error saving value in freecache: %v", err)
 		}
+	}
+}
+
+func (c *cache) Invalidate(ctx context.Context, requestIDs []string, impIDs []string) {
+	doInvalidate(c.requestDataCache, requestIDs)
+	doInvalidate(c.impDataCache, impIDs)
+}
+
+func doInvalidate(cache *freecache.Cache, ids []string) {
+	for _, id := range ids {
+		cache.Del([]byte(id))
+	}
+}
+
+func (c *cache) Update(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage) {
+	c.doUpdate(c.requestDataCache, storedRequests)
+	c.doUpdate(c.impDataCache, storedImps)
+}
+
+func (c *cache) doUpdate(cache *freecache.Cache, values map[string]json.RawMessage) {
+	toSave := make(map[string]json.RawMessage, len(values))
+	for id, data := range values {
+		if _, err := cache.Get([]byte(id)); err == nil {
+			toSave[id] = data
+		} else if err != freecache.ErrNotFound {
+			glog.Errorf("unexpected error from freecache: %v", err)
+		}
+	}
+
+	if len(toSave) > 0 {
+		c.doSave(cache, toSave)
 	}
 }

--- a/stored_requests/events/api/api.go
+++ b/stored_requests/events/api/api.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/prebid/prebid-server/stored_requests/events"
+)
+
+type eventsAPI struct {
+	updates       chan events.Update
+	invalidations chan events.Invalidation
+}
+
+// NewEventsAPI creates an EventProducer that generates cache events from HTTP requests.
+// The returned httprouter.Handle must be registered on both POST (update) and DELETE (invalidate)
+// methods and provided an `:id` param via the URL, e.g.:
+//
+// apiEvents, apiEventsHandler, err := NewEventsApi()
+// router.POST("/stored_requests/:id", apiEventsHandler)
+// router.DELETE("/stored_requests/:id", apiEventsHandler)
+// listener := events.Listen(cache, apiEvents)
+//
+// The returned HTTP endpoint should not be exposed on a public network without authentication
+// as it allows direct writing to the cache via Update.
+func NewEventsAPI() (events.EventProducer, httprouter.Handle) {
+	api := &eventsAPI{
+		invalidations: make(chan events.Invalidation),
+		updates:       make(chan events.Update),
+	}
+	return api, httprouter.Handle(api.HandleEvent)
+}
+
+func (api *eventsAPI) HandleEvent(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	//id := ps.ByName("id")
+
+	if r.Method == "POST" {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Missing config data.\n"))
+			return
+		}
+
+		// check if valid JSON
+		var config json.RawMessage
+		if err := json.Unmarshal(body, &config); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Invalid config data.\n"))
+			return
+		}
+
+		//api.updates <- map[string]json.RawMessage{id: config}
+	} else if r.Method == "DELETE" {
+		//api.invalidations <- []string{id}
+	} else {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (api *eventsAPI) Invalidations() <-chan events.Invalidation {
+	return api.invalidations
+}
+
+func (api *eventsAPI) Updates() <-chan events.Update {
+	return api.updates
+}

--- a/stored_requests/events/api/api_test.go
+++ b/stored_requests/events/api/api_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func TestGoodRequests(t *testing.T) {
+	// cache := in_memory.NewLRUCache(&config.InMemoryCache{
+	// 	RequestCacheSize: 256 * 1024,
+	// 	ImpCacheSize:     256 * 1024,
+	// 	TTL:              -1,
+	// })
+
+	// id := "1"
+	// config := fmt.Sprintf(`{"id": "%s"}`, id)
+	// cache.Save(context.Background(), map[string]json.RawMessage{id: json.RawMessage(config)})
+
+	// apiEvents, endpoint := NewEventsAPI()
+	// listener := events.Listen(cache, apiEvents)
+	// defer listener.Stop()
+
+	// config = fmt.Sprintf(`{"id": "%s", "updated": true}`, id)
+	// request, params := newRequest("POST", id, config)
+
+	// recorder := httptest.NewRecorder()
+	// endpoint(recorder, request, params)
+
+	// if recorder.Code != http.StatusOK {
+	// 	t.Errorf("Unexpected error from request: %s", recorder.Body.String())
+	// }
+
+	// for listener.UpdateCount() < 1 {
+	// 	// wait for listener goroutine to process the event
+	// }
+	// data := cache.Get(context.Background(), []string{id})
+	// if value, ok := data[id]; !ok || string(value) != config {
+	// 	t.Errorf("Updated key/value not present in cache after update.")
+	// }
+
+	// request, params = newRequest("DELETE", id, "")
+	// recorder = httptest.NewRecorder()
+	// endpoint(recorder, request, params)
+
+	// if recorder.Code != http.StatusOK {
+	// 	t.Errorf("Unexpected error from request: %s", recorder.Body.String())
+	// }
+
+	// for listener.InvalidationCount() < 1 {
+	// 	// wait for listener goroutine to process the event
+	// }
+	// data = cache.Get(context.Background(), []string{id})
+	// if _, ok := data[id]; ok {
+	// 	t.Errorf("Key/Value still present in cache after invalidation.")
+	// }
+}
+
+func TestBadRequests(t *testing.T) {
+	// cache := in_memory.NewLRUCache(&config.InMemoryCache{
+	// 	RequestCacheSize: 256 * 1024,
+	// 	ImpCacheSize:     256 * 1024,
+	// 	TTL:              -1,
+	// })
+
+	// apiEvents, endpoint := NewEventsAPI()
+	// listener := events.Listen(cache, apiEvents)
+	// defer listener.Stop()
+
+	// id := "1"
+	// config := "NOT JSON"
+	// request, params := newRequest("POST", id, config)
+
+	// recorder := httptest.NewRecorder()
+	// endpoint(recorder, request, params)
+
+	// if recorder.Code != http.StatusBadRequest {
+	// 	t.Errorf("Expected error from request, got OK")
+	// }
+
+	// request, params = newRequest("GET", id, "")
+	// recorder = httptest.NewRecorder()
+	// endpoint(recorder, request, params)
+
+	// if recorder.Code != http.StatusMethodNotAllowed {
+	// 	t.Errorf("Expected error from request, got OK")
+	// }
+}
+
+func newRequest(method string, id string, body string) (*http.Request, httprouter.Params) {
+	return httptest.NewRequest(method, fmt.Sprintf("/stored_requests/%s", id), strings.NewReader(body)),
+		httprouter.Params{httprouter.Param{Key: "id", Value: id}}
+}

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -3,7 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
-	"time"
+	"runtime"
 
 	"github.com/prebid/prebid-server/stored_requests"
 )
@@ -59,7 +59,7 @@ func (e *EventListener) WaitFor(ctx context.Context, updates int, invalidations 
 			if e.updateCount >= updates && e.invalidationCount >= invalidations {
 				return
 			}
-			time.Sleep(1 * time.Millisecond)
+			runtime.Gosched()
 		}
 	}
 }

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/prebid/prebid-server/stored_requests"
+)
+
+type Update struct {
+	Requests map[string]json.RawMessage
+	Imps     map[string]json.RawMessage
+}
+
+type Invalidation struct {
+	Requests []string
+	Imps     []string
+}
+
+// EventProducer will produce cache update and invalidation events on its channels
+type EventProducer interface {
+	Updates() <-chan Update
+	Invalidations() <-chan Invalidation
+}
+
+// EventListener provides information about how many events a listener has processed
+// and a mechanism to stop the listener goroutine
+type EventListener interface {
+	InvalidationCount() int
+	UpdateCount() int
+	Stop()
+}
+
+type eventListener struct {
+	invalidationCount int
+	updateCount       int
+	stop              chan struct{}
+}
+
+func (e eventListener) InvalidationCount() int {
+	return e.invalidationCount
+}
+
+func (e eventListener) UpdateCount() int {
+	return e.updateCount
+}
+
+func (e *eventListener) Stop() {
+	e.stop <- struct{}{}
+}
+
+// Listen will run a goroutine that updates/invalidates the cache when events occur
+func Listen(cache stored_requests.Cache, events EventProducer) EventListener {
+	listener := &eventListener{
+		invalidationCount: 0,
+		updateCount:       0,
+		stop:              make(chan struct{}),
+	}
+
+	go func() {
+		for {
+			select {
+			case update := <-events.Updates():
+				cache.Update(context.Background(), update.Requests, update.Requests)
+				listener.updateCount++
+			case invalidation := <-events.Invalidations():
+				cache.Invalidate(context.Background(), invalidation.Requests, invalidation.Imps)
+				listener.invalidationCount++
+			case <-listener.stop:
+				break
+			}
+		}
+	}()
+
+	return listener
+}

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/prebid/prebid-server/stored_requests"
 )
@@ -27,39 +28,52 @@ type EventProducer interface {
 
 // EventListener provides information about how many events a listener has processed
 // and a mechanism to stop the listener goroutine
-type EventListener interface {
-	InvalidationCount() int
-	UpdateCount() int
-	Stop()
-}
-
-type eventListener struct {
-	invalidationCount int
-	updateCount       int
+type EventListener struct {
 	stop              chan struct{}
+	updateCount       int
+	invalidationCount int
 }
 
-func (e eventListener) InvalidationCount() int {
-	return e.invalidationCount
-}
-
-func (e eventListener) UpdateCount() int {
-	return e.updateCount
-}
-
-func (e *eventListener) Stop() {
+// Stop the event listener
+func (e *EventListener) Stop() {
 	e.stop <- struct{}{}
 }
 
+// Counts returns the number of updates and invalidations that were propagated
+func (e *EventListener) Counts() (updates int, invalidations int) {
+	return e.updateCount, e.invalidationCount
+}
+
+// InvalidationCount is the number of propagated Invalidations
+func (e *EventListener) InvalidationCount() int {
+	return e.invalidationCount
+}
+
+// WaitFor the specified number of events to be propagated
+func (e *EventListener) WaitFor(ctx context.Context, updates int, invalidations int) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if e.updateCount >= updates && e.invalidationCount >= invalidations {
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+}
+
 // Listen will run a goroutine that updates/invalidates the cache when events occur
-func Listen(cache stored_requests.Cache, events EventProducer) EventListener {
-	listener := &eventListener{
-		invalidationCount: 0,
-		updateCount:       0,
+func Listen(cache stored_requests.Cache, events EventProducer) *EventListener {
+	listener := &EventListener{
 		stop:              make(chan struct{}),
+		updateCount:       0,
+		invalidationCount: 0,
 	}
 
 	go func() {
+		defer close(listener.stop)
 		for {
 			select {
 			case update := <-events.Updates():

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -7,14 +7,16 @@ import (
 	"github.com/prebid/prebid-server/stored_requests"
 )
 
+// Update represents a bulk update
 type Update struct {
-	Requests map[string]json.RawMessage
-	Imps     map[string]json.RawMessage
+	Requests map[string]json.RawMessage `json:"requests"`
+	Imps     map[string]json.RawMessage `json:"imps"`
 }
 
+// Invalidation represents a bulk invalidation
 type Invalidation struct {
-	Requests []string
-	Imps     []string
+	Requests []string `json:"requests"`
+	Imps     []string `json:"imps"`
 }
 
 // EventProducer will produce cache update and invalidation events on its channels

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -61,7 +61,7 @@ func (e *EventListener) Listen(cache stored_requests.Cache, events EventProducer
 	for {
 		select {
 		case update := <-events.Updates():
-			cache.Update(context.Background(), update.Requests, update.Requests)
+			cache.Update(context.Background(), update.Requests, update.Imps)
 			if e.onUpdate != nil {
 				e.onUpdate()
 			}

--- a/stored_requests/events/events_test.go
+++ b/stored_requests/events/events_test.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/stored_requests/caches/in_memory"
+)
+
+func TestListen(t *testing.T) {
+	ep := &dummyProducer{
+		updates:       make(chan Update),
+		invalidations: make(chan Invalidation),
+	}
+
+	cache := in_memory.NewLRUCache(&config.InMemoryCache{
+		RequestCacheSize: 256 * 1024,
+		ImpCacheSize:     256 * 1024,
+		TTL:              -1,
+	})
+
+	listener := Listen(cache, ep)
+	defer listener.Stop()
+
+	// id := "1"
+	// config := fmt.Sprintf(`{"id": "%s"}`, id)
+	// cache.Save(context.Background(), map[string]json.RawMessage{id: json.RawMessage(config)})
+
+	// config = fmt.Sprintf(`{"id": "%s", "updated": true}`, id)
+	// ep.updates <- map[string]json.RawMessage{id: json.RawMessage(config)}
+
+	// for listener.UpdateCount() < 1 {
+	// 	// wait for listener goroutine to process the event
+	// }
+	// data := cache.Get(context.Background(), []string{id})
+	// if value, ok := data[id]; !ok || string(value) != config {
+	// 	t.Errorf("Updated key/value not present in cache after update.")
+	// }
+
+	// ep.invalidations <- []string{id}
+	// for listener.InvalidationCount() < 1 {
+	// 	// wait for listener goroutine to process the event
+	// }
+	// data = cache.Get(context.Background(), []string{id})
+	// if _, ok := data[id]; ok {
+	// 	t.Errorf("Key/Value still present in cache after invalidation.")
+	// }
+}
+
+type dummyProducer struct {
+	updates       chan Update
+	invalidations chan Invalidation
+}
+
+func (p *dummyProducer) Updates() <-chan Update {
+	return p.updates
+}
+
+func (p *dummyProducer) Invalidations() <-chan Invalidation {
+	return p.invalidations
+}

--- a/stored_requests/fetcher.go
+++ b/stored_requests/fetcher.go
@@ -37,9 +37,9 @@ func (e NotFoundError) Error() string {
 
 // Cache is an intermediate layer which can be used to create more complex Fetchers by composition.
 // Implementations must be safe for concurrent access by multiple goroutines.
-// To add a Cache layer in front of the Fetcher, see WithCache()
+// To add a Cache layer in front of a Fetcher, see WithCache()
 type Cache interface {
-	// GetRequests works much like Fetcher.FetchRequests, with a few exceptions:
+	// Get works much like Fetcher.FetchRequests, with a few exceptions:
 	//
 	// 1. Any (actionable) errors should be logged by the implementation, rather than returned.
 	// 2. The returned maps _may_ be written to.
@@ -49,16 +49,94 @@ type Cache interface {
 	//
 	// Nil slices and empty strings are treated as "no ops". That is, a nil requestID will always produce a nil
 	// "stored request data" in the response.
-	GetRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
+	Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
 
-	// SaveRequests stores some data in the cache. The maps are from ID to the cached value.
-	//
-	// This is a best-effort method. If the cache call fails, implementations should log the error.
-	SaveRequests(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage)
+	// Invalidate will ensure that all values associated with the given IDs
+	// are no longer returned by the cache until new values are saved via Update
+	Invalidate(ctx context.Context, requestIDs []string, impIDs []string)
+
+	// Update will update the given values in the cache if they exist
+	// or ignore them if they don't
+	Update(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
+
+	// Save will add or overwrite the data in the cache at the given keys
+	Save(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
+}
+
+// ComposedCache creates an interface to treat a slice of caches as a single cache
+type ComposedCache []Cache
+
+// Get will attempt to Get from the caches in the order in which they are in the slice,
+// stopping as soon as a value is found (or when all caches have been exhausted)
+func (c ComposedCache) Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
+	requestData = make(map[string]json.RawMessage, len(requestIDs))
+	impData = make(map[string]json.RawMessage, len(impIDs))
+
+	remainingReqIDs := requestIDs
+	remainingImpIDs := impIDs
+
+	for _, cache := range c {
+		cachedReqData, cachedImpData := cache.Get(ctx, remainingReqIDs, remainingImpIDs)
+
+		if len(cachedReqData) > 0 {
+			// iterate over remainingIds from end, droppings ids as they are filled
+			for i := len(remainingReqIDs) - 1; i >= 0; i-- {
+				if config, ok := cachedReqData[remainingReqIDs[i]]; ok {
+					requestData[remainingReqIDs[i]] = config
+					remainingReqIDs = append(remainingReqIDs[:i], remainingReqIDs[i+1:]...)
+				}
+			}
+		}
+
+		if len(cachedImpData) > 0 {
+			// iterate over remainingIds from end, droppings ids as they are filled
+			for i := len(remainingImpIDs) - 1; i >= 0; i-- {
+				if config, ok := cachedImpData[remainingImpIDs[i]]; ok {
+					impData[remainingImpIDs[i]] = config
+					remainingImpIDs = append(remainingImpIDs[:i], remainingImpIDs[i+1:]...)
+				}
+			}
+		}
+
+		// return if all ids filled
+		if len(remainingReqIDs) == 0 && len(remainingImpIDs) == 0 {
+			return
+		}
+	}
+
+	return
+}
+
+// Invalidate will propagate invalidations to all underlying caches
+func (c ComposedCache) Invalidate(ctx context.Context, requestIDs []string, impIDs []string) {
+	for _, cache := range c {
+		cache.Invalidate(ctx, requestIDs, impIDs)
+	}
+}
+
+// Update will propagate updates to all underlying caches
+func (c ComposedCache) Update(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
+	for _, cache := range c {
+		cache.Update(ctx, requestData, impData)
+	}
+}
+
+// Save will propagate saves to all underlying caches
+func (c ComposedCache) Save(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
+	for _, cache := range c {
+		cache.Save(ctx, requestData, impData)
+	}
+}
+
+type fetcherWithCache struct {
+	fetcher Fetcher
+	cache   Cache
 }
 
 // WithCache returns a Fetcher which uses the given Cache before delegating to the original.
-// This can be called multiple times to compose Cache layers onto the backing Fetcher.
+// This can be called multiple times to compose Cache layers onto the backing Fetcher, though
+// it is usually more desirable to first compose caches with Compose, ensuring propagation of updates
+// and invalidations through all cache layers.
 func WithCache(fetcher Fetcher, cache Cache) Fetcher {
 	return &fetcherWithCache{
 		cache:   cache,
@@ -66,13 +144,8 @@ func WithCache(fetcher Fetcher, cache Cache) Fetcher {
 	}
 }
 
-type fetcherWithCache struct {
-	cache   Cache
-	fetcher Fetcher
-}
-
 func (f *fetcherWithCache) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
-	requestData, impData = f.cache.GetRequests(ctx, requestIDs, impIDs)
+	requestData, impData = f.cache.Get(ctx, requestIDs, impIDs)
 
 	// Fixes #311
 	leftoverImps := findLeftovers(impIDs, impData)
@@ -80,7 +153,7 @@ func (f *fetcherWithCache) FetchRequests(ctx context.Context, requestIDs []strin
 
 	fetcherReqData, fetcherImpData, errs := f.fetcher.FetchRequests(ctx, leftoverReqs, leftoverImps)
 
-	f.cache.SaveRequests(ctx, fetcherReqData, fetcherImpData)
+	f.cache.Save(ctx, fetcherReqData, fetcherImpData)
 
 	requestData = mergeData(requestData, fetcherReqData)
 	impData = mergeData(impData, fetcherImpData)
@@ -106,5 +179,6 @@ func mergeData(cachedData map[string]json.RawMessage, fetchedData map[string]jso
 			mergedData[key] = value
 		}
 	}
+
 	return
 }

--- a/stored_requests/multifetcher_test.go
+++ b/stored_requests/multifetcher_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMultiFetcher(t *testing.T) {
 	mf0 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"abc": json.RawMessage(`{}`),
 		},
 		mockGetImps: map[string]json.RawMessage{
@@ -18,7 +18,7 @@ func TestMultiFetcher(t *testing.T) {
 		returnErrs: []error{NotFoundError{"def", "Request"}, NotFoundError{"imp-1", "Imp"}},
 	}
 	mf1 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"def": json.RawMessage(`{}`),
 		},
 		mockGetImps: map[string]json.RawMessage{
@@ -40,7 +40,7 @@ func TestMultiFetcher(t *testing.T) {
 
 func TestMissingID(t *testing.T) {
 	mf0 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"abc": json.RawMessage(`{}`),
 		},
 		mockGetImps: map[string]json.RawMessage{
@@ -49,7 +49,7 @@ func TestMissingID(t *testing.T) {
 		returnErrs: []error{NotFoundError{"def", "Request"}, NotFoundError{"ghi", "Request"}, NotFoundError{"456", "Imp"}, NotFoundError{"789", "Imp"}},
 	}
 	mf1 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"def": json.RawMessage(`{}`),
 		},
 		mockGetImps: map[string]json.RawMessage{
@@ -70,13 +70,13 @@ func TestMissingID(t *testing.T) {
 
 func TestOtherError(t *testing.T) {
 	mf0 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"abc": json.RawMessage(`{}`),
 		},
 		returnErrs: []error{NotFoundError{"def", "Request"}, NotFoundError{"123", "Imp"}, errors.New("Other error")},
 	}
 	mf1 := &mockFetcher{
-		mockGetReq: map[string]json.RawMessage{
+		mockGetReqs: map[string]json.RawMessage{
 			"def": json.RawMessage(`{}`),
 		},
 		mockGetImps: map[string]json.RawMessage{


### PR DESCRIPTION
Proposed partial solution for #392. Includes implementation of an HTTP endpoint that could be exposed either behind authentication or on a private network to allow cache updates and invalidations.

**Example:** (adding hypothetical implementations for memcached `Cache` and Kafka `EventProducer`)
```go
// fetch from DB
db := db_fetcher.NewPostgresDb(dbCfg)
pgFetcher := db_fetcher.NewFetcher(db, cfg.Postgres.MakeAmpQuery)

// layer in-memory LRU on top of shared memcached instance
lruCache := in_memory.NewLRUCache(lruCfg)
memcachedCache := memcached.NewMemcachedCache(mcCfg)
caches := ComposedCache{lruCache, memcachedCache}

// subscribe caches to updates/invalidations from Kafka stream
kafkaEvents := events.NewKafkaEvents(kafkaCfg) 
listener := Listen(caches, kafkaEvents)

// layer caches on top of fetcher
configFetcher := WithCache(dbFetcher, caches)
```

`EventProducer`s could also be based on some pubsub technology, e.g. Postgres LISTEN/NOTIFY, Kafka, Kinesis.