### PR TITLE
Update conversant usersync url to be protocol relative

### DIFF
--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -89,6 +89,7 @@ func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 		// Fill in additional impression info
 
 		imp.DisplayManager = "prebid-s2s"
+		imp.DisplayManagerVer = "1.0.1"
 		imp.BidFloor = params.BidFloor
 		imp.TagID = params.TagID
 

--- a/config/config.go
+++ b/config/config.go
@@ -297,7 +297,7 @@ func SetupViper(v *viper.Viper) {
 	v.SetDefault("adapters.adform.endpoint", "http://adx.adform.net/adx")
 	v.SetDefault("adapters.adform.usersync_url", "//cm.adform.net/cookie?redirect_url=")
 	v.SetDefault("adapters.conversant.endpoint", "http://api.hb.ad.cpe.dotomi.com/s2s/header/24")
-	v.SetDefault("adapters.conversant.usersync_url", "http://prebid-match.dotomi.com/prebid/match?rurl=")
+	v.SetDefault("adapters.conversant.usersync_url", "//prebid-match.dotomi.com/prebid/match?rurl=")
 	v.SetDefault("adapters.brightroll.endpoint", "http://east-bid.ybp.yahoo.com/bid/appnexuspbs")
 	v.SetDefault("adapters.brightroll.usersync_url", "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr={{gdpr}}&euconsent={{gdpr_consent}}&url=")
 


### PR DESCRIPTION
Remove 'http:' from the conversant user sync URL so it works with both secure and non-secure protocols.