### PR TITLE
Include binaries in releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,21 @@ install:
 
 script:
     - "./validate.sh --nofmt --cov --race 10"
+
+before_deploy:
+    - go get github.com/mitchellh/gox
     - gox -os="linux" -arch="386" -output="{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...;
+
 
 deploy:
   provider: releases
   skip_cleanup: true
   api_key:
-    secure: dntpbyF93gk5ZU89GDkFVYiOUbC+zeIzyUjwC3FO9/VtHu8RMPtck4eoNgmxh3QwWzdNwjfy2+3pbJN4Z6bWbq59fk7AqkFXI2UAg8/ELCBf4hjrS3JHExmCQumvOhMovO9uNy7rOttkULnve+4SZ3Um7lqXhl0h2G1YGbuPPQbe19UI6yVpKDSLcDrHwnEny1/UIxELaOdJiHkZFcSyD6vU2eei1U5P7aPyDCXhEkHrBpVbiNjSlfgN3DGBaFK6xX76NzWigyK6Ko5dAwlmEyLhO3yGYGp2g28pYzuM6tHCBGg6w9ON13e/iXDrrdmeWDUpsmvCRPlqD4mT9cWYIVFOdPmGdH3vL0FRC4fmgAMbGwExZqRcNtQR9M07YP/EKV5wSEvUYdl2XZCjpvkfl0MDyUGcFYKpnjjUCoaZkYOsUscJ4FUCk9O7P0bNKBZrajqJsEk8udByHgOYujLbEtmgkJsuMVtkaThWoedIF0jTAtN5S9UfTKk9bWbIioAhMIpt6BJSKKTydwYTKJkAU1sASkr/2vB7J6OL6LuntmF2mFTRK4ou8+3hNMFkUG0t5DfGd4VwIMyaSb1kDU1IKzWC/cLMw4zjQfyxjFQkUEEoWD+qIkMbp+oD2dSzNUjFsYFjNwWOAAFhwniy3m+YduNJY+rbZHMNQ2F8MKk1r1g=
+    secure: TSJcbIpg2zTJuzUXwv0Un5DPztDTeIKQ2BuuO9KiWYY3Td/nKn0flTYE6B5O6iVqE96HKyj2j0W51rhnRTNDReRZv76L+YXLTJOTQEEQY/A+7XaUXRT0KIbr1EHaeU+4uPJe/8YXxq+nFNeqOjj+LY457WbvnQTIbraAmCgi4yNq4JR+J9BoCELkX0SnU7oq+brq9tJNL3V+7EHIVH6ZLa1lWOrapMnbrVils8gwzWR8XpbdaI+Sn30AGOFKZ0WE2ojZkZb8oZxyX0HKarIiykfZUUzRhlXlTJ0D81QOdc5AtPNR/2dqUXsUE8mRav9R3AJM2BCS2pnP29orCRQU/kxS/mRfx2oZhkr+OHPsNbJcGNSbqNKlM13bX2nL1ZJsJ6xL0VrkBFYlI01SWR12CT9DhZSqTmGPNEkt3fdzwuYtkJNfthb9e9obscnmJEHPSiZRv9dv/stP5LVJJHfFdrzM4+Qo3MCxLNOhmc+p93gsZPeuDGDlx8Tqv1KpN7sp0glbmOwyFAwbCVh5can/JPIAKsQi9VRyZAJvn+7sqqZCExN4TvFArq7pe0LjIVHUQZP9g/vS8HobQnPutmGxf8HqzVVEBnjMsXuiY4cVRecXVRM7crfJjLGr2e9ywIkUZMSD+bRkbRUZ0QQQPvWtcgRw5JmLKG9jDklj8BDkON8=
   file:
     - prebid-server_linux_386
   on:
-    repo: criteo-forks/prebid-server
+    repo: prebid/prebid-server
     tags: true
     branch:
         - master
-        - criteo


### PR DESCRIPTION
This includes #553, with a few extra changes:

- The API key to one I just made & encrypted
- The repo to `prebid/prebid-server`
- The release branch to `master`
- Moves some commands to `before_deploy` so that they don't slow down normal PR builds

Thanks @benjaminch!

If you have time to test out using `before_deploy` in your fork, I'd definitely appreciate it. If not, not a huge deal.