### PR TITLE
Reverted the crid requirement temporarily

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -361,9 +361,9 @@ func validateBid(bid *pbsOrtbBid) (bool, error) {
 	if bid.bid.Price == 0.0 {
 		return false, fmt.Errorf("Bid \"%s\" missing required field 'price'", bid.bid.ID)
 	}
-	// Check creative ID
-	if bid.bid.CrID == "" {
-		return false, fmt.Errorf("Bid \"%s\" missing creative ID", bid.bid.ID)
-	}
+	// TODO #427: Check creative ID after Bidders have had time to start returning it.
+	// if bid.bid.CrID == "" {
+	// 	return false, fmt.Errorf("Bid \"%s\" missing creative ID", bid.bid.ID)
+	// }
 	return true, nil
 }

--- a/exchange/validation_test.go
+++ b/exchange/validation_test.go
@@ -1,8 +1,9 @@
 package exchange
 
 import (
-	"github.com/mxmCherry/openrtb"
 	"testing"
+
+	"github.com/mxmCherry/openrtb"
 )
 
 func TestAllValidBids(t *testing.T) {
@@ -40,7 +41,7 @@ func TestAllValidBids(t *testing.T) {
 }
 
 func TestAllBadBids(t *testing.T) {
-	bids := make([]*pbsOrtbBid, 5)
+	bids := make([]*pbsOrtbBid, 4)
 	bids[0] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ID:    "one-bid",
@@ -55,27 +56,28 @@ func TestAllBadBids(t *testing.T) {
 			CrID:  "thatCreative",
 		},
 	}
+	// TODO #427: Add this back in after a breaking change window
+	// bids[2] = &pbsOrtbBid{
+	// 	bid: &openrtb.Bid{
+	// 		ID:    "123",
+	// 		ImpID: "456",
+	// 		Price: 0.44,
+	// 	},
+	// }
 	bids[2] = &pbsOrtbBid{
-		bid: &openrtb.Bid{
-			ID:    "123",
-			ImpID: "456",
-			Price: 0.44,
-		},
-	}
-	bids[3] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ImpID: "456",
 			Price: 0.44,
 			CrID:  "blah",
 		},
 	}
-	bids[4] = &pbsOrtbBid{}
+	bids[3] = &pbsOrtbBid{}
 	brw := &bidResponseWrapper{
 		adapterBids: &pbsOrtbSeatBid{
 			bids: bids,
 		},
 	}
-	assertBids(t, brw, 0, 5)
+	assertBids(t, brw, 0, 4)
 }
 
 func TestMixeddBids(t *testing.T) {
@@ -122,7 +124,7 @@ func TestMixeddBids(t *testing.T) {
 func assertBids(t *testing.T, brw *bidResponseWrapper, ebids int, eerrs int) {
 	errs := brw.validateBids()
 	if len(errs) != eerrs {
-		t.Errorf("Expected %d Errors validating bids, found %d", len(errs), eerrs)
+		t.Errorf("Expected %d Errors validating bids, found %d", eerrs, len(errs))
 	}
 	if len(brw.adapterBids.bids) != ebids {
 		t.Errorf("Expected %d bids, found %d bids", ebids, len(brw.adapterBids.bids))


### PR DESCRIPTION
Per #431, we've got to revert this temporarily so that Bidders have a breaking change window to implement this on their servers.

After a month or so, we can revert this and require it again.