### PR TITLE
Support not sending all bidder keys in targetinng

### DIFF
--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -118,11 +118,14 @@ to set these params on the response at `response.seatbid[i].bid[j].ext.prebid.ta
         ]
     },
     "includewinners": false // Optional param defaulting to true
+    "includebidderkeys": false // Optional param defaulting to true
 }
 ```
 The list of price granularity ranges must be given in order of increasing `max` values. If `precision` is omitted, it will default to `2`. The minimum of a range will be 0 or the previous `max`. Any cmp above the largest `max` will go in the `max` pricebucket.
 
 For backwards compatibility the following strings will also be allowed as price granularity definitions. There is no guarantee that these will be honored in the future. "One of ['low', 'med', 'high', 'auto', 'dense']" See [price granularity definitions](http://prebid.org/prebid-mobile/adops-price-granularity.html)
+
+One of "includewinners" or "includebidderkeys" must be true (both default to true if unset). If both were false, then no targeting keys would be set, which is better configured by omitting targeting altogether.
 
 **Response format** (returned in `bid.ext.prebid.targeting`)
 

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -96,8 +96,9 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 
 		if requestExt.Prebid.Targeting != nil {
 			targData = &targetData{
-				priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
-				includeWinners:   requestExt.Prebid.Targeting.IncludeWinners,
+				priceGranularity:  requestExt.Prebid.Targeting.PriceGranularity,
+				includeWinners:    requestExt.Prebid.Targeting.IncludeWinners,
+				includeBidderKeys: requestExt.Prebid.Targeting.IncludeBidderKeys,
 			}
 			if shouldCacheBids {
 				targData.includeCache = true

--- a/exchange/exchangetest/targeting-only-winners.json
+++ b/exchange/exchangetest/targeting-only-winners.json
@@ -1,0 +1,189 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            },
+            "audienceNetwork": {
+              "placementId": "some-placement"
+            }
+          }
+        },
+        {
+          "id": "imp-id-2",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 2
+            },
+            "audienceNetwork": {
+              "placementId": "some-other-placement"
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "targeting": {
+            "includebidderkeys": false
+          }
+        }
+      }
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "mockResponse": {
+        "pbsSeatBid": {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "winning-bid",
+                "impid": "my-imp-id",
+                "price": 0.71,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-1"
+              },
+              "bidType": "video"
+            },
+            {
+              "ortbBid": {
+                "id": "losing-bid",
+                "impid": "my-imp-id",
+                "price": 0.21,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-2"
+              },
+              "bidType": "video"
+            },
+            {
+              "ortbBid": {
+                "id": "other-bid",
+                "impid": "imp-id-2",
+                "price": 0.61,
+                "w": 300,
+                "h": 500,
+                "crid": "creative-3"
+              },
+              "bidType": "video"
+            }
+          ]
+        }
+      }
+    },
+    "audienceNetwork": {
+      "mockResponse": {
+        "pbsSeatBid": {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "contending-bid",
+                "impid": "my-imp-id",
+                "price": 0.51,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-4"
+              },
+              "bidType": "video"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "seatbid": [
+        {
+          "seat": "audienceNetwork",
+          "bid": [{
+            "id": "contending-bid",
+            "impid": "my-imp-id",
+            "price": 0.51,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-4",
+            "ext": {
+              "prebid": {
+                "type": "video",
+                "targeting": {
+                  "hb_creative_loadtype": "demand_sdk"
+                }
+              }
+            }
+          }]
+        },
+        {
+          "seat": "appnexus",
+          "bid": [{
+            "id": "winning-bid",
+            "impid": "my-imp-id",
+            "price": 0.71,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-1",
+            "ext": {
+              "prebid": {
+                "type": "video",
+                "targeting": {
+                  "hb_bidder": "appnexus",
+                  "hb_pb": "0.70",
+                  "hb_size": "200x250",
+                  "hb_creative_loadtype": "html"
+                }
+              }
+            }
+          },
+          {
+            "id": "losing-bid",
+            "impid": "my-imp-id",
+            "price": 0.21,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-2",
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          {
+            "id": "other-bid",
+            "impid": "imp-id-2",
+            "price": 0.61,
+            "w": 300,
+            "h": 500,
+            "crid": "creative-3",
+            "ext": {
+              "prebid": {
+                "type": "video",
+                "targeting": {
+                  "hb_bidder": "appnexus",
+                  "hb_pb": "0.60",
+                  "hb_size": "300x500",
+                  "hb_creative_loadtype": "html"
+                }
+              }
+            }
+          }]
+        }
+      ]
+    }
+  }
+}

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -17,9 +17,10 @@ const maxKeyLength = 20
 // All functions on this struct are all nil-safe.
 // If the value is nil, then no targeting data will be tracked.
 type targetData struct {
-	priceGranularity openrtb_ext.PriceGranularity
-	includeWinners   bool
-	includeCache     bool
+	priceGranularity  openrtb_ext.PriceGranularity
+	includeWinners    bool
+	includeBidderKeys bool
+	includeCache      bool
 }
 
 // setTargeting writes all the targeting params into the bids.
@@ -65,7 +66,9 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool) {
 }
 
 func (targData *targetData) addKeys(keys map[string]string, key openrtb_ext.TargetingKey, value string, bidderName openrtb_ext.BidderName, overallWinner bool) {
-	keys[key.BidderKey(bidderName, maxKeyLength)] = value
+	if targData.includeBidderKeys {
+		keys[key.BidderKey(bidderName, maxKeyLength)] = value
+	}
 	if targData.includeWinners && overallWinner {
 		keys[string(key)] = value
 	}

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -59,22 +59,6 @@ func assertKeyExists(t *testing.T, bid *openrtb.Bid, key string, expected bool) 
 	}
 }
 
-// Verify we do not set winning bid keys if includewinners is set false
-func TestExcludeWinners(t *testing.T) {
-	bids := runTargetingAuction(t, mockBids, false, false, true, false)
-
-	// Make sure that the cache keys exist on the bids where they're expected to
-	assertKeyExists(t, bids["winning-bid"], string(openrtb_ext.HbpbConstantKey), false)
-	assertKeyExists(t, bids["winning-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderAppnexus, maxKeyLength), true)
-
-	assertKeyExists(t, bids["contending-bid"], string(openrtb_ext.HbpbConstantKey), false)
-	assertKeyExists(t, bids["contending-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderRubicon, maxKeyLength), true)
-
-	assertKeyExists(t, bids["losing-bid"], string(openrtb_ext.HbpbConstantKey), false)
-	assertKeyExists(t, bids["losing-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderAppnexus, maxKeyLength), false)
-
-}
-
 // runAuction takes a bunch of mock bids by Bidder and runs an auction. It returns a map of Bids indexed by their ImpID.
 // If includeCache is true, the auction will be run with cacheing as well, so the cache targeting keys should exist.
 func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*openrtb.Bid, includeCache bool, includeWinners bool, includeBidderKeys bool, isApp bool) map[string]*openrtb.Bid {

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -15,28 +15,30 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
+// Using this set of bids in more than one test
+var mockBids = map[openrtb_ext.BidderName][]*openrtb.Bid{
+	openrtb_ext.BidderAppnexus: []*openrtb.Bid{&openrtb.Bid{
+		ID:    "losing-bid",
+		ImpID: "some-imp",
+		Price: 0.5,
+		CrID:  "1",
+	}, &openrtb.Bid{
+		ID:    "winning-bid",
+		ImpID: "some-imp",
+		Price: 0.7,
+		CrID:  "2",
+	}},
+	openrtb_ext.BidderRubicon: []*openrtb.Bid{&openrtb.Bid{
+		ID:    "contending-bid",
+		ImpID: "some-imp",
+		Price: 0.6,
+		CrID:  "3",
+	}},
+}
+
 // Prevents #378. This is not a JSON test because the cache ID values aren't reproducible, which makes them a pain to test in that format.
 func TestTargetingCache(t *testing.T) {
-	mockBids := map[openrtb_ext.BidderName][]*openrtb.Bid{
-		openrtb_ext.BidderAppnexus: []*openrtb.Bid{&openrtb.Bid{
-			ID:    "losing-bid",
-			ImpID: "some-imp",
-			Price: 0.5,
-			CrID:  "1",
-		}, &openrtb.Bid{
-			ID:    "winning-bid",
-			ImpID: "some-imp",
-			Price: 0.7,
-			CrID:  "2",
-		}},
-		openrtb_ext.BidderRubicon: []*openrtb.Bid{&openrtb.Bid{
-			ID:    "contending-bid",
-			ImpID: "some-imp",
-			Price: 0.6,
-			CrID:  "3",
-		}},
-	}
-	bids := runTargetingAuction(t, mockBids, true, true, false)
+	bids := runTargetingAuction(t, mockBids, true, true, true, false)
 
 	// Make sure that the cache keys exist on the bids where they're expected to
 	assertKeyExists(t, bids["winning-bid"], string(openrtb_ext.HbCacheKey), true)
@@ -57,9 +59,25 @@ func assertKeyExists(t *testing.T, bid *openrtb.Bid, key string, expected bool) 
 	}
 }
 
+// Verify we do not set winning bid keys if includewinners is set false
+func TestExcludeWinners(t *testing.T) {
+	bids := runTargetingAuction(t, mockBids, false, false, true, false)
+
+	// Make sure that the cache keys exist on the bids where they're expected to
+	assertKeyExists(t, bids["winning-bid"], string(openrtb_ext.HbpbConstantKey), false)
+	assertKeyExists(t, bids["winning-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderAppnexus, maxKeyLength), true)
+
+	assertKeyExists(t, bids["contending-bid"], string(openrtb_ext.HbpbConstantKey), false)
+	assertKeyExists(t, bids["contending-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderRubicon, maxKeyLength), true)
+
+	assertKeyExists(t, bids["losing-bid"], string(openrtb_ext.HbpbConstantKey), false)
+	assertKeyExists(t, bids["losing-bid"], openrtb_ext.HbpbConstantKey.BidderKey(openrtb_ext.BidderAppnexus, maxKeyLength), false)
+
+}
+
 // runAuction takes a bunch of mock bids by Bidder and runs an auction. It returns a map of Bids indexed by their ImpID.
 // If includeCache is true, the auction will be run with cacheing as well, so the cache targeting keys should exist.
-func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*openrtb.Bid, includeCache bool, includeWinners bool, isApp bool) map[string]*openrtb.Bid {
+func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*openrtb.Bid, includeCache bool, includeWinners bool, includeBidderKeys bool, isApp bool) map[string]*openrtb.Bid {
 	server := httptest.NewServer(http.HandlerFunc(mockServer))
 	defer server.Close()
 
@@ -74,7 +92,7 @@ func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*op
 
 	req := &openrtb.BidRequest{
 		Imp: imps,
-		Ext: buildTargetingExt(includeCache, includeWinners),
+		Ext: buildTargetingExt(includeCache, includeWinners, includeBidderKeys),
 	}
 	if isApp {
 		req.App = &openrtb.App{}
@@ -113,12 +131,16 @@ func buildAdapterMap(bids map[openrtb_ext.BidderName][]*openrtb.Bid, mockServerU
 	return adapterMap
 }
 
-func buildTargetingExt(includeCache bool, includeWinners bool) openrtb.RawJSON {
+func buildTargetingExt(includeCache bool, includeWinners bool, includeBidderKeys bool) openrtb.RawJSON {
 	var targeting string
-	if includeWinners {
+	if includeWinners && includeBidderKeys {
 		targeting = "{}"
+	} else if !includeWinners && includeBidderKeys {
+		targeting = `{"includewinners": false}`
+	} else if includeWinners && !includeBidderKeys {
+		targeting = `{"includebidderkeys": false}`
 	} else {
-		targeting = `{"includeWinners": false}`
+		targeting = `{"includewinners": false, "includebidderkeys": false}`
 	}
 
 	if includeCache {

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -45,8 +45,9 @@ type ExtRequestPrebidCacheBids struct{}
 
 // ExtRequestTargeting defines the contract for bidrequest.ext.prebid.targeting
 type ExtRequestTargeting struct {
-	PriceGranularity PriceGranularity `json:"pricegranularity"`
-	IncludeWinners   bool             `json:"includewinners"`
+	PriceGranularity  PriceGranularity `json:"pricegranularity"`
+	IncludeWinners    bool             `json:"includewinners"`
+	IncludeBidderKeys bool             `json:"includebidderkeys"`
 }
 
 // Make an unmarshaller that will set a default PriceGranularity
@@ -58,12 +59,16 @@ func (ert *ExtRequestTargeting) UnmarshalJSON(b []byte) error {
 	// define seperate type to prevent infinite recursive calls to UnmarshalJSON
 	type extRequestTargetingDefaults ExtRequestTargeting
 	defaults := &extRequestTargetingDefaults{
-		PriceGranularity: priceGranularityMed,
-		IncludeWinners:   true,
+		PriceGranularity:  priceGranularityMed,
+		IncludeWinners:    true,
+		IncludeBidderKeys: true,
 	}
 
 	err := json.Unmarshal(b, defaults)
 	if err == nil {
+		if !defaults.IncludeWinners && !defaults.IncludeBidderKeys {
+			return errors.New("ext.prebid.targeting: At least one of includewinners or includebidderkeys must be enabled to enable targeting support")
+		}
 		*ert = ExtRequestTargeting(*defaults)
 	}
 


### PR DESCRIPTION
Adds ext.prebid.targeting.includebidderkeys, defaults to true (current behavior) and supports setting it false. You will need includewinners set true (true by default) or no targeting set for a valid request.