### PR TITLE
Made auction max timeout configurable.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Configuration struct {
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
 	StatusResponse       string             `mapstructure:"status_response"`
-	DefaultTimeout       uint64             `mapstructure:"default_timeout_ms"`
+	MaxAuctionTimeout    uint64             `mapstructure:"max_auction_ms"`
 	CacheURL             Cache              `mapstructure:"cache"`
 	RecaptchaSecret      string             `mapstructure:"recaptcha_secret"`
 	HostCookie           HostCookie         `mapstructure:"host_cookie"`
@@ -29,6 +29,18 @@ type Configuration struct {
 	Analytics            Analytics          `mapstructure:"analytics"`
 	AMPTimeoutAdjustment int64              `mapstructure:"amp_timeout_adjustment_ms"`
 	GDPR                 GDPR               `mapstructure:"gdpr"`
+}
+
+// LimitAuctionTimeout returns the min of requested or cfg.MaxAuctionTimeout.
+// Both values treat "0" as "infinite".
+func (cfg *Configuration) LimitAuctionTimeout(requested time.Duration) time.Duration {
+	if cfg.MaxAuctionTimeout > 0 {
+		maxTimeout := time.Duration(cfg.MaxAuctionTimeout) * time.Millisecond
+		if requested == 0 || requested > maxTimeout {
+			return maxTimeout
+		}
+	}
+	return requested
 }
 
 func (cfg *Configuration) validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -22,8 +23,8 @@ func TestDefaults(t *testing.T) {
 		t.Error("Expected Admin Port 6060")
 	}
 
-	if cfg.DefaultTimeout != uint64(250) {
-		t.Error("Expected DefaultTimeout of 250ms")
+	if cfg.MaxAuctionTimeout != 250 {
+		t.Error("Expected MaxAuctionTimeout of 250ms")
 	}
 
 	if cfg.DataCache.Type != "dummy" {
@@ -50,7 +51,7 @@ external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
-default_timeout_ms: 123
+max_auction_ms: 123
 cache:
   scheme: http
   host: prebidcache.net
@@ -122,9 +123,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "host", cfg.Host, "prebid-server.prebid.org")
 	cmpInts(t, "port", cfg.Port, 1234)
 	cmpInts(t, "admin_port", cfg.AdminPort, 5678)
-	if cfg.DefaultTimeout != 123 {
-		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
-	}
+	cmpInts(t, "max_auction_ms", int(cfg.MaxAuctionTimeout), 123)
 	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")
 	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "prebidcache.net")
 	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")
@@ -161,7 +160,7 @@ func newViperWithDefaults() *viper.Viper {
 	v.SetDefault("external_url", "http://localhost:8000")
 	v.SetDefault("port", 8000)
 	v.SetDefault("admin_port", 6060)
-	v.SetDefault("default_timeout_ms", 250)
+	v.SetDefault("max_auction_ms", 250)
 	v.SetDefault("datacache.type", "dummy")
 
 	v.SetDefault("adapters.pubmatic.endpoint", "http://openbid-useast.pubmatic.com/translator?")
@@ -214,5 +213,24 @@ func TestOverflowedVendorID(t *testing.T) {
 
 	if err := cfg.validate(); err == nil {
 		t.Errorf("cfg.gdpr.host_vendor_id should prevent values over %d, but it doesn't", 0xffff)
+	}
+}
+
+func TestLimitTimeout(t *testing.T) {
+	doTimeoutTest(t, 10, 15, 10)
+	doTimeoutTest(t, 10, 0, 10)
+	doTimeoutTest(t, 5, 5, 10)
+	doTimeoutTest(t, 15, 15, 0)
+}
+
+func doTimeoutTest(t *testing.T, expected int, requested int, max uint64) {
+	t.Helper()
+	cfg := Configuration{
+		MaxAuctionTimeout: max,
+	}
+	expectedDuration := time.Duration(expected) * time.Millisecond
+	limited := cfg.LimitAuctionTimeout(time.Duration(requested) * time.Millisecond)
+	if limited != expectedDuration {
+		t.Errorf("Expected %dms timeout, got %dms", expectedDuration, limited/time.Millisecond)
 	}
 }

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -621,7 +621,7 @@ func init() {
 	viper.SetDefault("external_url", "http://localhost:8000")
 	viper.SetDefault("port", 8000)
 	viper.SetDefault("admin_port", 6060)
-	viper.SetDefault("default_timeout_ms", 250)
+	viper.SetDefault("max_timeout_ms", 5000)
 	viper.SetDefault("cache.expected_millis", 10)
 	viper.SetDefault("datacache.type", "dummy")
 	// no metrics configured by default (metrics{host|database|username|password})


### PR DESCRIPTION
This adds a configurable max timeout for auction requests. "0" means "no limit".

This lets PBS hosts effectively cap the max auction timeout they're willing to allow, which is important for some technical reasons.



I also found that the `DefaultTimeout` config option was unused throughout the code, so I deleted it.