### PR TITLE
Handle legacy => openrtb multiformat imps better.

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -74,7 +74,7 @@ type appnexusImpExt struct {
 
 func (a *AppNexusAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	anReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes, true)
+	anReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes)
 
 	if err != nil {
 		return nil, err

--- a/adapters/audienceNetwork/facebook.go
+++ b/adapters/audienceNetwork/facebook.go
@@ -120,7 +120,7 @@ func (a *FacebookAdapter) callOne(ctx context.Context, reqJSON bytes.Buffer) (re
 
 func (a *FacebookAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, placementId string, mtype pbs.MediaType, pubId string, unitInd int) (openrtb.BidRequest, error) {
 	// this method creates imps for all ad units for the bidder with a single media type
-	fbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype}, true)
+	fbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype})
 
 	if err != nil {
 		return openrtb.BidRequest{}, err

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -2,13 +2,14 @@ package beachfront
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/mxmCherry/openrtb"
-	"github.com/pkg/errors"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"strings"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
 const Seat = "beachfront"

--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -44,7 +44,7 @@ type conversantParams struct {
 
 func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	cnvrReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
+	cnvrReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes)
 
 	if err != nil {
 		return nil, err

--- a/adapters/indexExchange/index.go
+++ b/adapters/indexExchange/index.go
@@ -41,7 +41,7 @@ func (a *IndexAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 		}
 	}
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	indexReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
+	indexReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes)
 
 	if err != nil {
 		return nil, err

--- a/adapters/lifestreet/lifestreet.go
+++ b/adapters/lifestreet/lifestreet.go
@@ -84,7 +84,7 @@ func (a *LifestreetAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, re
 }
 
 func (a *LifestreetAdapter) MakeOpenRtbBidRequest(req *pbs.PBSRequest, bidder *pbs.PBSBidder, slotTag string, mtype pbs.MediaType, unitInd int) (openrtb.BidRequest, error) {
-	lsReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype}, true)
+	lsReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), []pbs.MediaType{mtype})
 
 	if err != nil {
 		return openrtb.BidRequest{}, err

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -52,7 +52,7 @@ func TestOpenRTB(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
@@ -90,7 +90,7 @@ func TestOpenRTBVideo(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO})
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
@@ -119,7 +119,7 @@ func TestOpenRTBVideoNoVideoData(t *testing.T) {
 			},
 		},
 	}
-	_, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO}, true)
+	_, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO})
 
 	assert.NotEqual(t, err, nil)
 
@@ -161,7 +161,7 @@ func TestOpenRTBVideoFilteredOut(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	for i := 0; i < len(resp.Imp); i++ {
 		if resp.Imp[i].Video != nil {
@@ -196,7 +196,7 @@ func TestOpenRTBMultiMediaImp(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, false)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
@@ -232,48 +232,12 @@ func TestOpenRTBMultiMediaImpFiltered(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, false)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(resp.Imp), 1)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, *resp.Imp[0].Banner.W, 10)
 	assert.EqualValues(t, resp.Imp[0].Video, (*openrtb.Video)(nil))
-}
-
-func TestOpenRTBSingleMediaImp(t *testing.T) {
-
-	pbReq := pbs.PBSRequest{}
-	pbBidder := pbs.PBSBidder{
-		BidderCode: "bannerCode",
-		AdUnits: []pbs.PBSAdUnit{
-			{
-				Code:       "unitCode",
-				MediaTypes: []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER},
-				Sizes: []openrtb.Format{
-					{
-						W: 10,
-						H: 12,
-					},
-				},
-				Video: pbs.PBSVideo{
-					Mimes:          []string{"video/mp4"},
-					Minduration:    15,
-					Maxduration:    30,
-					Startdelay:     5,
-					Skippable:      0,
-					PlaybackMethod: 1,
-				},
-			},
-		},
-	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_VIDEO, pbs.MEDIA_TYPE_BANNER}, true)
-	assert.Equal(t, err, nil)
-	assert.Equal(t, len(resp.Imp), 2)
-	assert.Equal(t, resp.Imp[0].ID, "unitCode")
-	assert.EqualValues(t, resp.Imp[0].Video.MaxDuration, 30)
-	assert.EqualValues(t, resp.Imp[0].Video.MinDuration, 15)
-	assert.Equal(t, resp.Imp[1].ID, "unitCode")
-	assert.EqualValues(t, *resp.Imp[1].Banner.W, 10)
 }
 
 func TestOpenRTBNoSize(t *testing.T) {
@@ -288,7 +252,7 @@ func TestOpenRTBNoSize(t *testing.T) {
 			},
 		},
 	}
-	_, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	_, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	if err == nil {
 		t.Errorf("Bids without impressions should not be allowed.")
 	}
@@ -335,7 +299,7 @@ func TestOpenRTBMobile(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, *resp.Imp[0].Banner.W, 300)
@@ -371,7 +335,7 @@ func TestOpenRTBEmptyUser(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.EqualValues(t, resp.User, &openrtb.User{})
 }
@@ -398,7 +362,7 @@ func TestOpenRTBUserWithCookie(t *testing.T) {
 		},
 	}
 	pbReq.Cookie = pbsCookie
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.EqualValues(t, resp.User.BuyerUID, "abcde")
 }
@@ -495,7 +459,7 @@ func TestGDPR(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
@@ -558,7 +522,7 @@ func TestGDPRMobile(t *testing.T) {
 			},
 		},
 	}
-	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}, true)
+	resp, err := MakeOpenRTBGeneric(&pbReq, &pbBidder, "test", []pbs.MediaType{pbs.MEDIA_TYPE_BANNER})
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.Imp[0].ID, "unitCode")
 	assert.EqualValues(t, *resp.Imp[0].Banner.W, 300)

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -46,7 +46,7 @@ func PrepareLogMessage(tID, pubId, adUnitId, bidID, details string, args ...inte
 
 func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
-	pbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
+	pbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes)
 
 	if err != nil {
 		logf("[PUBMATIC] Failed to make ortb request for request id [%s] \n", pbReq.ID)

--- a/adapters/pulsepoint/pulsepoint.go
+++ b/adapters/pulsepoint/pulsepoint.go
@@ -40,7 +40,7 @@ type PulsepointParams struct {
 
 func (a *PulsePointAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	mediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}
-	ppReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes, true)
+	ppReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes)
 
 	if err != nil {
 		return nil, err

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -332,7 +332,7 @@ func (a *RubiconAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *
 	callOneObjects := make([]callOneObject, 0, len(bidder.AdUnits))
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER, pbs.MEDIA_TYPE_VIDEO}
 
-	rubiReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes, true)
+	rubiReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), supportedMediaTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -71,8 +71,6 @@ func DummyRubiconServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("Request", string(body))
-
 	var breq openrtb.BidRequest
 	err = json.Unmarshal(body, &breq)
 	if err != nil {
@@ -938,8 +936,6 @@ func CreatePrebidRequest(server *httptest.Server, t *testing.T) (an *RubiconAdap
 	if err != nil {
 		t.Fatalf("Json encoding failed: %v", err)
 	}
-
-	fmt.Println("body", body)
 
 	req := httptest.NewRequest("POST", server.URL, body)
 	req.Header.Add("Referer", rubidata.page)

--- a/adapters/sovrn/sovrn.go
+++ b/adapters/sovrn/sovrn.go
@@ -41,7 +41,7 @@ func (s *SovrnAdapter) SkipNoCookies() bool {
 // Call send bid requests to sovrn and receive responses
 func (s *SovrnAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
 	supportedMediaTypes := []pbs.MediaType{pbs.MEDIA_TYPE_BANNER}
-	sReq, err := adapters.MakeOpenRTBGeneric(req, bidder, s.FamilyName(), supportedMediaTypes, true)
+	sReq, err := adapters.MakeOpenRTBGeneric(req, bidder, s.FamilyName(), supportedMediaTypes)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #603.

We'll have to release this careful and watch the bid responses when we do. It changes `/auction` behavior for all bidders, and `/openrtb2/auction` for bidders who haven't updated yet (see #603 for the list).

but... I have to imagine that the risk is worth it. In OpenRTB, you can't interpret bid responses unless each Imp had a unique ID. The code path which I deleted here was splitting a single legacy AdUnit into two Imps with the same ID... which should cause some nonsense to happen.