### PR TITLE
Revert "Fix tagid param for Sovrn"

### DIFF
--- a/static/bidder-params/sovrn.json
+++ b/static/bidder-params/sovrn.json
@@ -14,5 +14,5 @@
       "description": "The minimium acceptable bid, in CPM, using US Dollars"
     }
   },
-  "required": ["tagid"]
+  "required": ["tagId"]
 }


### PR DESCRIPTION
Reverts prebid/prebid-server#633

@rachelrj we actually saw on release that this breaks things for some publishers.

If you want to change this, it'll have to be backwards-compatible.  You can add `tagId` as a separate param, document `tagid` as deprecated, and then use `oneOf` to guarantee that one of the two exists.