### PR TITLE
Bid cpm adjustments

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -260,7 +260,7 @@ func (deps *endpointDeps) validateRequest(req *openrtb.BidRequest) error {
 
 func validateBidAdjustmentFactors(adjustmentFactors map[string]float64, aliases map[string]string) error {
 	for bidderToAdjust, adjustmentFactor := range adjustmentFactors {
-		if adjustmentFactor < 0 {
+		if adjustmentFactor <= 0 {
 			return fmt.Errorf("request.ext.prebid.bidadjustmentfactors.%s must not be negative. Got %f", bidderToAdjust, adjustmentFactor)
 		}
 		if _, isBidder := openrtb_ext.BidderMap[bidderToAdjust]; !isBidder {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -261,7 +261,7 @@ func (deps *endpointDeps) validateRequest(req *openrtb.BidRequest) error {
 func validateBidAdjustmentFactors(adjustmentFactors map[string]float64, aliases map[string]string) error {
 	for bidderToAdjust, adjustmentFactor := range adjustmentFactors {
 		if adjustmentFactor <= 0 {
-			return fmt.Errorf("request.ext.prebid.bidadjustmentfactors.%s must not be negative. Got %f", bidderToAdjust, adjustmentFactor)
+			return fmt.Errorf("request.ext.prebid.bidadjustmentfactors.%s must be a positive number. Got %f", bidderToAdjust, adjustmentFactor)
 		}
 		if _, isBidder := openrtb_ext.BidderMap[bidderToAdjust]; !isBidder {
 			if _, isAlias := aliases[bidderToAdjust]; !isAlias {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-invalid-bidder.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-invalid-bidder.json
@@ -1,0 +1,24 @@
+{
+  "id": "some-request-id",
+  "site": {
+      "page": "test.somepage.com"
+  },
+  "imp": [
+      {
+          "id": "my-imp-id",
+          "video": {
+              "mimes":["video/mp4"]
+          },
+          "ext": {
+              "appnexus": "good"
+          }
+      }
+  ],
+  "ext": {
+      "prebid": {
+          "bidadjustmentfactors": {
+              "unknown": -2.0
+          }
+      }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-invalid-bidder.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-invalid-bidder.json
@@ -17,7 +17,7 @@
   "ext": {
       "prebid": {
           "bidadjustmentfactors": {
-              "unknown": -2.0
+              "unknown": 2.0
           }
       }
   }

--- a/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-negative.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/bid-adjustment-negative.json
@@ -1,0 +1,24 @@
+{
+    "id": "some-request-id",
+    "site": {
+        "page": "test.somepage.com"
+    },
+    "imp": [
+        {
+            "id": "my-imp-id",
+            "video": {
+                "mimes":["video/mp4"]
+            },
+            "ext": {
+                "appnexus": "good"
+            }
+        }
+    ],
+    "ext": {
+        "prebid": {
+            "bidadjustmentfactors": {
+                "appnexus": -2.0
+            }
+        }
+    }
+}

--- a/endpoints/openrtb2/sample-requests/valid-whole/bid-adjustments.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/bid-adjustments.json
@@ -1,0 +1,28 @@
+{
+    "id": "some-request-id",
+    "site": {
+        "page": "test.somepage.com"
+    },
+    "imp": [
+        {
+            "id": "my-imp-id",
+            "video": {
+                "mimes":["video/mp4"]
+            },
+            "ext": {
+                "unknown": "good"
+            }
+        }
+    ],
+    "ext": {
+        "prebid": {
+            "bidadjustmentfactors": {
+                "appnexus": 2.0,
+                "unknown": 1.5
+            },
+            "aliases": {
+                "unknown": "appnexus"
+            }
+        }
+    }
+}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -47,7 +47,7 @@ func TestSingleBidder(t *testing.T) {
 		bids: mockBids,
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test")
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
 
 	// Make sure the goodSingleBidder was called with the expected arguments.
 	if bidderImpl.httpResponse == nil {
@@ -123,7 +123,7 @@ func TestMultiBidder(t *testing.T) {
 		bids: mockBids,
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test")
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
 
 	if seatBid == nil {
 		t.Fatalf("SeatBid should exist, because bids exist.")
@@ -305,7 +305,7 @@ func TestServerCallDebugging(t *testing.T) {
 
 	bids, _ := bidder.requestBid(context.Background(), &openrtb.BidRequest{
 		Test: 1,
-	}, "test")
+	}, "test", 1.0)
 
 	if len(bids.httpCalls) != 1 {
 		t.Errorf("We should log the server call if this is a test bid. Got %d", len(bids.httpCalls))
@@ -326,7 +326,7 @@ func TestServerCallDebugging(t *testing.T) {
 
 func TestErrorReporting(t *testing.T) {
 	bidder := adaptBidder(&bidRejector{}, nil)
-	bids, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test")
+	bids, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
 	if bids != nil {
 		t.Errorf("There should be no seatbid if no http requests are returned.")
 	}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -26,13 +26,20 @@ func TestSingleBidder(t *testing.T) {
 	requestHeaders := http.Header{}
 	requestHeaders.Add("Content-Type", "application/json")
 
+	bidAdjustment := 2.0
+	firstInitialPrice := 3.0
+	secondInitialPrice := 4.0
 	mockBids := []*adapters.TypedBid{
 		{
-			Bid:     &openrtb.Bid{},
+			Bid: &openrtb.Bid{
+				Price: firstInitialPrice,
+			},
 			BidType: openrtb_ext.BidTypeBanner,
 		},
 		{
-			Bid:     &openrtb.Bid{},
+			Bid: &openrtb.Bid{
+				Price: secondInitialPrice,
+			},
 			BidType: openrtb_ext.BidTypeVideo,
 		},
 	}
@@ -47,7 +54,7 @@ func TestSingleBidder(t *testing.T) {
 		bids: mockBids,
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", bidAdjustment)
 
 	// Make sure the goodSingleBidder was called with the expected arguments.
 	if bidderImpl.httpResponse == nil {
@@ -74,6 +81,12 @@ func TestSingleBidder(t *testing.T) {
 		if typedBid.BidType != seatBid.bids[index].bidType {
 			t.Errorf("Bid %d did not have the right type. Expected %s, got %s", index, typedBid.BidType, seatBid.bids[index].bidType)
 		}
+	}
+	if mockBids[0].Bid.Price != bidAdjustment*firstInitialPrice {
+		t.Errorf("Bid[0].Price was not adjusted properly. Expected %f, got %f", bidAdjustment*firstInitialPrice, mockBids[0].Bid.Price)
+	}
+	if mockBids[1].Bid.Price != bidAdjustment*secondInitialPrice {
+		t.Errorf("Bid[1].Price was not adjusted properly. Expected %f, got %f", bidAdjustment*secondInitialPrice, mockBids[1].Bid.Price)
 	}
 	if len(seatBid.httpCalls) != 0 {
 		t.Errorf("The bidder shouldn't log HttpCalls when request.test == 0. Found %d", len(seatBid.httpCalls))

--- a/exchange/exchange_json_test.go
+++ b/exchange/exchange_json_test.go
@@ -1,0 +1,301 @@
+package exchange
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/buger/jsonparser"
+
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/yudai/gojsondiff"
+	"github.com/yudai/gojsondiff/formatter"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+// DoTests executes tests for all the *.json files in this directory.
+func TestExchange(t *testing.T) {
+	if specFiles, err := ioutil.ReadDir("./exchangetest"); err == nil {
+		for _, specFile := range specFiles {
+			fileName := "./exchangetest/" + specFile.Name()
+			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
+			specData, err := loadFile(fileName)
+			if err != nil {
+				t.Fatalf("Failed to load contents of file %s: %v", fileDisplayName, err)
+			}
+
+			runSpec(t, fileDisplayName, specData)
+		}
+	}
+}
+
+// LoadFile reads and parses a file as a test case. If something goes wrong, it returns an error.
+func loadFile(filename string) (*exchangeSpec, error) {
+	specData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read file %s: %v", filename, err)
+	}
+
+	var spec exchangeSpec
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal JSON from file: %v", err)
+	}
+
+	return &spec, nil
+}
+
+func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
+	aliases, errs := parseAliases(&spec.IncomingRequest.OrtbRequest)
+	if len(errs) != 0 {
+		t.Fatalf("%s: Failed to parse aliases", filename)
+	}
+	ex := newExchangeForTests(t, filename, spec.OutgoingRequests, aliases)
+	bid, err := ex.HoldAuction(context.Background(), &spec.IncomingRequest.OrtbRequest, mockIdFetcher(spec.IncomingRequest.Usersyncs), pbsmetrics.Labels{})
+	extractResponseTimes(t, filename, bid)
+	diffOrtbResponses(t, filename, spec.Response.Bids, bid)
+	if err == nil {
+		if spec.Response.Error != "" {
+			t.Errorf("%s: Exchange did not return expected error: %s", filename, spec.Response.Error)
+		}
+	} else {
+		if err.Error() != spec.Response.Error {
+			t.Errorf("%s: Exchange returned different errors. Expected %s, got %s", filename, spec.Response.Error, err.Error())
+		}
+	}
+}
+
+// extractResponseTimes validates the format of bid.ext.responsetimemillis, and then removes it.
+// This is done because the response time will change from run to run, so it's impossible to hardcode a value
+// into the JSON. The best we can do is make sure that the property exists.
+func extractResponseTimes(t *testing.T, context string, bid *openrtb.BidResponse) {
+	if _, dataType, _, err := jsonparser.Get(bid.Ext, "responsetimemillis"); err != nil || dataType != jsonparser.Object {
+		t.Errorf("%s: Exchange did not return ext.responsetimemillis object: %v", context, err)
+		return
+	}
+	// Delete the response times so that they don't appear in the JSON, because they can't be tested reliably anyway.
+	// If there's no other ext, just delete it altogether.
+	bid.Ext = jsonparser.Delete(bid.Ext, "responsetimemillis")
+	if diff, err := gojsondiff.New().Compare(bid.Ext, []byte("{}")); err == nil && !diff.Modified() {
+		bid.Ext = nil
+	}
+}
+
+func newExchangeForTests(t *testing.T, filename string, expectations map[string]*bidderSpec, aliases map[string]string) Exchange {
+	adapters := make(map[openrtb_ext.BidderName]adaptedBidder)
+	for _, bidderName := range openrtb_ext.BidderMap {
+		if spec, ok := expectations[string(bidderName)]; ok {
+			adapters[bidderName] = &validatingBidder{
+				t:             t,
+				fileName:      filename,
+				bidderName:    string(bidderName),
+				expectations:  map[string]*bidderRequest{string(bidderName): spec.ExpectedRequest},
+				mockResponses: map[string]bidderResponse{string(bidderName): spec.MockResponse},
+			}
+		}
+	}
+	for alias, coreBidder := range aliases {
+		if spec, ok := expectations[alias]; ok {
+			if bidder, ok := adapters[openrtb_ext.BidderName(coreBidder)]; ok {
+				bidder.(*validatingBidder).expectations[alias] = spec.ExpectedRequest
+				bidder.(*validatingBidder).mockResponses[alias] = spec.MockResponse
+			} else {
+				adapters[openrtb_ext.BidderName(coreBidder)] = &validatingBidder{
+					t:             t,
+					fileName:      filename,
+					bidderName:    coreBidder,
+					expectations:  map[string]*bidderRequest{coreBidder: spec.ExpectedRequest},
+					mockResponses: map[string]bidderResponse{coreBidder: spec.MockResponse},
+				}
+			}
+		}
+	}
+
+	return &exchange{
+		adapterMap: adapters,
+		me:         pbsmetrics.NewMetricsEngine(&config.Configuration{}, openrtb_ext.BidderList()),
+		cache:      &wellBehavedCache{},
+		cacheTime:  0,
+	}
+}
+
+type exchangeSpec struct {
+	IncomingRequest  exchangeRequest        `json:"incomingRequest"`
+	OutgoingRequests map[string]*bidderSpec `json:"outgoingRequests"`
+	Response         exchangeResponse       `json:"response,omitempty"`
+}
+
+type exchangeRequest struct {
+	OrtbRequest openrtb.BidRequest `json:"ortbRequest"`
+	Usersyncs   map[string]string  `json:"usersyncs"`
+}
+
+type exchangeResponse struct {
+	Bids  *openrtb.BidResponse `json:"bids"`
+	Error string               `json:"error,omitempty"`
+}
+
+type bidderSpec struct {
+	ExpectedRequest *bidderRequest `json:"expectRequest"`
+	MockResponse    bidderResponse `json:"mockResponse"`
+}
+
+type bidderRequest struct {
+	OrtbRequest   openrtb.BidRequest `json:"ortbRequest"`
+	BidAdjustment float64            `json:"bidAdjustment"`
+}
+
+type bidderResponse struct {
+	SeatBid *bidderSeatBid `json:"pbsSeatBid,omitempty"`
+	Errors  []string       `json:"errors,omitempty"`
+}
+
+// bidderSeatBid is basically a subset of pbsOrtbSeatBid from exchange/bidder.go.
+// The only real reason I'm not reusing that type is because I don't want people to think that the
+// JSON property tags on those types are contracts in prod.
+type bidderSeatBid struct {
+	Bids []bidderBid `json:"pbsBids,omitempty"`
+}
+
+// bidderBid is basically a subset of pbsOrtbBid from exchange/bidder.go.
+// See the comment on bidderSeatBid for more info.
+type bidderBid struct {
+	Bid  *openrtb.Bid `json:"ortbBid,omitempty"`
+	Type string       `json:"bidType,omitempty"`
+}
+
+type mockIdFetcher map[string]string
+
+func (f mockIdFetcher) GetId(bidder openrtb_ext.BidderName) (id string, ok bool) {
+	id, ok = f[string(bidder)]
+	return
+}
+
+type validatingBidder struct {
+	t          *testing.T
+	fileName   string
+	bidderName string
+
+	// These are maps because they may contain aliases. They should _at least_ contain an entry for bidderName.
+	expectations  map[string]*bidderRequest
+	mockResponses map[string]bidderResponse
+}
+
+func (b *validatingBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (seatBid *pbsOrtbSeatBid, errs []error) {
+	if expectedRequest, ok := b.expectations[string(name)]; ok {
+		if expectedRequest != nil {
+			if expectedRequest.BidAdjustment != bidAdjustment {
+				b.t.Errorf("%s: Bidder %s got wrong bid adjustment. Expected %f, got %f", b.fileName, name, expectedRequest.BidAdjustment, bidAdjustment)
+			}
+			diffOrtbRequests(b.t, fmt.Sprintf("Request to %s in %s", string(name), b.fileName), &expectedRequest.OrtbRequest, request)
+		}
+	} else {
+		b.t.Errorf("%s: Bidder %s got unexpected request for alias %s. No input assertions.", b.fileName, b.bidderName, name)
+	}
+
+	if mockResponse, ok := b.mockResponses[string(name)]; ok {
+		if mockResponse.SeatBid != nil {
+			bids := make([]*pbsOrtbBid, len(mockResponse.SeatBid.Bids))
+			for i := 0; i < len(bids); i++ {
+				bids[i] = &pbsOrtbBid{
+					bid:     mockResponse.SeatBid.Bids[i].Bid,
+					bidType: openrtb_ext.BidType(mockResponse.SeatBid.Bids[i].Type),
+				}
+			}
+
+			seatBid = &pbsOrtbSeatBid{
+				bids: bids,
+			}
+		}
+
+		for _, err := range mockResponse.Errors {
+			errs = append(errs, errors.New(err))
+		}
+	} else {
+		b.t.Errorf("%s: Bidder %s got unexpected request for alias %s. No mock responses.", b.fileName, b.bidderName, name)
+	}
+
+	return
+}
+
+func diffOrtbRequests(t *testing.T, description string, expected *openrtb.BidRequest, actual *openrtb.BidRequest) {
+	t.Helper()
+	actualJSON, err := json.Marshal(actual)
+	if err != nil {
+		t.Fatalf("%s failed to marshal actual BidRequest into JSON. %v", description, err)
+	}
+
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("%s failed to marshal expected BidRequest into JSON. %v", description, err)
+	}
+
+	diffJson(t, description, actualJSON, expectedJSON)
+}
+
+func diffOrtbResponses(t *testing.T, description string, expected *openrtb.BidResponse, actual *openrtb.BidResponse) {
+	t.Helper()
+	// The OpenRTB spec is wonky here. Since "bidresponse.seatbid" is an array, order technically matters to any JSON diff or
+	// deep equals method. However, for all intents and purposes it really *doesn't* matter. ...so this nasty logic makes compares
+	// the seatbids in an order-independent way.
+	//
+	// Note that the same thing is technically true of the "seatbid[i].bid" array... but since none of our exchange code relies on
+	// this implementation detail, I'm cutting a corner and ignoring it here.
+	actualSeats := mapifySeatBids(t, description, actual.SeatBid)
+	expectedSeats := mapifySeatBids(t, description, expected.SeatBid)
+	actualJSON, err := json.Marshal(actualSeats)
+	if err != nil {
+		t.Fatalf("%s failed to marshal actual BidResponse into JSON. %v", description, err)
+	}
+
+	expectedJSON, err := json.Marshal(expectedSeats)
+	if err != nil {
+		t.Fatalf("%s failed to marshal expected BidResponse into JSON. %v", description, err)
+	}
+
+	diffJson(t, description, actualJSON, expectedJSON)
+}
+
+func mapifySeatBids(t *testing.T, context string, seatBids []openrtb.SeatBid) map[string]*openrtb.SeatBid {
+	seatMap := make(map[string]*openrtb.SeatBid, len(seatBids))
+	for i := 0; i < len(seatBids); i++ {
+		seatName := seatBids[i].Seat
+		if _, ok := seatMap[seatName]; ok {
+			t.Fatalf("%s: Contains duplicate Seat: %s", context, seatName)
+		} else {
+			seatMap[seatName] = &seatBids[i]
+		}
+	}
+	return seatMap
+}
+
+// diffJson compares two JSON byte arrays for structural equality. It will produce an error if either
+// byte array is not actually JSON.
+func diffJson(t *testing.T, description string, actual []byte, expected []byte) {
+	t.Helper()
+	diff, err := gojsondiff.New().Compare(actual, expected)
+	if err != nil {
+		t.Fatalf("%s json diff failed. %v", description, err)
+	}
+
+	if diff.Modified() {
+		var left interface{}
+		if err := json.Unmarshal(actual, &left); err != nil {
+			t.Fatalf("%s json did not match, but unmarhsalling failed. %v", description, err)
+		}
+		printer := formatter.NewAsciiFormatter(left, formatter.AsciiFormatterConfig{
+			ShowArrayIndex: true,
+		})
+		output, err := printer.Format(diff)
+		if err != nil {
+			t.Errorf("%s did not match, but diff formatting failed. %v", description, err)
+		} else {
+			t.Errorf("%s json did not match expected.\n\n%s", description, output)
+		}
+	}
+}

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -135,6 +135,13 @@ func buildImpExt(t *testing.T, jsonFilename string) openrtb.RawJSON {
 	return openrtb.RawJSON(toReturn)
 }
 
+// TODO: Replace most stuff in this file with "exchangetest" specs, to be executed by exchange_json_test.go.
+// Benefits include:
+//   1. The assertions are much more comprehensive and strict.
+//   2. No assupmtions about Exchange implementation details.
+//   3. The error messages are easier to debug.
+//
+// I'm just leaving these here for now to prove that the bidadjustmentfactors feature doesn't break any existing tests.
 func TestHoldAuction(t *testing.T) {
 	respStatus := 200
 	respBody := "{\"bid\":false}"

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -223,7 +223,7 @@ func TestGetAllBids(t *testing.T) {
 	blabels[openrtb_ext.BidderName("dummy")] = &pbsmetrics.AdapterLabels{}
 	blabels[openrtb_ext.BidderName("dummy2")] = &pbsmetrics.AdapterLabels{}
 	blabels[openrtb_ext.BidderName("dummy3")] = &pbsmetrics.AdapterLabels{}
-	adapterBids, adapterExtra := e.getAllBids(ctx, cleanRequests, nil, blabels)
+	adapterBids, adapterExtra := e.getAllBids(ctx, cleanRequests, nil, nil, blabels)
 	if len(adapterBids[BidderDummy].bids) != 2 {
 		t.Errorf("GetAllBids failed to get 2 bids from BidderDummy, found %d instead", len(adapterBids[BidderDummy].bids))
 	}
@@ -242,7 +242,7 @@ func TestGetAllBids(t *testing.T) {
 	if len(e.adapterMap[BidderDummy2].(*mockAdapter).errs) != 2 {
 		t.Errorf("GetAllBids, Bidder2 adapter error generation failed. Only seeing %d errors", len(e.adapterMap[BidderDummy2].(*mockAdapter).errs))
 	}
-	adapterBids, adapterExtra = e.getAllBids(ctx, cleanRequests, nil, blabels)
+	adapterBids, adapterExtra = e.getAllBids(ctx, cleanRequests, nil, nil, blabels)
 
 	if len(e.adapterMap[BidderDummy2].(*mockAdapter).errs) != 2 {
 		t.Errorf("GetAllBids, Bidder2 adapter error generation failed. Only seeing %d errors", len(e.adapterMap[BidderDummy2].(*mockAdapter).errs))
@@ -259,7 +259,7 @@ func TestGetAllBids(t *testing.T) {
 
 	// Test with null pointer for bid response
 	mockAdapterConfigErr2(e.adapterMap[BidderDummy2].(*mockAdapter))
-	adapterBids, adapterExtra = e.getAllBids(ctx, cleanRequests, nil, blabels)
+	adapterBids, adapterExtra = e.getAllBids(ctx, cleanRequests, nil, nil, blabels)
 
 	if len(adapterExtra[BidderDummy2].Errors) != 1 {
 		t.Errorf("GetAllBids failed to report 1 errors on Bidder2, found %d errors", len(adapterExtra[BidderDummy2].Errors))
@@ -498,7 +498,7 @@ type mockBidder struct {
 	lastRequest *openrtb.BidRequest
 }
 
-func (b *mockBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName) (*pbsOrtbSeatBid, []error) {
+func (b *mockBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
 	b.lastRequest = request
 	return nil, nil
 }
@@ -524,7 +524,7 @@ type mockAdapter struct {
 	errs    []error
 }
 
-func (a *mockAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName) (*pbsOrtbSeatBid, []error) {
+func (a *mockAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
 	return a.seatBid, a.errs
 }
 

--- a/exchange/exchangetest/aliases.json
+++ b/exchange/exchangetest/aliases.json
@@ -1,0 +1,123 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            },
+            "districtm": {
+              "placementId": 2
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "aliases": {
+            "districtm": "appnexus"
+          }
+        }
+      }
+    },
+    "usersyncs": {
+      "appnexus": "123"
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "expectRequest": {
+        "ortbRequest": {
+          "id": "some-request-id",
+          "site": {
+            "page": "test.somepage.com"
+          },
+          "user": {
+            "buyeruid": "123"
+          },
+          "imp": [
+            {
+              "id": "my-imp-id",
+              "video": {
+                "mimes": ["video/mp4"]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 1
+                }
+              }
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "aliases": {
+                "districtm": "appnexus"
+              }
+            }
+          }
+        },
+        "bidAdjustment": 1.0
+      },
+      "mockResponse": {
+        "errors": ["appnexus-error"]
+      }
+    },
+    "districtm": {
+      "expectRequest": {
+        "ortbRequest": {
+          "id": "some-request-id",
+          "site": {
+            "page": "test.somepage.com"
+          },
+          "user": {
+            "buyeruid": "123"
+          },
+          "imp": [
+            {
+              "id": "my-imp-id",
+              "video": {
+                "mimes": ["video/mp4"]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 2
+                }
+              }
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "aliases": {
+                "districtm": "appnexus"
+              }
+            }
+          }
+        },
+        "bidAdjustment": 1.0
+      },
+      "mockResponse": {
+        "errors": ["districtm-error"]
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "ext": {
+        "errors": {
+          "appnexus": ["appnexus-error"],
+          "districtm": ["districtm-error"]
+        }
+      }
+    }
+  }
+}

--- a/exchange/exchangetest/bid-consolidation-test.json
+++ b/exchange/exchangetest/bid-consolidation-test.json
@@ -1,0 +1,151 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            },
+            "rubicon": {
+              "accountId": 1,
+              "siteId": 2,
+              "zoneId": 3
+            }
+          }
+        },
+        {
+          "id": "imp-id-2",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            },
+            "rubicon": {
+              "accountId": 1,
+              "siteId": 2,
+              "zoneId": 3
+            }
+          }
+        }
+      ]
+    },
+    "usersyncs": {
+      "appnexus": "123",
+      "rubicon": "234"
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "mockResponse": {
+        "pbsSeatBid": {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "apn-bid",
+                "impid": "my-imp-id",
+                "price": 0.3,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-1"
+              },
+              "bidType": "video"
+            },
+            {
+              "ortbBid": {
+                "id": "apn-other-bid",
+                "impid": "imp-id-2",
+                "price": 0.6,
+                "w": 300,
+                "h": 500,
+                "crid": "creative-3"
+              },
+              "bidType": "video"
+            }
+          ]
+        }
+      }
+    },
+    "rubicon": {
+      "mockResponse": {
+        "pbsSeatBid": {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "rubi-bid",
+                "impid": "my-imp-id",
+                "price": 0.4,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-2"
+              },
+              "bidType": "video"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "seatbid": [
+        {
+          "seat": "rubicon",
+          "bid": [{
+            "id": "rubi-bid",
+            "impid": "my-imp-id",
+            "price": 0.4,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-2",
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          }]
+        },
+        {
+          "seat": "appnexus",
+          "bid": [{
+            "id": "apn-bid",
+            "impid": "my-imp-id",
+            "price": 0.3,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-1",
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          {
+            "id": "apn-other-bid",
+            "impid": "imp-id-2",
+            "price": 0.6,
+            "w": 300,
+            "h": 500,
+            "crid": "creative-3",
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          }]
+        }
+      ]
+    }
+  }
+}

--- a/exchange/exchangetest/bidadjustmentfactors.json
+++ b/exchange/exchangetest/bidadjustmentfactors.json
@@ -1,0 +1,126 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            },
+            "districtm": {
+              "placementId": 2
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "aliases": {
+            "districtm": "appnexus"
+          },
+          "bidadjustmentfactors": {
+            "appnexus": 2.5,
+            "districtm": 0.3
+          }
+        }
+      }
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "expectRequest": {
+        "ortbRequest": {
+          "id": "some-request-id",
+          "site": {
+            "page": "test.somepage.com"
+          },
+          "imp": [
+            {
+              "id": "my-imp-id",
+              "video": {
+                "mimes": ["video/mp4"]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 1
+                }
+              }
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "aliases": {
+                "districtm": "appnexus"
+              },
+              "bidadjustmentfactors": {
+                "appnexus": 2.5,
+                "districtm": 0.3
+              }
+            }
+          }
+        },
+        "bidAdjustment": 2.5
+      },
+      "mockResponse": {
+        "errors": ["appnexus-error"]
+      }
+    },
+    "districtm": {
+      "expectRequest": {
+        "ortbRequest": {
+          "id": "some-request-id",
+          "site": {
+            "page": "test.somepage.com"
+          },
+          "imp": [
+            {
+              "id": "my-imp-id",
+              "video": {
+                "mimes": ["video/mp4"]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 2
+                }
+              }
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "aliases": {
+                "districtm": "appnexus"
+              },
+              "bidadjustmentfactors": {
+                "appnexus": 2.5,
+                "districtm": 0.3
+              }
+            }
+          }
+        },
+        "bidAdjustment": 0.3
+      },
+      "mockResponse": {
+        "errors": ["districtm-error"]
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "ext": {
+        "errors": {
+          "appnexus": ["appnexus-error"],
+          "districtm": ["districtm-error"]
+        }
+      }
+    }
+  }
+}

--- a/exchange/legacy_test.go
+++ b/exchange/legacy_test.go
@@ -54,7 +54,7 @@ func TestSiteVideo(t *testing.T) {
 	mockAdapter := mockLegacyAdapter{}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon)
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
 	if len(errs) > 0 {
 		t.Errorf("Unexpected error requesting bids: %v", errs)
 	}
@@ -87,7 +87,7 @@ func TestAppBanner(t *testing.T) {
 	mockAdapter := mockLegacyAdapter{}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon)
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
 	if len(errs) > 0 {
 		t.Errorf("Unexpected error requesting bids: %v", errs)
 	}
@@ -130,7 +130,7 @@ func TestBidTransforms(t *testing.T) {
 	}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon)
+	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon, 1.0)
 	if len(errs) != 1 {
 		t.Fatalf("Bad error count. Expected 1, got %d", len(errs))
 	}
@@ -278,7 +278,7 @@ func TestErrorResponse(t *testing.T) {
 	}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon)
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
 	if len(errs) != 1 {
 		t.Fatalf("Bad error count. Expected 1, got %d", len(errs))
 	}
@@ -316,7 +316,7 @@ func TestWithTargeting(t *testing.T) {
 		}},
 	}
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	bid, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderFacebook)
+	bid, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderFacebook, 1.0)
 	if len(errs) != 0 {
 		t.Fatalf("This should not produce errors. Got %v", errs)
 	}

--- a/exchange/legacy_test.go
+++ b/exchange/legacy_test.go
@@ -108,12 +108,14 @@ func TestAppBanner(t *testing.T) {
 }
 
 func TestBidTransforms(t *testing.T) {
+	bidAdjustment := 0.3
+	initialBidPrice := 0.5
 	legalBid := &pbs.PBSBid{
 		BidID:             "bid-1",
 		AdUnitCode:        "adunit-1",
 		Creative_id:       "creative-1",
 		CreativeMediaType: "banner",
-		Price:             0.5,
+		Price:             initialBidPrice,
 		NURL:              "nurl",
 		Adm:               "ad-markup",
 		Width:             10,
@@ -130,7 +132,7 @@ func TestBidTransforms(t *testing.T) {
 	}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon, 1.0)
+	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon, bidAdjustment)
 	if len(errs) != 1 {
 		t.Fatalf("Bad error count. Expected 1, got %d", len(errs))
 	}
@@ -154,8 +156,8 @@ func TestBidTransforms(t *testing.T) {
 	if theBid.bid.CrID != legalBid.Creative_id {
 		t.Errorf("Bad creativeid. Expected %s, got %s", legalBid.Creative_id, theBid.bid.CrID)
 	}
-	if theBid.bid.Price != legalBid.Price {
-		t.Errorf("Bad price. Expected %f, got %f", legalBid.Price, theBid.bid.Price)
+	if theBid.bid.Price != initialBidPrice*bidAdjustment {
+		t.Errorf("Bad price. Expected %f, got %f", initialBidPrice*bidAdjustment, theBid.bid.Price)
 	}
 	if theBid.bid.NURL != legalBid.NURL {
 		t.Errorf("Bad NURL. Expected %s, got %s", legalBid.NURL, theBid.bid.NURL)

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -12,10 +12,11 @@ type ExtRequest struct {
 
 // ExtRequestPrebid defines the contract for bidrequest.ext.prebid
 type ExtRequestPrebid struct {
-	Aliases       map[string]string      `json:"aliases,omitempty"`
-	Cache         *ExtRequestPrebidCache `json:"cache,omitempty"`
-	StoredRequest *ExtStoredRequest      `json:"storedrequest,omitempty"`
-	Targeting     *ExtRequestTargeting   `json:"targeting,omitempty"`
+	Aliases              map[string]string      `json:"aliases,omitempty"`
+	BidAdjustmentFactors map[string]float64     `json:"bidadjustmentfactors,omitempty"`
+	Cache                *ExtRequestPrebidCache `json:"cache,omitempty"`
+	StoredRequest        *ExtStoredRequest      `json:"storedrequest,omitempty"`
+	Targeting            *ExtRequestTargeting   `json:"targeting,omitempty"`
 }
 
 // ExtRequestPrebidCache defines the contract for bidrequest.ext.prebid.cache


### PR DESCRIPTION
Fixes #350.

I also made some "exchange => adapter" JSON tests, because all of our existing ones are pretty fragile. Many of our tests in this package hit a lot of private methods and implementation details... and I've found them really hard to debug and maintain while working on a few of these recent features (aliases, targeting, and now this).

Although I think we can use this framework to replace most of the tests inside `exchange_test.go`, `utils_test.go`, and `targeting_test.go`, I left all those in for now to prove that I haven't broken anything. If you all like the JSON-style tests overall, I can port them in a folllowup PR.