### PR TITLE
Remove debug file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,13 @@ _testmain.go
 *.test
 *.prof
 
-# glide directory
+# dep directory
 vendor
 
 # build artifacts
 prebid-server
 build
+debug
 
 # config files
 pbs.*


### PR DESCRIPTION
Looks like a 19MB binary debug file was accidentally merged in [#248](https://github.com/prebid/prebid-server/pull/248/files#diff-ad42f6697b035b7580e4fef93be20b4d). This removes it and adds it to `.gitignore`.