### PR TITLE
Fixed a bug in the adapter metrics

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -155,8 +155,10 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			}
 			brw := new(bidResponseWrapper)
 			brw.bidder = aName
-			// Defer basic metrics to insure we capture them at the
-			defer e.me.RecordAdapterRequest(*bidlabels)
+			// Defer basic metrics to insure we capture them after all the values have been set
+			defer func() {
+				e.me.RecordAdapterRequest(*bidlabels)
+			}()
 			start := time.Now()
 
 			adjustmentFactor := 1.0


### PR DESCRIPTION
`defer` statements still evaluate the function arguments immediately--even though the function doesn't actually execute with them until later.

This is obfuscating the data we need to understand what's going on in #592.