### PR TITLE
Fix AMP targeting defaults

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -414,8 +414,9 @@ func defaultRequestExt(req *openrtb.BidRequest) (errs []error) {
 		setDefaults = true
 		extRequest.Prebid.Targeting = &openrtb_ext.ExtRequestTargeting{
 			// Fixes #452
-			IncludeWinners:   true,
-			PriceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			IncludeWinners:    true,
+			IncludeBidderKeys: true,
+			PriceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
 		}
 	}
 	if extRequest.Prebid.Cache == nil || extRequest.Prebid.Cache.Bids == nil {

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -151,6 +151,9 @@ func TestAmpTargetingDefaults(t *testing.T) {
 	if !extRequest.Prebid.Targeting.IncludeWinners {
 		t.Error("AMP defaults should set request.ext.targeting.includewinners to true")
 	}
+	if !extRequest.Prebid.Targeting.IncludeBidderKeys {
+		t.Error("AMP defaults should set request.ext.targeting.includebidderkeys to true")
+	}
 	if !reflect.DeepEqual(extRequest.Prebid.Targeting.PriceGranularity, openrtb_ext.PriceGranularityFromString("med")) {
 		t.Error("AMP defaults should set request.ext.targeting.pricegranularity to medium")
 	}


### PR DESCRIPTION
Per the `/openrtb2/auction` docs:

> "includewinners": false // Optional param defaulting to true
> "includebidderkeys": false // Optional param defaulting to true

AMP should probably be consistent with these.