### PR TITLE
Adds error code output to openrtb auction debugs.

### DIFF
--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -232,16 +232,14 @@ It will become impossible to fetch bids from Appnexus within that Request.
 `response.ext.responsetimemillis.{bidderName}` tells how long each bidder took to respond.
 These can help quantify the performance impact of "the slowest bidder."
 
+#### Bidder Errors
+
 `response.ext.errors.{bidderName}` contains messages which describe why a request may be "suboptimal".
 For example, suppose a `banner` and a `video` impression are offered to a bidder
 which only supports `banner`.
 
 In cases like these, the bidder can ignore the `video` impression and bid on the `banner` one.
 However, the publisher can improve performance by only offering impressions which the bidder supports.
-
-#### Bidder Errors
-
-`response.ext.errors` contains any errors reported by the bidders as they processed the request, broken out by bidder.
 
 For example, a request may return this in `response.ext`
 

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -264,10 +264,10 @@ For example, a request may return this in `response.ext`
 The codes currently defined are:
 
 ```
-0	NoErrorCode
-1	TimeoutCode
-2	BadInputCode
-3	BadServerResponseCode
+0   NoErrorCode
+1   TimeoutCode
+2   BadInputCode
+3   BadServerResponseCode
 999 UnknownErrorCode
 ```
 

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -270,7 +270,7 @@ The codes currently defined are:
 1	TimeoutCode
 2	BadInputCode
 3	BadServerResponseCode
-4	JSONEncodingCode
+999 UnknownErrorCode
 ```
 
 #### Debugging

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -239,6 +239,40 @@ which only supports `banner`.
 In cases like these, the bidder can ignore the `video` impression and bid on the `banner` one.
 However, the publisher can improve performance by only offering impressions which the bidder supports.
 
+#### Bidder Errors
+
+`response.ext.errors` contains any errors reported by the bidders as they processed the request, broken out by bidder.
+
+For example, a request may return this in `response.ext`
+
+```
+{
+  "errors": {
+    "appnexus": [
+      {
+        "code": 2,
+        "message": "A hybrid Banner/Audio Imp was offered, but Appnexus doesn't support Audio."
+      }
+    ],
+    "rubicon": [
+      {
+        "code": 1, "The request exceeded the timeout allocated"
+      }
+    ]
+  }
+}
+```
+
+The codes currently defined are:
+
+```
+0	NoErrorCode
+1	TimeoutCode
+2	BadInputCode
+3	BadServerResponseCode
+4	JSONEncodingCode
+```
+
 #### Debugging
 
 `response.ext.debug.httpcalls.{bidder}` will be populated **only if** `request.test` **was set to 1**.

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -7,7 +7,6 @@ const (
 	TimeoutCode
 	BadInputCode
 	BadServerResponseCode
-	JSONEncodingCode
 )
 
 // We should use this code for any Error interface that is not in this package
@@ -69,18 +68,6 @@ func (err *BadServerResponse) Error() string {
 
 func (err *BadServerResponse) Code() int {
 	return BadServerResponseCode
-}
-
-type JSONEncoding struct {
-	Message string
-}
-
-func (err *JSONEncoding) Error() string {
-	return err.Message
-}
-
-func (err *JSONEncoding) Code() int {
-	return JSONEncodingCode
 }
 
 // DecodeError provides the error code for an error, as defined above

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -7,14 +7,14 @@ const (
 	TimeoutCode
 	BadInputCode
 	BadServerResponseCode
+	JSONEncodingCode
 )
 
 // We should use this code for any Error interface that is not in this package
 const UnknownErrorCode = 999
 
-// PBSError provides an interface to use if we want to deal with any error type created in this package.
-type PBSError interface {
-	Error() string
+// Coder provides an interface to use if we want to check the code of an error type created in this package.
+type Coder interface {
 	Code() int
 }
 
@@ -69,4 +69,24 @@ func (err *BadServerResponse) Error() string {
 
 func (err *BadServerResponse) Code() int {
 	return BadServerResponseCode
+}
+
+type JSONEncoding struct {
+	Message string
+}
+
+func (err *JSONEncoding) Error() string {
+	return err.Message
+}
+
+func (err *JSONEncoding) Code() int {
+	return JSONEncodingCode
+}
+
+// DecodeError provides the error code for an error, as defined above
+func DecodeError(err error) int {
+	if ce, ok := err.(Coder); ok {
+		return ce.Code()
+	}
+	return UnknownErrorCode
 }

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -171,6 +171,9 @@ func (bidder *bidderAdapter) doRequest(ctx context.Context, req *adapters.Reques
 
 	httpResp, err := ctxhttp.Do(ctx, bidder.Client, httpReq)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			err = &errortypes.Timeout{Message: err.Error()}
+		}
 		return &httpCallInfo{
 			request: req,
 			err:     err,

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -356,7 +356,7 @@ func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.B
 func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) ([]openrtb.Bid, []error) {
 	bids := make([]openrtb.Bid, 0, len(Bids))
 	errList := make([]error, 0, 1)
-	for i, thisBid := range Bids {
+	for _, thisBid := range Bids {
 		bidExt := &openrtb_ext.ExtBid{
 			Bidder: thisBid.bid.Ext,
 			Prebid: &openrtb_ext.ExtBidPrebid{
@@ -367,7 +367,7 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) (
 
 		ext, err := json.Marshal(bidExt)
 		if err != nil {
-			errList = append(errList, &errortypes.JSONEncoding{Message: fmt.Sprintf("Error writing SeatBid.Bid[%d].Ext: %s", i, err.Error())})
+			errList = append(errList, err)
 		} else {
 			bids = append(bids, *thisBid.bid)
 			bids[len(bids)-1].Ext = ext

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -232,17 +232,15 @@ func errorsToMetric(errs []error) map[pbsmetrics.AdapterError]struct{} {
 	ret := make(map[pbsmetrics.AdapterError]struct{}, len(errs))
 	var s struct{}
 	for _, err := range errs {
-		if _, ok := err.(*errortypes.Timeout); ok {
+		switch errortypes.DecodeError(err) {
+		case errortypes.TimeoutCode:
 			ret[pbsmetrics.AdapterErrorTimeout] = s
-		} else {
-			switch err.(type) {
-			case *errortypes.BadInput:
-				ret[pbsmetrics.AdapterErrorBadInput] = s
-			case *errortypes.BadServerResponse:
-				ret[pbsmetrics.AdapterErrorBadServerResponse] = s
-			default:
-				ret[pbsmetrics.AdapterErrorUnknown] = s
-			}
+		case errortypes.BadInputCode:
+			ret[pbsmetrics.AdapterErrorBadInput] = s
+		case errortypes.BadServerResponseCode:
+			ret[pbsmetrics.AdapterErrorBadServerResponse] = s
+		default:
+			ret[pbsmetrics.AdapterErrorUnknown] = s
 		}
 	}
 	return ret

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -41,7 +41,7 @@ type exchange struct {
 // Container to pass out response ext data from the GetAllBids goroutines back into the main thread
 type seatResponseExtra struct {
 	ResponseTimeMillis int
-	Errors             []string
+	Errors             []openrtb_ext.ExtBidderError
 }
 
 type bidResponseWrapper struct {
@@ -180,7 +180,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			ae.ResponseTimeMillis = int(elapsed / time.Millisecond)
 			// Timing statistics
 			e.me.RecordAdapterTime(*bidlabels, time.Since(start))
-			serr := errsToStrings(err)
+			serr := errsToBidderErrors(err)
 			bidlabels.AdapterBids = bidsToMetric(bids)
 			bidlabels.AdapterErrors = errorsToMetric(err)
 			// Append any bid validation errors to the error list
@@ -232,7 +232,7 @@ func errorsToMetric(errs []error) map[pbsmetrics.AdapterError]struct{} {
 	ret := make(map[pbsmetrics.AdapterError]struct{}, len(errs))
 	var s struct{}
 	for _, err := range errs {
-		if err == context.DeadlineExceeded {
+		if _, ok := err.(*errortypes.Timeout); ok {
 			ret[pbsmetrics.AdapterErrorTimeout] = s
 		} else {
 			switch err.(type) {
@@ -248,10 +248,11 @@ func errorsToMetric(errs []error) map[pbsmetrics.AdapterError]struct{} {
 	return ret
 }
 
-func errsToStrings(errs []error) []string {
-	serr := make([]string, len(errs))
+func errsToBidderErrors(errs []error) []openrtb_ext.ExtBidderError {
+	serr := make([]openrtb_ext.ExtBidderError, len(errs))
 	for i := 0; i < len(errs); i++ {
-		serr[i] = errs[i].Error()
+		serr[i].Code = errortypes.DecodeError(errs[i])
+		serr[i].Message = errs[i].Error()
 	}
 	return serr
 }
@@ -287,7 +288,7 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 // Extract all the data from the SeatBids and build the ExtBidResponse
 func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, req *openrtb.BidRequest, resolvedRequest json.RawMessage, errList []error) *openrtb_ext.ExtBidResponse {
 	bidResponseExt := &openrtb_ext.ExtBidResponse{
-		Errors:             make(map[openrtb_ext.BidderName][]string, len(adapterBids)),
+		Errors:             make(map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError, len(adapterBids)),
 		ResponseTimeMillis: make(map[openrtb_ext.BidderName]int, len(adapterBids)),
 	}
 	if req.Test == 1 {
@@ -311,11 +312,7 @@ func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pb
 			bidResponseExt.Errors[a] = adapterExtra[a].Errors
 		}
 		if len(errList) > 0 {
-			s := make([]string, len(errList))
-			for i := 0; i < len(errList); i++ {
-				s[i] = errList[i].Error()
-			}
-			bidResponseExt.Errors["prebid"] = s
+			bidResponseExt.Errors["prebid"] = errsToBidderErrors(errList)
 		}
 		bidResponseExt.ResponseTimeMillis[a] = adapterExtra[a].ResponseTimeMillis
 		// Defering the filling of bidResponseExt.Usersync[a] until later
@@ -339,24 +336,28 @@ func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.B
 
 		ext, err := json.Marshal(sbExt)
 		if err != nil {
-			adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, fmt.Sprintf("Error writing SeatBid.Ext: %s", err.Error()))
+			extError := openrtb_ext.ExtBidderError{
+				Code:    errortypes.DecodeError(err),
+				Message: fmt.Sprintf("Error writing SeatBid.Ext: %s", err.Error()),
+			}
+			adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, extError)
 		}
 		seatBid.Ext = ext
 	}
 
-	var errList []string
+	var errList []error
 	seatBid.Bid, errList = e.makeBid(adapterBid.bids, adapter)
 	if len(errList) > 0 {
-		adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, errList...)
+		adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, errsToBidderErrors(errList)...)
 	}
 
 	return seatBid
 }
 
 // Create the Bid array inside of SeatBid
-func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) ([]openrtb.Bid, []string) {
+func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) ([]openrtb.Bid, []error) {
 	bids := make([]openrtb.Bid, 0, len(Bids))
-	errList := make([]string, 0, 1)
+	errList := make([]error, 0, 1)
 	for i, thisBid := range Bids {
 		bidExt := &openrtb_ext.ExtBid{
 			Bidder: thisBid.bid.Ext,
@@ -368,7 +369,7 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) (
 
 		ext, err := json.Marshal(bidExt)
 		if err != nil {
-			errList = append(errList, fmt.Sprintf("Error writing SeatBid.Bid[%d].Ext: %s", i, err.Error()))
+			errList = append(errList, &errortypes.JSONEncoding{Message: fmt.Sprintf("Error writing SeatBid.Bid[%d].Ext: %s", i, err.Error())})
 		} else {
 			bids = append(bids, *thisBid.bid)
 			bids[len(bids)-1].Ext = ext

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -8,7 +8,7 @@ import (
 type ExtBidResponse struct {
 	Debug *ExtResponseDebug `json:"debug,omitempty"`
 	// ExtResponseErrors defines the contract for bidresponse.ext.errors
-	Errors map[BidderName][]string `json:"errors,omitempty"`
+	Errors map[BidderName][]ExtBidderError `json:"errors,omitempty"`
 	// ExtResponseTimeMillis defines the contract for bidresponse.ext.responsetimemillis
 	ResponseTimeMillis map[BidderName]int `json:"responsetimemillis,omitempty"`
 	// ExtResponseUserSync defines the contract for bidresponse.ext.usersync
@@ -34,6 +34,12 @@ type ExtResponseSyncData struct {
 type ExtUserSync struct {
 	Url  string       `json:"url"`
 	Type UserSyncType `json:"type"`
+}
+
+// ExtBidderError defines an error object to be returned, consiting of a machine readable error code, and a human readable error message string.
+type ExtBidderError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 // ExtHttpCall defines the contract for a bidresponse.ext.debug.httpcalls.{bidder}[i]


### PR DESCRIPTION
This expands the reporting of errors in debug requests to include error codes. This will allow for some automation in analyzing debug reports, as scripts can focus on the error codes rather than trying to pattern match against error messages.