### PR TITLE
Used the pointer error type consistently everywhere

### DIFF
--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -106,7 +106,7 @@ func (a *AdformAdapter) Call(ctx context.Context, request *pbs.PBSRequest, bidde
 	responseBody := string(body)
 
 	if response.StatusCode == http.StatusBadRequest {
-		return nil, adapters.BadInputError{
+		return nil, &adapters.BadInputError{
 			Message: fmt.Sprintf("HTTP status %d; body: %s", response.StatusCode, responseBody),
 		}
 	}

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -99,7 +99,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		}
 
 		if params.PlacementId == 0 && (params.InvCode == "" || params.Member == "") {
-			return nil, adapters.BadInputError{
+			return nil, &adapters.BadInputError{
 				Message: "No placement or member+invcode provided",
 			}
 		}
@@ -188,7 +188,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	responseBody := string(body)
 
 	if anResp.StatusCode == http.StatusBadRequest {
-		return nil, adapters.BadInputError{
+		return nil, &adapters.BadInputError{
 			Message: fmt.Sprintf("HTTP status %d; body: %s", anResp.StatusCode, responseBody),
 		}
 	}
@@ -312,7 +312,7 @@ func keys(m map[string]bool) []string {
 func preprocess(imp *openrtb.Imp) (string, error) {
 	// We don't support audio imps yet.
 	if imp.Audio != nil {
-		return "", adapters.BadInputError{
+		return "", &adapters.BadInputError{
 			Message: fmt.Sprintf("Appnexus doesn't support audio Imps. Ignoring Imp ID=%s", imp.ID),
 		}
 	}
@@ -339,7 +339,7 @@ func preprocess(imp *openrtb.Imp) (string, error) {
 	}
 
 	if appnexusExt.PlacementId == 0 && (appnexusExt.InvCode == "" || appnexusExt.Member == "") {
-		return "", adapters.BadInputError{
+		return "", &adapters.BadInputError{
 			Message: "No placement or member+invcode provided",
 		}
 	}
@@ -403,7 +403,7 @@ func (a *AppNexusAdapter) MakeBids(internalRequest *openrtb.BidRequest, external
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		return nil, []error{adapters.BadInputError{
+		return nil, []error{&adapters.BadInputError{
 			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode),
 		}}
 	}

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -88,6 +88,10 @@ func (a *FacebookAdapter) callOne(ctx context.Context, reqJSON bytes.Buffer) (re
 		return
 	}
 
+	if anResp.StatusCode == http.StatusNoContent {
+		return
+	}
+
 	if anResp.StatusCode != http.StatusOK {
 		err = &adapters.BadServerResponseError{
 			Message: fmt.Sprintf("HTTP status %d; body: %s", anResp.StatusCode, result.ResponseBody),

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -40,7 +40,7 @@ type BadInputError struct {
 	Message string
 }
 
-func (err BadInputError) Error() string {
+func (err *BadInputError) Error() string {
 	return err.Message
 }
 

--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -190,7 +190,7 @@ func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {
-		return nil, adapters.BadInputError{
+		return nil, &adapters.BadInputError{
 			Message: fmt.Sprintf("HTTP status: %d, body: %s", resp.StatusCode, string(body)),
 		}
 	}

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -135,7 +135,7 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	}
 
 	if !(adSlotFlag) {
-		return nil, adapters.BadInputError{
+		return nil, &adapters.BadInputError{
 			Message: "Incorrect adSlot / Publisher param",
 		}
 	}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -353,7 +353,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 					default:
 						blabels.AdapterStatus = pbsmetrics.AdapterStatusErr
 						bidder.Error = err.Error()
-						if _, isBadInput := err.(adapters.BadInputError); !isBadInput {
+						if _, isBadInput := err.(*adapters.BadInputError); !isBadInput {
 							if _, isBadServer := err.(adapters.BadServerResponseError); !isBadServer {
 								glog.Warningf("Error from bidder %v. Ignoring all bids: %v", bidder.BidderCode, err)
 							}


### PR DESCRIPTION
Followup changes to #467... some error messages were not getting pruned from the logs because adapters returned errors as a pointer-type, but the type-check in `pbs_light.go` looked for a concrete struct-type.

See https://play.golang.org/p/uHl9SCmD_pw

By changing `func (err BadInputError) Error() string` to `func (err *BadInputError) Error() string`, the code no longer compiles if someone passes back the concrete struct. Apparently the original version let them work either way.