### PR TITLE
Require consent string if gdpr is active

### DIFF
--- a/docs/endpoints/cookieSync.md
+++ b/docs/endpoints/cookieSync.md
@@ -21,7 +21,7 @@ must supply a JSON object to define the list of bidders that may need to be sync
 
 `gdpr` is optional. It should be 1 if GDPR is in effect, 0 if not, and omitted if the caller is unsure.
 
-`gdpr_consent` is optional. If present, it should be an [unpadded base64-URL](https://tools.ietf.org/html/rfc4648#page-7) encoded [Vendor Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-).
+`gdpr_consent` is required if `gdpr` is `1`, and optional otherwise. If present, it should be an [unpadded base64-URL](https://tools.ietf.org/html/rfc4648#page-7) encoded [Vendor Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-).
 
 If `gdpr` is  omitted, callers are still encouraged to send `gdpr_consent` if they have it.
 Depending on how the Prebid Server host company has configured their servers, they may or may not require it for cookie syncs.

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -82,6 +82,13 @@ func (deps *cookieSyncDeps) Endpoint(w http.ResponseWriter, r *http.Request, _ h
 		return
 	}
 
+	if parsedReq.GDPR != nil && *parsedReq.GDPR == 1 && parsedReq.Consent == "" {
+		co.Status = http.StatusBadRequest
+		co.Errors = append(co.Errors, errors.New("gdpr_consent is required if gdpr is 1"))
+		http.Error(w, "gdpr_consent is required if gdpr=1", http.StatusBadRequest)
+		return
+	}
+
 	if len(biddersJSON) == 0 {
 		parsedReq.Bidders = make([]string, 0, len(deps.syncers))
 		for bidder := range deps.syncers {

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -36,7 +36,7 @@ func TestGDPRPreventsCookie(t *testing.T) {
 }
 
 func TestGDPRPreventsBidders(t *testing.T) {
-	rr := doPost(`{"gdpr":1,"bidders":["appnexus", "pubmatic", "lifestreet"]}`, nil, true, map[openrtb_ext.BidderName]usersync.Usersyncer{
+	rr := doPost(`{"gdpr":1,"bidders":["appnexus", "pubmatic", "lifestreet"],"gdpr_consent":"BOONs2HOONs2HABABBENAGgAAAAPrABACGA"}`, nil, true, map[openrtb_ext.BidderName]usersync.Usersyncer{
 		openrtb_ext.BidderLifestreet: usersyncers.NewLifestreetSyncer("someurl.com"),
 	})
 	assertIntsMatch(t, http.StatusOK, rr.Code)
@@ -50,6 +50,12 @@ func TestGDPRIgnoredIfZero(t *testing.T) {
 
 	assertSyncsExist(t, rr.Body.Bytes(), "appnexus", "pubmatic")
 	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+}
+
+func TestGDPRConsentRequired(t *testing.T) {
+	rr := doPost(`{"gdpr":1,"bidders":["appnexus", "pubmatic"]}`, nil, false, nil)
+	assertIntsMatch(t, http.StatusBadRequest, rr.Code)
+	assertStringsMatch(t, "gdpr_consent is required if gdpr=1\n", rr.Body.String())
 }
 
 func TestCookieSyncHasCookies(t *testing.T) {

--- a/endpoints/setuid_test.go
+++ b/endpoints/setuid_test.go
@@ -166,7 +166,7 @@ func assertBoolsMatch(t *testing.T, expected bool, actual bool) {
 func assertStringsMatch(t *testing.T, expected string, actual string) {
 	t.Helper()
 	if expected != actual {
-		t.Errorf("Expected %s, got %s", expected, actual)
+		t.Errorf(`Expected "%s", got "%s"`, expected, actual)
 	}
 }
 


### PR DESCRIPTION
If `gdpr` is in effect, we can't do anything without a `gdpr_consent` string. This just makes it official with a 400 response.

This is technically a breaking change, but... very low risk, since it these APIs were only released about an hour ago.