### PR TITLE
Fixed ./validate.sh --nofmt output bug.

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -38,7 +38,7 @@ if $AUTOFMT; then
     done
   fi
 else
-  test $GOFMT_LINES -eq 0 || die "gofmt needs to be run, ${GOFMT_LINES} files have issues.  Below is a list of files to review:\n`gofmt -l *.go pbs adapters`"
+  test $GOFMT_LINES -eq 0 || die "gofmt needs to be run, ${GOFMT_LINES} files have issues.  Below is a list of files to review:\n`gofmt -l $GOGLOB`"
 fi
 
 # Run the actual tests. Make sure there's enough coverage too, if the flags call for it.


### PR DESCRIPTION
#526 noted that `./validate.sh --nofmt` produced blank output. I got this while running it on their branch:

```
dbemiller-mac:prebid-server dbemiller$ ./validate.sh --nofmt
gofmt needs to be run, 1 files have issues.  Below is a list of files to review:
```

This PR fixes that. Looks like it was still printing a hardcoded list of files, so formatting issues in these new directories wouldn't get printed properly. 