### PR TITLE
Legacy metrics fix

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -250,7 +250,10 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 	// Defer here because we need pbs_req defined.
 	defer func() {
 		deps.metricsEngine.RecordRequest(labels)
-		deps.metricsEngine.RecordRequestTime(labels, time.Since(pbs_req.Start))
+		// handles the case that ParsePBSRequest returns an error, so pbs_req.Start is not defined
+		if pbs_req != nil {
+			deps.metricsEngine.RecordRequestTime(labels, time.Since(pbs_req.Start))
+		}
 	}()
 
 	if err != nil {


### PR DESCRIPTION
Quick fix for metrics null pointer in legacy auction when JSON parsing fails.