### PR TITLE
Checked for some missing errors

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -740,6 +740,9 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 		storedReqIds = []string{storedBidRequestId}
 	}
 	storedRequests, storedImps, errs := deps.storedReqFetcher.FetchRequests(ctx, storedReqIds, impIds)
+	if len(errs) != 0 {
+		return nil, errs
+	}
 
 	// Apply the Stored BidRequest, if it exists
 	resolvedRequest := requestJson
@@ -880,7 +883,7 @@ func writeError(errs []error, w http.ResponseWriter) bool {
 	if len(errs) > 0 {
 		w.WriteHeader(http.StatusBadRequest)
 		for _, err := range errs {
-			w.Write([]byte(fmt.Sprintf("Invalid request format: %s\n", err.Error())))
+			w.Write([]byte(fmt.Sprintf("Invalid request: %s\n", err.Error())))
 		}
 		return true
 	}


### PR DESCRIPTION
Looks like we forgot to handle these errors... which made some error messages really janky.

For example, on `master` if you make a request with an unknown Stored Imp ID, it gives:

```
Invalid request format: Invalid JSON Document
```

With these changes, it gives:

```
Invalid request: Stored Imp with ID="a36d4986-e8ed-4600-b701-711280205985" not found.
```