### PR TITLE
Collect nurl/adm metrics

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -198,6 +198,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 					for _, bid := range bids.bids {
 						var cpm = float64(bid.bid.Price * 1000)
 						e.me.RecordAdapterPrice(*bidlabels, cpm)
+						e.me.RecordAdapterBidAdm(*bidlabels, bid.bidType, bid.bid.AdM != "")
 					}
 				}
 			}

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -356,10 +356,15 @@ func (me *Metrics) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext
 		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))
 		return
 	}
-	if hasAdm {
-		am.MarkupMetrics[bidType].AdmMeter.Mark(1)
+
+	if metricsForType, ok := am.MarkupMetrics[bidType]; ok {
+		if hasAdm {
+			metricsForType.AdmMeter.Mark(1)
+		} else {
+			metricsForType.NurlMeter.Mark(1)
+		}
 	} else {
-		am.MarkupMetrics[bidType].NurlMeter.Mark(1)
+		glog.Errorf("bid/adm metrics map entry does not exist for type %s. This is a bug, and should be reported.", bidType)
 	}
 	return
 }

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -53,6 +53,12 @@ type AdapterMetrics struct {
 	RequestTimer      metrics.Timer
 	PriceHistogram    metrics.Histogram
 	BidsReceivedMeter metrics.Meter
+	MarkupMetrics     map[openrtb_ext.BidType]*MarkupDeliveryMetrics
+}
+
+type MarkupDeliveryMetrics struct {
+	AdmMeter  metrics.Meter
+	NurlMeter metrics.Meter
 }
 
 type accountMetrics struct {
@@ -102,7 +108,7 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderNa
 		exchanges: exchanges,
 	}
 	for _, a := range exchanges {
-		newMetrics.AdapterMetrics[a] = makeBlankAdapterMetrics(registry, a)
+		newMetrics.AdapterMetrics[a] = makeBlankAdapterMetrics()
 	}
 
 	return newMetrics
@@ -141,7 +147,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName) *
 }
 
 // Part of setting up blank metrics, the adapter metrics.
-func makeBlankAdapterMetrics(registry metrics.Registry, exchanges openrtb_ext.BidderName) *AdapterMetrics {
+func makeBlankAdapterMetrics() *AdapterMetrics {
 	blankMeter := &metrics.NilMeter{}
 	newAdapter := &AdapterMetrics{
 		NoCookieMeter:     blankMeter,
@@ -152,8 +158,25 @@ func makeBlankAdapterMetrics(registry metrics.Registry, exchanges openrtb_ext.Bi
 		RequestTimer:      &metrics.NilTimer{},
 		PriceHistogram:    &metrics.NilHistogram{},
 		BidsReceivedMeter: blankMeter,
+		MarkupMetrics:     makeBlankBidMarkupMetrics(),
 	}
 	return newAdapter
+}
+
+func makeBlankBidMarkupMetrics() map[openrtb_ext.BidType]*MarkupDeliveryMetrics {
+	return map[openrtb_ext.BidType]*MarkupDeliveryMetrics{
+		openrtb_ext.BidTypeAudio:  makeBlankMarkupDeliveryMetrics(),
+		openrtb_ext.BidTypeBanner: makeBlankMarkupDeliveryMetrics(),
+		openrtb_ext.BidTypeNative: makeBlankMarkupDeliveryMetrics(),
+		openrtb_ext.BidTypeVideo:  makeBlankMarkupDeliveryMetrics(),
+	}
+}
+
+func makeBlankMarkupDeliveryMetrics() *MarkupDeliveryMetrics {
+	return &MarkupDeliveryMetrics{
+		AdmMeter:  &metrics.NilMeter{},
+		NurlMeter: &metrics.NilMeter{},
+	}
 }
 
 func registerAdapterMetrics(registry metrics.Registry, adapterOrAccount string, exchange string, am *AdapterMetrics) {
@@ -164,10 +187,22 @@ func registerAdapterMetrics(registry metrics.Registry, adapterOrAccount string, 
 	am.RequestMeter = metrics.GetOrRegisterMeter(fmt.Sprintf("%[1]s.%[2]s.requests", adapterOrAccount, exchange), registry)
 	am.RequestTimer = metrics.GetOrRegisterTimer(fmt.Sprintf("%[1]s.%[2]s.request_time", adapterOrAccount, exchange), registry)
 	am.PriceHistogram = metrics.GetOrRegisterHistogram(fmt.Sprintf("%[1]s.%[2]s.prices", adapterOrAccount, exchange), registry, metrics.NewExpDecaySample(1028, 0.015))
+	am.MarkupMetrics = map[openrtb_ext.BidType]*MarkupDeliveryMetrics{
+		openrtb_ext.BidTypeBanner: makeDeliveryMetrics(registry, adapterOrAccount+"."+exchange, openrtb_ext.BidTypeBanner),
+		openrtb_ext.BidTypeVideo:  makeDeliveryMetrics(registry, adapterOrAccount+"."+exchange, openrtb_ext.BidTypeVideo),
+		openrtb_ext.BidTypeAudio:  makeDeliveryMetrics(registry, adapterOrAccount+"."+exchange, openrtb_ext.BidTypeAudio),
+		openrtb_ext.BidTypeNative: makeDeliveryMetrics(registry, adapterOrAccount+"."+exchange, openrtb_ext.BidTypeNative),
+	}
 	if adapterOrAccount != "adapter" {
 		am.BidsReceivedMeter = metrics.GetOrRegisterMeter(fmt.Sprintf("%[1]s.%[2]s.bids_received", adapterOrAccount, exchange), registry)
 	}
+}
 
+func makeDeliveryMetrics(registry metrics.Registry, prefix string, bidType openrtb_ext.BidType) *MarkupDeliveryMetrics {
+	return &MarkupDeliveryMetrics{
+		AdmMeter:  metrics.GetOrRegisterMeter(prefix+"."+string(bidType)+".adm_bids_received", registry),
+		NurlMeter: metrics.GetOrRegisterMeter(prefix+"."+string(bidType)+".nurl_bids_received", registry),
+	}
 }
 
 // getAccountMetrics gets or registers the account metrics for account "id".
@@ -199,7 +234,7 @@ func (me *Metrics) getAccountMetrics(id string) *accountMetrics {
 	am.priceHistogram = metrics.GetOrRegisterHistogram(fmt.Sprintf("account.%s.prices", id), me.metricsRegistry, metrics.NewExpDecaySample(1028, 0.015))
 	am.adapterMetrics = make(map[openrtb_ext.BidderName]*AdapterMetrics, len(me.exchanges))
 	for _, a := range me.exchanges {
-		am.adapterMetrics[a] = makeBlankAdapterMetrics(me.metricsRegistry, a)
+		am.adapterMetrics[a] = makeBlankAdapterMetrics()
 		registerAdapterMetrics(me.metricsRegistry, fmt.Sprintf("account.%s", id), string(a), am.adapterMetrics[a])
 	}
 
@@ -311,6 +346,22 @@ func (me *Metrics) RecordAdapterBidsReceived(labels AdapterLabels, bids int64) {
 	// Account-Adapter metrics
 	aam := me.getAccountMetrics(labels.PubID).adapterMetrics[labels.Adapter]
 	aam.BidsReceivedMeter.Mark(bids)
+}
+
+// RecordAdapterBidAdm implements a part of the MetricsEngine interface.
+// This tracks how many bids from each Bidder use `adm` vs. `nurl.
+func (me *Metrics) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+	am, ok := me.AdapterMetrics[labels.Adapter]
+	if !ok {
+		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))
+		return
+	}
+	if hasAdm {
+		am.MarkupMetrics[bidType].AdmMeter.Mark(1)
+	} else {
+		am.MarkupMetrics[bidType].NurlMeter.Mark(1)
+	}
+	return
 }
 
 // RecordAdapterPrice implements a part of the MetricsEngine interface. Generates a histogram of winning bid prices

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -7,14 +7,6 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
-func TestRecordBidType(t *testing.T) {
-	registry := metrics.NewRegistry()
-	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
-
-	m.RecordAdapterBidAdm(AdapterLabels{}, openrtb_ext.BidTypeBanner, true)
-	// TODO: Finish this
-}
-
 func TestNewMetrics(t *testing.T) {
 	registry := metrics.NewRegistry()
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus, openrtb_ext.BidderRubicon})
@@ -31,6 +23,23 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "amp_no_cookie_requests", m.AmpNoCookieMeter)
 	ensureContainsAdapterMetrics(t, registry, "adapter.appnexus", m.AdapterMetrics["appnexus"])
 	ensureContainsAdapterMetrics(t, registry, "adapter.rubicon", m.AdapterMetrics["rubicon"])
+}
+
+func TestRecordBidType(t *testing.T) {
+	registry := metrics.NewRegistry()
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
+
+	m.RecordAdapterBidAdm(AdapterLabels{
+		Adapter: openrtb_ext.BidderAppnexus,
+	}, openrtb_ext.BidTypeBanner, true)
+	VerifyMetrics(t, "Appnexus Banner Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
+	VerifyMetrics(t, "Appnexus Banner Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
+
+	m.RecordAdapterBidAdm(AdapterLabels{
+		Adapter: openrtb_ext.BidderAppnexus,
+	}, openrtb_ext.BidTypeVideo, false)
+	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)
+	VerifyMetrics(t, "Appnexus Video Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].NurlMeter.Count(), 1)
 }
 
 func ensureContains(t *testing.T, registry metrics.Registry, name string, metric interface{}) {

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -1,12 +1,19 @@
 package pbsmetrics
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/rcrowley/go-metrics"
 )
+
+func TestRecordBidType(t *testing.T) {
+	registry := metrics.NewRegistry()
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
+
+	m.RecordAdapterBidAdm(AdapterLabels{}, openrtb_ext.BidTypeBanner, true)
+	// TODO: Finish this
+}
 
 func TestNewMetrics(t *testing.T) {
 	registry := metrics.NewRegistry()
@@ -26,27 +33,34 @@ func TestNewMetrics(t *testing.T) {
 	ensureContainsAdapterMetrics(t, registry, "adapter.rubicon", m.AdapterMetrics["rubicon"])
 }
 
-func ensureMissing(t *testing.T, registry metrics.Registry, name string) {
-	t.Helper()
-	if registry.Get(name) != nil {
-		t.Errorf("Found unexpected metric in registry: %s", name)
-	}
-}
-
 func ensureContains(t *testing.T, registry metrics.Registry, name string, metric interface{}) {
 	t.Helper()
-	if registry.Get(name) != metric {
+	if inRegistry := registry.Get(name); inRegistry == nil {
+		t.Errorf("No metric in registry at %s.", name)
+	} else if inRegistry != metric {
 		t.Errorf("Bad value stored at metric %s.", name)
 	}
 }
 
 func ensureContainsAdapterMetrics(t *testing.T, registry metrics.Registry, name string, adapterMetrics *AdapterMetrics) {
 	t.Helper()
-	ensureContains(t, registry, fmt.Sprintf("%s.no_cookie_requests", name), adapterMetrics.NoCookieMeter)
-	ensureContains(t, registry, fmt.Sprintf("%s.error_requests", name), adapterMetrics.ErrorMeter)
-	ensureContains(t, registry, fmt.Sprintf("%s.requests", name), adapterMetrics.RequestMeter)
-	ensureContains(t, registry, fmt.Sprintf("%s.no_bid_requests", name), adapterMetrics.NoBidMeter)
-	ensureContains(t, registry, fmt.Sprintf("%s.timeout_requests", name), adapterMetrics.TimeoutMeter)
-	ensureContains(t, registry, fmt.Sprintf("%s.request_time", name), adapterMetrics.RequestTimer)
-	ensureContains(t, registry, fmt.Sprintf("%s.prices", name), adapterMetrics.PriceHistogram)
+	ensureContains(t, registry, name+".no_cookie_requests", adapterMetrics.NoCookieMeter)
+	ensureContains(t, registry, name+".error_requests", adapterMetrics.ErrorMeter)
+	ensureContains(t, registry, name+".requests", adapterMetrics.RequestMeter)
+	ensureContains(t, registry, name+".no_bid_requests", adapterMetrics.NoBidMeter)
+	ensureContains(t, registry, name+".timeout_requests", adapterMetrics.TimeoutMeter)
+	ensureContains(t, registry, name+".request_time", adapterMetrics.RequestTimer)
+	ensureContains(t, registry, name+".prices", adapterMetrics.PriceHistogram)
+	ensureContainsBidTypeMetrics(t, registry, name, adapterMetrics.MarkupMetrics)
+}
+
+func ensureContainsBidTypeMetrics(t *testing.T, registry metrics.Registry, prefix string, mdm map[openrtb_ext.BidType]*MarkupDeliveryMetrics) {
+	ensureContains(t, registry, prefix+".banner.adm_bids_received", mdm[openrtb_ext.BidTypeBanner].AdmMeter)
+	ensureContains(t, registry, prefix+".banner.nurl_bids_received", mdm[openrtb_ext.BidTypeBanner].NurlMeter)
+	ensureContains(t, registry, prefix+".video.adm_bids_received", mdm[openrtb_ext.BidTypeVideo].AdmMeter)
+	ensureContains(t, registry, prefix+".video.nurl_bids_received", mdm[openrtb_ext.BidTypeVideo].NurlMeter)
+	ensureContains(t, registry, prefix+".audio.adm_bids_received", mdm[openrtb_ext.BidTypeAudio].AdmMeter)
+	ensureContains(t, registry, prefix+".audio.nurl_bids_received", mdm[openrtb_ext.BidTypeAudio].NurlMeter)
+	ensureContains(t, registry, prefix+".native.adm_bids_received", mdm[openrtb_ext.BidTypeNative].AdmMeter)
+	ensureContains(t, registry, prefix+".native.nurl_bids_received", mdm[openrtb_ext.BidTypeNative].NurlMeter)
 }

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -121,6 +121,9 @@ type MetricsEngine interface {
 	RecordRequestTime(labels Labels, length time.Duration) // ignores adapter. only statusOk and statusErr fom status
 	RecordAdapterRequest(labels AdapterLabels)
 	RecordAdapterBidsReceived(labels AdapterLabels, bids int64)
+	// This records whether or not a bid of a particular type uses `adm` or `nurl`.
+	// Since the legacy endpoints don't have a bid type, it can only count bids from OpenRTB and AMP.
+	RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)
 	RecordAdapterTime(labels AdapterLabels, length time.Duration)
 	RecordCookieSync(labels Labels)        // May ignore all labels
@@ -211,6 +214,13 @@ func (me *MultiMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bi
 	}
 }
 
+// RecordAdapterBidAdm across all engines
+func (me *MultiMetricsEngine) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+	for _, thisME := range *me {
+		thisME.RecordAdapterBidAdm(labels, bidType, hasAdm)
+	}
+}
+
 // RecordAdapterPrice across all engines
 func (me *MultiMetricsEngine) RecordAdapterPrice(labels AdapterLabels, cpm float64) {
 	for _, thisME := range *me {
@@ -274,6 +284,11 @@ func (me *DummyMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 
 // RecordAdapterBidsReceived as a noop
 func (me *DummyMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bids int64) {
+	return
+}
+
+// RecordAdapterBidAdm as a noop
+func (me *DummyMetricsEngine) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	return
 }
 


### PR DESCRIPTION
Pretty self-explanatory... goal here is to capture metrics how frequently Bidders use Adm vs. NURL for each bid type, to help prioritize features.