### PR TITLE
Adding a decorator which enforces the {bidder}.yaml info files

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -32,6 +32,12 @@ type Bidder interface {
 	MakeBids(internalRequest *openrtb.BidRequest, externalRequest *RequestData, response *ResponseData) (*BidderResponse, []error)
 }
 
+func BadInput(msg string) *BadInputError {
+	return &BadInputError{
+		Message: msg,
+	}
+}
+
 // BadInputError should be used when returning errors which are caused by bad input.
 // It should _not_ be used if the error is a server-side issue (e.g. failed to send the external request).
 //

--- a/adapters/info.go
+++ b/adapters/info.go
@@ -36,17 +36,13 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest) ([]*RequestD
 	var allowedMediaTypes []openrtb_ext.BidType
 	if request.Site != nil {
 		if i.info.Capabilities.Site == nil {
-			return nil, []error{&BadInputError{
-				Message: "this bidder does not support site requests",
-			}}
+			return nil, []error{BadInput("this bidder does not support site requests")}
 		}
 		allowedMediaTypes = i.info.Capabilities.Site.MediaTypes
 	}
 	if request.App != nil {
 		if i.info.Capabilities.App == nil {
-			return nil, []error{&BadInputError{
-				Message: "this bidder does not support app requests",
-			}}
+			return nil, []error{BadInput("this bidder does not support app requests")}
 		}
 		allowedMediaTypes = i.info.Capabilities.App.MediaTypes
 	}
@@ -75,27 +71,19 @@ func (i *InfoAwareBidder) pruneImps(imps []openrtb.Imp, allowedTypes []openrtb_e
 	for i := 0; i < len(imps); i++ {
 		if !allowBanner && imps[i].Banner != nil {
 			imps[i].Banner = nil
-			errs = append(errs, &BadInputError{
-				Message: fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i),
-			})
+			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i)))
 		}
 		if !allowVideo && imps[i].Video != nil {
 			imps[i].Video = nil
-			errs = append(errs, &BadInputError{
-				Message: fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i),
-			})
+			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i)))
 		}
 		if !allowAudio && imps[i].Audio != nil {
 			imps[i].Audio = nil
-			errs = append(errs, &BadInputError{
-				Message: fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i),
-			})
+			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i)))
 		}
 		if !allowNative && imps[i].Native != nil {
 			imps[i].Native = nil
-			errs = append(errs, &BadInputError{
-				Message: fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i),
-			})
+			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i)))
 		}
 		if !hasAnyTypes(&imps[i]) {
 			numToFilter = numToFilter + 1
@@ -131,9 +119,7 @@ func (i *InfoAwareBidder) filterImps(imps []openrtb.Imp, numToFilter int) ([]ope
 		if hasAnyTypes(&imps[i]) {
 			newImps = append(newImps, imps[i])
 		} else {
-			errs = append(errs, &BadInputError{
-				Message: fmt.Sprintf("request.imp[%d] has no supported MediaTypes. It will be ignored", i),
-			})
+			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] has no supported MediaTypes. It will be ignored", i)))
 		}
 	}
 	return newImps, errs

--- a/adapters/info.go
+++ b/adapters/info.go
@@ -1,12 +1,127 @@
 package adapters
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/golang/glog"
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	yaml "gopkg.in/yaml.v2"
 )
+
+// EnforceBidderInfo decorates the input Bidder by making sure that all the requests
+// to it are in sync with its static/bidder-info/{bidder}.yaml file.
+//
+// It adjusts incoming requests in the following ways:
+//   1. If App or Site traffic is not supported by the info file, then requests from
+//      those sources will be rejected before the delegate is called.
+//   2. If a given MediaType is not supported for the platform, then it will be set
+//      to nil before the request is forwarded to the delegate.
+//   3. Any Imps which have no MediaTypes left will be removed.
+//   4. If there are no valid Imps left, the delegate won't be called at all.
+func EnforceBidderInfo(bidder Bidder, info BidderInfo) Bidder {
+	return &InfoAwareBidder{
+		Bidder: bidder,
+		info:   info,
+	}
+}
+
+type InfoAwareBidder struct {
+	Bidder
+	info BidderInfo
+}
+
+func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest) ([]*RequestData, []error) {
+	var allowedMediaTypes []openrtb_ext.BidType
+	if request.Site != nil {
+		if i.info.Capabilities.Site == nil {
+			return nil, []error{errors.New("this bidder does not support site requests")}
+		}
+		allowedMediaTypes = i.info.Capabilities.Site.MediaTypes
+	}
+	if request.App != nil {
+		if i.info.Capabilities.App == nil {
+			return nil, []error{errors.New("this bidder does not support app requests")}
+		}
+		allowedMediaTypes = i.info.Capabilities.App.MediaTypes
+	}
+
+	// Filtering imps is quite expensive (array filter with large, non-pointer elements)... but should be rare,
+	// because it only happens if the publisher makes a really bad request.
+	//
+	// To avoid allocating new arrays and copying in the normal case, we'll make one pass to
+	// see if any imps need to be removed, and another to do the removing if necessary.
+	numToFilter, errs := i.pruneImps(request.Imp, allowedMediaTypes)
+	if numToFilter != 0 {
+		request.Imp = i.filterImps(request.Imp, numToFilter)
+	}
+	reqs, delegateErrs := i.MakeRequests(request)
+	return reqs, append(errs, delegateErrs...)
+}
+
+// pruneImps trims invalid media types from each imp, and returns true if any of the
+// Imps have _no_ valid Media Types left.
+func (i *InfoAwareBidder) pruneImps(imps []openrtb.Imp, allowedTypes []openrtb_ext.BidType) (int, []error) {
+	allowBanner, allowVideo, allowAudio, allowNative := parseAllowedTypes(allowedTypes)
+	numToFilter := 0
+	var errs []error
+	for i := 0; i < len(imps); i++ {
+		if !allowBanner {
+			imps[i].Banner = nil
+			errs = append(errs, fmt.Errorf("request.imp[%d] uses banner, but this bidder doesn't support it", i))
+		}
+		if !allowVideo {
+			imps[i].Video = nil
+			errs = append(errs, fmt.Errorf("request.imp[%d] uses video, but this bidder doesn't support it", i))
+		}
+		if !allowAudio {
+			imps[i].Audio = nil
+			errs = append(errs, fmt.Errorf("request.imp[%d] uses audio, but this bidder doesn't support it", i))
+		}
+		if !allowNative {
+			imps[i].Native = nil
+			errs = append(errs, fmt.Errorf("request.imp[%d] uses native, but this bidder doesn't support it", i))
+		}
+		if !hasAnyTypes(&imps[i]) {
+			numToFilter = numToFilter + 1
+		}
+	}
+	return numToFilter, errs
+}
+
+func parseAllowedTypes(allowedTypes []openrtb_ext.BidType) (allowBanner bool, allowVideo bool, allowAudio bool, allowNative bool) {
+	for _, allowedType := range allowedTypes {
+		switch allowedType {
+		case openrtb_ext.BidTypeBanner:
+			allowBanner = true
+		case openrtb_ext.BidTypeVideo:
+			allowVideo = true
+		case openrtb_ext.BidTypeAudio:
+			allowAudio = true
+		case openrtb_ext.BidTypeNative:
+			allowNative = true
+		}
+	}
+	return
+}
+
+func hasAnyTypes(imp *openrtb.Imp) bool {
+	return imp.Banner != nil || imp.Video != nil || imp.Audio != nil || imp.Native != nil
+}
+
+func (i *InfoAwareBidder) filterImps(imps []openrtb.Imp, numToFilter int) []openrtb.Imp {
+	newImps := make([]openrtb.Imp, 0, numToFilter)
+	thisIndex := 0
+	for i := 0; i < len(imps); i++ {
+		if hasAnyTypes(&imps[i]) {
+			newImps[thisIndex] = imps[i]
+			thisIndex = thisIndex + 1
+		}
+	}
+	return newImps
+}
 
 type BidderInfos map[string]BidderInfo
 

--- a/adapters/info.go
+++ b/adapters/info.go
@@ -1,7 +1,6 @@
 package adapters
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -37,13 +36,17 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest) ([]*RequestD
 	var allowedMediaTypes []openrtb_ext.BidType
 	if request.Site != nil {
 		if i.info.Capabilities.Site == nil {
-			return nil, []error{errors.New("this bidder does not support site requests")}
+			return nil, []error{&BadInputError{
+				Message: "this bidder does not support site requests",
+			}}
 		}
 		allowedMediaTypes = i.info.Capabilities.Site.MediaTypes
 	}
 	if request.App != nil {
 		if i.info.Capabilities.App == nil {
-			return nil, []error{errors.New("this bidder does not support app requests")}
+			return nil, []error{&BadInputError{
+				Message: "this bidder does not support app requests",
+			}}
 		}
 		allowedMediaTypes = i.info.Capabilities.App.MediaTypes
 	}
@@ -72,19 +75,27 @@ func (i *InfoAwareBidder) pruneImps(imps []openrtb.Imp, allowedTypes []openrtb_e
 	for i := 0; i < len(imps); i++ {
 		if !allowBanner && imps[i].Banner != nil {
 			imps[i].Banner = nil
-			errs = append(errs, fmt.Errorf("request.imp[%d] uses banner, but this bidder doesn't support it", i))
+			errs = append(errs, &BadInputError{
+				Message: fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i),
+			})
 		}
 		if !allowVideo && imps[i].Video != nil {
 			imps[i].Video = nil
-			errs = append(errs, fmt.Errorf("request.imp[%d] uses video, but this bidder doesn't support it", i))
+			errs = append(errs, &BadInputError{
+				Message: fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i),
+			})
 		}
 		if !allowAudio && imps[i].Audio != nil {
 			imps[i].Audio = nil
-			errs = append(errs, fmt.Errorf("request.imp[%d] uses audio, but this bidder doesn't support it", i))
+			errs = append(errs, &BadInputError{
+				Message: fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i),
+			})
 		}
 		if !allowNative && imps[i].Native != nil {
 			imps[i].Native = nil
-			errs = append(errs, fmt.Errorf("request.imp[%d] uses native, but this bidder doesn't support it", i))
+			errs = append(errs, &BadInputError{
+				Message: fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i),
+			})
 		}
 		if !hasAnyTypes(&imps[i]) {
 			numToFilter = numToFilter + 1
@@ -120,7 +131,9 @@ func (i *InfoAwareBidder) filterImps(imps []openrtb.Imp, numToFilter int) ([]ope
 		if hasAnyTypes(&imps[i]) {
 			newImps = append(newImps, imps[i])
 		} else {
-			errs = append(errs, fmt.Errorf("request.imp[%d] has no supported MediaTypes. It will be ignored", i))
+			errs = append(errs, &BadInputError{
+				Message: fmt.Sprintf("request.imp[%d] has no supported MediaTypes. It will be ignored", i),
+			})
 		}
 	}
 	return newImps, errs

--- a/adapters/info_test.go
+++ b/adapters/info_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAppNotSupported(t *testing.T) {
@@ -22,11 +23,11 @@ func TestAppNotSupported(t *testing.T) {
 	bids, errs := constrained.MakeRequests(&openrtb.BidRequest{
 		App: &openrtb.App{},
 	})
-	if len(errs) != 1 || errs[0].Error() != "this bidder does not support app requests" {
-		t.Errorf("Unexpected error: %s", errs[0].Error())
+	if !assert.Len(t, errs, 1) || !assert.EqualError(t, errs[0], "this bidder does not support app requests") {
+		return
 	}
-	if len(bids) != 0 {
-		t.Errorf("Got %d unexpected bids", len(bids))
+	if !assert.Len(t, bids, 0) {
+		return
 	}
 }
 
@@ -43,12 +44,33 @@ func TestSiteNotSupported(t *testing.T) {
 	bids, errs := constrained.MakeRequests(&openrtb.BidRequest{
 		Site: &openrtb.Site{},
 	})
-	if len(errs) != 1 || errs[0].Error() != "this bidder does not support site requests" {
-		t.Errorf("Unexpected error: %s", errs[0].Error())
+	if !assert.Len(t, errs, 1) || !assert.EqualError(t, errs[0], "this bidder does not support site requests") {
+		return
 	}
-	if len(bids) != 0 {
-		t.Errorf("Got %d unexpected bids", len(bids))
+	if !assert.Len(t, bids, 0) {
+		return
 	}
+}
+
+func TestImpFiltering(t *testing.T) {
+	bidder := &mockBidder{}
+	info := adapters.BidderInfo{
+		Capabilities: &adapters.CapabilitiesInfo{
+			Site: &adapters.PlatformInfo{
+				MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeVideo},
+			},
+			App: &adapters.PlatformInfo{
+				MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner},
+			},
+		},
+	}
+
+	constrained := adapters.EnforceBidderInfo(bidder, info)
+	_, _ = constrained.MakeRequests(&openrtb.BidRequest{
+		Imp:  []openrtb.Imp{},
+		Site: &openrtb.Site{},
+	})
+
 }
 
 type mockBidder struct {
@@ -70,23 +92,16 @@ func TestParsing(t *testing.T) {
 	if infos[string(mockBidderName)].Maintainer.Email != "some-email@domain.com" {
 		t.Errorf("Bad maintainer email. Got %s", infos[string(mockBidderName)].Maintainer.Email)
 	}
-	assertBoolsEqual(t, true, infos.HasAppSupport(mockBidderName))
-	assertBoolsEqual(t, true, infos.HasSiteSupport(mockBidderName))
+	assert.Equal(t, true, infos.HasAppSupport(mockBidderName))
+	assert.Equal(t, true, infos.HasSiteSupport(mockBidderName))
 
-	assertBoolsEqual(t, true, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeBanner))
-	assertBoolsEqual(t, false, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeVideo))
-	assertBoolsEqual(t, false, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeAudio))
-	assertBoolsEqual(t, true, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeNative))
+	assert.Equal(t, true, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeBanner))
+	assert.Equal(t, false, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeVideo))
+	assert.Equal(t, false, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeAudio))
+	assert.Equal(t, true, infos.SupportsAppMediaType(mockBidderName, openrtb_ext.BidTypeNative))
 
-	assertBoolsEqual(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeBanner))
-	assertBoolsEqual(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeVideo))
-	assertBoolsEqual(t, false, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeAudio))
-	assertBoolsEqual(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeNative))
-}
-
-func assertBoolsEqual(t *testing.T, expected bool, actual bool) {
-	t.Helper()
-	if actual != expected {
-		t.Errorf("expected %t, got %t", expected, actual)
-	}
+	assert.Equal(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeBanner))
+	assert.Equal(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeVideo))
+	assert.Equal(t, false, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeAudio))
+	assert.Equal(t, true, infos.SupportsWebMediaType(mockBidderName, openrtb_ext.BidTypeNative))
 }

--- a/adapters/info_test.go
+++ b/adapters/info_test.go
@@ -27,6 +27,7 @@ func TestAppNotSupported(t *testing.T) {
 		return
 	}
 	assert.EqualError(t, errs[0], "this bidder does not support app requests")
+	assert.IsType(t, &adapters.BadInputError{}, errs[0])
 	assert.Len(t, bids, 0)
 }
 
@@ -47,6 +48,7 @@ func TestSiteNotSupported(t *testing.T) {
 		return
 	}
 	assert.EqualError(t, errs[0], "this bidder does not support site requests")
+	assert.IsType(t, &adapters.BadInputError{}, errs[0])
 	assert.Len(t, bids, 0)
 }
 
@@ -93,6 +95,11 @@ func TestImpFiltering(t *testing.T) {
 	assert.EqualError(t, errs[3], "request.imp[1] has no supported MediaTypes. It will be ignored")
 	assert.EqualError(t, errs[4], "request.imp[3] has no supported MediaTypes. It will be ignored")
 	assert.EqualError(t, errs[5], "mock MakeRequests error")
+	assert.IsType(t, &adapters.BadInputError{}, errs[0])
+	assert.IsType(t, &adapters.BadInputError{}, errs[1])
+	assert.IsType(t, &adapters.BadInputError{}, errs[2])
+	assert.IsType(t, &adapters.BadInputError{}, errs[3])
+	assert.IsType(t, &adapters.BadInputError{}, errs[4])
 
 	req := bidder.gotRequest
 	if !assert.Len(t, req.Imp, 2) {


### PR DESCRIPTION
This contributes to #555.

Goal here is to make an object which wraps a Bidder and screens invalid bids before calling it.

In a future PR, this can be used to simplify adapter code. For example, in the APN adapter, we have:

```
	if imp.Audio != nil {
		return "", &adapters.BadInputError{
			Message: fmt.Sprintf("Appnexus doesn't support audio Imps. Ignoring Imp ID=%s", imp.ID),
		}
	}
```

Other adapters do similar. This offers a way to consolidate that logic into one place and standardize the error messages.