### PR TITLE
GDPR-aware Usersyncers

### DIFF
--- a/usersync/adform.go
+++ b/usersync/adform.go
@@ -15,7 +15,8 @@ func NewAdformSyncer(usersyncURL string, externalURL string) Usersyncer {
 	}
 
 	return &syncer{
-		familyName: "adform",
-		syncInfo:   info,
+		familyName:   "adform",
+		gdprVendorID: 50,
+		syncInfo:     info,
 	}
 }

--- a/usersync/appnexus.go
+++ b/usersync/appnexus.go
@@ -10,7 +10,8 @@ func NewAppnexusSyncer(externalURL string) Usersyncer {
 	usersyncURL := "//ib.adnxs.com/getuid?"
 
 	return &syncer{
-		familyName: "adnxs",
+		familyName:   "adnxs",
+		gdprVendorID: 32,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
 			Type:        "redirect",

--- a/usersync/appnexus_test.go
+++ b/usersync/appnexus_test.go
@@ -8,12 +8,15 @@ func TestAppNexusSyncer(t *testing.T) {
 	an := NewAppnexusSyncer("localhost")
 	syncInfo := an.GetUsersyncInfo()
 	if syncInfo.URL != "//ib.adnxs.com/getuid?localhost%2Fsetuid%3Fbidder%3Dadnxs%26uid%3D%24UID" {
-		t.Fatalf("should have matched")
+		t.Errorf("should have matched")
 	}
 	if syncInfo.Type != "redirect" {
-		t.Fatalf("should be redirect")
+		t.Errorf("should be redirect")
 	}
 	if syncInfo.SupportCORS != false {
-		t.Fatalf("should have been false")
+		t.Errorf("should have been false")
+	}
+	if an.GDPRVendorID() != 32 {
+		t.Errorf("Wrong Appnexus GDPR VendorID. Got %d", an.GDPRVendorID())
 	}
 }

--- a/usersync/conversant.go
+++ b/usersync/conversant.go
@@ -9,7 +9,8 @@ func NewConversantSyncer(usersyncURL string, externalURL string) Usersyncer {
 	redirectURI := fmt.Sprintf("%s/setuid?bidder=conversant&uid=", externalURL)
 
 	return &syncer{
-		familyName: "conversant",
+		familyName:   "conversant",
+		gdprVendorID: 24,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirectURI)),
 			Type:        "redirect",

--- a/usersync/conversant_test.go
+++ b/usersync/conversant_test.go
@@ -20,4 +20,7 @@ func TestConversantSyncer(t *testing.T) {
 	if info.SupportCORS != false {
 		t.Fatalf("user sync should not support CORS")
 	}
+	if syncer.GDPRVendorID() != 24 {
+		t.Errorf("Wrong Conversant GDPR VendorID. Got %d", syncer.GDPRVendorID())
+	}
 }

--- a/usersync/indexExchange.go
+++ b/usersync/indexExchange.go
@@ -2,7 +2,8 @@ package usersync
 
 func NewIndexSyncer(userSyncURL string) Usersyncer {
 	return &syncer{
-		familyName: "indexExchange",
+		familyName:   "indexExchange",
+		gdprVendorID: 10,
 		syncInfo: &UsersyncInfo{
 			URL:         userSyncURL,
 			Type:        "redirect",

--- a/usersync/indexExchange_test.go
+++ b/usersync/indexExchange_test.go
@@ -5,7 +5,8 @@ import (
 )
 
 func TestIndexSyncer(t *testing.T) {
-	info := NewIndexSyncer("//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D").GetUsersyncInfo()
+	syncer := NewIndexSyncer("//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D")
+	info := syncer.GetUsersyncInfo()
 	if info.URL != "//ssum-sec.casalemedia.com/usermatchredir?s=184932&cb=localhost%2Fsetuid%3Fbidder%3DindexExchange%26uid%3D" {
 		t.Fatalf("should have matched")
 	}
@@ -14,5 +15,8 @@ func TestIndexSyncer(t *testing.T) {
 	}
 	if info.SupportCORS != false {
 		t.Fatalf("should have been false")
+	}
+	if syncer.GDPRVendorID() != 10 {
+		t.Errorf("Wrong Index GDPR VendorID. Got %d", syncer.GDPRVendorID())
 	}
 }

--- a/usersync/lifestreet.go
+++ b/usersync/lifestreet.go
@@ -10,7 +10,8 @@ func NewLifestreetSyncer(externalURL string) Usersyncer {
 	usersyncURL := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl="
 
 	return &syncer{
-		familyName: "lifestreet",
+		familyName:   "lifestreet",
+		gdprVendorID: 67,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
 			Type:        "redirect",

--- a/usersync/lifestreet_test.go
+++ b/usersync/lifestreet_test.go
@@ -7,7 +7,8 @@ import (
 func TestLifestreetSyncer(t *testing.T) {
 	url := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl=localhost%2Fsetuid%3Fbidder%3Dlifestreet%26uid%3D%24%24visitor_cookie%24%24"
 
-	info := NewLifestreetSyncer("localhost").GetUsersyncInfo()
+	syncer := NewLifestreetSyncer("localhost")
+	info := syncer.GetUsersyncInfo()
 	if info.URL != url {
 		t.Fatalf("User Sync Info URL '%s' doesn't match '%s'", info.URL, url)
 	}
@@ -16,5 +17,8 @@ func TestLifestreetSyncer(t *testing.T) {
 	}
 	if info.SupportCORS != false {
 		t.Fatalf("should have been false")
+	}
+	if syncer.GDPRVendorID() != 67 {
+		t.Errorf("Wrong Lifestreet GDPR VendorID. Got %d", syncer.GDPRVendorID())
 	}
 }

--- a/usersync/openx.go
+++ b/usersync/openx.go
@@ -11,7 +11,8 @@ func NewOpenxSyncer(externalURL string) Usersyncer {
 	redirectURL := fmt.Sprintf("%s/setuid?bidder=openx&uid=${UID}", externalURL)
 
 	return &syncer{
-		familyName: "openx",
+		familyName:   "openx",
+		gdprVendorID: 69,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("https://rtb.openx.net/sync/prebid?r=%s", url.QueryEscape(redirectURL)),
 			Type:        "redirect",

--- a/usersync/openx_test.go
+++ b/usersync/openx_test.go
@@ -16,4 +16,7 @@ func TestOpenxSyncer(t *testing.T) {
 	if syncInfo.SupportCORS != false {
 		t.Fatalf("should have been false")
 	}
+	if openx.GDPRVendorID() != 69 {
+		t.Errorf("Wrong OpenX GDPR VendorID. Got %d", openx.GDPRVendorID())
+	}
 }

--- a/usersync/pubmatic.go
+++ b/usersync/pubmatic.go
@@ -10,7 +10,8 @@ func NewPubmaticSyncer(externalURL string) Usersyncer {
 	usersyncURL := "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
 
 	return &syncer{
-		familyName: "pubmatic",
+		familyName:   "pubmatic",
+		gdprVendorID: 76,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirectUri)),
 			Type:        "iframe",

--- a/usersync/pubmatic_test.go
+++ b/usersync/pubmatic_test.go
@@ -5,7 +5,8 @@ import (
 )
 
 func TestPubmaticSyncer(t *testing.T) {
-	info := NewPubmaticSyncer("localhost").GetUsersyncInfo()
+	pubmatic := NewPubmaticSyncer("localhost")
+	info := pubmatic.GetUsersyncInfo()
 	if info.URL != "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect=localhost%2Fsetuid%3Fbidder%3Dpubmatic%26uid%3D" {
 		t.Fatalf("should have matched")
 	}
@@ -14,5 +15,8 @@ func TestPubmaticSyncer(t *testing.T) {
 	}
 	if info.SupportCORS != false {
 		t.Fatalf("should have been false")
+	}
+	if pubmatic.GDPRVendorID() != 76 {
+		t.Errorf("Wrong Appnexus GDPR VendorID. Got %d", pubmatic.GDPRVendorID())
 	}
 }

--- a/usersync/pulsepoint.go
+++ b/usersync/pulsepoint.go
@@ -9,7 +9,8 @@ func NewPulsepointSyncer(externalURL string) Usersyncer {
 	redirect_uri := fmt.Sprintf("%s/setuid?bidder=pulsepoint&uid=%s", externalURL, "%%VGUID%%")
 	usersyncURL := "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl="
 	return &syncer{
-		familyName: "pulsepoint",
+		familyName:   "pulsepoint",
+		gdprVendorID: 81,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%s%s", usersyncURL, url.QueryEscape(redirect_uri)),
 			Type:        "redirect",

--- a/usersync/pulsepoint_test.go
+++ b/usersync/pulsepoint_test.go
@@ -6,9 +6,13 @@ import (
 )
 
 func TestPulsepointSyncer(t *testing.T) {
-	info := NewPulsepointSyncer("http://localhost").GetUsersyncInfo()
+	pulsepoint := NewPulsepointSyncer("http://localhost")
+	info := pulsepoint.GetUsersyncInfo()
 	verifyStringValue(info.Type, "redirect", t)
 	verifyStringValue(info.URL, "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl=http%3A%2F%2Flocalhost%2Fsetuid%3Fbidder%3Dpulsepoint%26uid%3D%25%25VGUID%25%25", t)
+	if pulsepoint.GDPRVendorID() != 81 {
+		t.Errorf("Wrong Pulsepoint GDPR VendorID. Got %d", pulsepoint.GDPRVendorID())
+	}
 }
 
 func verifyStringValue(value string, expected string, t *testing.T) {

--- a/usersync/rubicon.go
+++ b/usersync/rubicon.go
@@ -2,7 +2,8 @@ package usersync
 
 func NewRubiconSyncer(usersyncURL string) Usersyncer {
 	return &syncer{
-		familyName: "rubicon",
+		familyName:   "rubicon",
+		gdprVendorID: 52,
 		syncInfo: &UsersyncInfo{
 			URL:         usersyncURL,
 			Type:        "redirect",

--- a/usersync/rubicon_test.go
+++ b/usersync/rubicon_test.go
@@ -22,4 +22,7 @@ func TestRubiconSyncer(t *testing.T) {
 	if syncer.FamilyName() != "rubicon" {
 		t.Errorf("FamilyName '%s' != 'rubicon'", syncer.FamilyName())
 	}
+	if syncer.GDPRVendorID() != 52 {
+		t.Errorf("Wrong Rubicon GDPR VendorID. Got %d", syncer.GDPRVendorID())
+	}
 }

--- a/usersync/sovrn.go
+++ b/usersync/sovrn.go
@@ -9,7 +9,8 @@ func NewSovrnSyncer(externalURL string, usersyncURL string) Usersyncer {
 	redirectURI := fmt.Sprintf("%s/setuid?bidder=sovrn&uid=$UID", externalURL)
 
 	return &syncer{
-		familyName: "sovrn",
+		familyName:   "sovrn",
+		gdprVendorID: 13,
 		syncInfo: &UsersyncInfo{
 			URL:         fmt.Sprintf("%sredir=%s", usersyncURL, url.QueryEscape(redirectURI)),
 			Type:        "redirect",

--- a/usersync/sovrn_test.go
+++ b/usersync/sovrn_test.go
@@ -1,0 +1,18 @@
+package usersync
+
+import "testing"
+
+func TestSovrnSyncer(t *testing.T) {
+
+	syncer := NewSovrnSyncer("external.com", "sovrn-sync.com")
+	info := syncer.GetUsersyncInfo()
+	if info.Type != "redirect" {
+		t.Fatalf("should be redirect")
+	}
+	if info.SupportCORS != false {
+		t.Fatalf("should have been false")
+	}
+	if syncer.GDPRVendorID() != 13 {
+		t.Errorf("Wrong Sovrn GDPR VendorID. Got %d", syncer.GDPRVendorID())
+	}
+}

--- a/usersync/usersync.go
+++ b/usersync/usersync.go
@@ -15,6 +15,13 @@ type Usersyncer interface {
 	// For example, if this Usersyncer syncs with adnxs.com, then this
 	// should return "adnxs".
 	FamilyName() string
+
+	// GDPRVendorID returns the ID in the IAB Global Vendor List which refers to this Bidder.
+	// The Global Vendor list can be found here: https://vendorlist.consensu.org/vendorlist.json
+	// Bidders can register for the list here: https://register.consensu.org/
+	//
+	// If you're not on the list, this should return 0.
+	GDPRVendorID() uint16
 }
 
 type UsersyncInfo struct {
@@ -50,8 +57,9 @@ func NewSyncerMap(cfg *config.Configuration) map[openrtb_ext.BidderName]Usersync
 }
 
 type syncer struct {
-	familyName string
-	syncInfo   *UsersyncInfo
+	familyName   string
+	gdprVendorID uint16
+	syncInfo     *UsersyncInfo
 }
 
 func (s *syncer) GetUsersyncInfo() *UsersyncInfo {
@@ -60,4 +68,8 @@ func (s *syncer) GetUsersyncInfo() *UsersyncInfo {
 
 func (s *syncer) FamilyName() string {
 	return s.familyName
+}
+
+func (s *syncer) GDPRVendorID() uint16 {
+	return s.gdprVendorID
 }

--- a/usersync/usersync.go
+++ b/usersync/usersync.go
@@ -17,10 +17,12 @@ type Usersyncer interface {
 	FamilyName() string
 
 	// GDPRVendorID returns the ID in the IAB Global Vendor List which refers to this Bidder.
+	//
 	// The Global Vendor list can be found here: https://vendorlist.consensu.org/vendorlist.json
 	// Bidders can register for the list here: https://register.consensu.org/
 	//
-	// If you're not on the list, this should return 0.
+	// If you're not on the list, this should return 0. If Prebid Server is run by a GDPR-conscious host
+	// company (as defined in the application config), it will _not_ sync user IDs with you.
 	GDPRVendorID() uint16
 }
 

--- a/usersync/usersync.go
+++ b/usersync/usersync.go
@@ -21,8 +21,9 @@ type Usersyncer interface {
 	// The Global Vendor list can be found here: https://vendorlist.consensu.org/vendorlist.json
 	// Bidders can register for the list here: https://register.consensu.org/
 	//
-	// If you're not on the list, this should return 0. If Prebid Server is run by a GDPR-conscious host
-	// company (as defined in the application config), it will _not_ sync user IDs with you.
+	// If you're not on the list, this should return 0. If cookie sync requests have GDPR consent info,
+	// or the Prebid Server host company configures its deploy to be "cautious" when no GDPR info exists
+	// in the request, it will _not_ sync user IDs with you.
 	GDPRVendorID() uint16
 }
 

--- a/usersync/usersync_test.go
+++ b/usersync/usersync_test.go
@@ -18,7 +18,10 @@ func TestSyncers(t *testing.T) {
 	}
 }
 
-func TestSyncerVendorIDs(t *testing.T) {
+// Bidders may have an ID on the IAB-maintained global vendor list.
+// This makes sure that we don't have conflicting IDs among Bidders in our project,
+// since that's almost certainly a bug.
+func TestVendorIDUniqueness(t *testing.T) {
 	cfg := &config.Configuration{}
 	syncers := NewSyncerMap(cfg)
 

--- a/usersync/usersync_test.go
+++ b/usersync/usersync_test.go
@@ -17,3 +17,21 @@ func TestSyncers(t *testing.T) {
 		}
 	}
 }
+
+func TestSyncerVendorIDs(t *testing.T) {
+	cfg := &config.Configuration{}
+	syncers := NewSyncerMap(cfg)
+
+	idMap := make(map[uint16]openrtb_ext.BidderName, len(syncers))
+	for name, syncer := range syncers {
+		id := syncer.GDPRVendorID()
+		if id == 0 {
+			continue
+		}
+
+		if oldName, ok := idMap[id]; ok {
+			t.Errorf("GDPR VendorList ID %d used by both %s and %s. These must be unique.", id, oldName, name)
+		}
+		idMap[id] = name
+	}
+}


### PR DESCRIPTION
This contributes towards #501 by building a mechanism for Bidders to identify themselves as part of the IAB's [Global Vendor List](https://vendorlist.consensu.org/vendorlist.json).

Existing Bidders who are already on the vendor list should verify that I got the right ID here.

There are no functional changes yet.