### PR TITLE
Adds map support to config logging.

### DIFF
--- a/config/structlog.go
+++ b/config/structlog.go
@@ -66,6 +66,8 @@ func logMapWithLogger(v reflect.Value, prefix string, logger func(msg string, ar
 		} else {
 			// Use Sprintf("%v", k.Interface) to handle non-string keys. Should not be possible to have a key
 			// too complex to represent by %v.
+			// NOTE: This will break if we have an unexported map in the object. If so we will have to switch
+			// on k.Kind() rather than rely on fmt.Sprintf("%v") doing that work.
 			logGeneralWithLogger(v.MapIndex(k), extendMapPrefix(prefix, fmt.Sprintf("%v", k.Interface())), logger)
 		}
 	}

--- a/config/structlog.go
+++ b/config/structlog.go
@@ -25,6 +25,8 @@ func logGeneralWithLogger(v reflect.Value, prefix string, logger func(msg string
 	switch v.Kind() {
 	case reflect.Struct:
 		logStructWithLogger(v, prefix, logger)
+	case reflect.Map:
+		logMapWithLogger(v, prefix, logger)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		logger("%s: %d", prefix, v.Int())
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
@@ -54,6 +56,21 @@ func logStructWithLogger(v reflect.Value, prefix string, logger func(msg string,
 	}
 }
 
+func logMapWithLogger(v reflect.Value, prefix string, logger func(msg string, args ...interface{})) {
+	if v.Kind() != reflect.Map {
+		glog.Fatalf("LogMap called on type %s, whuch is not a map!", v.Type().String())
+	}
+	for _, k := range v.MapKeys() {
+		if k.Kind() == reflect.String && !allowedName(k.String()) {
+			logger("%s: <REDACTED>", extendMapPrefix(prefix, k.String()))
+		} else {
+			// Use Sprintf("%v", k.Interface) to handle non-string keys. Should not be possible to have a key
+			// too complex to represent by %v.
+			logGeneralWithLogger(v.MapIndex(k), extendMapPrefix(prefix, fmt.Sprintf("%v", k.Interface())), logger)
+		}
+	}
+}
+
 func fieldNameByTag(f reflect.StructField) string {
 	match := mapregex.FindStringSubmatch(string(f.Tag))
 	if len(match) == 0 || len(match[1]) == 0 {
@@ -76,4 +93,11 @@ func extendPrefix(prefix string, field string) string {
 		return fmt.Sprintf("%s%s", prefix, field)
 	}
 	return fmt.Sprintf("%s.%s", prefix, field)
+}
+
+func extendMapPrefix(prefix string, field string) string {
+	if len(strings.Trim(prefix, " \t")) == 0 {
+		return fmt.Sprintf("%s<map>[%s]", prefix, field)
+	}
+	return fmt.Sprintf("%s[%s]", prefix, field)
 }

--- a/config/structlog_test.go
+++ b/config/structlog_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 type testStruct struct {
-	myint    int    `mapstructure:"this_int"`
-	mystring string `mapstructure:"mystring"`
-	flag     bool
-	sub      innerStruct `mapstructure:"sub"`
+	Myint    int    `mapstructure:"this_int"`
+	Mystring string `mapstructure:"mystring"`
+	Flag     bool
+	Sub      innerStruct `mapstructure:"sub"`
+	Caps     map[string]string
 }
 
 type innerStruct struct {
@@ -21,9 +22,10 @@ type innerStruct struct {
 
 var expected string = `this_int: 5
 mystring: foobar
-((flag)): false
+((Flag)): false
 sub.int1: 3
 sub.password: <REDACTED>
+((Caps))[Alabama]: Montgomery
 `
 
 func TestBasic(t *testing.T) {
@@ -34,11 +36,15 @@ func TestBasic(t *testing.T) {
 	}
 
 	testCfg := testStruct{
-		myint:    5,
-		mystring: "foobar",
-		sub: innerStruct{
+		Myint:    5,
+		Mystring: "foobar",
+		Sub: innerStruct{
 			int1:     3,
 			password: "secret",
+		},
+		// Can't do more than one entry as order is not guaranteed.
+		Caps: map[string]string{
+			"Alabama": "Montgomery",
 		},
 	}
 


### PR DESCRIPTION
The adaptor configs are stored in a map, so were left out of logging. This fixes #561 