### PR TITLE
The conversant adapter doesn't work on app requests

### DIFF
--- a/adapters/conversant/conversant.go
+++ b/adapters/conversant/conversant.go
@@ -50,6 +50,14 @@ func (a *ConversantAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidde
 		return nil, err
 	}
 
+	// Without this, the code crashes with a nil-pointer dereference below, on
+	// cnvrReq.Site.ID = params.SiteID
+	if cnvrReq.Site == nil {
+		return nil, &adapters.BadInputError{
+			Message: "Conversant doesn't support App requests",
+		}
+	}
+
 	// Create a map of impression objects for both request creation
 	// and response parsing.
 

--- a/static/bidder-info/conversant.yaml
+++ b/static/bidder-info/conversant.yaml
@@ -1,9 +1,6 @@
 maintainer:
   email: "mediapsr@conversantmedia.com"
 capabilities:
-  app:
-    mediaTypes:
-      - banner
   site:
     mediaTypes:
       - banner


### PR DESCRIPTION
Seeing some nil-pointer dereferences related to this:

```
goroutine 2066291 [running]:
github.com/prebid/prebid-server/adapters/conversant.(*ConversantAdapter).Call(0xc4203f5400, 0x55dd7cb97640, 0xc45496a5a0, 0xc45850f1d0, 0xc448d88c80, 0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/prebid/prebid-server/adapters/conversant/conversant.go:82 +0x45b
```