### PR TITLE
GDPR support for legacy adapters

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -148,11 +148,17 @@ func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 			},
 			AT:   1,
 			TMax: req.TimeoutMillis,
+			Regs: req.Regs,
 		}, nil
 	}
 
 	buyerUID, _, _ := req.Cookie.GetUID(bidderFamily)
 	id, _, _ := req.Cookie.GetUID("adnxs")
+
+	var userExt openrtb.RawJSON
+	if req.User != nil {
+		userExt = req.User.Ext
+	}
 
 	return openrtb.BidRequest{
 		ID:  req.Tid,
@@ -165,6 +171,7 @@ func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		User: &openrtb.User{
 			BuyerUID: buyerUID,
 			ID:       id,
+			Ext:      userExt,
 		},
 		Source: &openrtb.Source{
 			FD:  1, // upstream, aka header
@@ -172,6 +179,7 @@ func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 		},
 		AT:   1,
 		TMax: req.TimeoutMillis,
+		Regs: req.Regs,
 	}, nil
 }
 

--- a/exchange/legacy.go
+++ b/exchange/legacy.go
@@ -131,6 +131,7 @@ func (bidder *adaptedAdapter) toLegacyRequest(req *openrtb.BidRequest) (*pbs.PBS
 		Url:    url,
 		Domain: domain,
 		// Start is excluded because no legacy adapters read from it
+		Regs: req.Regs,
 	}, nil
 }
 

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -171,6 +171,7 @@ type PBSRequest struct {
 	Cookie  *PBSCookie    `json:"-"`
 	Url     string        `json:"-"`
 	Domain  string        `json:"-"`
+	Regs    *openrtb.Regs `json:"-"`
 	Start   time.Time
 }
 


### PR DESCRIPTION
Please review the following change that passes along the two GDPR parameters for legacy adapters.  Essentially the adapters do not need to change as long as the openrtb request generated by MakeOpenRTBGeneric is used directly.

* Add Regs to PBSRequest
* Pass along Regs in legacy conversion
* In MakeOpenRTBGeneric, picks up User.Ext if available, and also picks up Regs.