### PR TITLE
Cleaning up more useless log errors

### DIFF
--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -124,7 +124,7 @@ func (a *AdformAdapter) Call(ctx context.Context, request *pbs.PBSRequest, bidde
 	}
 
 	if response.StatusCode != 200 {
-		return nil, adapters.BadServerResponseError{
+		return nil, &adapters.BadServerResponseError{
 			Message: fmt.Sprintf("HTTP status %d; body: %s", response.StatusCode, responseBody),
 		}
 	}

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -194,7 +194,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	}
 
 	if anResp.StatusCode != http.StatusOK {
-		return nil, adapters.BadServerResponseError{
+		return nil, &adapters.BadServerResponseError{
 			Message: fmt.Sprintf("HTTP status %d; body: %s", anResp.StatusCode, responseBody),
 		}
 	}
@@ -215,7 +215,7 @@ func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 		for _, bid := range sb.Bid {
 			bidID := bidder.LookupBidID(bid.ImpID)
 			if bidID == "" {
-				return nil, adapters.BadServerResponseError{
+				return nil, &adapters.BadServerResponseError{
 					Message: fmt.Sprintf("Unknown ad unit code '%s'", bid.ImpID),
 				}
 			}

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -57,7 +57,7 @@ type BadServerResponseError struct {
 	Message string
 }
 
-func (err BadServerResponseError) Error() string {
+func (err *BadServerResponseError) Error() string {
 	return err.Message
 }
 

--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -196,7 +196,7 @@ func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, adapters.BadServerResponseError{
+		return nil, &adapters.BadServerResponseError{
 			Message: fmt.Sprintf("HTTP status: %d, body: %s", resp.StatusCode, string(body)),
 		}
 	}
@@ -209,7 +209,7 @@ func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 
 	err = json.Unmarshal(body, &bidResp)
 	if err != nil {
-		return nil, adapters.BadServerResponseError{
+		return nil, &adapters.BadServerResponseError{
 			Message: err.Error(),
 		}
 	}

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -3,8 +3,6 @@ package adapters
 import (
 	"github.com/prebid/prebid-server/pbs"
 
-	"errors"
-
 	"github.com/mxmCherry/openrtb"
 )
 
@@ -100,7 +98,9 @@ func MakeOpenRTBGeneric(req *pbs.PBSRequest, bidder *pbs.PBSBidder, bidderFamily
 				case pbs.MEDIA_TYPE_VIDEO:
 					video := makeVideo(unit)
 					if video == nil {
-						return openrtb.BidRequest{}, errors.New("Invalid AdUnit: VIDEO media type with no video data")
+						return openrtb.BidRequest{}, &BadInputError{
+							Message: "Invalid AdUnit: VIDEO media type with no video data",
+						}
 					}
 					newImp.Video = video
 				default:

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -210,7 +210,7 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 
 			bidID := bidder.LookupBidID(bid.ImpID)
 			if bidID == "" {
-				return nil, adapters.BadServerResponseError{
+				return nil, &adapters.BadServerResponseError{
 					Message: fmt.Sprintf("Unknown ad unit code '%s'", bid.ImpID),
 				}
 			}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -249,7 +249,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 						blabels.AdapterStatus = pbsmetrics.AdapterStatusErr
 						bidder.Error = err.Error()
 						if _, isBadInput := err.(*adapters.BadInputError); !isBadInput {
-							if _, isBadServer := err.(adapters.BadServerResponseError); !isBadServer {
+							if _, isBadServer := err.(*adapters.BadServerResponseError); !isBadServer {
 								glog.Warningf("Error from bidder %v. Ignoring all bids: %v", bidder.BidderCode, err)
 							}
 						}


### PR DESCRIPTION
This silences some more error messages we can't really do anything about... either because they're errors from the caller or the remote server.

```
W0524 14:34:00.258090       1 pbs_light.go:253] Error from bidder pulsepoint. Ignoring all bids: HTTP status: 500
W0524 14:44:52.729724       1 pbs_light.go:253] Error from bidder districtm. Ignoring all bids: Invalid AdUnit: VIDEO media type with no video data
```