### PR TITLE
setuid metrics and legacy auction fixes

### DIFF
--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -33,19 +33,25 @@ func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalyti
 		}
 
 		query := r.URL.Query()
+		bidder := query.Get("bidder")
 		if shouldReturn, status, body := preventSyncsGDPR(query.Get("gdpr"), query.Get("gdpr_consent"), perms); shouldReturn {
 			w.WriteHeader(status)
 			w.Write([]byte(body))
-			metrics.RecordUserIDSet(pbsmetrics.UserLabels{Action: pbsmetrics.RequestActionGDPR})
+			metrics.RecordUserIDSet(pbsmetrics.UserLabels{
+				Action: pbsmetrics.RequestActionGDPR,
+				Bidder: openrtb_ext.BidderName(bidder),
+			})
 			so.Status = status
 			return
 		}
 
-		bidder := query.Get("bidder")
 		if bidder == "" {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(`"bidder" query param is required`))
-			metrics.RecordUserIDSet(pbsmetrics.UserLabels{Action: pbsmetrics.RequestActionErr})
+			metrics.RecordUserIDSet(pbsmetrics.UserLabels{
+				Action: pbsmetrics.RequestActionErr,
+				Bidder: openrtb_ext.BidderName(bidder),
+			})
 			so.Status = http.StatusBadRequest
 			return
 		}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -352,8 +353,11 @@ func TestCacheVideoOnly(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	syncers := usersyncers.NewSyncerMap(cfg)
+	gdprPerms := gdpr.NewPermissions(nil, config.GDPR{
+		HostVendorID: 0,
+	}, nil, nil)
 	prebid_cache_client.InitPrebidCache(server.URL)
-	cacheVideoOnly(bids, ctx, w, &auctionDeps{cfg, syncers, &pbsmetrics.DummyMetricsEngine{}}, &pbsmetrics.Labels{})
+	cacheVideoOnly(bids, ctx, w, &auctionDeps{cfg, syncers, gdprPerms, &pbsmetrics.DummyMetricsEngine{}}, &pbsmetrics.Labels{})
 	if bids[0].CacheID != "UUID-1" {
 		t.Errorf("UUID was '%s', should have been 'UUID-1'", bids[0].CacheID)
 	}


### PR DESCRIPTION
Was looking at our `/setuid` metrics... and it became clear that nearly all the traffic to it was coming from legacy `/auction` requests.

Unlike `/openrtb2/auction` calls, `/auction` calls return cookie syncs (similar to `/cookie_sync`). And while the newest versions of `Prebid.js` ignore these, there must still be a lot of older versions out in the wild.

Although our `/setuid` endpoint rejects these, everyone will see much better performance if we never return them in the first place.