### PR TITLE
Consolidates 2 metrics engine functions and fixes missing metric from…

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -199,7 +199,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 					for _, bid := range bids.bids {
 						var cpm = float64(bid.bid.Price * 1000)
 						e.me.RecordAdapterPrice(*bidlabels, cpm)
-						e.me.RecordAdapterBidsReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")
+						e.me.RecordAdapterBidReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")
 					}
 				}
 			}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -199,7 +199,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 					for _, bid := range bids.bids {
 						var cpm = float64(bid.bid.Price * 1000)
 						e.me.RecordAdapterPrice(*bidlabels, cpm)
-						e.me.RecordAdapterBidAdm(*bidlabels, bid.bidType, bid.bid.AdM != "")
+						e.me.RecordAdapterBidsReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")
 					}
 				}
 			}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -267,9 +267,9 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 						deps.metricsEngine.RecordAdapterPrice(blables, cpm)
 						switch bid.CreativeMediaType {
 						case "banner":
-							deps.metricsEngine.RecordAdapterBidsReceived(blabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
+							deps.metricsEngine.RecordAdapterBidReceived(blabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
 						case "video":
-							deps.metricsEngine.RecordAdapterBidsReceived(blabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
+							deps.metricsEngine.RecordAdapterBidReceived(blabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
 						}
 						bid.ResponseTime = bidder.ResponseTime
 					}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -267,9 +267,9 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 						deps.metricsEngine.RecordAdapterPrice(blables, cpm)
 						switch bid.CreativeMediaType {
 						case "banner":
-							deps.metricsEngine.RecordAdapterBidAdm(blabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
+							deps.metricsEngine.RecordAdapterBidsReceived(blabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
 						case "video":
-							deps.metricsEngine.RecordAdapterBidAdm(blabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
+							deps.metricsEngine.RecordAdapterBidsReceived(blabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
 						}
 						bid.ResponseTime = bidder.ResponseTime
 					}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -262,7 +262,6 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 				} else if bid_list != nil {
 					bid_list = checkForValidBidSize(bid_list, bidder)
 					bidder.NumBids = len(bid_list)
-					deps.metricsEngine.RecordAdapterBidsReceived(blabels, int64(bidder.NumBids))
 					for _, bid := range bid_list {
 						var cpm = float64(bid.Price * 1000)
 						deps.metricsEngine.RecordAdapterPrice(blables, cpm)

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -331,21 +331,6 @@ func (me *Metrics) RecordAdapterRequest(labels AdapterLabels) {
 	}
 }
 
-// RecordAdapterBidsReceived implements a part of the MetricsEngine interface. This tracks the number of bids received
-// from a bidder.
-func (me *Metrics) RecordAdapterBidsReceived(labels AdapterLabels, bids int64) {
-	am, ok := me.AdapterMetrics[labels.Adapter]
-	if !ok {
-		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))
-		return
-	}
-	// Adapter metrics
-	am.BidsReceivedMeter.Mark(bids)
-	// Account-Adapter metrics
-	aam := me.getAccountMetrics(labels.PubID).adapterMetrics[labels.Adapter]
-	aam.BidsReceivedMeter.Mark(bids)
-}
-
 // RecordAdapterBidAdm implements a part of the MetricsEngine interface.
 // This tracks how many bids from each Bidder use `adm` vs. `nurl.
 func (me *Metrics) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
@@ -354,6 +339,12 @@ func (me *Metrics) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext
 		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))
 		return
 	}
+
+	// Adapter metrics
+	am.BidsReceivedMeter.Mark(1)
+	// Account-Adapter metrics
+	aam := me.getAccountMetrics(labels.PubID).adapterMetrics[labels.Adapter]
+	aam.BidsReceivedMeter.Mark(1)
 
 	if metricsForType, ok := am.MarkupMetrics[bidType]; ok {
 		if hasAdm {

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -331,9 +331,9 @@ func (me *Metrics) RecordAdapterRequest(labels AdapterLabels) {
 	}
 }
 
-// RecordAdapterBidsReceived implements a part of the MetricsEngine interface.
+// RecordAdapterBidReceived implements a part of the MetricsEngine interface.
 // This tracks how many bids from each Bidder use `adm` vs. `nurl.
-func (me *Metrics) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+func (me *Metrics) RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	am, ok := me.AdapterMetrics[labels.Adapter]
 	if !ok {
 		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -331,9 +331,9 @@ func (me *Metrics) RecordAdapterRequest(labels AdapterLabels) {
 	}
 }
 
-// RecordAdapterBidAdm implements a part of the MetricsEngine interface.
+// RecordAdapterBidsReceived implements a part of the MetricsEngine interface.
 // This tracks how many bids from each Bidder use `adm` vs. `nurl.
-func (me *Metrics) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+func (me *Metrics) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	am, ok := me.AdapterMetrics[labels.Adapter]
 	if !ok {
 		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -38,13 +38,13 @@ func TestRecordBidType(t *testing.T) {
 	registry := metrics.NewRegistry()
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
 
-	m.RecordAdapterBidAdm(AdapterLabels{
+	m.RecordAdapterBidsReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeBanner, true)
 	VerifyMetrics(t, "Appnexus Banner Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
 	VerifyMetrics(t, "Appnexus Banner Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
 
-	m.RecordAdapterBidAdm(AdapterLabels{
+	m.RecordAdapterBidsReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeVideo, false)
 	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -38,13 +38,13 @@ func TestRecordBidType(t *testing.T) {
 	registry := metrics.NewRegistry()
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
 
-	m.RecordAdapterBidsReceived(AdapterLabels{
+	m.RecordAdapterBidReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeBanner, true)
 	VerifyMetrics(t, "Appnexus Banner Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
 	VerifyMetrics(t, "Appnexus Banner Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
 
-	m.RecordAdapterBidsReceived(AdapterLabels{
+	m.RecordAdapterBidReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeVideo, false)
 	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -140,7 +140,7 @@ type MetricsEngine interface {
 	RecordAdapterRequest(labels AdapterLabels)
 	// This records whether or not a bid of a particular type uses `adm` or `nurl`.
 	// Since the legacy endpoints don't have a bid type, it can only count bids from OpenRTB and AMP.
-	RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
+	RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)
 	RecordAdapterTime(labels AdapterLabels, length time.Duration)
 	RecordCookieSync(labels Labels)        // May ignore all labels
@@ -224,10 +224,10 @@ func (me *MultiMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 	}
 }
 
-// RecordAdapterBidAdm across all engines
-func (me *MultiMetricsEngine) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+// RecordAdapterBidsReceived across all engines
+func (me *MultiMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	for _, thisME := range *me {
-		thisME.RecordAdapterBidAdm(labels, bidType, hasAdm)
+		thisME.RecordAdapterBidsReceived(labels, bidType, hasAdm)
 	}
 }
 
@@ -293,12 +293,7 @@ func (me *DummyMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 }
 
 // RecordAdapterBidsReceived as a noop
-func (me *DummyMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bids int64) {
-	return
-}
-
-// RecordAdapterBidAdm as a noop
-func (me *DummyMetricsEngine) RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+func (me *DummyMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	return
 }
 

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -138,7 +138,6 @@ type MetricsEngine interface {
 	RecordImps(labels Labels, numImps int)                 // ignores adapter. only statusOk and statusErr fom status
 	RecordRequestTime(labels Labels, length time.Duration) // ignores adapter. only statusOk and statusErr fom status
 	RecordAdapterRequest(labels AdapterLabels)
-	RecordAdapterBidsReceived(labels AdapterLabels, bids int64)
 	// This records whether or not a bid of a particular type uses `adm` or `nurl`.
 	// Since the legacy endpoints don't have a bid type, it can only count bids from OpenRTB and AMP.
 	RecordAdapterBidAdm(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
@@ -222,13 +221,6 @@ func (me *MultiMetricsEngine) RecordRequestTime(labels Labels, length time.Durat
 func (me *MultiMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 	for _, thisME := range *me {
 		thisME.RecordAdapterRequest(labels)
-	}
-}
-
-// RecordAdapterBidsReceived across all engines
-func (me *MultiMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bids int64) {
-	for _, thisME := range *me {
-		thisME.RecordAdapterBidsReceived(labels, bids)
 	}
 }
 

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -140,7 +140,7 @@ type MetricsEngine interface {
 	RecordAdapterRequest(labels AdapterLabels)
 	// This records whether or not a bid of a particular type uses `adm` or `nurl`.
 	// Since the legacy endpoints don't have a bid type, it can only count bids from OpenRTB and AMP.
-	RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
+	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)
 	RecordAdapterTime(labels AdapterLabels, length time.Duration)
 	RecordCookieSync(labels Labels)        // May ignore all labels
@@ -224,10 +224,10 @@ func (me *MultiMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 	}
 }
 
-// RecordAdapterBidsReceived across all engines
-func (me *MultiMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+// RecordAdapterBidReceived across all engines
+func (me *MultiMetricsEngine) RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	for _, thisME := range *me {
-		thisME.RecordAdapterBidsReceived(labels, bidType, hasAdm)
+		thisME.RecordAdapterBidReceived(labels, bidType, hasAdm)
 	}
 }
 
@@ -292,8 +292,8 @@ func (me *DummyMetricsEngine) RecordAdapterRequest(labels AdapterLabels) {
 	return
 }
 
-// RecordAdapterBidsReceived as a noop
-func (me *DummyMetricsEngine) RecordAdapterBidsReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
+// RecordAdapterBidReceived as a noop
+func (me *DummyMetricsEngine) RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	return
 }
 

--- a/pbsmetrics/metrics_test.go
+++ b/pbsmetrics/metrics_test.go
@@ -65,7 +65,6 @@ func TestMultiMetricsEngine(t *testing.T) {
 		metricsEngine.RecordRequestTime(labels, time.Millisecond*20)
 		metricsEngine.RecordAdapterRequest(blabels)
 		metricsEngine.RecordAdapterPrice(blabels, 1.34)
-		metricsEngine.RecordAdapterBidsReceived(blabels, 2)
 		metricsEngine.RecordAdapterTime(blabels, time.Millisecond*20)
 	}
 	VerifyMetrics(t, "RequestStatuses.OpenRTB2.OK", goEngine.RequestStatuses[ReqTypeORTB2][RequestStatusOK].Count(), 5)


### PR DESCRIPTION
… exchange

`RecordAdapterBidsReceived()` was missing from the openrtb code. Also this is mostly redundant with `RecordAdapterBidAdm()` as the total count from the second is the metric from the first. This collapses the counting into `RecordAdapterBidAdm()`, which happens to fix the missing `RecordAdapterBidsReceived()` from openrtb. 