### PR TITLE
Fixed beachfront imports

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -2,13 +2,14 @@ package beachfront
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/mxmCherry/openrtb"
-	"github.com/pkg/errors"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"strings"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
 const Seat = "beachfront"


### PR DESCRIPTION
I noticed this while working on #604.

`pkg/errors` is a third-party lib... which we're not using. It's a transient dependency... so PBS doesn't build unless you run `dep ensure` again to pick it up. But when you do, it changes your lockfile.

So... this reverts it to plain old `errors`.