### PR TITLE
Silence psql type errors

### DIFF
--- a/cache/postgrescache/postgrescache.go
+++ b/cache/postgrescache/postgrescache.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"encoding/gob"
 
+	"github.com/prebid/prebid-server/stored_requests"
+
 	"github.com/coocood/freecache"
+	"github.com/lib/pq"
 	"github.com/prebid/prebid-server/cache"
 )
 
@@ -115,9 +118,20 @@ func (s *configService) Get(key string) (string, error) {
 	if b, err := s.shared.lru.Get([]byte(key)); err == nil {
 		return string(b), nil
 	}
+
 	var config string
 	if err := s.shared.db.QueryRow("SELECT config FROM s2sconfig_config where uuid = $1 LIMIT 1", key).Scan(&config); err != nil {
 		/* TODO -- We should store failed attempts in the LRU as well to stop from hitting to DB */
+		if pqErr, ok := err.(*pq.Error); ok {
+			// If the user didn't give us a UUID, the query fails with this error. Wrap it so that we don't
+			// pollute the app logs with bad user input.
+			if string(pqErr.Code) == "22P02" {
+				err = &stored_requests.NotFoundError{
+					ID:       key,
+					DataType: "Legacy Config",
+				}
+			}
+		}
 		return "", err
 	}
 	s.shared.lru.Set([]byte(key), []byte(config), s.shared.ttlSeconds)

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prebid/prebid-server/stored_requests"
+
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
 	"golang.org/x/net/publicsuffix"
@@ -309,8 +311,10 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *Hos
 		if unit.ConfigID != "" {
 			bidders, err = ConfigGet(cache, unit.ConfigID)
 			if err != nil {
+				if _, notFound := err.(*stored_requests.NotFoundError); !notFound {
+					glog.Warningf("Failed to load config '%s' from cache: %v", unit.ConfigID, err)
+				}
 				// proceed with other ad units
-				glog.Warningf("Failed to load config '%s' from cache: %v", unit.ConfigID, err)
 				continue
 			}
 		}

--- a/stored_requests/fetcher.go
+++ b/stored_requests/fetcher.go
@@ -23,8 +23,8 @@ type Fetcher interface {
 	FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error)
 }
 
-// NotFoundError is an error type to flag that an ID was not found, but there was otherwise no issue
-// with the query. This was added to support Multifetcher and any other case where we might expect
+// NotFoundError is an error type to flag that an ID was not found by the Fetcher.
+// This was added to support Multifetcher and any other case where we might expect
 // that all IDs would not be found, and want to disentangle those errors from the others.
 type NotFoundError struct {
 	ID       string


### PR DESCRIPTION
The app logs have a bunch of messages like this:

> W0426 15:57:43.175661       1 pbsrequest.go:313] Failed to load config '7698' from cache: pq: invalid input syntax for uuid: "7698"

I traced this back to the fact that Postgres throws an error on queries if you try to compare a UUID-typed column to a String which doesn't have the UUID format. For example, the legacy data SQL query:

```
SELECT config FROM s2sconfig_config where uuid = '7698' LIMIT 1;
```

Users shouldn't be able to spam the app logs by sending bad requests, so... this fixes that.