### PR TITLE
Close the database safely

### DIFF
--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -52,8 +52,10 @@ func NewStoredRequests(cfg *config.StoredRequests, client *http.Client, router *
 	shutdown = func() {
 		shutdown1()
 		shutdown2()
-		if err := db.Close(); err != nil {
-			glog.Errorf("Error closing DB connection: %v", err)
+		if db != nil {
+			if err := db.Close(); err != nil {
+				glog.Errorf("Error closing DB connection: %v", err)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
Tiny bugfix for an issue I found while debugging something else.

This has pretty minimal impact... if the app config doesn't include a database connection, then there's a nil dereference when trying to shut down the server.

Still... a little annoying.