### PR TITLE
Moves metrics definitions to its own package to avoid circular depend…

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/usersync"
 )
 
@@ -49,7 +50,7 @@ func (deps *cookieSyncDeps) Endpoint(w http.ResponseWriter, r *http.Request, _ h
 
 	defer deps.pbsAnalytics.LogCookieSyncObject(&co)
 
-	deps.metrics.RecordCookieSync(pbsmetrics.Labels{})
+	deps.metrics.RecordCookieSync(metricsdef.Labels{})
 	userSyncCookie := usersync.ParsePBSCookieFromRequest(r, deps.optOutCookie)
 	if !userSyncCookie.AllowSyncs() {
 		http.Error(w, "User has opted out", http.StatusUnauthorized)

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -57,13 +58,13 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	// Set this as an AMP request in Metrics.
 
 	start := time.Now()
-	labels := pbsmetrics.Labels{
-		Source:        pbsmetrics.DemandUnknown,
-		RType:         pbsmetrics.ReqTypeAMP,
+	labels := metricsdef.Labels{
+		Source:        metricsdef.DemandUnknown,
+		RType:         metricsdef.ReqTypeAMP,
 		PubID:         "",
-		Browser:       pbsmetrics.BrowserOther,
-		CookieFlag:    pbsmetrics.CookieFlagUnknown,
-		RequestStatus: pbsmetrics.RequestStatusOK,
+		Browser:       metricsdef.BrowserOther,
+		CookieFlag:    metricsdef.CookieFlagUnknown,
+		RequestStatus: metricsdef.RequestStatusOK,
 	}
 	defer func() {
 		deps.metricsEngine.RecordRequest(labels)
@@ -74,7 +75,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	isSafari := checkSafari(r)
 	if isSafari {
-		labels.Browser = pbsmetrics.BrowserSafari
+		labels.Browser = metricsdef.BrowserSafari
 	}
 
 	// Add AMP headers
@@ -98,7 +99,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 			w.Write([]byte(fmt.Sprintf("Invalid request format: %s\n", err.Error())))
 		}
 		ao.Errors = append(ao.Errors, errL...)
-		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
+		labels.RequestStatus = metricsdef.RequestStatusBadInput
 		return
 	}
 
@@ -113,13 +114,13 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie.OptOutCookie))
 	if req.App != nil {
-		labels.Source = pbsmetrics.DemandApp
+		labels.Source = metricsdef.DemandApp
 	} else {
-		labels.Source = pbsmetrics.DemandWeb
+		labels.Source = metricsdef.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
-			labels.CookieFlag = pbsmetrics.CookieFlagNo
+			labels.CookieFlag = metricsdef.CookieFlagNo
 		} else {
-			labels.CookieFlag = pbsmetrics.CookieFlagYes
+			labels.CookieFlag = metricsdef.CookieFlagYes
 		}
 	}
 	response, err := deps.ex.HoldAuction(ctx, req, usersyncs, labels)

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -320,7 +321,7 @@ type mockAmpExchange struct {
 	lastRequest *openrtb.BidRequest
 }
 
-func (m *mockAmpExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels pbsmetrics.Labels) (*openrtb.BidResponse, error) {
+func (m *mockAmpExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels metricsdef.Labels) (*openrtb.BidResponse, error) {
 	m.lastRequest = bidRequest
 
 	response := &openrtb.BidResponse{

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/prebid"
 	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/prebid/prebid-server/usersync"
@@ -63,13 +64,13 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	// We can respect timeouts more accurately if we note the *real* start time, and use it
 	// to compute the auction timeout.
 	start := time.Now()
-	labels := pbsmetrics.Labels{
-		Source:        pbsmetrics.DemandUnknown,
-		RType:         pbsmetrics.ReqTypeORTB2,
+	labels := metricsdef.Labels{
+		Source:        metricsdef.DemandUnknown,
+		RType:         metricsdef.ReqTypeORTB2,
 		PubID:         "",
-		Browser:       pbsmetrics.BrowserOther,
-		CookieFlag:    pbsmetrics.CookieFlagUnknown,
-		RequestStatus: pbsmetrics.RequestStatusOK,
+		Browser:       metricsdef.BrowserOther,
+		CookieFlag:    metricsdef.CookieFlagUnknown,
+		RequestStatus: metricsdef.RequestStatusOK,
 	}
 	numImps := 0
 	defer func() {
@@ -81,13 +82,13 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	isSafari := checkSafari(r)
 	if isSafari {
-		labels.Browser = pbsmetrics.BrowserSafari
+		labels.Browser = metricsdef.BrowserSafari
 	}
 
 	req, errL := deps.parseRequest(r)
 
 	if writeError(errL, w) {
-		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
+		labels.RequestStatus = metricsdef.RequestStatusBadInput
 		return
 	}
 
@@ -108,13 +109,13 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie.OptOutCookie))
 	if req.App != nil {
-		labels.Source = pbsmetrics.DemandApp
+		labels.Source = metricsdef.DemandApp
 	} else {
-		labels.Source = pbsmetrics.DemandWeb
+		labels.Source = metricsdef.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
-			labels.CookieFlag = pbsmetrics.CookieFlagNo
+			labels.CookieFlag = metricsdef.CookieFlagNo
 		} else {
-			labels.CookieFlag = pbsmetrics.CookieFlagYes
+			labels.CookieFlag = metricsdef.CookieFlagYes
 		}
 	}
 
@@ -123,7 +124,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	ao.Request = req
 	ao.Response = response
 	if err != nil {
-		labels.RequestStatus = pbsmetrics.RequestStatusErr
+		labels.RequestStatus = metricsdef.RequestStatusErr
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "Critical error while running the auction: %v", err)
 		glog.Errorf("/openrtb2/auction Critical error: %v", err)

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
 	"github.com/rcrowley/go-metrics"
 )
@@ -497,7 +498,7 @@ type nobidExchange struct {
 	gotRequest *openrtb.BidRequest
 }
 
-func (e *nobidExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels pbsmetrics.Labels) (*openrtb.BidResponse, error) {
+func (e *nobidExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels metricsdef.Labels) (*openrtb.BidResponse, error) {
 	e.gotRequest = bidRequest
 	return &openrtb.BidResponse{
 		ID:    bidRequest.ID,
@@ -508,7 +509,7 @@ func (e *nobidExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.Bid
 
 type brokenExchange struct{}
 
-func (e *brokenExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels pbsmetrics.Labels) (*openrtb.BidResponse, error) {
+func (e *brokenExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels metricsdef.Labels) (*openrtb.BidResponse, error) {
 	return nil, errors.New("Critical, unrecoverable error.")
 }
 
@@ -811,7 +812,7 @@ type mockExchange struct {
 	lastRequest *openrtb.BidRequest
 }
 
-func (m *mockExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels pbsmetrics.Labels) (*openrtb.BidResponse, error) {
+func (m *mockExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidRequest, ids exchange.IdFetcher, labels metricsdef.Labels) (*openrtb.BidResponse, error) {
 	m.lastRequest = bidRequest
 	return &openrtb.BidResponse{
 		SeatBid: []openrtb.SeatBid{{

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/usersync"
 )
 
@@ -27,7 +28,7 @@ func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalyti
 		pc := usersync.ParsePBSCookieFromRequest(r, &cfg.OptOutCookie)
 		if !pc.AllowSyncs() {
 			w.WriteHeader(http.StatusUnauthorized)
-			metrics.RecordUserIDSet(pbsmetrics.UserLabels{Action: pbsmetrics.RequestActionOptOut})
+			metrics.RecordUserIDSet(metricsdef.UserLabels{Action: metricsdef.RequestActionOptOut})
 			so.Status = http.StatusUnauthorized
 			return
 		}
@@ -37,8 +38,8 @@ func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalyti
 		if shouldReturn, status, body := preventSyncsGDPR(query.Get("gdpr"), query.Get("gdpr_consent"), perms); shouldReturn {
 			w.WriteHeader(status)
 			w.Write([]byte(body))
-			metrics.RecordUserIDSet(pbsmetrics.UserLabels{
-				Action: pbsmetrics.RequestActionGDPR,
+			metrics.RecordUserIDSet(metricsdef.UserLabels{
+				Action: metricsdef.RequestActionGDPR,
 				Bidder: openrtb_ext.BidderName(bidder),
 			})
 			so.Status = status
@@ -48,8 +49,8 @@ func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalyti
 		if bidder == "" {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(`"bidder" query param is required`))
-			metrics.RecordUserIDSet(pbsmetrics.UserLabels{
-				Action: pbsmetrics.RequestActionErr,
+			metrics.RecordUserIDSet(metricsdef.UserLabels{
+				Action: metricsdef.RequestActionErr,
 				Bidder: openrtb_ext.BidderName(bidder),
 			})
 			so.Status = http.StatusBadRequest
@@ -68,8 +69,8 @@ func NewSetUIDEndpoint(cfg config.HostCookie, perms gdpr.Permissions, pbsanalyti
 		}
 
 		if err == nil {
-			labels := pbsmetrics.UserLabels{
-				Action: pbsmetrics.RequestActionSet,
+			labels := metricsdef.UserLabels{
+				Action: metricsdef.RequestActionSet,
 				Bidder: openrtb_ext.BidderName(bidder),
 			}
 			metrics.RecordUserIDSet(labels)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/rcrowley/go-metrics"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
@@ -72,7 +73,7 @@ func TestRaceIntegration(t *testing.T) {
 
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	ex := NewExchange(server.Client(), &wellBehavedCache{}, cfg, theMetrics)
-	_, err := ex.HoldAuction(context.Background(), newRaceCheckingRequest(t), &emptyUsersync{}, pbsmetrics.Labels{})
+	_, err := ex.HoldAuction(context.Background(), newRaceCheckingRequest(t), &emptyUsersync{}, metricsdef.Labels{})
 	if err != nil {
 		t.Errorf("HoldAuction returned unexpected error: %v", err)
 	}
@@ -193,7 +194,7 @@ func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
 	}
 	ex := newExchangeForTests(t, filename, spec.OutgoingRequests, aliases)
 	biddersInAuction := findBiddersInAuction(t, filename, &spec.IncomingRequest.OrtbRequest)
-	bid, err := ex.HoldAuction(context.Background(), &spec.IncomingRequest.OrtbRequest, mockIdFetcher(spec.IncomingRequest.Usersyncs), pbsmetrics.Labels{})
+	bid, err := ex.HoldAuction(context.Background(), &spec.IncomingRequest.OrtbRequest, mockIdFetcher(spec.IncomingRequest.Usersyncs), metricsdef.Labels{})
 	responseTimes := extractResponseTimes(t, filename, bid)
 	for _, bidderName := range biddersInAuction {
 		if _, ok := responseTimes[bidderName]; !ok {

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
@@ -84,7 +85,7 @@ func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*op
 		req.Site = &openrtb.Site{}
 	}
 
-	bidResp, err := ex.HoldAuction(context.Background(), req, &mockFetcher{}, pbsmetrics.Labels{})
+	bidResp, err := ex.HoldAuction(context.Background(), req, &mockFetcher{}, metricsdef.Labels{})
 
 	if err != nil {
 		t.Fatalf("Unexpected errors running auction: %v", err)

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/usersync/usersyncers"
 )
@@ -359,7 +360,7 @@ func TestCacheVideoOnly(t *testing.T) {
 		HostVendorID: 0,
 	}, nil, nil)
 	prebid_cache_client.InitPrebidCache(server.URL)
-	cacheVideoOnly(bids, ctx, w, &auctionDeps{cfg, syncers, gdprPerms, &pbsmetrics.DummyMetricsEngine{}}, &pbsmetrics.Labels{})
+	cacheVideoOnly(bids, ctx, w, &auctionDeps{cfg, syncers, gdprPerms, &pbsmetrics.DummyMetricsEngine{}}, &metricsdef.Labels{})
 	if bids[0].CacheID != "UUID-1" {
 		t.Errorf("UUID was '%s', should have been 'UUID-1'", bids[0].CacheID)
 	}

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -23,28 +24,28 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "usersync.rubicon.gdpr_prevent", m.userSyncGDPRPrevent["rubicon"])
 	ensureContains(t, registry, "usersync.unknown.gdpr_prevent", m.userSyncGDPRPrevent["unknown"])
 
-	ensureContains(t, registry, "requests.ok.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusOK])
-	ensureContains(t, registry, "requests.badinput.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusBadInput])
-	ensureContains(t, registry, "requests.err.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusErr])
-	ensureContains(t, registry, "requests.ok.openrtb2", m.RequestStatuses[ReqTypeORTB2][RequestStatusOK])
-	ensureContains(t, registry, "requests.badinput.openrtb2", m.RequestStatuses[ReqTypeORTB2][RequestStatusBadInput])
-	ensureContains(t, registry, "requests.err.openrtb2", m.RequestStatuses[ReqTypeORTB2][RequestStatusErr])
-	ensureContains(t, registry, "requests.ok.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusOK])
-	ensureContains(t, registry, "requests.badinput.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusBadInput])
-	ensureContains(t, registry, "requests.err.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusErr])
+	ensureContains(t, registry, "requests.ok.legacy", m.RequestStatuses[metricsdef.ReqTypeLegacy][metricsdef.RequestStatusOK])
+	ensureContains(t, registry, "requests.badinput.legacy", m.RequestStatuses[metricsdef.ReqTypeLegacy][metricsdef.RequestStatusBadInput])
+	ensureContains(t, registry, "requests.err.legacy", m.RequestStatuses[metricsdef.ReqTypeLegacy][metricsdef.RequestStatusErr])
+	ensureContains(t, registry, "requests.ok.openrtb2", m.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusOK])
+	ensureContains(t, registry, "requests.badinput.openrtb2", m.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusBadInput])
+	ensureContains(t, registry, "requests.err.openrtb2", m.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusErr])
+	ensureContains(t, registry, "requests.ok.amp", m.RequestStatuses[metricsdef.ReqTypeAMP][metricsdef.RequestStatusOK])
+	ensureContains(t, registry, "requests.badinput.amp", m.RequestStatuses[metricsdef.ReqTypeAMP][metricsdef.RequestStatusBadInput])
+	ensureContains(t, registry, "requests.err.amp", m.RequestStatuses[metricsdef.ReqTypeAMP][metricsdef.RequestStatusErr])
 }
 
 func TestRecordBidType(t *testing.T) {
 	registry := metrics.NewRegistry()
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
 
-	m.RecordAdapterBidReceived(AdapterLabels{
+	m.RecordAdapterBidReceived(metricsdef.AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeBanner, true)
 	VerifyMetrics(t, "Appnexus Banner Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
 	VerifyMetrics(t, "Appnexus Banner Nurl Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
 
-	m.RecordAdapterBidReceived(AdapterLabels{
+	m.RecordAdapterBidReceived(metricsdef.AdapterLabels{
 		Adapter: openrtb_ext.BidderAppnexus,
 	}, openrtb_ext.BidTypeVideo, false)
 	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[openrtb_ext.BidderAppnexus].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)
@@ -54,8 +55,8 @@ func TestRecordBidType(t *testing.T) {
 func TestRecordGDPRRejection(t *testing.T) {
 	registry := metrics.NewRegistry()
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus})
-	m.RecordUserIDSet(UserLabels{
-		Action: RequestActionGDPR,
+	m.RecordUserIDSet(metricsdef.UserLabels{
+		Action: metricsdef.RequestActionGDPR,
 		Bidder: openrtb_ext.BidderAppnexus,
 	})
 	VerifyMetrics(t, "GDPR sync rejects", m.userSyncGDPRPrevent[openrtb_ext.BidderAppnexus].Count(), 1)

--- a/pbsmetrics/metrics_test.go
+++ b/pbsmetrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/pbsmetrics/metricsdef"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -42,22 +43,22 @@ func TestMultiMetricsEngine(t *testing.T) {
 	engineList[1] = &DummyMetricsEngine{}
 	var metricsEngine MetricsEngine
 	metricsEngine = &engineList
-	labels := Labels{
-		Source:        DemandWeb,
-		RType:         ReqTypeORTB2,
+	labels := metricsdef.Labels{
+		Source:        metricsdef.DemandWeb,
+		RType:         metricsdef.ReqTypeORTB2,
 		PubID:         "test1",
-		Browser:       BrowserSafari,
-		CookieFlag:    CookieFlagYes,
-		RequestStatus: RequestStatusOK,
+		Browser:       metricsdef.BrowserSafari,
+		CookieFlag:    metricsdef.CookieFlagYes,
+		RequestStatus: metricsdef.RequestStatusOK,
 	}
-	blabels := AdapterLabels{
-		Source:        DemandWeb,
-		RType:         ReqTypeORTB2,
+	blabels := metricsdef.AdapterLabels{
+		Source:        metricsdef.DemandWeb,
+		RType:         metricsdef.ReqTypeORTB2,
 		Adapter:       openrtb_ext.BidderPubmatic,
 		PubID:         "test1",
-		Browser:       BrowserSafari,
-		CookieFlag:    CookieFlagYes,
-		AdapterStatus: AdapterStatusOK,
+		Browser:       metricsdef.BrowserSafari,
+		CookieFlag:    metricsdef.CookieFlagYes,
+		AdapterStatus: metricsdef.AdapterStatusOK,
 	}
 	for i := 0; i < 5; i++ {
 		metricsEngine.RecordRequest(labels)
@@ -67,12 +68,12 @@ func TestMultiMetricsEngine(t *testing.T) {
 		metricsEngine.RecordAdapterPrice(blabels, 1.34)
 		metricsEngine.RecordAdapterTime(blabels, time.Millisecond*20)
 	}
-	VerifyMetrics(t, "RequestStatuses.OpenRTB2.OK", goEngine.RequestStatuses[ReqTypeORTB2][RequestStatusOK].Count(), 5)
-	VerifyMetrics(t, "RequestStatuses.Legacy.OK", goEngine.RequestStatuses[ReqTypeLegacy][RequestStatusOK].Count(), 0)
-	VerifyMetrics(t, "RequestStatuses.AMP.OK", goEngine.RequestStatuses[ReqTypeAMP][RequestStatusOK].Count(), 0)
-	VerifyMetrics(t, "RequestStatuses.OpenRTB2.Error", goEngine.RequestStatuses[ReqTypeORTB2][RequestStatusErr].Count(), 0)
-	VerifyMetrics(t, "RequestStatuses.OpenRTB2.BadInput", goEngine.RequestStatuses[ReqTypeORTB2][RequestStatusBadInput].Count(), 0)
-	VerifyMetrics(t, "Request", goEngine.RequestStatuses[ReqTypeORTB2][RequestStatusOK].Count(), 5)
+	VerifyMetrics(t, "RequestStatuses.OpenRTB2.OK", goEngine.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusOK].Count(), 5)
+	VerifyMetrics(t, "RequestStatuses.Legacy.OK", goEngine.RequestStatuses[metricsdef.ReqTypeLegacy][metricsdef.RequestStatusOK].Count(), 0)
+	VerifyMetrics(t, "RequestStatuses.AMP.OK", goEngine.RequestStatuses[metricsdef.ReqTypeAMP][metricsdef.RequestStatusOK].Count(), 0)
+	VerifyMetrics(t, "RequestStatuses.OpenRTB2.Error", goEngine.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusErr].Count(), 0)
+	VerifyMetrics(t, "RequestStatuses.OpenRTB2.BadInput", goEngine.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusBadInput].Count(), 0)
+	VerifyMetrics(t, "Request", goEngine.RequestStatuses[metricsdef.ReqTypeORTB2][metricsdef.RequestStatusOK].Count(), 5)
 	VerifyMetrics(t, "ImpMeter", goEngine.ImpMeter.Count(), 10)
 	VerifyMetrics(t, "NoCookieMeter", goEngine.NoCookieMeter.Count(), 0)
 	VerifyMetrics(t, "SafariRequestMeter", goEngine.SafariRequestMeter.Count(), 5)

--- a/pbsmetrics/metricsdef/metricsdef.go
+++ b/pbsmetrics/metricsdef/metricsdef.go
@@ -1,0 +1,119 @@
+package metricsdef
+
+import "github.com/prebid/prebid-server/openrtb_ext"
+
+// Labels defines the labels that can be attached to the metrics.
+type Labels struct {
+	Source        DemandSource
+	RType         RequestType
+	PubID         string // exchange specific ID, so we cannot compile in values
+	Browser       Browser
+	CookieFlag    CookieFlag
+	RequestStatus RequestStatus
+}
+
+// AdapterLabels defines the labels that can be attached to the adapter metrics.
+type AdapterLabels struct {
+	Source        DemandSource
+	RType         RequestType
+	Adapter       openrtb_ext.BidderName
+	PubID         string // exchange specific ID, so we cannot compile in values
+	Browser       Browser
+	CookieFlag    CookieFlag
+	AdapterStatus AdapterStatus
+}
+
+// Label typecasting. Se below the type definitions for possible values
+
+// DemandSource : Demand source enumeration
+type DemandSource string
+
+// RequestType : Request type enumeration
+type RequestType string
+
+// Browser type enumeration
+type Browser string
+
+// CookieFlag : User ID cookie exists flag
+type CookieFlag string
+
+// RequestStatus : The request return status
+type RequestStatus string
+
+// AdapterStatus : The radapter execution status
+type AdapterStatus string
+
+// The demand sources
+const (
+	DemandWeb     DemandSource = "web"
+	DemandApp     DemandSource = "app"
+	DemandUnknown DemandSource = "unknown"
+)
+
+// The request types (endpoints)
+const (
+	ReqTypeLegacy RequestType = "legacy"
+	ReqTypeORTB2  RequestType = "openrtb2"
+	ReqTypeAMP    RequestType = "amp"
+)
+
+func RequestTypes() []RequestType {
+	return []RequestType{
+		ReqTypeLegacy,
+		ReqTypeORTB2,
+		ReqTypeAMP,
+	}
+}
+
+// Browser flag; at this point we only care about identifying Safari
+const (
+	BrowserSafari Browser = "safari"
+	BrowserOther  Browser = "other"
+)
+
+// Cookie flag
+const (
+	CookieFlagYes     CookieFlag = "exists"
+	CookieFlagNo      CookieFlag = "no"
+	CookieFlagUnknown CookieFlag = "unknown"
+)
+
+// Request/return status
+const (
+	RequestStatusOK       RequestStatus = "ok"
+	RequestStatusBadInput RequestStatus = "badinput"
+	RequestStatusErr      RequestStatus = "err"
+)
+
+func RequestStatuses() []RequestStatus {
+	return []RequestStatus{
+		RequestStatusOK,
+		RequestStatusBadInput,
+		RequestStatusErr,
+	}
+}
+
+// Adapter execution status
+const (
+	AdapterStatusOK      AdapterStatus = "ok"
+	AdapterStatusErr     AdapterStatus = "err"
+	AdapterStatusNoBid   AdapterStatus = "nobid"
+	AdapterStatusTimeout AdapterStatus = "timeout"
+)
+
+// UserLabels : Labels for /setuid endpoint
+type UserLabels struct {
+	Action RequestAction
+	Bidder openrtb_ext.BidderName
+}
+
+// RequestAction : The setuid request result
+type RequestAction string
+
+// /setuid action labels
+const (
+	RequestActionSet    RequestAction = "set"
+	RequestActionOptOut RequestAction = "opt_out"
+	RequestActionGDPR   RequestAction = "gdpr"
+	RequestActionErr    RequestAction = "err"
+)


### PR DESCRIPTION
…encies adding new metrics backends.

Ran into an issue developing a second metrics backend into its own package. There are definitions needed to implement the metrics interface, but they are defined in `pbsmetrics`. The master metrics package cannot keep them and import packages implementing the interface.

We should also move the go-metrics package to its own package at some point.