### PR TITLE
Added technical docs on cookie syncs

### DIFF
--- a/docs/developers/cookie-syncs.md
+++ b/docs/developers/cookie-syncs.md
@@ -1,0 +1,30 @@
+# Cookie Sync Technical Details
+
+This document describes the mechancis of a Prebid Server cookie sync.
+
+## Motivation
+
+Many Bidders track users through Cookies. Since Bidders will generally serve ads from a different domain
+than where Prebid Server is hosted, those cookies must be consolidated under the Prebid Server domain so
+that they can be sent to each demand source in [/openrtb2/auction](../endpoints/openrtb2/auction.md) calls.
+
+## How to do it?
+
+Start by calling [`/cookie_sync`](../endpoints/cookieSync.md). For each element of `response.bidder_status`,
+call `GET element.usersync.url`. That endpoint should respond with a redirect which will complete the cookie sync.
+
+## Mechanics
+
+Bidders who support cookie syncs must implement an endpoint under their domain which accepts
+an encoded URI for redirects. For example:
+
+> GET some-bidder-domain.com/usersync-url?redirectUri=www.prebid-domain.com%2Fsetuid%3Fbidder%3Dsomebidder%26uid%3D%24UID
+
+This example endpoint would URL-decode the `redirectUri` param to get `www.prebid-domain.com/setuid?bidder=somebidder&uid=$UID`.
+It would then replace the `$UID` macro with the user's ID from their cookie. Supposing this user's ID was "132",
+it would then return a redirect to `www.prebid-domain.com/setuid?bidder=somebidder&uid=132`.
+
+Prebid Server would then save this ID mapping of `somebidder: 132` under the cookie at `prebid-domain.com`.
+
+When the client then calls `www.prebid-domain.com/openrtb2/auction`, the ID for `somebidder` will be available in the Cookie.
+Prebid Server will then stick this into `request.user.buyeruid` in the OpenRTB request it sends to `somebidder`'s Bidder.

--- a/docs/endpoints/cookieSync.md
+++ b/docs/endpoints/cookieSync.md
@@ -1,7 +1,11 @@
-# Handling cookie syncs.
+# Starting Cookie Syncs
+
+This endpoint is used during cookie syncs. For technical details, see the
+[Cookie Sync developer docs](../developers/cookie-syncs.md).
 
 ## POST /cookie_sync
 
+### Sample Request
 This returns a set of URLs to enable cookie syncs across bidders. (See Prebid.js documentation?) The request
 must supply a JSON object to define the list of bidders that may need to be synced.
 

--- a/docs/endpoints/setuid.md
+++ b/docs/endpoints/setuid.md
@@ -1,20 +1,16 @@
 # Saving User Syncs
 
-This endpoint is used by bidders to sync user IDs with Prebid Server.
-If a user runs an [auction](./openrtb2/auction.md) _without_ specifying `request.user.buyeruid`,
-then Prebid Server will set it to the uid saved here before forwarding the request to the Bidder.
+This endpoint is used during cookie syncs. For technical details, see the
+[Cookie Sync developer docs](../developers/cookie-syncs.md).
 
 ## `GET /setuid`
 
-This endpoint can be used to save UserIDs for a Bidder. These UIDs will be saved in a Cookie,
-so they will not translate across Prebid Server instances hosted on different domains.
-
-Saved IDs will be recognized for 7 days before being considered "stale" and being re-synced.
+This endpoint saves a UserID for a Bidder in the Cookie. Saved IDs will be recognized for 7 days before being considered "stale" and being re-synced.
 
 ### Query Params
 
 - `bidder`: The FamilyName of the [Usersyncer](../../usersync/usersync.go) which is being synced.
-- `uid`: The User's ID in the given domain.
+- `uid`: The ID which the Bidder uses to recognize this user.
 
 ### Sample request
 


### PR DESCRIPTION
Beefing up the cookie sync docs.

I started writing GDPR docs, and realized I was describing lots of things which are already happening today. I figured I may as well put them in a separate PR which we can merge sooner.