### PR TITLE
AMP targeting defaults should included the winning targets

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -297,6 +297,8 @@ func defaultRequestExt(req *openrtb.BidRequest) (errs []error) {
 	if extRequest.Prebid.Targeting == nil {
 		setDefaults = true
 		extRequest.Prebid.Targeting = &openrtb_ext.ExtRequestTargeting{
+			// Fixes #452
+			IncludeWinners:   true,
 			PriceGranularity: openrtb_ext.PriceGranularityMedium,
 		}
 	}

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -132,6 +132,28 @@ func TestAmpDebug(t *testing.T) {
 	}
 }
 
+// Prevents #452
+func TestAmpTargetingDefaults(t *testing.T) {
+	req := &openrtb.BidRequest{}
+	if errs := defaultRequestExt(req); len(errs) != 0 {
+		t.Fatalf("Unexpected error defaulting request.ext for AMP: %v", errs)
+	}
+
+	var extRequest openrtb_ext.ExtRequest
+	if err := json.Unmarshal(req.Ext, &extRequest); err != nil {
+		t.Fatalf("Unexpected error unmarshalling defaulted request.ext for AMP: %v", err)
+	}
+	if extRequest.Prebid.Targeting == nil {
+		t.Fatal("AMP defaults should set request.ext.targeting")
+	}
+	if !extRequest.Prebid.Targeting.IncludeWinners {
+		t.Error("AMP defaults should set request.ext.targeting.includewinners to true")
+	}
+	if extRequest.Prebid.Targeting.PriceGranularity != openrtb_ext.PriceGranularityMedium {
+		t.Error("AMP defaults should set request.ext.targeting.pricegranularity to medium")
+	}
+}
+
 type mockAmpStoredReqFetcher struct {
 	data map[string]json.RawMessage
 }


### PR DESCRIPTION
During #452, I noticed that the AMP default targeting doesn't include keys for the winning bids.

This isn't the intended default. I don't know if it's the root cause of #452... but it's something we should fix regardless.