### PR TITLE
Improve config logging & validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/spf13/viper"
 )
 
@@ -31,20 +33,52 @@ type Configuration struct {
 	GDPR                 GDPR               `mapstructure:"gdpr"`
 }
 
-func (cfg *Configuration) validate() error {
+type configErrors []error
+
+func (c configErrors) Error() string {
+	if len(c) == 0 {
+		return ""
+	}
+	buf := bytes.Buffer{}
+	buf.WriteString("validation errors are:\n\n")
+	for _, err := range c {
+		buf.WriteString("  ")
+		buf.WriteString(err.Error())
+		buf.WriteString("\n")
+	}
+	buf.WriteString("\n")
+	return buf.String()
+}
+
+func (cfg *Configuration) logValues() {
+	glog.Infof("external_url=%s", cfg.ExternalURL)
+	glog.Infof("host=%s", cfg.Host)
+	glog.Infof("port=%d", cfg.Port)
+	glog.Infof("admin_port=%d", cfg.AdminPort)
+	glog.Infof("status_response=%s", cfg.StatusResponse)
+	cfg.AuctionTimeouts.logValues()
+	cfg.CacheURL.logValues()
+	glog.Infof("recaptcha_secret=%s", cfg.RecaptchaSecret)
+	cfg.HostCookie.logValues()
+	cfg.Metrics.logValues()
+	cfg.DataCache.logValues()
+	cfg.StoredRequests.logValues()
+	// TODO: Log Adapter info
+	glog.Infof("max_request_size=%d", cfg.MaxRequestSize)
+	cfg.Analytics.logValues()
+	glog.Infof("amp_timeout_adjustment_ms=%d", cfg.AMPTimeoutAdjustment)
+	cfg.GDPR.logValues()
+}
+
+func (cfg *Configuration) validate() configErrors {
+	var errs configErrors
+	errs = cfg.AuctionTimeouts.validate(errs)
+	errs = cfg.StoredRequests.validate(errs)
 	if cfg.MaxRequestSize < 0 {
-		return fmt.Errorf("cfg.max_request_size must be a positive number. Got  %d", cfg.MaxRequestSize)
+		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))
 	}
-
-	if err := cfg.AuctionTimeouts.validate(); err != nil {
-		return err
-	}
-
-	if err := cfg.StoredRequests.validate(); err != nil {
-		return err
-	}
-
-	return cfg.GDPR.validate()
+	errs = cfg.GDPR.validate(errs)
+	return errs
 }
 
 type AuctionTimeouts struct {
@@ -54,11 +88,16 @@ type AuctionTimeouts struct {
 	Max uint64 `mapstructure:"max"`
 }
 
-func (cfg *AuctionTimeouts) validate() error {
+func (cfg *AuctionTimeouts) logValues() {
+	glog.Infof("auction_timeout_ms.default=%d", cfg.Default)
+	glog.Infof("auction_timeout_ms.max=%d", cfg.Max)
+}
+
+func (cfg *AuctionTimeouts) validate(errs configErrors) configErrors {
 	if cfg.Max < cfg.Default {
-		return fmt.Errorf("auction_timeouts_ms.max cannot be less than auction_timeouts_ms.default. max=%d, default=%d", cfg.Max, cfg.Default)
+		errs = append(errs, fmt.Errorf("auction_timeouts_ms.max cannot be less than auction_timeouts_ms.default. max=%d, default=%d", cfg.Max, cfg.Default))
 	}
-	return nil
+	return errs
 }
 
 // LimitAuctionTimeout returns the min of requested or cfg.MaxAuctionTimeout.
@@ -82,9 +121,27 @@ type GDPR struct {
 	Timeouts            GDPRTimeouts `mapstructure:"timeouts_ms"`
 }
 
+func (cfg *GDPR) logValues() {
+	glog.Infof("gdpr.host_vendor_id=%d", cfg.HostVendorID)
+	glog.Infof("gdpr.usersync_if_ambiguous=%t", cfg.UsersyncIfAmbiguous)
+	cfg.Timeouts.logValues()
+}
+
+func (cfg *GDPR) validate(errs configErrors) configErrors {
+	if cfg.HostVendorID < 0 || cfg.HostVendorID > 0xffff {
+		errs = append(errs, fmt.Errorf("gdpr.host_vendor_id must be in the range [0, %d]. Got %d", 0xffff, cfg.HostVendorID))
+	}
+	return errs
+}
+
 type GDPRTimeouts struct {
 	InitVendorlistFetch   int `mapstructure:"init_vendorlist_fetches"`
 	ActiveVendorlistFetch int `mapstructure:"active_vendorlist_fetch"`
+}
+
+func (cfg *GDPRTimeouts) logValues() {
+	glog.Infof("gdpr.timeouts_ms.init_vendorlist_fetches=%d", cfg.InitVendorlistFetch)
+	glog.Infof("gdpr.timeouts_ms.active_vendorlist_fetch=%d", cfg.ActiveVendorlistFetch)
 }
 
 func (t *GDPRTimeouts) InitTimeout() time.Duration {
@@ -95,21 +152,21 @@ func (t *GDPRTimeouts) ActiveTimeout() time.Duration {
 	return time.Duration(t.ActiveVendorlistFetch) * time.Millisecond
 }
 
-func (cfg *GDPR) validate() error {
-	if cfg.HostVendorID < 0 || cfg.HostVendorID > 0xffff {
-		return fmt.Errorf("host_vendor_id must be in the range [0, %d]. Got %d", 0xffff, cfg.HostVendorID)
-	}
-
-	return nil
-}
-
 type Analytics struct {
 	File FileLogs `mapstructure:"file"`
+}
+
+func (cfg *Analytics) logValues() {
+	cfg.File.logValues()
 }
 
 //Corresponding config for FileLogger as a PBS Analytics Module
 type FileLogs struct {
 	Filename string `mapstructure:"filename"`
+}
+
+func (cfg *FileLogs) logValues() {
+	glog.Infof("analytics.file.filename=%s", cfg.Filename)
 }
 
 type HostCookie struct {
@@ -121,6 +178,16 @@ type HostCookie struct {
 	OptOutCookie Cookie `mapstructure:"optout_cookie"`
 	// Cookie timeout in days
 	TTL int64 `mapstructure:"ttl_days"`
+}
+
+func (cfg *HostCookie) logValues() {
+	glog.Infof("host_cookie.domain=%s", cfg.Domain)
+	glog.Infof("host_cookie.family=%s", cfg.Family)
+	glog.Infof("host_cookie.cookie_name=%s", cfg.CookieName)
+	glog.Infof("host_cookie.opt_out_url=%s", cfg.OptOutURL)
+	glog.Infof("host_cookie.opt_in_url=%s", cfg.OptInURL)
+	glog.Infof("host_cookie.optout_cookie=%s", cfg.OptOutCookie)
+	glog.Infof("host_cookie.ttl_days=%d", cfg.TTL)
 }
 
 type Adapter struct {
@@ -138,6 +205,10 @@ type Metrics struct {
 	Influxdb InfluxMetrics `mapstructure:"influxdb"`
 }
 
+func (cfg *Metrics) logValues() {
+	cfg.Influxdb.logValues()
+}
+
 type InfluxMetrics struct {
 	Host     string `mapstructure:"host"`
 	Database string `mapstructure:"database"`
@@ -145,11 +216,25 @@ type InfluxMetrics struct {
 	Password string `mapstructure:"password"`
 }
 
+func (cfg *InfluxMetrics) logValues() {
+	glog.Infof("metrics.influxdb.host=%s", cfg.Host)
+	glog.Infof("metrics.influxdb.database=%s", cfg.Database)
+	glog.Infof("metrics.influxdb.username=%s", cfg.Username)
+	// Omit passwords from the log, for security
+}
+
 type DataCache struct {
 	Type       string `mapstructure:"type"`
 	Filename   string `mapstructure:"filename"`
 	CacheSize  int    `mapstructure:"cache_size"`
 	TTLSeconds int    `mapstructure:"ttl_seconds"`
+}
+
+func (cfg *DataCache) logValues() {
+	glog.Infof("datacache.type=%s", cfg.Type)
+	glog.Infof("datacache.filename=%s", cfg.Filename)
+	glog.Infof("datacache.cache_size=%d", cfg.CacheSize)
+	glog.Infof("datacache.ttl_seconds=%d", cfg.TTLSeconds)
 }
 
 type Cache struct {
@@ -169,18 +254,29 @@ type Cache struct {
 	ExpectedTimeMillis int `mapstructure:"expected_millis"`
 }
 
+func (cfg *Cache) logValues() {
+	glog.Infof("cache.scheme=%s", cfg.Scheme)
+	glog.Infof("cache.host=%s", cfg.Host)
+	glog.Infof("cache.query=%s", cfg.Query)
+	glog.Infof("cache.expected_millis=%d", cfg.ExpectedTimeMillis)
+}
+
 type Cookie struct {
 	Name  string `mapstructure:"name"`
 	Value string `mapstructure:"value"`
 }
 
-// New uses viper to get our server configurations
+// New uses viper to get our server configurations.
 func New(v *viper.Viper) (*Configuration, error) {
 	var c Configuration
 	if err := v.Unmarshal(&c); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("viper failed to unmarshal app config: %v", err)
 	}
-	return &c, c.validate()
+	c.logValues()
+	if errs := c.validate(); len(errs) > 0 {
+		return &c, errs
+	}
+	return &c, nil
 }
 
 //Allows for protocol relative URL if scheme is empty
@@ -291,5 +387,4 @@ func SetupViper(v *viper.Viper) {
 	v.SetEnvPrefix("PBS")
 	v.AutomaticEnv()
 	v.ReadInConfig()
-
 }

--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ func (cfg *HostCookie) logValues() {
 	glog.Infof("host_cookie.cookie_name=%s", cfg.CookieName)
 	glog.Infof("host_cookie.opt_out_url=%s", cfg.OptOutURL)
 	glog.Infof("host_cookie.opt_in_url=%s", cfg.OptInURL)
-	glog.Infof("host_cookie.optout_cookie=%s", cfg.OptOutCookie)
+	cfg.OptOutCookie.logValues()
 	glog.Infof("host_cookie.ttl_days=%d", cfg.TTL)
 }
 
@@ -264,6 +264,11 @@ func (cfg *Cache) logValues() {
 type Cookie struct {
 	Name  string `mapstructure:"name"`
 	Value string `mapstructure:"value"`
+}
+
+func (cfg *Cookie) logValues() {
+	glog.Infof("host_cookie.optout_cookie.name=%s", cfg.Name)
+	glog.Infof("host_cookie.optout_cookie.value=%s", cfg.Value)
 }
 
 // New uses viper to get our server configurations.

--- a/config/config.go
+++ b/config/config.go
@@ -63,7 +63,9 @@ func (cfg *Configuration) logValues() {
 	cfg.Metrics.logValues()
 	cfg.DataCache.logValues()
 	cfg.StoredRequests.logValues()
-	// TODO: Log Adapter info
+	for name, adapter := range cfg.Adapters {
+		adapter.logValues(name)
+	}
 	glog.Infof("max_request_size=%d", cfg.MaxRequestSize)
 	cfg.Analytics.logValues()
 	glog.Infof("amp_timeout_adjustment_ms=%d", cfg.AMPTimeoutAdjustment)
@@ -199,6 +201,15 @@ type Adapter struct {
 		Password string `mapstructure:"password"`
 		Tracker  string `mapstructure:"tracker"`
 	} `mapstructure:"xapi"` // needed for Rubicon
+}
+
+func (cfg *Adapter) logValues(name string) {
+	glog.Infof("adapters.%s.endpoint=%s", name, cfg.Endpoint)
+	glog.Infof("adapters.%s.usersync_url=%s", name, cfg.UserSyncURL)
+	glog.Infof("adapters.%s.platform_id=%s", name, cfg.PlatformID)
+	glog.Infof("adapters.%s.xapi.username=%s", name, cfg.XAPI.Username)
+	// Don't log passwords for security reasons
+	glog.Infof("adapters.%s.xapi.tracker=%s", name, cfg.XAPI.Tracker)
 }
 
 type Metrics struct {

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -118,12 +118,10 @@ func (cfg *PostgresConfig) validate(errs configErrors) configErrors {
 }
 
 func (cfg *PostgresConfig) logValues() {
-	if cfg.ConnectionInfo.Database != "" {
-		cfg.ConnectionInfo.logValues()
-		cfg.FetcherQueries.logValues()
-		cfg.CacheInitialization.logValues()
-		cfg.PollUpdates.logValues()
-	}
+	cfg.ConnectionInfo.logValues()
+	cfg.FetcherQueries.logValues()
+	cfg.CacheInitialization.logValues()
+	cfg.PollUpdates.logValues()
 }
 
 // PostgresConnection has options which put types to the Postgres Connection string. See:
@@ -249,12 +247,10 @@ func (cfg *PostgresCacheInitializer) validate(errs configErrors) configErrors {
 }
 
 func (cfg *PostgresCacheInitializer) logValues() {
-	if cfg.Query == "" && cfg.AmpQuery == "" {
-		glog.Infof("The postgres cache will not load Stored Request data at startup. Requests may be slow for a bit.")
-		return
-	}
-
 	glog.Infof("initialize_caches.timeout_ms=%d", cfg.Timeout)
+	glog.Infof("initialize_caches.query=%s", cfg.Query)
+	glog.Infof("initialize_caches.amp_query=%d", cfg.AmpQuery)
+
 }
 
 type PostgresUpdatePolling struct {

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -405,8 +405,8 @@ func (cfg *InMemoryCache) validate(errs configErrors) configErrors {
 }
 
 func (cfg *InMemoryCache) logValues() {
-	glog.Info("stored_requests.in_memory_cache.type=%s", cfg.Type)
-	glog.Info("stored_requests.in_memory_cache.ttl=%d", cfg.TTL)
-	glog.Info("stored_requests.in_memory_cache.request_cache_size_bytes=%d", cfg.RequestCacheSize)
-	glog.Info("stored_requests.in_memory_cache.imp_cache_size_bytes=%d", cfg.ImpCacheSize)
+	glog.Infof("stored_requests.in_memory_cache.type=%s", cfg.Type)
+	glog.Infof("stored_requests.in_memory_cache.ttl=%d", cfg.TTL)
+	glog.Infof("stored_requests.in_memory_cache.request_cache_size_bytes=%d", cfg.RequestCacheSize)
+	glog.Infof("stored_requests.in_memory_cache.imp_cache_size_bytes=%d", cfg.ImpCacheSize)
 }

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -51,35 +51,53 @@ func (cfg HTTPEventsConfig) RefreshRateDuration() time.Duration {
 	return time.Duration(cfg.RefreshRate) * time.Second
 }
 
+func (cfg *HTTPEventsConfig) logValues() {
+	glog.Infof("stored_requests.http_events.amp_endpoint=%s", cfg.AmpEndpoint)
+	glog.Infof("stored_requests.http_events.endpoint=%s", cfg.AmpEndpoint)
+	glog.Infof("stored_requests.http_events.refresh_rate_seconds=%d", cfg.RefreshRate)
+	glog.Infof("stored_requests.http_events.timeout_ms=%d", cfg.Timeout)
+}
+
 // HTTPFetcherConfig configures a stored_requests/backends/http_fetcher/fetcher.go
 type HTTPFetcherConfig struct {
 	Endpoint    string `mapstructure:"endpoint"`
 	AmpEndpoint string `mapstructure:"amp_endpoint"`
 }
 
-func (cfg *StoredRequests) validate() error {
+func (cfg *HTTPFetcherConfig) logValues() {
+	glog.Infof("stored_requests.http.endpoint=%s", cfg.Endpoint)
+	glog.Infof("stored_requests.http.amp_endpoint=%s", cfg.AmpEndpoint)
+}
+
+func (cfg *StoredRequests) logValues() {
+	glog.Infof("stored_requests.filesystem=%t", cfg.Files)
+	cfg.Postgres.logValues()
+	cfg.HTTP.logValues()
+	cfg.InMemoryCache.logValues()
+	glog.Infof("stored_requests.cache_events_api=%t", cfg.CacheEventsAPI)
+	cfg.HTTPEvents.logValues()
+}
+
+func (cfg *StoredRequests) validate(errs configErrors) configErrors {
 	if cfg.InMemoryCache.Type == "none" {
 		if cfg.CacheEventsAPI {
-			return errors.New("stored_requests.cache_events_api requires a configured in_memory_cache")
+			errs = append(errs, errors.New("stored_requests.cache_events_api must be false if stored_requests.in_memory_cache=none"))
 		}
 
 		if cfg.HTTPEvents.RefreshRate != 0 {
-			return errors.New("stored_requests.http_events requires a configured in_memory_cache")
+			errs = append(errs, errors.New("stored_requests.http_events.refresh_rate_seconds must be 0 if stored_requests.in_memory_cache=none"))
 		}
 
 		if cfg.Postgres.PollUpdates.Query != "" {
-			return errors.New("stored_requests.poll_for_updates requires a configured in_memory_cache")
+			errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.query must be empty if stored_requests.in_memory_cache=none"))
 		}
 		if cfg.Postgres.CacheInitialization.Query != "" {
-			return errors.New("stored_requests.initialize_caches requires a configured in_memory_cache")
+			errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.query must be empty if stored_requests.in_memory_cache=none"))
 		}
 	}
-
-	if err := cfg.InMemoryCache.validate(); err != nil {
-		return err
-	}
-
-	return cfg.Postgres.validate()
+	errs = cfg.InMemoryCache.validate(errs)
+	errs = cfg.Postgres.validate(errs)
+	return errs
 }
 
 // PostgresConfig configures the Stored Request ecosystem to use Postgres. This must include a Fetcher,
@@ -91,35 +109,21 @@ type PostgresConfig struct {
 	PollUpdates         PostgresUpdatePolling    `mapstructure:"poll_for_updates"`
 }
 
-func (cfg *PostgresConfig) validate() error {
+func (cfg *PostgresConfig) validate(errs configErrors) configErrors {
 	if cfg.ConnectionInfo.Database == "" {
-		return nil
+		return errs
 	}
 
-	return cfg.PollUpdates.validate()
+	return cfg.PollUpdates.validate(errs)
 }
 
-func (cfg *PostgresUpdatePolling) validate() error {
-	if cfg.Query == "" && cfg.AmpQuery == "" {
-		return nil
+func (cfg *PostgresConfig) logValues() {
+	if cfg.ConnectionInfo.Database != "" {
+		cfg.ConnectionInfo.logValues()
+		cfg.FetcherQueries.logValues()
+		cfg.CacheInitialization.logValues()
+		cfg.PollUpdates.logValues()
 	}
-
-	if cfg.RefreshRate <= 0 {
-		return errors.New("stored_requests.postgres.poll_for_updates.refresh_rate_seconds must be positive.")
-	}
-
-	if cfg.Timeout <= 0 {
-		return errors.New("stored_requests.postgres.poll_for_updates.timeout_ms must be positive.")
-	}
-
-	if !strings.Contains(cfg.Query, "$1") || strings.Contains(cfg.Query, "$2") {
-		return errors.New("stored_requests.postgres.poll_for_updates.query must contain exactly one wildcard.")
-	}
-	if !strings.Contains(cfg.AmpQuery, "$1") || strings.Contains(cfg.AmpQuery, "$2") {
-		return errors.New("stored_requests.postgres.poll_for_updates.amp_query must contain exactly one wildcard.")
-	}
-
-	return nil
 }
 
 // PostgresConnection has options which put types to the Postgres Connection string. See:
@@ -130,6 +134,14 @@ type PostgresConnection struct {
 	Port     int    `mapstructure:"port"`
 	Username string `mapstructure:"user"`
 	Password string `mapstructure:"password"`
+}
+
+func (cfg *PostgresConnection) logValues() {
+	glog.Infof("stored_requests.postgres.connection.dbname=%s", cfg.Database)
+	glog.Infof("stored_requests.postgres.connection.host=%s", cfg.Host)
+	glog.Infof("stored_requests.postgres.connection.port=%d", cfg.Port)
+	glog.Infof("stored_requests.postgres.connection.user=%s", cfg.Username)
+	// Don't log the password here for security reasons
 }
 
 func (cfg *PostgresConnection) ConnString() string {
@@ -198,6 +210,11 @@ type PostgresFetcherQueries struct {
 	AmpQueryTemplate string `mapstructure:"amp_query"`
 }
 
+func (cfg *PostgresFetcherQueries) logValues() {
+	glog.Infof("stored_requests.postgres.fetcher.query=%s", cfg.QueryTemplate)
+	glog.Infof("stored_requests.postgres.fetcher.amp_query=%s", cfg.AmpQueryTemplate)
+}
+
 type PostgresCacheInitializer struct {
 	Timeout int `mapstructure:"timeout_ms"`
 	// Query should be something like:
@@ -214,20 +231,30 @@ type PostgresCacheInitializer struct {
 	AmpQuery string `mapstructure:"amp_query"`
 }
 
-func (cfg *PostgresCacheInitializer) validate() error {
+func (cfg *PostgresCacheInitializer) validate(errs configErrors) configErrors {
 	if cfg.Query == "" && cfg.AmpQuery == "" {
-		return nil
+		return errs
 	}
+
 	if cfg.Timeout <= 0 {
-		return errors.New("stored_requests.postgres.initialize_caches.timeout_ms must be positive.")
+		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.timeout_ms must be positive"))
 	}
 	if strings.Contains(cfg.Query, "$") {
-		return errors.New("stored_requests.postgres.initialize_caches.query should not contain any wildcards.")
+		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.query should not contain any wildcards (e.g. $1)"))
 	}
 	if strings.Contains(cfg.AmpQuery, "$") {
-		return errors.New("stored_requests.postgres.initialize_caches.amp_query cannot contain any wildcards.")
+		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.amp_query should not contain any wildcards (e.g. $1)"))
 	}
-	return nil
+	return errs
+}
+
+func (cfg *PostgresCacheInitializer) logValues() {
+	if cfg.Query == "" && cfg.AmpQuery == "" {
+		glog.Infof("The postgres cache will not load Stored Request data at startup. Requests may be slow for a bit.")
+		return
+	}
+
+	glog.Infof("initialize_caches.timeout_ms=%d", cfg.Timeout)
 }
 
 type PostgresUpdatePolling struct {
@@ -252,6 +279,35 @@ type PostgresUpdatePolling struct {
 
 	// AmpQuery is the same as Query, but used for the `/openrtb2/amp` endpoint.
 	AmpQuery string `mapstructure:"amp_query"`
+}
+
+func (cfg *PostgresUpdatePolling) logValues() {
+	glog.Infof("stored_requests.postgres.poll_for_updates.refresh_rate_seconds=%d", cfg.RefreshRate)
+	glog.Infof("stored_requests.postgres.poll_for_updates.timeout_ms=%d", cfg.Timeout)
+	glog.Infof("stored_requests.postgres.poll_for_updates.query=%s", cfg.Query)
+	glog.Infof("stored_requests.postgres.poll_for_updates.amp_query=%s", cfg.AmpQuery)
+}
+
+func (cfg *PostgresUpdatePolling) validate(errs configErrors) configErrors {
+	if cfg.Query == "" && cfg.AmpQuery == "" {
+		return errs
+	}
+
+	if cfg.RefreshRate <= 0 {
+		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.refresh_rate_seconds must be > 0"))
+	}
+
+	if cfg.Timeout <= 0 {
+		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.timeout_ms must be > 0"))
+	}
+
+	if !strings.Contains(cfg.Query, "$1") || strings.Contains(cfg.Query, "$2") {
+		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.query must contain exactly one wildcard"))
+	}
+	if !strings.Contains(cfg.AmpQuery, "$1") || strings.Contains(cfg.AmpQuery, "$2") {
+		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.amp_query must contain exactly one wildcard"))
+	}
+	return errs
 }
 
 // MakeQuery builds a query which can fetch numReqs Stored Requetss and numImps Stored Imps.
@@ -325,27 +381,36 @@ type InMemoryCache struct {
 	ImpCacheSize int `mapstructure:"imp_cache_size_bytes"`
 }
 
-func (inMemCache *InMemoryCache) validate() error {
-	switch inMemCache.Type {
+func (cfg *InMemoryCache) validate(errs configErrors) configErrors {
+	switch cfg.Type {
 	case "none":
-		return nil
+		// No errors for no config options
 	case "unbounded":
-		if inMemCache.TTL != 0 {
-			return fmt.Errorf("stored_requests.in_memory_cache must be 0 for unbounded caches. Got %d", inMemCache.TTL)
+		if cfg.TTL != 0 {
+			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache must be 0 for unbounded caches. Got %d", cfg.TTL))
 		}
-		if inMemCache.RequestCacheSize != 0 {
-			return fmt.Errorf("stored_requests.request_cache_size_bytes must be 0 for unbounded caches. Got %d", inMemCache.RequestCacheSize)
+		if cfg.RequestCacheSize != 0 {
+			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.request_cache_size_bytes must be 0 for unbounded caches. Got %d", cfg.RequestCacheSize))
 		}
-		if inMemCache.ImpCacheSize != 0 {
-			return fmt.Errorf("stored_requests.imp_cache_size_bytes must be 0 for unbounded caches. Got %d", inMemCache.ImpCacheSize)
+		if cfg.ImpCacheSize != 0 {
+			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.imp_cache_size_bytes must be 0 for unbounded caches. Got %d", cfg.ImpCacheSize))
 		}
-		return nil
 	case "lru":
-		if inMemCache.RequestCacheSize <= 0 || inMemCache.ImpCacheSize <= 0 {
-			return fmt.Errorf("Stored requests In-Memory caches need finite sizes when set to lru. Given: TTL=%d, request-cache-size=%d, imp-cache-size=%d.", inMemCache.TTL, inMemCache.RequestCacheSize, inMemCache.ImpCacheSize)
+		if cfg.RequestCacheSize <= 0 {
+			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.request_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got %d", cfg.RequestCacheSize))
 		}
-		return nil
+		if cfg.ImpCacheSize <= 0 {
+			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.imp_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got %d", cfg.ImpCacheSize))
+		}
+	default:
+		errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.type %s is invalid", cfg.Type))
 	}
+	return errs
+}
 
-	return fmt.Errorf("Stored requests In-Memory cache set to unknown type \"%s\". Given: TTL=%d, request-cache-size=%d, imp-cache-size=%d.", inMemCache.Type, inMemCache.TTL, inMemCache.RequestCacheSize, inMemCache.ImpCacheSize)
+func (cfg *InMemoryCache) logValues() {
+	glog.Info("stored_requests.in_memory_cache.type=%s", cfg.Type)
+	glog.Info("stored_requests.in_memory_cache.ttl=%d", cfg.TTL)
+	glog.Info("stored_requests.in_memory_cache.request_cache_size_bytes=%d", cfg.RequestCacheSize)
+	glog.Info("stored_requests.in_memory_cache.imp_cache_size_bytes=%d", cfg.ImpCacheSize)
 }

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -76,54 +76,54 @@ func TestPostgressConnString(t *testing.T) {
 }
 
 func TestInMemoryCacheValidation(t *testing.T) {
-	assertNilErr(t, (&InMemoryCache{
+	assertNoErrs(t, (&InMemoryCache{
 		Type: "unbounded",
-	}).validate())
-	assertNilErr(t, (&InMemoryCache{
+	}).validate(nil))
+	assertNoErrs(t, (&InMemoryCache{
 		Type: "none",
-	}).validate())
-	assertNilErr(t, (&InMemoryCache{
+	}).validate(nil))
+	assertNoErrs(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     1000,
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type: "unrecognized",
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type:         "unbounded",
 		ImpCacheSize: 1000,
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type:             "unbounded",
 		RequestCacheSize: 1000,
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type: "unbounded",
 		TTL:  500,
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 0,
 		ImpCacheSize:     1000,
-	}).validate())
-	assertErrExists(t, (&InMemoryCache{
+	}).validate(nil))
+	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     0,
-	}).validate())
+	}).validate(nil))
 }
 
-func assertErrExists(t *testing.T, err error) {
+func assertErrsExist(t *testing.T, err configErrors) {
 	t.Helper()
-	if err == nil {
+	if len(err) == 0 {
 		t.Error("Expected error was not not found.")
 	}
 }
 
-func assertNilErr(t *testing.T, err error) {
+func assertNoErrs(t *testing.T, err configErrors) {
 	t.Helper()
-	if err != nil {
+	if len(err) > 0 {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 }

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -124,7 +124,7 @@ func assertErrsExist(t *testing.T, err configErrors) {
 func assertNoErrs(t *testing.T, err configErrors) {
 	t.Helper()
 	if len(err) > 0 {
-		t.Errorf("Got unexpected error: %v", err)
+		t.Errorf("Got unexpected error(s): %v", err)
 	}
 }
 

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -646,7 +646,7 @@ func main() {
 	config.SetupViper(v)
 	cfg, err := config.New(v)
 	if err != nil {
-		glog.Fatalf("Viper was unable to read configurations: %v", err)
+		glog.Fatalf("Configuration could not be loaded or did not pass validation: %v", err)
 	}
 
 	if err := serve(cfg); err != nil {


### PR DESCRIPTION
There should be no breaking changes here. Goals are to:

1. Log all the config values which _aren't_ sensitive (e.g. passwords) when the app starts.
2. Validate the entire config at once, and return all the error messages rather than quitting after the first one.

A bad config produces errs like these on app startup:

```bash
I0613 11:35:43.478783   62284 config.go:127] gdpr.host_vendor_id=32
I0613 11:35:43.478787   62284 config.go:128] gdpr.usersync_if_ambiguous=false
I0613 11:35:43.478792   62284 config.go:145] gdpr.timeouts_ms.init_vendorlist_fetches=60000
I0613 11:35:43.478797   62284 config.go:146] gdpr.timeouts_ms.active_vendorlist_fetch=1000
F0613 11:35:43.478809   62284 pbs_light.go:649] Configuration could not be loaded or did not pass validation: validation errors are:

  stored_requests.in_memory_cache.request_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got 0
  stored_requests.in_memory_cache.imp_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got 0

dbemiller-mac:prebid-server dbemiller$
```