### PR TITLE
Cleaning up some maps and syncer docs

### DIFF
--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -31,8 +31,8 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_e
 		openrtb_ext.BidderAdform:      adaptBidder(adform.NewAdformBidder(client, cfg.Adapters["adform"].Endpoint), client),
 		openrtb_ext.BidderAdtelligent: adaptBidder(adtelligent.NewAdtelligentBidder(client), client),
 		openrtb_ext.BidderAppnexus:    adaptBidder(appnexus.NewAppNexusBidder(client, cfg.Adapters["appnexus"].Endpoint), client),
+		openrtb_ext.BidderBrightroll:  adaptBidder(brightroll.NewBrightrollBidder(cfg.Adapters["brightroll"].Endpoint), client),
 		// TODO #267: Upgrade the Conversant adapter
-		openrtb_ext.BidderBrightroll: adaptBidder(brightroll.NewBrightrollBidder(cfg.Adapters["brightroll"].Endpoint), client),
 		openrtb_ext.BidderConversant: adaptLegacyAdapter(conversant.NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["conversant"].Endpoint)),
 		openrtb_ext.BidderEPlanning:  adaptBidder(eplanning.NewEPlanningBidder(client, cfg.Adapters["eplanning"].Endpoint), client),
 		// TODO #211: Upgrade the Facebook adapter

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -28,9 +28,13 @@ import (
 
 func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_ext.BidderName]adaptedBidder {
 	return map[openrtb_ext.BidderName]adaptedBidder{
-		openrtb_ext.BidderAppnexus: adaptBidder(appnexus.NewAppNexusBidder(client, cfg.Adapters["appnexus"].Endpoint), client),
+		openrtb_ext.BidderAdform:      adaptBidder(adform.NewAdformBidder(client, cfg.Adapters["adform"].Endpoint), client),
+		openrtb_ext.BidderAdtelligent: adaptBidder(adtelligent.NewAdtelligentBidder(client), client),
+		openrtb_ext.BidderAppnexus:    adaptBidder(appnexus.NewAppNexusBidder(client, cfg.Adapters["appnexus"].Endpoint), client),
 		// TODO #267: Upgrade the Conversant adapter
+		openrtb_ext.BidderBrightroll: adaptBidder(brightroll.NewBrightrollBidder(cfg.Adapters["brightroll"].Endpoint), client),
 		openrtb_ext.BidderConversant: adaptLegacyAdapter(conversant.NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["conversant"].Endpoint)),
+		openrtb_ext.BidderEPlanning:  adaptBidder(eplanning.NewEPlanningBidder(client, cfg.Adapters["eplanning"].Endpoint), client),
 		// TODO #211: Upgrade the Facebook adapter
 		openrtb_ext.BidderFacebook: adaptLegacyAdapter(audienceNetwork.NewAdapterFromFacebook(adapters.DefaultHTTPAdapterConfig, cfg.Adapters["facebook"].PlatformID)),
 		// TODO #212: Upgrade the Index adapter
@@ -45,10 +49,6 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_e
 		openrtb_ext.BidderRubicon: adaptBidder(rubicon.NewRubiconBidder(client, cfg.Adapters["rubicon"].Endpoint, cfg.Adapters["rubicon"].XAPI.Username,
 			cfg.Adapters["rubicon"].XAPI.Password, cfg.Adapters["rubicon"].XAPI.Tracker), client),
 		openrtb_ext.BidderSomoaudience: adaptBidder(somoaudience.NewSomoaudienceBidder(), client),
-		openrtb_ext.BidderAdtelligent:  adaptBidder(adtelligent.NewAdtelligentBidder(client), client),
-		openrtb_ext.BidderAdform:       adaptBidder(adform.NewAdformBidder(client, cfg.Adapters["adform"].Endpoint), client),
 		openrtb_ext.BidderSovrn:        adaptBidder(sovrn.NewSovrnBidder(client, cfg.Adapters["sovrn"].Endpoint), client),
-		openrtb_ext.BidderEPlanning:    adaptBidder(eplanning.NewEPlanningBidder(client, cfg.Adapters["eplanning"].Endpoint), client),
-		openrtb_ext.BidderBrightroll:   adaptBidder(brightroll.NewBrightrollBidder(cfg.Adapters["brightroll"].Endpoint), client),
 	}
 }

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -23,7 +23,9 @@ const (
 	BidderAdtelligent  BidderName = "adtelligent"
 	BidderAdform       BidderName = "adform"
 	BidderAppnexus     BidderName = "appnexus"
+	BidderBrightroll   BidderName = "brightroll"
 	BidderConversant   BidderName = "conversant"
+	BidderEPlanning    BidderName = "eplanning"
 	BidderFacebook     BidderName = "audienceNetwork"
 	BidderIndex        BidderName = "indexExchange"
 	BidderLifestreet   BidderName = "lifestreet"
@@ -33,8 +35,6 @@ const (
 	BidderRubicon      BidderName = "rubicon"
 	BidderSomoaudience BidderName = "somoaudience"
 	BidderSovrn        BidderName = "sovrn"
-	BidderEPlanning    BidderName = "eplanning"
-	BidderBrightroll   BidderName = "brightroll"
 )
 
 // BidderMap stores all the valid OpenRTB 2.x Bidders in the project. This map *must not* be mutated.
@@ -43,7 +43,9 @@ var BidderMap = map[string]BidderName{
 	"adform":          BidderAdform,
 	"appnexus":        BidderAppnexus,
 	"audienceNetwork": BidderFacebook,
+	"brightroll":      BidderBrightroll,
 	"conversant":      BidderConversant,
+	"eplanning":       BidderEPlanning,
 	"indexExchange":   BidderIndex,
 	"lifestreet":      BidderLifestreet,
 	"openx":           BidderOpenx,
@@ -52,8 +54,6 @@ var BidderMap = map[string]BidderName{
 	"rubicon":         BidderRubicon,
 	"somoaudience":    BidderSomoaudience,
 	"sovrn":           BidderSovrn,
-	"eplanning":       BidderEPlanning,
-	"brightroll":      BidderBrightroll,
 }
 
 // BidderList returns the values of the BidderMap

--- a/usersync/cookie.go
+++ b/usersync/cookie.go
@@ -22,8 +22,7 @@ var customBidderTTLs = map[string]time.Duration{}
 // bidderToFamilyNames maps the BidderName to Adapter.Name() for the early adapters.
 // If a mapping isn't listed here, then we assume that the two are the same.
 var bidderToFamilyNames = map[openrtb_ext.BidderName]string{
-	openrtb_ext.BidderAppnexus:     "adnxs",
-	openrtb_ext.BidderSomoaudience: "mobileadtrading",
+	openrtb_ext.BidderAppnexus: "adnxs",
 }
 
 // PBSCookie is the cookie used in Prebid Server.

--- a/usersync/usersync.go
+++ b/usersync/usersync.go
@@ -9,9 +9,10 @@ type Usersyncer interface {
 	//
 	// For more information about user syncs, see http://clearcode.cc/2015/12/cookie-syncing/
 	GetUsersyncInfo(gdpr string, consent string) *UsersyncInfo
-	// FamilyName identifies the space of cookies for this usersyncer.
-	// For example, if this Usersyncer syncs with adnxs.com, then this
-	// should return "adnxs".
+	// FamilyName should be the same as the `BidderName` for this Usersyncer.
+	// This function only exists for legacy reasons.
+	// TODO #362: when the appnexus usersyncer is consistent, delete this and use the key
+	// of NewSyncerMap() here instead.
 	FamilyName() string
 
 	// GDPRVendorID returns the ID in the IAB Global Vendor List which refers to this Bidder.

--- a/usersync/usersyncers/somoaudience.go
+++ b/usersync/usersyncers/somoaudience.go
@@ -12,7 +12,7 @@ func NewSomoaudienceSyncer(externalURL string) *syncer {
 	usersyncURL := "//publisher-east.mobileadtrading.com/usersync?ru="
 
 	return &syncer{
-		familyName:          "mobileadtrading",
+		familyName:          "somoaudience",
 		syncEndpointBuilder: resolveMacros(usersyncURL + redirectURL),
 		syncType:            SyncTypeRedirect,
 	}

--- a/usersync/usersyncers/somoaudience.go
+++ b/usersync/usersyncers/somoaudience.go
@@ -7,7 +7,7 @@ import (
 
 func NewSomoaudienceSyncer(externalURL string) *syncer {
 	externalURL = strings.TrimRight(externalURL, "/")
-	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dmobileadtrading%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
+	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 
 	usersyncURL := "//publisher-east.mobileadtrading.com/usersync?ru="
 

--- a/usersync/usersyncers/somoaudience_test.go
+++ b/usersync/usersyncers/somoaudience_test.go
@@ -7,7 +7,7 @@ import (
 func TestSomoaudienceSyncer(t *testing.T) {
 	somo := NewSomoaudienceSyncer("localhost")
 	syncInfo := somo.GetUsersyncInfo("", "")
-	if syncInfo.URL != "//publisher-east.mobileadtrading.com/usersync?ru=localhost%2Fsetuid%3Fbidder%3Dmobileadtrading%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24%7BUID%7D" {
+	if syncInfo.URL != "//publisher-east.mobileadtrading.com/usersync?ru=localhost%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24%7BUID%7D" {
 		t.Fatalf("should have matched")
 	}
 	if syncInfo.Type != "redirect" {

--- a/usersync/usersyncers/syncer.go
+++ b/usersync/usersyncers/syncer.go
@@ -12,9 +12,13 @@ import (
 // The same keys should exist in this map as in the exchanges map.
 func NewSyncerMap(cfg *config.Configuration) map[openrtb_ext.BidderName]usersync.Usersyncer {
 	return map[openrtb_ext.BidderName]usersync.Usersyncer{
+		openrtb_ext.BidderAdform:       NewAdformSyncer(cfg.Adapters["adform"].UserSyncURL, cfg.ExternalURL),
+		openrtb_ext.BidderAdtelligent:  NewAdtelligentSyncer(cfg.ExternalURL),
 		openrtb_ext.BidderAppnexus:     NewAppnexusSyncer(cfg.ExternalURL),
-		openrtb_ext.BidderFacebook:     NewFacebookSyncer(cfg.Adapters["facebook"].UserSyncURL),
+		openrtb_ext.BidderBrightroll:   NewBrightrollSyncer(cfg.Adapters["brightroll"].UserSyncURL, cfg.ExternalURL),
 		openrtb_ext.BidderConversant:   NewConversantSyncer(cfg.Adapters["conversant"].UserSyncURL, cfg.ExternalURL),
+		openrtb_ext.BidderEPlanning:    NewEPlanningSyncer(cfg.Adapters["eplanning"].UserSyncURL, cfg.ExternalURL),
+		openrtb_ext.BidderFacebook:     NewFacebookSyncer(cfg.Adapters["facebook"].UserSyncURL),
 		openrtb_ext.BidderIndex:        NewIndexSyncer(cfg.Adapters["indexexchange"].UserSyncURL),
 		openrtb_ext.BidderLifestreet:   NewLifestreetSyncer(cfg.ExternalURL),
 		openrtb_ext.BidderOpenx:        NewOpenxSyncer(cfg.ExternalURL),
@@ -22,11 +26,7 @@ func NewSyncerMap(cfg *config.Configuration) map[openrtb_ext.BidderName]usersync
 		openrtb_ext.BidderPulsepoint:   NewPulsepointSyncer(cfg.ExternalURL),
 		openrtb_ext.BidderRubicon:      NewRubiconSyncer(cfg.Adapters["rubicon"].UserSyncURL),
 		openrtb_ext.BidderSomoaudience: NewSomoaudienceSyncer(cfg.ExternalURL),
-		openrtb_ext.BidderAdform:       NewAdformSyncer(cfg.Adapters["adform"].UserSyncURL, cfg.ExternalURL),
 		openrtb_ext.BidderSovrn:        NewSovrnSyncer(cfg.ExternalURL, cfg.Adapters["sovrn"].UserSyncURL),
-		openrtb_ext.BidderAdtelligent:  NewAdtelligentSyncer(cfg.ExternalURL),
-		openrtb_ext.BidderEPlanning:    NewEPlanningSyncer(cfg.Adapters["eplanning"].UserSyncURL, cfg.ExternalURL),
-		openrtb_ext.BidderBrightroll:   NewBrightrollSyncer(cfg.Adapters["brightroll"].UserSyncURL, cfg.ExternalURL),
 	}
 }
 


### PR DESCRIPTION
This PR just has a few minor cleanups.

I alphabetized the various maps, because this reduces the chance of code conflicts when multiple adapters get submitted.

I also noticed in #516 that they were following the docs, but the docs for `FamilyName()` on the `Usersyncer` were outdated. This updates the docs, leaves a TODO there, and updates their usersync key to be the bidder name instead, to be consistent with all the other bidders out there.