### PR TITLE
Added a metric type for network errors

### DIFF
--- a/cache/postgrescache/postgrescache_test.go
+++ b/cache/postgrescache/postgrescache_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/coocood/freecache"
 	"github.com/erikstmartin/go-testdb"
-	"github.com/golang/glog"
 )
 
 type StubCache struct {
@@ -54,7 +53,7 @@ func TestPostgresDbPriceGranularity(t *testing.T) {
 
 	account, err := dataCache.Accounts().Get("bdc928ef-f725-4688-8171-c104cc715bdf")
 	if err != nil {
-		glog.Errorf("test postgres db errored: %v", err)
+		t.Fatalf("test postgres db errored: %v", err)
 	}
 
 	if account.ID != "bdc928ef-f725-4688-8171-c104cc715bdf" {
@@ -83,7 +82,7 @@ func TestPostgresDbNullPriceGranularity(t *testing.T) {
 
 	account, err := dataCache.Accounts().Get("bdc928ef-f725-4688-8171-c104cc715bdf")
 	if err != nil {
-		glog.Errorf("test postgres db errored: %v", err)
+		t.Fatalf("test postgres db errored: %v", err)
 	}
 
 	if account.ID != "bdc928ef-f725-4688-8171-c104cc715bdf" {

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -188,7 +188,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(ampResponse); err != nil {
-		glog.Errorf("/openrtb2/amp Error encoding response: %v", err)
+		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
 		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/amp Error encoding response: %v", err))
 	}
 }

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -188,8 +188,9 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(ampResponse); err != nil {
+		glog.Warningf("/openrtb2/amp Failed to send response: %v", err)
 		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
-		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/amp Error encoding response: %v", err))
+		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/amp Failed to send response: %v", err))
 	}
 }
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -146,8 +146,9 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(response); err != nil {
+		glog.Warningf("/openrtb2/auction Failed to send response: %v", err)
 		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
-		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Error encoding response: %v", err))
+		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to send response: %v", err))
 	}
 }
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -146,7 +146,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(response); err != nil {
-		glog.Errorf("/openrtb2/auction Error encoding response: %v", err)
+		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
 		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Error encoding response: %v", err))
 	}
 }

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -26,15 +26,19 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "requests.ok.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusOK])
 	ensureContains(t, registry, "requests.badinput.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusBadInput])
 	ensureContains(t, registry, "requests.err.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusErr])
+	ensureContains(t, registry, "requests.networkerr.legacy", m.RequestStatuses[ReqTypeLegacy][RequestStatusNetworkErr])
 	ensureContains(t, registry, "requests.ok.openrtb2-web", m.RequestStatuses[ReqTypeORTB2Web][RequestStatusOK])
 	ensureContains(t, registry, "requests.badinput.openrtb2-web", m.RequestStatuses[ReqTypeORTB2Web][RequestStatusBadInput])
 	ensureContains(t, registry, "requests.err.openrtb2-web", m.RequestStatuses[ReqTypeORTB2Web][RequestStatusErr])
+	ensureContains(t, registry, "requests.networkerr.openrtb2-web", m.RequestStatuses[ReqTypeORTB2Web][RequestStatusNetworkErr])
 	ensureContains(t, registry, "requests.ok.openrtb2-app", m.RequestStatuses[ReqTypeORTB2App][RequestStatusOK])
 	ensureContains(t, registry, "requests.badinput.openrtb2-app", m.RequestStatuses[ReqTypeORTB2App][RequestStatusBadInput])
 	ensureContains(t, registry, "requests.err.openrtb2-app", m.RequestStatuses[ReqTypeORTB2App][RequestStatusErr])
+	ensureContains(t, registry, "requests.networkerr.openrtb2-app", m.RequestStatuses[ReqTypeORTB2App][RequestStatusNetworkErr])
 	ensureContains(t, registry, "requests.ok.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusOK])
 	ensureContains(t, registry, "requests.badinput.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusBadInput])
 	ensureContains(t, registry, "requests.err.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusErr])
+	ensureContains(t, registry, "requests.networkerr.amp", m.RequestStatuses[ReqTypeAMP][RequestStatusNetworkErr])
 }
 
 func TestRecordBidType(t *testing.T) {

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -113,9 +113,10 @@ func CookieTypes() []CookieFlag {
 
 // Request/return status
 const (
-	RequestStatusOK       RequestStatus = "ok"
-	RequestStatusBadInput RequestStatus = "badinput"
-	RequestStatusErr      RequestStatus = "err"
+	RequestStatusOK         RequestStatus = "ok"
+	RequestStatusBadInput   RequestStatus = "badinput"
+	RequestStatusErr        RequestStatus = "err"
+	RequestStatusNetworkErr RequestStatus = "networkerr"
 )
 
 func RequestStatuses() []RequestStatus {
@@ -123,6 +124,7 @@ func RequestStatuses() []RequestStatus {
 		RequestStatusOK,
 		RequestStatusBadInput,
 		RequestStatusErr,
+		RequestStatusNetworkErr,
 	}
 }
 


### PR DESCRIPTION
Capturing some metrics on network errors, so we can see how frequently they're happening.

Also downgrading them to `warning`, because they're not unexpected. They're basically all `i/o timeout` or `broken pipe` messages... which just means the network is slow or the browser closed the connection before we could respond. Neither really means that PBS is in critical trouble.