### PR TITLE
Removed legitimate interest, updated "allow sync" logic

### DIFF
--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -23,38 +23,24 @@ type permissionsImpl struct {
 }
 
 func (p *permissionsImpl) HostCookiesAllowed(ctx context.Context, consent string) (bool, error) {
-	// If we're not given a consent string, respect the preferences in the app config.
-	if consent == "" {
-		return p.cfg.UsersyncIfAmbiguous, nil
-	}
-
-	data, err := base64.RawURLEncoding.DecodeString(consent)
-	if err != nil {
-		return false, err
-	}
-
-	parsedConsent, err := vendorconsent.Parse([]byte(data))
-	if err != nil {
-		return false, err
-	}
-
-	vendorList, err := p.fetchVendorList(ctx, parsedConsent.VendorListVersion())
-	if err != nil {
-		return false, err
-	}
-
-	// Config validation makes uint16 conversion safe here
-	return hasPermissions(parsedConsent, vendorList, uint16(p.cfg.HostVendorID), consentconstants.InfoStorageAccess), nil
+	return p.allowSync(ctx, uint16(p.cfg.HostVendorID), consent)
 }
 
 func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+	id, ok := p.vendorIDs[bidder]
+	if ok {
+		return p.allowSync(ctx, id, consent)
+	}
+	return p.allowSync(ctx, 0, consent)
+}
+
+func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, consent string) (bool, error) {
 	// If we're not given a consent string, respect the preferences in the app config.
 	if consent == "" {
 		return p.cfg.UsersyncIfAmbiguous, nil
 	}
 
-	id, ok := p.vendorIDs[bidder]
-	if !ok {
+	if vendorID == 0 {
 		return false, nil
 	}
 
@@ -73,21 +59,16 @@ func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 		return false, err
 	}
 
-	return hasPermissions(parsedConsent, vendorList, id, consentconstants.AdSelectionDeliveryReporting), nil
-}
-
-func hasPermissions(consent vendorconsent.VendorConsents, vendorList vendorlist.VendorList, vendorID uint16, purpose consentconstants.Purpose) bool {
 	vendor := vendorList.Vendor(vendorID)
 	if vendor == nil {
-		return false
+		return false, nil
 	}
 
-	// If the host declared writing cookies to be a "normal" purpose, only do the sync if the user consented to it.
-	if vendor.Purpose(purpose) && consent.PurposeAllowed(purpose) && consent.VendorConsent(vendorID) {
-		return true
+	if vendor.Purpose(consentconstants.InfoStorageAccess) && parsedConsent.PurposeAllowed(consentconstants.InfoStorageAccess) && parsedConsent.VendorConsent(vendorID) {
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 type alwaysAllow struct{}

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -31,17 +31,18 @@ func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	if ok {
 		return p.allowSync(ctx, id, consent)
 	}
-	return p.allowSync(ctx, 0, consent)
+
+	if consent == "" {
+		return p.cfg.UsersyncIfAmbiguous, nil
+	}
+
+	return false, nil
 }
 
 func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, consent string) (bool, error) {
 	// If we're not given a consent string, respect the preferences in the app config.
 	if consent == "" {
 		return p.cfg.UsersyncIfAmbiguous, nil
-	}
-
-	if vendorID == 0 {
-		return false, nil
 	}
 
 	data, err := base64.RawURLEncoding.DecodeString(consent)

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -81,9 +81,6 @@ func hasPermissions(consent vendorconsent.VendorConsents, vendorList vendorlist.
 	if vendor == nil {
 		return false
 	}
-	if vendor.LegitimateInterest(purpose) {
-		return true
-	}
 
 	// If the host declared writing cookies to be a "normal" purpose, only do the sync if the user consented to it.
 	if vendor.Purpose(purpose) && consent.PurposeAllowed(purpose) && consent.VendorConsent(vendorID) {

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -49,10 +49,10 @@ func TestNoConsentAndRejectByDefault(t *testing.T) {
 func TestAllowedSyncs(t *testing.T) {
 	vendorListData := mockVendorListData(t, 1, map[uint16]*purposes{
 		2: &purposes{
-			purposes: []uint8{1}, // cookie reads/writes
+			purposes: []uint8{1},
 		},
 		3: &purposes{
-			purposes: []uint8{3}, // ad personalization
+			purposes: []uint8{1},
 		},
 	})
 	perms := permissionsImpl{

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -15,14 +15,12 @@ import (
 func TestVendorFetch(t *testing.T) {
 	vendorListOne := mockVendorListData(t, 1, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2},
-			legitimateInterests: []uint8{3},
+			purposes: []uint8{1, 2},
 		},
 	})
 	vendorListTwo := mockVendorListData(t, 2, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2, 3},
-			legitimateInterests: nil,
+			purposes: []uint8{1, 2, 3},
 		},
 	})
 	server := httptest.NewServer(http.HandlerFunc(mockServer(2, map[int]string{
@@ -49,14 +47,12 @@ func TestVendorFetch(t *testing.T) {
 func TestLazyFetch(t *testing.T) {
 	firstVendorList := mockVendorListData(t, 1, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2},
-			legitimateInterests: []uint8{3},
+			purposes: []uint8{1, 2},
 		},
 	})
 	secondVendorList := mockVendorListData(t, 2, map[uint16]*purposes{
 		3: &purposes{
-			purposes:            []uint8{1},
-			legitimateInterests: []uint8{2},
+			purposes: []uint8{1},
 		},
 	})
 	server := httptest.NewServer(http.HandlerFunc(mockServer(1, map[int]string{
@@ -72,15 +68,12 @@ func TestLazyFetch(t *testing.T) {
 	vendor := list.Vendor(3)
 	assertBoolsEqual(t, true, vendor.Purpose(1))
 	assertBoolsEqual(t, false, vendor.Purpose(2))
-	assertBoolsEqual(t, false, vendor.LegitimateInterest(1))
-	assertBoolsEqual(t, true, vendor.LegitimateInterest(2))
 }
 
 func TestInitialTimeout(t *testing.T) {
 	list := mockVendorListData(t, 1, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2},
-			legitimateInterests: []uint8{3},
+			purposes: []uint8{1, 2},
 		},
 	})
 	server := httptest.NewServer(http.HandlerFunc(mockServer(1, map[int]string{
@@ -98,14 +91,12 @@ func TestInitialTimeout(t *testing.T) {
 func TestFetchThrottling(t *testing.T) {
 	vendorListTwo := mockVendorListData(t, 2, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2},
-			legitimateInterests: []uint8{3},
+			purposes: []uint8{1, 2},
 		},
 	})
 	vendorListThree := mockVendorListData(t, 3, map[uint16]*purposes{
 		32: &purposes{
-			purposes:            []uint8{1, 2},
-			legitimateInterests: []uint8{3},
+			purposes: []uint8{1, 2},
 		},
 	})
 	server := httptest.NewServer(http.HandlerFunc(mockServer(1, map[int]string{
@@ -181,9 +172,8 @@ func mockServer(latestVersion int, responses map[int]string) func(http.ResponseW
 
 func mockVendorListData(t *testing.T, version uint16, vendors map[uint16]*purposes) string {
 	type vendorContract struct {
-		ID                  uint16  `json:"id"`
-		Purposes            []uint8 `json:"purposeIds"`
-		LegitimateInterests []uint8 `json:"legIntPurposeIds"`
+		ID       uint16  `json:"id"`
+		Purposes []uint8 `json:"purposeIds"`
 	}
 
 	type vendorListContract struct {
@@ -195,9 +185,8 @@ func mockVendorListData(t *testing.T, version uint16, vendors map[uint16]*purpos
 		vendors := make([]vendorContract, 0, len(input))
 		for id, purpose := range input {
 			vendors = append(vendors, vendorContract{
-				ID:                  id,
-				Purposes:            purpose.purposes,
-				LegitimateInterests: purpose.legitimateInterests,
+				ID:       id,
+				Purposes: purpose.purposes,
 			})
 		}
 		return vendors
@@ -229,6 +218,5 @@ func testConfig() config.GDPR {
 }
 
 type purposes struct {
-	purposes            []uint8
-	legitimateInterests []uint8
+	purposes []uint8
 }


### PR DESCRIPTION
This makes two changes based on recent finds:

1. It removes the logic which lets syncs happen based on legitimate interest.
2. It updates the logic so that bidder syncs happen if they have consent _to access the cookie_--not based on ad personalization.

------------------------------------------------------------------------------------------
## Why ignore legitimate interest? 

There are some [new pubvendors.json docs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/pubvendors.json%20v1.0%20Draft%20for%20Public%20Comment.md#sspdsp-integration-), which say

> If a publisher whitelists a vendor claiming legitimate interest then Legitimate Interest can take precedence over the information in the Consent String

I thought legitimate interest took precedence over consent... but it looks like this `pubvendors.json` spec gives publishers a way to "object" to vendors who claim legitimate interest that they don't trust.

Since we aren't supporting `pubvendors.json` (at least yet), we can't really support this... so this plays it safe and limits syncs to explicit consent.

If this upsets Bidders, we could let Usersyncers whose sync endpoints understand consent strings bypass this check... but based on lots of conversations I had (and the changes for (2)), I don't think it'll be an issue.

------------------------------------------------------------------------------------------
## Why consider Cookie Access for sync URLs?

Nearly every Usersync endpoint reads from the Cookie. I feel dumb for not realizing this. But as a result, it really doesn't make sense to drop a sync URL for someone who can't read from the Cookie.

Similarly, ad targeting & personalization have nothing to do with the sync itself. That only matters during the Auction, which has its own consent string.