### PR TITLE
Remove ad-hoc Config reads

### DIFF
--- a/adapters/adform/adform_test.go
+++ b/adapters/adform/adform_test.go
@@ -201,7 +201,10 @@ func preparePrebidRequest(serverUrl string, t *testing.T) *pbs.PBSRequest {
 	prebidHttpRequest.Header.Add("Cookie", fakeWriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()
-	r, err := pbs.ParsePBSRequest(prebidHttpRequest, cacheClient, &pbs.HostCookieSettings{})
+	r, err := pbs.ParsePBSRequest(prebidHttpRequest, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &pbs.HostCookieSettings{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -369,7 +369,10 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/audienceNetwork/facebook_test.go
+++ b/adapters/audienceNetwork/facebook_test.go
@@ -215,7 +215,10 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	return pbReq, err
 }
 

--- a/adapters/conversant/conversant_test.go
+++ b/adapters/conversant/conversant_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -614,7 +615,10 @@ func ParseRequest(req *pbs.PBSRequest) (*pbs.PBSRequest, error) {
 	cache, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cache, &hcs)
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cache, &hcs)
 
 	return parsedReq, err
 }

--- a/adapters/lifestreet/lifestreet_test.go
+++ b/adapters/lifestreet/lifestreet_test.go
@@ -232,7 +232,10 @@ func TestLifestreetBasicResponse(t *testing.T) {
 
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -635,7 +635,10 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs)
+	_, err = pbs.ParsePBSRequest(httpReq, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -230,7 +230,10 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs)
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -955,7 +955,10 @@ func CreatePrebidRequest(server *httptest.Server, t *testing.T) (an *RubiconAdap
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err = pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err = pbs.ParsePBSRequest(req, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	pbReq.IsDebug = true
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)

--- a/adapters/sovrn/sovrn_test.go
+++ b/adapters/sovrn/sovrn_test.go
@@ -192,7 +192,10 @@ func SampleSovrnRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs)
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, cacheClient, &hcs)
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/buger/jsonparser"
 
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/stored_requests"
 
 	"github.com/golang/glog"
-	"github.com/spf13/viper"
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/blang/semver"
@@ -217,7 +217,7 @@ func ParseMediaTypes(types []string) []MediaType {
 	return mtypes
 }
 
-func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings) (*PBSRequest, error) {
+func ParsePBSRequest(r *http.Request, cfg *config.AuctionTimeouts, cache cache.Cache, hostCookieSettings *HostCookieSettings) (*PBSRequest, error) {
 	defer r.Body.Close()
 
 	pbsReq := &PBSRequest{}
@@ -231,9 +231,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *Hos
 		return nil, fmt.Errorf("No ad units specified")
 	}
 
-	if pbsReq.TimeoutMillis == 0 || pbsReq.TimeoutMillis > 2000 {
-		pbsReq.TimeoutMillis = int64(viper.GetInt("default_timeout_ms"))
-	}
+	pbsReq.TimeoutMillis = int64(cfg.LimitAuctionTimeout(time.Duration(pbsReq.TimeoutMillis)*time.Millisecond) / time.Millisecond)
 
 	if pbsReq.Device == nil {
 		pbsReq.Device = &openrtb.Device{}

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -73,7 +73,10 @@ func TestParseSimpleRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -155,7 +158,10 @@ func TestHeaderParsing(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed")
 	}
@@ -237,7 +243,10 @@ func TestParseConfig(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -318,7 +327,10 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -414,7 +426,10 @@ func TestParseMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -514,7 +529,10 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -618,7 +636,10 @@ func TestParseRequestWithInstl(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -670,7 +691,10 @@ func TestParsePBSRequestUsesHostCookie(t *testing.T) {
 		},
 	}
 
-	pbs_req, err2 := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err2 := ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err2 != nil {
 		t.Fatalf("Parse simple request failed %v", err2)
 	}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -136,7 +136,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 	}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, dataCache, &hostCookieSettings)
+	pbs_req, err := pbs.ParsePBSRequest(r, &deps.cfg.AuctionTimeouts, dataCache, &hostCookieSettings)
 	// Defer here because we need pbs_req defined.
 	defer func() {
 		if pbs_req == nil {

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -73,7 +73,10 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := pbs.ParsePBSRequest(r, &config.AuctionTimeouts{
+		Default: 2000,
+		Max:     2000,
+	}, d, &hcs)
 	if err != nil {
 		t.Errorf("Unexpected error on parsing %v", err)
 	}


### PR DESCRIPTION
`ParsePBSRequest` (legacy code) had an explicit call to `viper.GetInt("default_timeout_ms")`

This bit me recently, because I assumed that the `Configuration` object was the source of truth, and removed that property from the app config

So... this uses the `Configuration` object and passes it around everywhere.