### PR TITLE
Windows - Resolved load json schema error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _obj
 _test
 .cover/
 .idea/
+.vscode/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -93,7 +93,10 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 		if _, isValid := BidderMap[bidderName]; !isValid {
 			return nil, fmt.Errorf("File %s/%s does not match a valid BidderName.", schemaDirectory, fileInfo.Name())
 		}
-		toOpen, _ := filepath.Abs(filepath.Join(schemaDirectory, fileInfo.Name()))
+		toOpen, err := filepath.Abs(filepath.Join(schemaDirectory, fileInfo.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get an absolute representation of the path: %s, %v", toOpen, err)
+		}
 		schemaLoader := gojsonschema.NewReferenceLoader("file:///" + toOpen)
 		loadedSchema, err := gojsonschema.NewSchema(schemaLoader)
 		if err != nil {

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/mxmCherry/openrtb"
@@ -81,7 +81,6 @@ type BidderParamValidator interface {
 // NewBidderParamsValidator makes a BidderParamValidator, assuming all the necessary files exist in the filesystem.
 // This will error if, for example, a Bidder gets added but no JSON schema is written for them.
 func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, error) {
-	filesystem := http.Dir(schemaDirectory)
 	fileInfos, err := ioutil.ReadDir(schemaDirectory)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read JSON schemas from directory %s. %v", schemaDirectory, err)
@@ -94,11 +93,11 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 		if _, isValid := BidderMap[bidderName]; !isValid {
 			return nil, fmt.Errorf("File %s/%s does not match a valid BidderName.", schemaDirectory, fileInfo.Name())
 		}
-
-		schemaLoader := gojsonschema.NewReferenceLoaderFileSystem(fmt.Sprintf("file:///%s", fileInfo.Name()), filesystem)
+		toOpen, _ := filepath.Abs(filepath.Join(schemaDirectory, fileInfo.Name()))
+		schemaLoader := gojsonschema.NewReferenceLoader("file:///" + toOpen)
 		loadedSchema, err := gojsonschema.NewSchema(schemaLoader)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to load json schema at %s/%s: %v", schemaDirectory, fileInfo.Name(), err)
+			return nil, fmt.Errorf("Failed to load json schema at %s: %v", toOpen, err)
 		}
 
 		fileBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", schemaDirectory, fileInfo.Name()))


### PR DESCRIPTION
When trying to run the project on Windows, I received the following error:

```
F0322 22:26:04.060973    9724 pbs_light.go:904] Failed to create the bidder params validator. Failed to load json schema at ./static/bidder-params/adform.json: Reference {0xc042133780 {[]} false true false true false} must be canonical
goroutine 1 [running]:
```

These changes resolve this error.

I also added .vscode/ to the .gitignore file.