### PR TITLE
Adding  endpoint exposing prebid-server version

### DIFF
--- a/endpoints/version.go
+++ b/endpoints/version.go
@@ -1,0 +1,32 @@
+package endpoints
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+type versionModel struct {
+	Revision string `json:"revision"`
+}
+
+// NewVersionEndpoint returns the latest commit sha1 from wich the binary was built
+func NewVersionEndpoint(version string) func(w http.ResponseWriter, r *http.Request) {
+	if version == "" {
+		version = "not-set"
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		jsonOutput, err := json.Marshal(versionModel{
+			Revision: version,
+		})
+		if err != nil {
+			glog.Errorf("/version Critical error when trying to marshal versionModel: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(jsonOutput)
+	}
+}

--- a/endpoints/version_test.go
+++ b/endpoints/version_test.go
@@ -1,0 +1,48 @@
+package endpoints
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	// Setup:
+	var testCases = []struct {
+		input    string
+		expected string
+	}{
+		{"", `{"revision": "not-set"}`},
+		{"abc", `{"revision": "abc"}`},
+		{"d6cd1e2bd19e03a81132a23b2025920577f84e37", `{"revision": "d6cd1e2bd19e03a81132a23b2025920577f84e37"}`},
+	}
+
+	for _, tc := range testCases {
+
+		handler := NewVersionEndpoint(tc.input)
+		w := httptest.NewRecorder()
+
+		// Execute:
+		handler(w, nil)
+
+		// Verify:
+		var result, expected versionModel
+		err := json.NewDecoder(w.Body).Decode(&result)
+		if err != nil {
+			t.Errorf("Bad response body. Expected: %s, got an error %s", tc.expected, err)
+		}
+
+		err = json.Unmarshal([]byte(tc.expected), &expected)
+		if err != nil {
+			t.Errorf("Error while trying to unmarshal expected result JSON")
+		}
+
+		if !reflect.DeepEqual(expected, result) {
+			responseBodyBytes, _ := ioutil.ReadAll(w.Body)
+			responseBodyString := string(responseBodyBytes)
+			t.Errorf("Bad response body. Expected: %s, got %s", tc.expected, responseBodyString)
+		}
+	}
+}

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
-	_ "net/http/pprof"
+	"net/http/pprof"
 	"sort"
 	"strconv"
 	"time"
@@ -59,6 +59,14 @@ import (
 
 	storedRequestsConf "github.com/prebid/prebid-server/stored_requests/config"
 )
+
+// Holds binary revision string
+// Set manually at build time using:
+//    go build -ldflags "-X main.Rev=`git rev-parse --short HEAD`"
+// Populated automatically at build / release time via .travis.yml
+//   `gox -os="linux" -arch="386" -output="{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...;`
+// See issue #559
+var Rev string
 
 var hostCookieSettings pbs.HostCookieSettings
 
@@ -649,7 +657,7 @@ func main() {
 		glog.Fatalf("Configuration could not be loaded or did not pass validation: %v", err)
 	}
 
-	if err := serve(cfg); err != nil {
+	if err := serve(Rev, cfg); err != nil {
 		glog.Errorf("prebid-server failed: %v", err)
 	}
 }
@@ -672,7 +680,7 @@ func newExchangeMap(cfg *config.Configuration) map[string]adapters.Adapter {
 	}
 }
 
-func serve(cfg *config.Configuration) error {
+func serve(revision string, cfg *config.Configuration) error {
 	router := httprouter.New()
 	theClient := &http.Client{
 		Transport: &http.Transport{
@@ -775,6 +783,20 @@ func serve(cfg *config.Configuration) error {
 	// Add no cache headers
 	noCacheHandler := NoCache{corsRouter}
 
-	server.Listen(cfg, noCacheHandler, metricsEngine)
+	// Add endpoints to the admin server
+	// Making sure to add pprof routes
+	adminRouter := http.NewServeMux()
+
+	// Register pprof handlers
+	adminRouter.HandleFunc("/debug/pprof/", pprof.Index)
+	adminRouter.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	adminRouter.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	adminRouter.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	adminRouter.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// Register prebid-server defined admin handlers
+	adminRouter.HandleFunc("/version", endpoints.NewVersionEndpoint(revision))
+
+	server.Listen(cfg, noCacheHandler, adminRouter, metricsEngine)
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Listen blocks forever, serving PBS requests on the given port. This will block forever, until the process is shut down.
-func Listen(cfg *config.Configuration, handler http.Handler, metrics pbsmetrics.MetricsEngine) {
+func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.Handler, metrics pbsmetrics.MetricsEngine) {
 	stopSignals := make(chan os.Signal)
 	signal.Notify(stopSignals, syscall.SIGTERM, syscall.SIGINT)
 
@@ -27,7 +27,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, metrics pbsmetrics.
 	stopMain := make(chan os.Signal)
 	done := make(chan struct{})
 
-	adminServer := newAdminServer(cfg)
+	adminServer := newAdminServer(cfg, adminHandler)
 	go shutdownAfterSignals(adminServer, stopAdmin, done)
 
 	mainServer := newMainServer(cfg, handler)
@@ -50,9 +50,10 @@ func Listen(cfg *config.Configuration, handler http.Handler, metrics pbsmetrics.
 	return
 }
 
-func newAdminServer(cfg *config.Configuration) *http.Server {
+func newAdminServer(cfg *config.Configuration, handler http.Handler) *http.Server {
 	return &http.Server{
-		Addr: cfg.Host + ":" + strconv.Itoa(cfg.AdminPort),
+		Addr:    cfg.Host + ":" + strconv.Itoa(cfg.AdminPort),
+		Handler: handler,
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,7 +14,7 @@ func TestNewAdminServer(t *testing.T) {
 		AdminPort: 6060,
 		Port:      8000,
 	}
-	server := newAdminServer(cfg)
+	server := newAdminServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != "prebid.com:6060" {
 		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:6060", server.Addr)
 	}


### PR DESCRIPTION
This CL includes:
  * Creating a new handler `/version` exposing the current binary
    revision
  * Update Building scripts

This CL doesn't include:
  * The newly created endpoint `/version` is not set in the router, it
    will be added in another CL

Add an endpoint exposing binary revision #559