### PR TITLE
Configure status response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,10 +9,13 @@ import (
 
 // Configuration
 type Configuration struct {
-	ExternalURL          string             `mapstructure:"external_url"`
-	Host                 string             `mapstructure:"host"`
-	Port                 int                `mapstructure:"port"`
-	AdminPort            int                `mapstructure:"admin_port"`
+	ExternalURL string `mapstructure:"external_url"`
+	Host        string `mapstructure:"host"`
+	Port        int    `mapstructure:"port"`
+	AdminPort   int    `mapstructure:"admin_port"`
+	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
+	// If empty, it will return a 204 with no content.
+	StatusResponse       string             `mapstructure:"status_response"`
 	DefaultTimeout       uint64             `mapstructure:"default_timeout_ms"`
 	CacheURL             Cache              `mapstructure:"cache"`
 	RecaptchaSecret      string             `mapstructure:"recaptcha_secret"`

--- a/docs/endpoints/status.md
+++ b/docs/endpoints/status.md
@@ -1,0 +1,9 @@
+## `GET /status`
+
+This endpoint will return a 2xx response whenever Prebid Server is ready to serve requests.
+Its exact response can be [configured](../developers/configuration.md) with the `status_response`
+config option. For eample, in `pbs.yaml`:
+
+```yaml
+status_response: "ok"
+```

--- a/endpoints/status.go
+++ b/endpoints/status.go
@@ -1,0 +1,22 @@
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// NewStatusEndpoint returns a handler which writes the given response when the app is ready to serve requests.
+func NewStatusEndpoint(response string) func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Today, the app always considers itself ready to serve requests.
+	if response == "" {
+		return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+
+	responseBytes := []byte(response)
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.Write(responseBytes)
+	}
+}

--- a/endpoints/status_test.go
+++ b/endpoints/status_test.go
@@ -1,0 +1,28 @@
+package endpoints
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatusNoContent(t *testing.T) {
+	handler := NewStatusEndpoint("")
+	w := httptest.NewRecorder()
+	handler(w, nil, nil)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Bad code for empty content. Expected %d, got %d", http.StatusNoContent, w.Code)
+	}
+}
+
+func TestStatusWithContent(t *testing.T) {
+	handler := NewStatusEndpoint("ready")
+	w := httptest.NewRecorder()
+	handler(w, nil, nil)
+	if w.Code != http.StatusOK {
+		t.Errorf("Bad code for empty content. Expected %d, got %d", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ready" {
+		t.Errorf("Bad status body. Expected %s, got %s", "ready", w.Body.String())
+	}
+}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prebid/prebid-server/cache/filecache"
 	"github.com/prebid/prebid-server/cache/postgrescache"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/endpoints"
 	infoEndpoints "github.com/prebid/prebid-server/endpoints/info"
 	"github.com/prebid/prebid-server/endpoints/openrtb2"
 	"github.com/prebid/prebid-server/exchange"
@@ -588,10 +589,6 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 	}
 }
 
-func status(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	w.Write([]byte("ready"))
-}
-
 // NewJsonDirectoryServer is used to serve .json files from a directory as a single blob. For example,
 // given a directory containing the files "a.json" and "b.json", this returns a Handle which serves JSON like:
 //
@@ -846,7 +843,7 @@ func serve(cfg *config.Configuration) error {
 	router.GET("/bidders/params", NewJsonDirectoryServer(paramsValidator))
 	router.POST("/cookie_sync", (&cookieSyncDeps{syncers, &(hostCookieSettings.OptOutCookie), metricsEngine, pbsAnalytics}).CookieSync)
 	router.POST("/validate", validate)
-	router.GET("/status", status)
+	router.GET("/status", endpoints.NewStatusEndpoint(cfg.StatusResponse))
 	router.GET("/", serveIndex)
 	router.ServeFiles("/static/*filepath", http.Dir("static"))
 


### PR DESCRIPTION
Following some more requests about this... apparently different types of test frameworks require different responses from the health check.

Making this configurable so we can beef up our CI.