### PR TITLE
GDPR-friendly /setuid 

### DIFF
--- a/docs/endpoints/setuid.md
+++ b/docs/endpoints/setuid.md
@@ -10,8 +10,13 @@ This endpoint saves a UserID for a Bidder in the Cookie. Saved IDs will be recog
 ### Query Params
 
 - `bidder`: The FamilyName of the [Usersyncer](../../usersync/usersync.go) which is being synced.
-- `uid`: The ID which the Bidder uses to recognize this user.
+- `uid`: The ID which the Bidder uses to recognize this user. If undefined, the UID for `bidder` will be deleted.
+- `gdpr`: This should be `1` if GDPR is in effect, `0` if not, and undefined if the caller isn't sure
+- `gdpr_consent`: This is required if `gdpr` is one, and optional (but encouraged) otherwise. If present, it should be an [unpadded base64-URL](https://tools.ietf.org/html/rfc4648#page-7) encoded [Vendor Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-).
+
+If the `gdpr` and `gdpr_consent` params are included, this bidder will _not_ write a cookie unless the
+Prebid Server host company is allowed to save cookies for that user.
 
 ### Sample request
 
-`GET http://prebid.site.com/setuid?bidder=adnxs&uid=12345`
+`GET http://prebid.site.com/setuid?bidder=adnxs&uid=12345&gdpr=1&gdpr_consent=BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw`

--- a/docs/endpoints/setuid.md
+++ b/docs/endpoints/setuid.md
@@ -14,8 +14,12 @@ This endpoint saves a UserID for a Bidder in the Cookie. Saved IDs will be recog
 - `gdpr`: This should be `1` if GDPR is in effect, `0` if not, and undefined if the caller isn't sure
 - `gdpr_consent`: This is required if `gdpr` is one, and optional (but encouraged) otherwise. If present, it should be an [unpadded base64-URL](https://tools.ietf.org/html/rfc4648#page-7) encoded [Vendor Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-).
 
-If the `gdpr` and `gdpr_consent` params are included, this bidder will _not_ write a cookie unless the
-Prebid Server host company is allowed to save cookies for that user.
+If the `gdpr` and `gdpr_consent` params are included, this endpoint will _not_ write a cookie unless:
+
+1. The Vendor ID set by the Prebid Server host company has permission to save cookies for that user.
+2. The Prebid Server host company did not configure it to run with GDPR support.
+
+If in doubt, contact the company hosting Prebid Server and ask if they're GDPR-ready.
 
 ### Sample request
 

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -1,19 +1,20 @@
 package endpoints
 
 import (
+	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/usersync"
 )
 
-func NewSetUIDEndpoint(cfg config.HostCookie, pbsanalytics analytics.PBSAnalyticsModule, metrics pbsmetrics.MetricsEngine) httprouter.Handle {
+func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalytics analytics.PBSAnalyticsModule, metrics pbsmetrics.MetricsEngine) httprouter.Handle {
 	cookieTTL := time.Duration(cfg.TTL) * 24 * time.Hour
 	return httprouter.Handle(func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		so := analytics.SetUIDObject{
@@ -31,17 +32,26 @@ func NewSetUIDEndpoint(cfg config.HostCookie, pbsanalytics analytics.PBSAnalytic
 			return
 		}
 
-		query := getRawQueryMap(r.URL.RawQuery)
-		bidder := query["bidder"]
+		query := r.URL.Query()
+		if shouldReturn, status, body := preventSyncsGDPR(query.Get("gdpr"), query.Get("gdpr_consent"), perms); shouldReturn {
+			w.WriteHeader(status)
+			w.Write([]byte(body))
+			metrics.RecordUserIDSet(pbsmetrics.UserLabels{Action: pbsmetrics.RequestActionGDPR})
+			so.Status = status
+			return
+		}
+
+		bidder := query.Get("bidder")
 		if bidder == "" {
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`"bidder" query param is required`))
 			metrics.RecordUserIDSet(pbsmetrics.UserLabels{Action: pbsmetrics.RequestActionErr})
 			so.Status = http.StatusBadRequest
 			return
 		}
 		so.Bidder = bidder
 
-		uid := query["uid"]
+		uid := query.Get("uid")
 		so.UID = uid
 
 		var err error = nil
@@ -64,16 +74,33 @@ func NewSetUIDEndpoint(cfg config.HostCookie, pbsanalytics analytics.PBSAnalytic
 	})
 }
 
-func getRawQueryMap(query string) map[string]string {
-	m := make(map[string]string)
-	for _, kv := range strings.SplitN(query, "&", -1) {
-		if len(kv) == 0 {
-			continue
+func preventSyncsGDPR(gdprEnabled string, gdprConsent string, perms gdpr.Permissions) (bool, int, string) {
+	switch gdprEnabled {
+	case "0":
+		return false, 0, ""
+	case "1":
+		if gdprConsent == "" {
+			return true, http.StatusBadRequest, "gdpr_consent is required when gdpr=1"
 		}
-		pair := strings.SplitN(kv, "=", 2)
-		if len(pair) == 2 {
-			m[pair[0]] = pair[1]
+		fallthrough
+	case "":
+		if allowed, err := perms.HostCookiesAllowed(context.Background(), gdprConsent); err != nil {
+			if _, ok := err.(*gdpr.ErrorMalformedConsent); ok {
+				return true, http.StatusBadRequest, "gdpr_consent was invalid. " + err.Error()
+			} else {
+				// We can't really distinguish between requests that are for a new version of the global vendor list, and
+				// ones which are simply malformed (version number is much too large).
+				// Since we try to fetch new versions as requests come in for them, PBS *should* self-correct
+				// rather quickly, meaning that most of these will be malformed strings.
+				return true, http.StatusBadRequest, "No global vendor list was available to interpret this consent string. If this is a new, valid version, it should become available soon."
+			}
+			return true, http.StatusOK, "Unable to interpret consent string. No cookies will be saved"
+		} else if !allowed {
+			return true, http.StatusOK, "The gdpr_consent string prevents cookies from being saved"
+		} else {
+			return false, 0, ""
 		}
+	default:
+		return true, http.StatusBadRequest, "the gdpr query param must be either 0 or 1. You gave " + gdprEnabled
 	}
-	return m
 }

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -94,7 +94,6 @@ func preventSyncsGDPR(gdprEnabled string, gdprConsent string, perms gdpr.Permiss
 				// rather quickly, meaning that most of these will be malformed strings.
 				return true, http.StatusBadRequest, "No global vendor list was available to interpret this consent string. If this is a new, valid version, it should become available soon."
 			}
-			return true, http.StatusOK, "Unable to interpret consent string. No cookies will be saved"
 		} else if !allowed {
 			return true, http.StatusOK, "The gdpr_consent string prevents cookies from being saved"
 		} else {

--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -10,9 +10,13 @@ import (
 
 type Permissions interface {
 	// Determines whether or not the host company is allowed to read/write cookies.
+	//
+	// If the consent string was nonsenical, the returned error will be an ErrorMalformedConsent.
 	HostCookiesAllowed(ctx context.Context, consent string) (bool, error)
 
 	// Determines whether or not the given bidder is allowed to user personal info for ad targeting.
+	//
+	// If the consent string was nonsenical, the returned error will be an ErrorMalformedConsent.
 	BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error)
 }
 
@@ -28,4 +32,15 @@ func NewPermissions(ctx context.Context, cfg config.GDPR, vendorIDs map[openrtb_
 		vendorIDs:       vendorIDs,
 		fetchVendorList: newVendorListFetcher(ctx, client, vendorListURLMaker),
 	}
+}
+
+// An ErrorMalformedConsent will be returned by the Permissions interface if
+// the consent string argument was the reason for the failure.
+type ErrorMalformedConsent struct {
+	consent string
+	cause   error
+}
+
+func (e *ErrorMalformedConsent) Error() string {
+	return "malformed consent string " + e.consent + ": " + e.cause.Error()
 }

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -117,7 +117,7 @@ func TestFetchThrottling(t *testing.T) {
 	_, err := fetcher(context.Background(), 2)
 	assertNilErr(t, err)
 	_, err = fetcher(context.Background(), 3)
-	assertErr(t, err)
+	assertErr(t, err, false)
 }
 
 func TestMalformedVendorlistFetch(t *testing.T) {
@@ -126,7 +126,7 @@ func TestMalformedVendorlistFetch(t *testing.T) {
 
 	fetcher := newVendorListFetcher(context.Background(), server.Client(), testURLMaker(server))
 	_, err := fetcher(context.Background(), 1)
-	assertErr(t, err)
+	assertErr(t, err, false)
 }
 
 func TestMissingVendorlistFetch(t *testing.T) {
@@ -135,7 +135,7 @@ func TestMissingVendorlistFetch(t *testing.T) {
 
 	fetcher := newVendorListFetcher(context.Background(), server.Client(), testURLMaker(server))
 	_, err := fetcher(context.Background(), 2)
-	assertErr(t, err)
+	assertErr(t, err, false)
 }
 
 // mockServer returns a handler which returns the given response for each global vendor list version.

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -772,7 +772,7 @@ func serve(cfg *config.Configuration) error {
 	}
 
 	router.GET("/getuids", userSyncDeps.GetUIDs)
-	router.GET("/setuid", endpoints.NewSetUIDEndpoint(cfg.HostCookie, pbsAnalytics, metricsEngine))
+	router.GET("/setuid", endpoints.NewSetUIDEndpoint(cfg.HostCookie, nil, pbsAnalytics, metricsEngine)) // TODO: Don't let this be nil in the merge
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -47,6 +47,7 @@ import (
 	infoEndpoints "github.com/prebid/prebid-server/endpoints/info"
 	"github.com/prebid/prebid-server/endpoints/openrtb2"
 	"github.com/prebid/prebid-server/exchange"
+	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -740,6 +741,7 @@ func serve(cfg *config.Configuration) error {
 	}
 
 	syncers := usersyncers.NewSyncerMap(cfg)
+	gdprPerms := gdpr.NewPermissions(context.Background(), cfg.GDPR, nil, theClient) // TODO: replace `nil` here on mege conflict
 
 	router.POST("/auction", (&auctionDeps{cfg, syncers, metricsEngine}).auction)
 	router.POST("/openrtb2/auction", openrtbEndpoint)
@@ -772,7 +774,7 @@ func serve(cfg *config.Configuration) error {
 	}
 
 	router.GET("/getuids", userSyncDeps.GetUIDs)
-	router.GET("/setuid", endpoints.NewSetUIDEndpoint(cfg.HostCookie, nil, pbsAnalytics, metricsEngine)) // TODO: Don't let this be nil in the merge
+	router.GET("/setuid", endpoints.NewSetUIDEndpoint(cfg.HostCookie, gdprPerms, pbsAnalytics, metricsEngine))
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -23,6 +23,9 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "amp_no_cookie_requests", m.AmpNoCookieMeter)
 	ensureContainsAdapterMetrics(t, registry, "adapter.appnexus", m.AdapterMetrics["appnexus"])
 	ensureContainsAdapterMetrics(t, registry, "adapter.rubicon", m.AdapterMetrics["rubicon"])
+	ensureContains(t, registry, "usersync.appnexus.gdpr_prevent", m.userSyncGDPRPrevent["appnexus"])
+	ensureContains(t, registry, "usersync.rubicon.gdpr_prevent", m.userSyncGDPRPrevent["rubicon"])
+	ensureContains(t, registry, "usersync.unknown.gdpr_prevent", m.userSyncGDPRPrevent["unknown"])
 }
 
 func TestRecordBidType(t *testing.T) {
@@ -40,6 +43,16 @@ func TestRecordBidType(t *testing.T) {
 	}, openrtb_ext.BidTypeVideo, false)
 	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)
 	VerifyMetrics(t, "Appnexus Video Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].NurlMeter.Count(), 1)
+}
+
+func TestRecordGDPRRejection(t *testing.T) {
+	registry := metrics.NewRegistry()
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
+	m.RecordUserIDSet(UserLabels{
+		Action: RequestActionGDPR,
+		Bidder: openrtb_ext.BidderAppnexus,
+	})
+	VerifyMetrics(t, "GDPR sync rejects", m.userSyncGDPRPrevent[openrtb_ext.BidderAppnexus].Count(), 1)
 }
 
 func ensureContains(t *testing.T, registry metrics.Registry, name string, metric interface{}) {

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -104,6 +104,7 @@ type RequestAction string
 const (
 	RequestActionSet    RequestAction = "set"
 	RequestActionOptOut RequestAction = "opt_out"
+	RequestActionGDPR   RequestAction = "gdpr"
 	RequestActionErr    RequestAction = "err"
 )
 


### PR DESCRIPTION
This fixes #504, updating the `/setuid` endpoint. See the issue (or the docs in the PR) for the behavior.