### PR TITLE
Make Pulsepoint params accept values like "200X150"

### DIFF
--- a/static/bidder-params/pulsepoint.json
+++ b/static/bidder-params/pulsepoint.json
@@ -14,7 +14,7 @@
     },
     "cf": {
       "type": "string",
-      "pattern": "(^[0-9]+X[0-9]+$)|(^[0-9]+x[0-9]+$)",
+      "pattern": "^[0-9]+[xX][0-9]+$",
       "description": "The size of the ad slot being sold. This should be a string like 300X250"
     }
   },

--- a/static/bidder-params/pulsepoint.json
+++ b/static/bidder-params/pulsepoint.json
@@ -14,8 +14,8 @@
     },
     "cf": {
       "type": "string",
-      "pattern": "^[0-9]+x[0-9]+$",
-      "description": "The size of the ad slot being sold. This should be a string like 300x250"
+      "pattern": "(^[0-9]+X[0-9]+$)|(^[0-9]+x[0-9]+$)",
+      "description": "The size of the ad slot being sold. This should be a string like 300X250"
     }
   },
   "required": ["cp", "ct", "cf"]


### PR DESCRIPTION
In https://github.com/prebid/Prebid.js/issues/2623, one of the bidder params uses a capital `X` to separate the width & height of `cf` param.

This looks like it's what the `pulsepoint.md` example in their Prebid.js file expects... so I figured we'd just change it here.

We need to accept both forms, of course, since there may be `x` sizes in the DB. This fixes #535 