### PR TITLE
Updates 3 parameter names and adds one new one

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -42,24 +42,26 @@ type KeyVal struct {
 }
 
 type appnexusParams struct {
-	LegacyPlacementId       int      `json:"placementId"`
-	LegacyInvCode           string   `json:"invCode"`
-	LegacyTrafficSourceCode string   `json:"trafficSourceCode"`
-	PlacementId             int      `json:"placement_id"`
-	InvCode                 string   `json:"inv_code"`
-	Member                  string   `json:"member"`
-	Keywords                []KeyVal `json:"keywords"`
-	TrafficSourceCode       string   `json:"traffic_source_code"`
-	Reserve                 float64  `json:"reserve"`
-	Position                string   `json:"position"`
-	UsePmtRule              *bool    `json:"use_pmt_rule"`
+	LegacyPlacementId       int             `json:"placementId"`
+	LegacyInvCode           string          `json:"invCode"`
+	LegacyTrafficSourceCode string          `json:"trafficSourceCode"`
+	PlacementId             int             `json:"placement_id"`
+	InvCode                 string          `json:"inv_code"`
+	Member                  string          `json:"member"`
+	Keywords                []KeyVal        `json:"keywords"`
+	TrafficSourceCode       string          `json:"traffic_source_code"`
+	Reserve                 float64         `json:"reserve"`
+	Position                string          `json:"position"`
+	UsePmtRule              *bool           `json:"use_pmt_rule"`
+	PrivateSizes            json.RawMessage `json:"private_sizes"`
 }
 
 type appnexusImpExtAppnexus struct {
-	PlacementID       int    `json:"placement_id,omitempty"`
-	Keywords          string `json:"keywords,omitempty"`
-	TrafficSourceCode string `json:"traffic_source_code,omitempty"`
-	UsePmtRule        *bool  `json:"use_pmt_rule,omitempty"`
+	PlacementID       int             `json:"placement_id,omitempty"`
+	Keywords          string          `json:"keywords,omitempty"`
+	TrafficSourceCode string          `json:"traffic_source_code,omitempty"`
+	UsePmtRule        *bool           `json:"use_pmt_rule,omitempty"`
+	PrivateSizes      json.RawMessage `json:"private_sizes,omitempty"`
 }
 
 type appnexusBidExt struct {
@@ -146,6 +148,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			TrafficSourceCode: params.TrafficSourceCode,
 			Keywords:          keywordStr,
 			UsePmtRule:        params.UsePmtRule,
+			PrivateSizes:      params.PrivateSizes,
 		}}
 		anReq.Imp[i].Ext, err = json.Marshal(&impExt)
 	}
@@ -357,6 +360,7 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 		TrafficSourceCode: appnexusExt.TrafficSourceCode,
 		Keywords:          makeKeywordStr(appnexusExt.Keywords),
 		UsePmtRule:        appnexusExt.UsePmtRule,
+		PrivateSizes:      appnexusExt.PrivateSizes,
 	}}
 	var err error
 	if imp.Ext, err = json.Marshal(&impExt); err != nil {

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -42,19 +42,24 @@ type KeyVal struct {
 }
 
 type appnexusParams struct {
-	PlacementId       int      `json:"placementId"`
-	InvCode           string   `json:"invCode"`
-	Member            string   `json:"member"`
-	Keywords          []KeyVal `json:"keywords"`
-	TrafficSourceCode string   `json:"trafficSourceCode"`
-	Reserve           float64  `json:"reserve"`
-	Position          string   `json:"position"`
+	LegacyPlacementId       int      `json:"placementId"`
+	LegacyInvCode           string   `json:"invCode"`
+	LegacyTrafficSourceCode string   `json:"trafficSourceCode"`
+	PlacementId             int      `json:"placement_id"`
+	InvCode                 string   `json:"inv_code"`
+	Member                  string   `json:"member"`
+	Keywords                []KeyVal `json:"keywords"`
+	TrafficSourceCode       string   `json:"traffic_source_code"`
+	Reserve                 float64  `json:"reserve"`
+	Position                string   `json:"position"`
+	UsePmtRule              *bool    `json:"use_pmt_rule"`
 }
 
 type appnexusImpExtAppnexus struct {
 	PlacementID       int    `json:"placement_id,omitempty"`
 	Keywords          string `json:"keywords,omitempty"`
 	TrafficSourceCode string `json:"traffic_source_code,omitempty"`
+	UsePmtRule        *bool  `json:"use_pmt_rule,omitempty"`
 }
 
 type appnexusBidExt struct {
@@ -82,6 +87,17 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		err := json.Unmarshal(unit.Params, &params)
 		if err != nil {
 			return nil, err
+		}
+		// Accept legacy Appnexus parameters if we don't have modern ones
+		// Don't worry if both is set as validation rules should prevent, and this is temporary anyway.
+		if params.PlacementId == 0 && params.LegacyPlacementId != 0 {
+			params.PlacementId = params.LegacyPlacementId
+		}
+		if params.InvCode == "" && params.LegacyInvCode != "" {
+			params.InvCode = params.LegacyInvCode
+		}
+		if params.TrafficSourceCode == "" && params.LegacyTrafficSourceCode != "" {
+			params.TrafficSourceCode = params.LegacyTrafficSourceCode
 		}
 
 		if params.PlacementId == 0 && (params.InvCode == "" || params.Member == "") {
@@ -129,6 +145,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			PlacementID:       params.PlacementId,
 			TrafficSourceCode: params.TrafficSourceCode,
 			Keywords:          keywordStr,
+			UsePmtRule:        params.UsePmtRule,
 		}}
 		anReq.Imp[i].Ext, err = json.Marshal(&impExt)
 	}
@@ -296,6 +313,18 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 		return "", err
 	}
 
+	// Accept legacy Appnexus parameters if we don't have modern ones
+	// Don't worry if both is set as validation rules should prevent, and this is temporary anyway.
+	if appnexusExt.PlacementId == 0 && appnexusExt.LegacyPlacementId != 0 {
+		appnexusExt.PlacementId = appnexusExt.LegacyPlacementId
+	}
+	if appnexusExt.InvCode == "" && appnexusExt.LegacyInvCode != "" {
+		appnexusExt.InvCode = appnexusExt.LegacyInvCode
+	}
+	if appnexusExt.TrafficSourceCode == "" && appnexusExt.LegacyTrafficSourceCode != "" {
+		appnexusExt.TrafficSourceCode = appnexusExt.LegacyTrafficSourceCode
+	}
+
 	if appnexusExt.PlacementId == 0 && (appnexusExt.InvCode == "" || appnexusExt.Member == "") {
 		return "", errors.New("No placement or member+invcode provided")
 	}
@@ -327,6 +356,7 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 		PlacementID:       appnexusExt.PlacementId,
 		TrafficSourceCode: appnexusExt.TrafficSourceCode,
 		Keywords:          makeKeywordStr(appnexusExt.Keywords),
+		UsePmtRule:        appnexusExt.UsePmtRule,
 	}}
 	var err error
 	if imp.Ext, err = json.Marshal(&impExt); err != nil {

--- a/adapters/appnexus/appnexustest/exemplary/native-1.1.json
+++ b/adapters/appnexus/appnexustest/exemplary/native-1.1.json
@@ -10,7 +10,7 @@
         },
         "ext": {
           "bidder": {
-            "placementId": 9880618
+            "placement_id": 9880618
           }
         }
       }

--- a/adapters/appnexus/appnexustest/exemplary/optional-params.json
+++ b/adapters/appnexus/appnexustest/exemplary/optional-params.json
@@ -19,14 +19,15 @@
         "ext": {
           "bidder": {
             "member": "103",
-            "invCode": "abc",
+            "inv_code": "abc",
             "reserve": 20,
             "position": "below",
-            "trafficSourceCode": "trafficSource",
+            "traffic_source_code": "trafficSource",
             "keywords": [
               {"key": "foo", "value": ["bar","baz"]},
               {"key": "valueless"}
-            ]
+            ],
+            "use_pmt_rule": true
           }
         }
       }
@@ -56,7 +57,8 @@
               "ext": {
                 "appnexus": {
                   "keywords": "foo=bar,foo=baz,valueless",
-                  "traffic_source_code": "trafficSource"
+                  "traffic_source_code": "trafficSource",
+                  "use_pmt_rule": true
                 }
               }
             }

--- a/adapters/appnexus/appnexustest/exemplary/optional-params.json
+++ b/adapters/appnexus/appnexustest/exemplary/optional-params.json
@@ -27,7 +27,8 @@
               {"key": "foo", "value": ["bar","baz"]},
               {"key": "valueless"}
             ],
-            "use_pmt_rule": true
+            "use_pmt_rule": true,
+            "private_sizes": [{"w": 300, "h": 250}]
           }
         }
       }
@@ -58,7 +59,8 @@
                 "appnexus": {
                   "keywords": "foo=bar,foo=baz,valueless",
                   "traffic_source_code": "trafficSource",
-                  "use_pmt_rule": true
+                  "use_pmt_rule": true,
+                  "private_sizes": [{"w": 300, "h": 250}]
                 }
               }
             }

--- a/adapters/appnexus/appnexustest/exemplary/simple-banner.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-banner.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "placementId": 10433394
+            "placement_id": 10433394
           }
         }
       }

--- a/adapters/appnexus/appnexustest/params/race/banner.json
+++ b/adapters/appnexus/appnexustest/params/race/banner.json
@@ -1,8 +1,8 @@
 {
-  "placementId": 10433394,
+  "placement_id": 10433394,
   "reserve": 20,
   "position": "below",
-  "trafficSourceCode": "trafficSource",
+  "traffic_source_code": "trafficSource",
   "keywords": [
     {"key": "foo", "value": ["bar","baz"]},
     {"key": "valueless"}

--- a/adapters/appnexus/appnexustest/params/race/video.json
+++ b/adapters/appnexus/appnexustest/params/race/video.json
@@ -1,8 +1,8 @@
 {
-  "placementId": 10433394,
+  "placement_id": 10433394,
   "reserve": 20,
   "position": "below",
-  "trafficSourceCode": "trafficSource",
+  "traffic_source_code": "trafficSource",
   "keywords": [
     {"key": "foo", "value": ["bar","baz"]},
     {"key": "valueless"}

--- a/adapters/appnexus/params_test.go
+++ b/adapters/appnexus/params_test.go
@@ -46,6 +46,7 @@ var validParams = []string{
 	`{"placementId":123, "keywords":[{"key":"foo","value":["bar"]}]}`,
 	`{"placement_id":123, "keywords":[{"key":"foo","value":["bar", "baz"]}]}`,
 	`{"placement_id":123, "keywords":[{"key":"foo"}]}`,
+	`{"placement_id":123, "use_pmt_rule": true, "private_sizes": [{"w": 300, "h":250}]}`,
 }
 
 var invalidParams = []string{
@@ -68,4 +69,7 @@ var invalidParams = []string{
 	`{"placement_id":123, "keywords":["foo"]}`,
 	`{"placementId":123, "keywords":[{"key":"foo","value":[]}]}`,
 	`{"placementId":123, "keywords":[{"value":["bar"]}]}`,
+	`{"placement_id":123, "use_pmt_rule": "true"}`,
+	`{"placement_id":123, "private_sizes": [[300,250]]}`,
+	`{"placement_id":123, "private_sizes": [{"w": "300", "h": "250"}]}`,
 }

--- a/adapters/appnexus/params_test.go
+++ b/adapters/appnexus/params_test.go
@@ -39,13 +39,13 @@ func TestInvalidParams(t *testing.T) {
 }
 
 var validParams = []string{
-	`{"placementId":123}`,
+	`{"placement_id":123}`,
 	`{"placementId":123,"position":"above"}`,
-	`{"placementId":123,"position":"below"}`,
-	`{"member":"123","invCode":"456"}`,
+	`{"placement_id":123,"position":"below"}`,
+	`{"member":"123","inv_code":"456"}`,
 	`{"placementId":123, "keywords":[{"key":"foo","value":["bar"]}]}`,
-	`{"placementId":123, "keywords":[{"key":"foo","value":["bar", "baz"]}]}`,
-	`{"placementId":123, "keywords":[{"key":"foo"}]}`,
+	`{"placement_id":123, "keywords":[{"key":"foo","value":["bar", "baz"]}]}`,
+	`{"placement_id":123, "keywords":[{"key":"foo"}]}`,
 }
 
 var invalidParams = []string{
@@ -56,15 +56,16 @@ var invalidParams = []string{
 	`4.2`,
 	`[]`,
 	`{}`,
-	`{"placementId":"123"}`,
+	`{"placement_id":"123"}`,
+	`{"placement_id":123, "placementId":123}`,
 	`{"member":"123"}`,
 	`{"member":"123","invCode":45}`,
 	`{"placementId":"123","member":"123","invCode":45}`,
-	`{"placementId":123, "position":"left"}`,
-	`{"placementId":123, "position":"left"}`,
-	`{"placementId":123, "reserve":"45"}`,
-	`{"placementId":123, "keywords":[]}`,
-	`{"placementId":123, "keywords":["foo"]}`,
+	`{"placement_id":123, "position":"left"}`,
+	`{"placement_id":123, "position":"left"}`,
+	`{"placement_id":123, "reserve":"45"}`,
+	`{"placement_id":123, "keywords":[]}`,
+	`{"placement_id":123, "keywords":["foo"]}`,
 	`{"placementId":123, "keywords":[{"key":"foo","value":[]}]}`,
 	`{"placementId":123, "keywords":[{"value":["bar"]}]}`,
 }

--- a/openrtb_ext/imp_appnexus.go
+++ b/openrtb_ext/imp_appnexus.go
@@ -2,13 +2,17 @@ package openrtb_ext
 
 // ExtImpAppnexus defines the contract for bidrequest.imp[i].ext.appnexus
 type ExtImpAppnexus struct {
-	PlacementId       int                     `json:"placementId"`
-	InvCode           string                  `json:"invCode"`
-	Member            string                  `json:"member"`
-	Keywords          []*ExtImpAppnexusKeyVal `json:"keywords"`
-	TrafficSourceCode string                  `json:"trafficSourceCode"`
-	Reserve           float64                 `json:"reserve"`
-	Position          string                  `json:"position"`
+	LegacyPlacementId       int                     `json:"placementId"`
+	LegacyInvCode           string                  `json:"invCode"`
+	LegacyTrafficSourceCode string                  `json:"trafficSourceCode"`
+	PlacementId             int                     `json:"placement_id"`
+	InvCode                 string                  `json:"inv_code"`
+	Member                  string                  `json:"member"`
+	Keywords                []*ExtImpAppnexusKeyVal `json:"keywords"`
+	TrafficSourceCode       string                  `json:"traffic_source_code"`
+	Reserve                 float64                 `json:"reserve"`
+	Position                string                  `json:"position"`
+	UsePmtRule              *bool                   `json:"use_pmt_rule"`
 }
 
 // ExtImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.appnexus.keywords[i]

--- a/openrtb_ext/imp_appnexus.go
+++ b/openrtb_ext/imp_appnexus.go
@@ -15,7 +15,8 @@ type ExtImpAppnexus struct {
 	Reserve                 float64                 `json:"reserve"`
 	Position                string                  `json:"position"`
 	UsePmtRule              *bool                   `json:"use_pmt_rule"`
-	PrivateSizes            json.RawMessage         `json:"private_sizes"`
+	// At this time we do no processing on the private sizes, so just leaving it as a JSON blob.
+	PrivateSizes json.RawMessage `json:"private_sizes"`
 }
 
 // ExtImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.appnexus.keywords[i]

--- a/openrtb_ext/imp_appnexus.go
+++ b/openrtb_ext/imp_appnexus.go
@@ -1,5 +1,7 @@
 package openrtb_ext
 
+import "encoding/json"
+
 // ExtImpAppnexus defines the contract for bidrequest.imp[i].ext.appnexus
 type ExtImpAppnexus struct {
 	LegacyPlacementId       int                     `json:"placementId"`
@@ -13,6 +15,7 @@ type ExtImpAppnexus struct {
 	Reserve                 float64                 `json:"reserve"`
 	Position                string                  `json:"position"`
 	UsePmtRule              *bool                   `json:"use_pmt_rule"`
+	PrivateSizes            json.RawMessage         `json:"private_sizes"`
 }
 
 // ExtImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.appnexus.keywords[i]

--- a/static/bidder-params/appnexus.json
+++ b/static/bidder-params/appnexus.json
@@ -66,6 +66,18 @@
     "use_pmt_rule": {
       "type": "boolean",
       "description": "Boolean to signal AppNexus to apply the relevant payment rule"
+    },
+    "private_sizes" :{
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "w": { "type": "integer" },
+          "h": { "type": "integer" }
+        },
+        "required": [ "w", "h"]
+      },
+      "description": "Private sizes (ex: [{\"w\": 300, \"h\": 250},{...}]), experimental, may not be supported."
     }
   },
 

--- a/static/bidder-params/appnexus.json
+++ b/static/bidder-params/appnexus.json
@@ -5,13 +5,21 @@
 
   "type": "object",
   "properties": {
-    "placementId": {
+    "placement_id": {
       "type": "integer",
       "description": "An ID which identifies this placement of the impression"
     },
-    "invCode": {
+    "placementId": {
+      "type": "integer",
+      "description": "Deprecated"
+    },
+    "inv_code": {
       "type": "string",
       "description": "A code identifying the inventory of this placement."
+    },
+    "invCode": {
+      "type": "string",
+      "description": "Deprecated"
     },
     "member": {
       "type": "string",
@@ -38,9 +46,13 @@
         "required": ["key"]
       }
     },
-    "trafficSourceCode": {
+    "traffic_source_code": {
       "type": "string",
       "description": "Specifies the third-party source of this impression."
+    },
+    "trafficSourceCode": {
+      "type": "string",
+      "description": "Deprecated"
     },
     "reserve": {
       "type": "number",
@@ -50,13 +62,25 @@
       "type": "string",
       "enum": ["above", "below"],
       "description": "Specifies the ad unit as above or below the fold"
+    },
+    "use_pmt_rule": {
+      "type": "boolean",
+      "description": "Boolean to signal AppNexus to apply the relevant payment rule"
     }
   },
 
   "oneOf": [{
-    "required": ["placementId"]
+    "oneOf": [{
+      "required": ["placementId"]
+    }, {
+      "required": ["placement_id"]
+    }]
   }, {
-    "required": ["invCode", "member"]
+    "oneOf": [{
+      "required": ["invCode", "member"]
+    }, {
+      "required": ["inv_code", "member"]
+    }]
   }],
 
   "not": {

--- a/static/bidder-params/appnexus.json
+++ b/static/bidder-params/appnexus.json
@@ -11,7 +11,7 @@
     },
     "placementId": {
       "type": "integer",
-      "description": "Deprecated"
+      "description": "Deprecated, use placement_id instead."
     },
     "inv_code": {
       "type": "string",
@@ -19,7 +19,7 @@
     },
     "invCode": {
       "type": "string",
-      "description": "Deprecated"
+      "description": "Deprecated, use inv_code instead."
     },
     "member": {
       "type": "string",
@@ -52,7 +52,7 @@
     },
     "trafficSourceCode": {
       "type": "string",
-      "description": "Deprecated"
+      "description": "Deprecated, use traffic_source_code instead."
     },
     "reserve": {
       "type": "number",


### PR DESCRIPTION
We want to move the appnexus parameters from camelCase to snake_case. This affects 3 parameters (`placementId`, `invCode`, and `trafficSourceCode`). In this PR, the appnexus adapter will accept either version of the parameter name, at some point in the future we will disable the old names. We also add one new parameter: `use_pmt_rule`.