### PR TITLE
Currency support #280 - step 1

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -56,6 +56,9 @@ type pbsOrtbBid struct {
 type pbsOrtbSeatBid struct {
 	// bids is the list of bids which this adaptedBidder wishes to make.
 	bids []*pbsOrtbBid
+	// currency is the currency in which the bids are made.
+	// Should be a valid curreny ISO code.
+	currency string
 	// httpCalls is the list of debugging info. It should only be populated if the request.test == 1.
 	// This will become response.ext.debug.httpcalls.{bidder} on the final Response.
 	httpCalls []*openrtb_ext.ExtHttpCall
@@ -103,8 +106,11 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 
 	seatBid := &pbsOrtbSeatBid{
 		bids:      make([]*pbsOrtbBid, 0, len(reqData)),
+		currency:  "USD",
 		httpCalls: make([]*openrtb_ext.ExtHttpCall, 0, len(reqData)),
 	}
+
+	firstHTTPCallCurrency := ""
 
 	// If the bidder made multiple requests, we still want them to enter as many bids as possible...
 	// even if the timeout occurs sometime halfway through.
@@ -116,18 +122,43 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 		}
 
 		if httpInfo.err == nil {
+
 			bidResponse, moreErrs := bidder.Bidder.MakeBids(request, httpInfo.request, httpInfo.response)
 			errs = append(errs, moreErrs...)
+
 			if bidResponse != nil {
-				for i := 0; i < len(bidResponse.Bids); i++ {
-					if bidResponse.Bids[i].Bid != nil {
-						// TODO #280: Convert the bid price
-						bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment
+
+				if bidResponse.Currency == "" {
+					bidResponse.Currency = "USD"
+				}
+
+				// Related to #281 - currency support
+				// Prebid can't make sure that each HTTP call returns bids with the same currency as the others.
+				// If a Bidder makes two HTTP calls, and their servers respond with different currencies,
+				// we will consider the first call currency as standard currency and then reject others which contradict it.
+				if firstHTTPCallCurrency == "" { // First HTTP call
+					firstHTTPCallCurrency = bidResponse.Currency
+				}
+
+				// TODO: #281 - Once currencies rate conversion is out, this shouldn't be an issue anymore, we will only
+				// need to convert the bid price based on the currency.
+				if firstHTTPCallCurrency == bidResponse.Currency {
+					for i := 0; i < len(bidResponse.Bids); i++ {
+						if bidResponse.Bids[i].Bid != nil {
+							// TODO #280: Convert the bid price
+							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment
+						}
+						seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
+							bid:     bidResponse.Bids[i].Bid,
+							bidType: bidResponse.Bids[i].BidType,
+						})
 					}
-					seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
-						bid:     bidResponse.Bids[i].Bid,
-						bidType: bidResponse.Bids[i].BidType,
-					})
+				} else {
+					errs = append(errs, fmt.Errorf(
+						"Bid currencies mistmatch found. Expected all bids to have the same currencies. Expected '%s', was: '%s'",
+						firstHTTPCallCurrency,
+						bidResponse.Currency,
+					))
 				}
 			}
 		} else {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
+	"golang.org/x/text/currency"
 
 	"github.com/mxmCherry/openrtb"
 
@@ -171,7 +173,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			elapsed := time.Since(start)
 			brw.adapterBids = bids
 			// validate bids ASAP, so we don't waste time on invalid bids.
-			err2 := brw.validateBids()
+			err2 := brw.validateBids(request)
 			if len(err2) > 0 {
 				err = append(err, err2...)
 			}
@@ -378,15 +380,21 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName) (
 }
 
 // validateBids will run some validation checks on the returned bids and excise any invalid bids
-func (brw *bidResponseWrapper) validateBids() (err []error) {
+func (brw *bidResponseWrapper) validateBids(request *openrtb.BidRequest) (err []error) {
 	// Exit early if there is nothing to do.
 	if brw.adapterBids == nil || len(brw.adapterBids.bids) == 0 {
 		return
 	}
-	// TODO #280: Exit if there is a currency mismatch between currencies passed in bid request
-	// and the currency received in the bid.
-	// Check also if the currency received exists.
+
 	err = make([]error, 0, len(brw.adapterBids.bids))
+
+	// By design, default currency is USD.
+	if cerr := validateCurrency(request.Cur, brw.adapterBids.currency); cerr != nil {
+		brw.adapterBids.bids = nil
+		err = append(err, cerr)
+		return
+	}
+
 	validBids := make([]*pbsOrtbBid, 0, len(brw.adapterBids.bids))
 	for _, bid := range brw.adapterBids.bids {
 		if ok, berr := validateBid(bid); ok {
@@ -400,6 +408,42 @@ func (brw *bidResponseWrapper) validateBids() (err []error) {
 		brw.adapterBids.bids = validBids
 	}
 	return err
+}
+
+// validateCurrency will run currency validation checks and return true if it passes, false otherwise.
+func validateCurrency(requestAllowedCurrencies []string, bidCurrency string) error {
+	// Default currency is `USD` by design.
+	defaultCurrency := "USD"
+	// Make sure bid currency is a valid ISO currency code
+	if bidCurrency == "" {
+		// If bid currency is not set, then consider it's default currency.
+		bidCurrency = defaultCurrency
+	}
+	currencyUnit, cerr := currency.ParseISO(bidCurrency)
+	if cerr != nil {
+		return cerr
+	}
+	// Make sure the bid currency is allowed from bid request via `cur` field.
+	// If `cur` field array from bid request is empty, then consider it accepts the default currency.
+	currencyAllowed := false
+	if len(requestAllowedCurrencies) == 0 {
+		requestAllowedCurrencies = []string{defaultCurrency}
+	}
+	for _, allowedCurrency := range requestAllowedCurrencies {
+		if strings.ToUpper(allowedCurrency) == currencyUnit.String() {
+			currencyAllowed = true
+			break
+		}
+	}
+	if currencyAllowed == false {
+		return fmt.Errorf(
+			"Bid currency is not allowed. Was '%s', wants: ['%s']",
+			currencyUnit.String(),
+			strings.Join(requestAllowedCurrencies, "', '"),
+		)
+	}
+
+	return nil
 }
 
 // validateBid will run the supplied bid through validation checks and return true if it passes, false otherwise.
@@ -420,5 +464,6 @@ func validateBid(bid *pbsOrtbBid) (bool, error) {
 	if bid.bid.CrID == "" {
 		return false, fmt.Errorf("Bid \"%s\" missing creative ID", bid.bid.ID)
 	}
+
 	return true, nil
 }

--- a/exchange/validation_test.go
+++ b/exchange/validation_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestAllValidBids(t *testing.T) {
+	brq := &openrtb.BidRequest{}
+
 	bids := make([]*pbsOrtbBid, 3)
+
 	bids[0] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ID:    "one-bid",
@@ -37,11 +40,13 @@ func TestAllValidBids(t *testing.T) {
 			bids: bids,
 		},
 	}
-	assertBids(t, brw, 3, 0)
+	assertBids(t, brq, brw, 3, 0)
 }
 
 func TestAllBadBids(t *testing.T) {
+	brq := &openrtb.BidRequest{}
 	bids := make([]*pbsOrtbBid, 5)
+
 	bids[0] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
 			ID:    "one-bid",
@@ -76,10 +81,12 @@ func TestAllBadBids(t *testing.T) {
 			bids: bids,
 		},
 	}
-	assertBids(t, brw, 0, 5)
+	assertBids(t, brq, brw, 0, 5)
 }
 
 func TestMixeddBids(t *testing.T) {
+	brq := &openrtb.BidRequest{}
+
 	bids := make([]*pbsOrtbBid, 5)
 	bids[0] = &pbsOrtbBid{
 		bid: &openrtb.Bid{
@@ -117,16 +124,135 @@ func TestMixeddBids(t *testing.T) {
 			bids: bids,
 		},
 	}
-	assertBids(t, brw, 2, 3)
+	assertBids(t, brq, brw, 2, 3)
 }
 
-func assertBids(t *testing.T, brw *bidResponseWrapper, ebids int, eerrs int) {
-	errs := brw.validateBids()
+func TestCurrencyBids(t *testing.T) {
+	currencyTestCases := []struct {
+		brqCur           []string
+		brpCur           string
+		defaultCur       string
+		expectedValidBid bool
+	}{
+		// Case bid request and bid response don't specify any currencies.
+		// Expected to be valid since both bid request / response will be overriden with default currency (USD).
+		{
+			brqCur:           []string{},
+			brpCur:           "",
+			expectedValidBid: true,
+		},
+		// Case bid request specifies a currency (default one) but bid response doesn't.
+		// Expected to be valid since bid response will be overriden with default currency (USD).
+		{
+			brqCur:           []string{"USD"},
+			brpCur:           "",
+			expectedValidBid: true,
+		},
+		// Case bid request specifies more than 1 currency (default one and another one) but bid response doesn't.
+		// Expected to be valid since bid response will be overriden with default currency (USD).
+		{
+			brqCur:           []string{"USD", "EUR"},
+			brpCur:           "",
+			expectedValidBid: true,
+		},
+		// Case bid request specifies more than 1 currency (default one and another one) and bid response specifies default currency (USD).
+		// Expected to be valid.
+		{
+			brqCur:           []string{"USD", "EUR"},
+			brpCur:           "USD",
+			expectedValidBid: true,
+		},
+		// Case bid request specifies more than 1 currency (default one and another one) and bid response specifies the second currency allowed (not USD).
+		// Expected to be valid.
+		{
+			brqCur:           []string{"USD", "EUR"},
+			brpCur:           "EUR",
+			expectedValidBid: true,
+		},
+		// Case bid request specifies only 1 currency which is not the default one.
+		// Bid response doesn't specify any currency.
+		// Expected to be invalid.
+		{
+			brqCur:           []string{"JPY"},
+			brpCur:           "",
+			expectedValidBid: false,
+		},
+		// Case bid request doesn't specify any currencies.
+		// Bid response specifies a currency which is not the default one.
+		// Expected to be invalid.
+		{
+			brqCur:           []string{},
+			brpCur:           "JPY",
+			expectedValidBid: false,
+		},
+		// Case bid request specifies a currency.
+		// Bid response specifies a currency which is not the one specified in bid request.
+		// Expected to be invalid.
+		{
+			brqCur:           []string{"USD"},
+			brpCur:           "EUR",
+			expectedValidBid: false,
+		},
+		// Case bid request specifies several currencies.
+		// Bid response specifies a currency which is not the one specified in bid request.
+		// Expected to be invalid.
+		{
+			brqCur:           []string{"USD", "EUR"},
+			brpCur:           "JPY",
+			expectedValidBid: false,
+		},
+	}
+
+	for _, tc := range currencyTestCases {
+
+		brq := &openrtb.BidRequest{
+			Cur: tc.brqCur,
+		}
+
+		bids := make([]*pbsOrtbBid, 2)
+		bids[0] = &pbsOrtbBid{
+			bid: &openrtb.Bid{
+				ID:    "one-bid",
+				ImpID: "thisImp",
+				Price: 0.45,
+				CrID:  "thisCreative",
+			},
+		}
+		bids[1] = &pbsOrtbBid{
+			bid: &openrtb.Bid{
+				ID:    "thatBid",
+				ImpID: "thatImp",
+				Price: 0.44,
+				CrID:  "thatCreative",
+			},
+		}
+
+		brw := &bidResponseWrapper{
+			adapterBids: &pbsOrtbSeatBid{
+				bids:     bids,
+				currency: tc.brpCur,
+			},
+		}
+
+		expectedValidBids := len(bids)
+		expectedErrs := 0
+
+		if tc.expectedValidBid != true {
+			// If currency mistmatch, we should have one error
+			expectedErrs = 1
+			expectedValidBids = 0
+		}
+
+		assertBids(t, brq, brw, expectedValidBids, expectedErrs)
+	}
+}
+
+func assertBids(t *testing.T, brq *openrtb.BidRequest, brw *bidResponseWrapper, ebids int, eerrs int) {
+	errs := brw.validateBids(brq)
 	if len(errs) != eerrs {
 		t.Errorf("Expected %d Errors validating bids, found %d", eerrs, len(errs))
 	}
 	if len(brw.adapterBids.bids) != ebids {
 		t.Errorf("Expected %d bids, found %d bids", ebids, len(brw.adapterBids.bids))
 	}
-
 }


### PR DESCRIPTION
This CL allows prebid server to reject any bids having a currency mismatch between allowed
currencies in the bid request and the currency declared in bids.

For the time being, if allowed currencies are not declared in bid request or in bid
the currency is implicitly set to `USD` to prevent from any breaking changes.

This CL includes:
- Prebid server to reject bids having currency mistmatch

Tnis CL doesn't include:
- Changing the default currency (which is USD)

More details in #280