### PR TITLE
Update Conversant adapter to use new domain

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -644,7 +644,7 @@ func init() {
 	viper.SetDefault("adapters.adform.endpoint", "http://adx.adform.net/adx")
 	viper.SetDefault("adapters.adform.usersync_url", "//cm.adform.net/cookie?redirect_url=")
 	viper.SetDefault("max_request_size", 1024*256)
-	viper.SetDefault("adapters.conversant.endpoint", "http://media.msg.dotomi.com/s2s/header/24")
+	viper.SetDefault("adapters.conversant.endpoint", "http://api.hb.ad.cpe.dotomi.com/s2s/header/24")
 	viper.SetDefault("adapters.conversant.usersync_url", "http://prebid-match.dotomi.com/prebid/match?rurl=")
 	viper.SetDefault("host_cookie.ttl_days", 90)
 


### PR DESCRIPTION
Switching Conversant adapter to point to a new sub-domain 