### PR TITLE
Fixed some nil-pointers in the Adform adapter

### DIFF
--- a/adapters/adapterstest/test_json.go
+++ b/adapters/adapterstest/test_json.go
@@ -259,6 +259,12 @@ func diffStrings(t *testing.T, description string, actual string, expected strin
 // diffJson compares two JSON byte arrays for structural equality. It will produce an error if either
 // byte array is not actually JSON.
 func diffJson(t *testing.T, description string, actual []byte, expected []byte) {
+	if len(actual) == 0 && len(expected) == 0 {
+		return
+	}
+	if len(actual) != 0 || len(expected) != 0 {
+		t.Fatalf("%s json diff failed. Expected %d bytes in body, but got %d.", description, len(expected), len(actual))
+	}
 	diff, err := gojsondiff.New().Compare(actual, expected)
 	if err != nil {
 		t.Fatalf("%s json diff failed. %v", description, err)

--- a/adapters/adapterstest/test_json.go
+++ b/adapters/adapterstest/test_json.go
@@ -262,7 +262,7 @@ func diffJson(t *testing.T, description string, actual []byte, expected []byte) 
 	if len(actual) == 0 && len(expected) == 0 {
 		return
 	}
-	if len(actual) != 0 || len(expected) != 0 {
+	if len(actual) == 0 || len(expected) == 0 {
 		t.Fatalf("%s json diff failed. Expected %d bytes in body, but got %d.", description, len(expected), len(actual))
 	}
 	diff, err := gojsondiff.New().Compare(actual, expected)

--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -369,14 +369,42 @@ func openRtbToAdformRequest(request *openrtb.BidRequest) (*adformRequest, []erro
 
 	return &adformRequest{
 		adUnits:       adUnits,
-		ip:            request.Device.IP,
-		advertisingId: request.Device.IFA,
-		userAgent:     request.Device.UA,
+		ip:            getIPSafely(request.Device),
+		advertisingId: getIFASafely(request.Device),
+		userAgent:     getUASafely(request.Device),
 		isSecure:      secure,
 		referer:       referer,
-		userId:        request.User.BuyerUID,
+		userId:        getBuyerUIDSafely(request.User),
 		tid:           tid,
 	}, errors
+}
+
+func getIPSafely(device *openrtb.Device) string {
+	if device == nil {
+		return ""
+	}
+	return device.IP
+}
+
+func getIFASafely(device *openrtb.Device) string {
+	if device == nil {
+		return ""
+	}
+	return device.IFA
+}
+
+func getUASafely(device *openrtb.Device) string {
+	if device == nil {
+		return ""
+	}
+	return device.UA
+}
+
+func getBuyerUIDSafely(user *openrtb.User) string {
+	if user == nil {
+		return ""
+	}
+	return user.BuyerUID
 }
 
 func (a *AdformAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {

--- a/adapters/adform/adform_test.go
+++ b/adapters/adform/adform_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/pbs"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
+
+func TestJsonSamples(t *testing.T) {
+	adapterstest.RunJSONBidderTest(t, "adformtest", NewAdformBidder(nil, "http://adx.adform.net/adx"))
+}
 
 type aTagInfo struct {
 	mid       uint32

--- a/adapters/adform/adformtest/supplemental/user-nil.json
+++ b/adapters/adform/adformtest/supplemental/user-nil.json
@@ -1,0 +1,39 @@
+{
+  "mockBidRequest": {
+    "id": "unsupported-audio-request",
+    "imp": [
+      {
+        "id": "unsupported-audio-imp",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "mid": 1,
+            "priceType": "gross"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://adx.adform.net/adx/?CC=1&rp=4&fd=1&stid=&ip=&pt=gross&bWlkPTE"
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Saw some errors about nil-dereferencing in the logs recently... this fixes those.

Also includes some updates to the `test_json` file because the adform request body is empty, and the JSON tests didn't handle that very well.

@volhalink @vstatkevich I'm not sure what request you actually expect on your server if the `User` or `Device` are nil. You should check this and update it. This just stops your code from crashing if they are.