### PR TITLE
Disabled CGO during the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.8 AS build
 WORKDIR /go/src/github.com/prebid/prebid-server/
 RUN apk add -U --no-cache go git dep musl-dev
 ENV GOPATH /go
+ENV CGO_ENABLED 0
 COPY ./ ./
 RUN dep ensure
 RUN go build .


### PR DESCRIPTION
CGO is generally bad news. There's a blog post on it here... and I tend to agree: https://dave.cheney.net/2016/01/18/cgo-is-not-go

Disabling it to make sure it doesn't creep in sometime in the future.