### PR TITLE
pulsepoint bidder: Adding BidType to Bids

### DIFF
--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -176,14 +177,15 @@ func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 			}
 
 			pbid := pbs.PBSBid{
-				BidID:       bidID,
-				AdUnitCode:  bid.ImpID,
-				BidderCode:  bidder.BidderCode,
-				Price:       bid.Price,
-				Adm:         bid.AdM,
-				Creative_id: bid.CrID,
-				Width:       bid.W,
-				Height:      bid.H,
+				BidID:             bidID,
+				AdUnitCode:        bid.ImpID,
+				BidderCode:        bidder.BidderCode,
+				Price:             bid.Price,
+				Adm:               bid.AdM,
+				Creative_id:       bid.CrID,
+				Width:             bid.W,
+				Height:            bid.H,
+				CreativeMediaType: string(openrtb_ext.BidTypeBanner),
 			}
 			bids = append(bids, &pbid)
 		}

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -39,7 +39,7 @@ type PulsepointParams struct {
 }
 
 func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
-	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
+	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}
 	ppReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
 
 	if err != nil {

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -101,6 +102,7 @@ func TestPulsePointBiddingBehavior(t *testing.T) {
 	adapterstest.VerifyIntValue(int(bids[0].Width), 728, t)
 	adapterstest.VerifyIntValue(int(bids[0].Height), 90, t)
 	adapterstest.VerifyIntValue(int(bids[0].Price*100), 210, t)
+	adapterstest.VerifyStringValue(bids[0].CreativeMediaType, string(openrtb_ext.BidTypeBanner), t)
 }
 
 /**

--- a/static/bidder-info/pulsepoint.yaml
+++ b/static/bidder-info/pulsepoint.yaml
@@ -7,4 +7,3 @@ capabilities:
   site:
     mediaTypes:
       - banner
-      - video


### PR DESCRIPTION
Currently the validation `ParseBidType` in `bid.go`, rejects the bids submitted from the `pulsepoint` bidder. Test page [here](http://projects.contextweb.com/av/gdpr/pb_s2s.html).