### PR TITLE
Recover from panics inside goroutines

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -139,6 +139,14 @@ func newRaceCheckingRequest(t *testing.T) *openrtb.BidRequest {
 	}
 }
 
+func TestPanicRecovery(t *testing.T) {
+	panicker := func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels) {
+		panic("panic!")
+	}
+	recovered := recoverSafely(panicker)
+	recovered(openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, nil, nil)
+}
+
 func buildImpExt(t *testing.T, jsonFilename string) openrtb.RawJSON {
 	adapterFolders, err := ioutil.ReadDir("../adapters")
 	if err != nil {

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -680,6 +680,14 @@ func TestViperEnv(t *testing.T) {
 	compareStrings(t, "Viper error: host_cookie.ttl_days expected to be %s, found %s", "60", v.Get("host_cookie.ttl_days").(string))
 }
 
+func TestPanicRecovery(t *testing.T) {
+	panicker := func(bidder *pbs.PBSBidder, blables pbsmetrics.AdapterLabels) {
+		panic("panic!")
+	}
+	recovered := recoverSafely(panicker)
+	recovered(nil, pbsmetrics.AdapterLabels{})
+}
+
 func compareStrings(t *testing.T, message string, expect string, actual string) {
 	if expect != actual {
 		t.Errorf(message, expect, actual)


### PR DESCRIPTION
Today, bad Bidder code can cause the server to crash (e.g. nil-pointer dereferences).

The root cause is `panics`, which crash the process if they're not caught. Although Go's HTTP Server catches panics from the handlers, there's nothing to recover inside the goroutines we create ourselves.

This adds some safeguards so they get logged as errors rather than crashing the process.

I do plan to add this to the metrics... but was undecided on whether to do it in this PR or another one. Let me know either way.