### PR TITLE
fix native request double encoding

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -330,11 +330,7 @@ func fillAndValidateNative(n *openrtb.Native, impIndex int) error {
 	if err != nil {
 		return err
 	}
-	encoded, err := json.Marshal(string(serialized))
-	if err != nil {
-		return err
-	}
-	n.Request = string(encoded)
+	n.Request = string(serialized)
 	return nil
 }
 


### PR DESCRIPTION
Prebid Server double encodes native request that's sent to bidders, causing bidders unable to bid.
This fix removes one of the encoding so it works fine now.