### PR TITLE
Default OpenRTB to first-price auction

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -649,12 +649,22 @@ func (deps *endpointDeps) setFieldsImplicitly(httpReq *http.Request, bidReq *ope
 	}
 
 	deps.setUserImplicitly(httpReq, bidReq)
+	setAuctionTypeImplicitly(bidReq)
 }
 
 // setDeviceImplicitly uses implicit info from httpReq to populate bidReq.Device
 func setDeviceImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
 	setIPImplicitly(httpReq, bidReq) // Fixes #230
 	setUAImplicitly(httpReq, bidReq)
+}
+
+// setAuctionTypeImplicitly sets the auction type to 1 if it wasn't on the request,
+// since header bidding is generally a first-price auction.
+func setAuctionTypeImplicitly(bidReq *openrtb.BidRequest) {
+	if bidReq.AT == 0 {
+		bidReq.AT = 1
+	}
+	return
 }
 
 // setSiteImplicitly uses implicit info from httpReq to populate bidReq.Site

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -278,6 +278,15 @@ func TestUserAgentOverride(t *testing.T) {
 	}
 }
 
+func TestAuctionTypeDefault(t *testing.T) {
+	bidReq := &openrtb.BidRequest{}
+	setAuctionTypeImplicitly(bidReq)
+
+	if bidReq.AT != 1 {
+		t.Errorf("Expected request.at to be 1. Got %d", bidReq.AT)
+	}
+}
+
 // TestImplicitIPs prevents #230
 func TestImplicitIPs(t *testing.T) {
 	ex := &nobidExchange{}


### PR DESCRIPTION
OpenRTB lets you specify whether the auction is a first price or second price auction.

Since we're header bidding, we're almost always a first-price auction. As always, this default can be overridden if it's defined by the HTTP Request or Stored Request explicitly.