### PR TITLE
Fixed the validation logic on unbounded caches

### DIFF
--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -330,8 +330,14 @@ func (inMemCache *InMemoryCache) validate() error {
 	case "none":
 		return nil
 	case "unbounded":
-		if inMemCache.TTL <= 0 {
-			return errors.New("Stored requests In-Memory caches need a TTL when unbounded")
+		if inMemCache.TTL != 0 {
+			return fmt.Errorf("stored_requests.in_memory_cache must be 0 for unbounded caches. Got %d", inMemCache.TTL)
+		}
+		if inMemCache.RequestCacheSize != 0 {
+			return fmt.Errorf("stored_requests.request_cache_size_bytes must be 0 for unbounded caches. Got %d", inMemCache.RequestCacheSize)
+		}
+		if inMemCache.ImpCacheSize != 0 {
+			return fmt.Errorf("stored_requests.imp_cache_size_bytes must be 0 for unbounded caches. Got %d", inMemCache.ImpCacheSize)
 		}
 		return nil
 	case "lru":

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -75,6 +75,59 @@ func TestPostgressConnString(t *testing.T) {
 	assertHasValue(t, params, "sslmode", "disable")
 }
 
+func TestInMemoryCacheValidation(t *testing.T) {
+	assertNilErr(t, (&InMemoryCache{
+		Type: "unbounded",
+	}).validate())
+	assertNilErr(t, (&InMemoryCache{
+		Type: "none",
+	}).validate())
+	assertNilErr(t, (&InMemoryCache{
+		Type:             "lru",
+		RequestCacheSize: 1000,
+		ImpCacheSize:     1000,
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type: "unrecognized",
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type:         "unbounded",
+		ImpCacheSize: 1000,
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type:             "unbounded",
+		RequestCacheSize: 1000,
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type: "unbounded",
+		TTL:  500,
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type:             "lru",
+		RequestCacheSize: 0,
+		ImpCacheSize:     1000,
+	}).validate())
+	assertErrExists(t, (&InMemoryCache{
+		Type:             "lru",
+		RequestCacheSize: 1000,
+		ImpCacheSize:     0,
+	}).validate())
+}
+
+func assertErrExists(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Error("Expected error was not not found.")
+	}
+}
+
+func assertNilErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+}
+
 func assertHasValue(t *testing.T, m map[string]string, key string, val string) {
 	t.Helper()
 	realVal, ok := m[key]


### PR DESCRIPTION
Bug from #539 which is blocking release... unbounded caches don't require a TTL. In fact they don't support one at all.

I also tightened up the validation on cache size, just because it was a little loose.