### PR TITLE
Build go binary inside alpine container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM alpine
+FROM alpine:edge AS build
+WORKDIR /go/src/github.com/prebid/prebid-server/
+RUN apk add -U --no-cache go git fftw-dev musl-dev dep
+ENV GOPATH /go
+COPY ./ ./
+RUN dep ensure
+RUN go build .
+
+
+FROM alpine:edge AS release
 MAINTAINER Brian O'Kelley <bokelley@appnexus.com>
-ADD prebid-server prebid-server
+WORKDIR /usr/local/bin/
+COPY --from=build /go/src/github.com/prebid/prebid-server/prebid-server .
 COPY static static/
 COPY stored_requests/data stored_requests/data
+RUN apk add -U --no-cache ca-certificates
 EXPOSE 8000
-ENTRYPOINT ["/prebid-server"]
+ENTRYPOINT ["/usr/local/bin/prebid-server"]
 CMD ["-v", "1", "-logtostderr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:edge AS build
+FROM alpine:3.8 AS build
 WORKDIR /go/src/github.com/prebid/prebid-server/
-RUN apk add -U --no-cache go git fftw-dev musl-dev dep
+RUN apk add -U --no-cache go git dep musl-dev
 ENV GOPATH /go
 COPY ./ ./
 RUN dep ensure
 RUN go build .
 
 
-FROM alpine:edge AS release
+FROM alpine:3.8 AS release
 MAINTAINER Brian O'Kelley <bokelley@appnexus.com>
 WORKDIR /usr/local/bin/
 COPY --from=build /go/src/github.com/prebid/prebid-server/prebid-server .


### PR DESCRIPTION
In old Dockerfile, you build go binary outside of the docker. Because of this, the binary can be linked with glibc and it will crash when it starts inside the alpine container (alpine uses musl, that not compatible with glibc).
Solution: build the go binary in an alpine environment.