### PR TITLE
Require Bid.CrID properties

### DIFF
--- a/docs/developers/add-new-bidder.md
+++ b/docs/developers/add-new-bidder.md
@@ -78,3 +78,14 @@ Update the [NewSyncerMap function](../../usersync/usersync.go) to make your Bidd
 ## Contribute
 
 Finally, [Contribute](contributing.md) your Bidder to the project.
+
+## Server requirements
+
+**Note**: In order to be part of the auction, all bids must include:
+
+- An ID
+- An ImpID which matches one of the `Imp[i].ID`s from the incoming `BidRequest`
+- A positive `Bid.Price`
+- A `Bid.CrID` which uniquely identifies the Creative in the bid.
+
+Bids which don't satisfy these standards will be filtered out before Prebid Server responds.

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -358,12 +358,11 @@ func validateBid(bid *pbsOrtbBid) (bool, error) {
 	if bid.bid.ImpID == "" {
 		return false, fmt.Errorf("Bid \"%s\" missing required field 'impid'", bid.bid.ID)
 	}
-	if bid.bid.Price == 0.0 {
-		return false, fmt.Errorf("Bid \"%s\" missing required field 'price'", bid.bid.ID)
+	if bid.bid.Price < 0.0 {
+		return false, fmt.Errorf("Bid \"%s\" does not contain a positive 'price'", bid.bid.ID)
 	}
-	// TODO #427: Check creative ID after Bidders have had time to start returning it.
-	// if bid.bid.CrID == "" {
-	// 	return false, fmt.Errorf("Bid \"%s\" missing creative ID", bid.bid.ID)
-	// }
+	if bid.bid.CrID == "" {
+		return false, fmt.Errorf("Bid \"%s\" missing creative ID", bid.bid.ID)
+	}
 	return true, nil
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -358,7 +358,7 @@ func validateBid(bid *pbsOrtbBid) (bool, error) {
 	if bid.bid.ImpID == "" {
 		return false, fmt.Errorf("Bid \"%s\" missing required field 'impid'", bid.bid.ID)
 	}
-	if bid.bid.Price < 0.0 {
+	if bid.bid.Price <= 0.0 {
 		return false, fmt.Errorf("Bid \"%s\" does not contain a positive 'price'", bid.bid.ID)
 	}
 	if bid.bid.CrID == "" {

--- a/exchange/validation_test.go
+++ b/exchange/validation_test.go
@@ -41,7 +41,7 @@ func TestAllValidBids(t *testing.T) {
 }
 
 func TestAllBadBids(t *testing.T) {
-	bids := make([]*pbsOrtbBid, 4)
+	bids := make([]*pbsOrtbBid, 5)
 	bids[0] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ID:    "one-bid",
@@ -56,28 +56,27 @@ func TestAllBadBids(t *testing.T) {
 			CrID:  "thatCreative",
 		},
 	}
-	// TODO #427: Add this back in after a breaking change window
-	// bids[2] = &pbsOrtbBid{
-	// 	bid: &openrtb.Bid{
-	// 		ID:    "123",
-	// 		ImpID: "456",
-	// 		Price: 0.44,
-	// 	},
-	// }
 	bids[2] = &pbsOrtbBid{
+		bid: &openrtb.Bid{
+			ID:    "123",
+			ImpID: "456",
+			Price: 0.44,
+		},
+	}
+	bids[3] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ImpID: "456",
 			Price: 0.44,
 			CrID:  "blah",
 		},
 	}
-	bids[3] = &pbsOrtbBid{}
+	bids[4] = &pbsOrtbBid{}
 	brw := &bidResponseWrapper{
 		adapterBids: &pbsOrtbSeatBid{
 			bids: bids,
 		},
 	}
-	assertBids(t, brw, 0, 4)
+	assertBids(t, brw, 0, 5)
 }
 
 func TestMixeddBids(t *testing.T) {


### PR DESCRIPTION
This PR includes a breaking change for Bidders.

This was originally added in #414, complained about in #427, and reverted in #432. It is scheduled to be merged sometime in early May, to allow Bidders time to make the necessary changes.

See the `docs/developers/add-new-bidder.md` file in the diff for a summary of the changes.