### PR TITLE
Made a test useful again

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,6 +63,7 @@ func TestWait(t *testing.T) {
 		inbound <- os.Interrupt
 	}(inbound)
 
+	wait(inbound, done, chan1, chan2, chan3)
 	// If this doesn't hang, then wait() is sending and receiving messages as expected.
 }
 


### PR DESCRIPTION
Was looking at general code coverage and noticed this `wait` method wasn't covered... this test (which was intended to cover it) didn't. Seems like a careless mistake.