### PR TITLE
Creat a Fail-To_Bid error

### DIFF
--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -7,6 +7,7 @@ const (
 	TimeoutCode
 	BadInputCode
 	BadServerResponseCode
+	FailedToRequestBidsCode
 )
 
 // We should use this code for any Error interface that is not in this package
@@ -68,6 +69,23 @@ func (err *BadServerResponse) Error() string {
 
 func (err *BadServerResponse) Code() int {
 	return BadServerResponseCode
+}
+
+// FailedToRequestBids is an error to cover the case where an adapter failed to generate any http requests to get bids,
+// but did not generate any error messages. This should not happen in practice and will signal that an adapter is poorly
+// coded. If there was something wrong with a request such that an adapter could not generate a bid, then it should
+// generate an error explaining the deficiency. Otherwise it will be extremely difficult to debug the reason why an
+// adapter is not bidding.
+type FailedToRequestBids struct {
+	Message string
+}
+
+func (err *FailedToRequestBids) Error() string {
+	return err.Message
+}
+
+func (err *FailedToRequestBids) Code() int {
+	return FailedToRequestBidsCode
 }
 
 // DecodeError provides the error code for an error, as defined above

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -85,6 +85,10 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 	reqData, errs := bidder.Bidder.MakeRequests(request)
 
 	if len(reqData) == 0 {
+		// If the adapter failed to generate both requests and errors, this is an error.
+		if len(errs) == 0 {
+			errs = append(errs, &errortypes.FailedToRequestBids{Message: "The adapter failed to generate any bid requests, but also failed to generate an error explaining why"})
+		}
 		return nil, errs
 	}
 

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -240,7 +240,7 @@ func errorsToMetric(errs []error) map[pbsmetrics.AdapterError]struct{} {
 		case errortypes.BadServerResponseCode:
 			ret[pbsmetrics.AdapterErrorBadServerResponse] = s
 		case errortypes.FailedToRequestBidsCode:
-			ret[pbsmetrics.AdapterErrorFailedToBid] = s
+			ret[pbsmetrics.AdapterErrorFailedToRequestBids] = s
 		default:
 			ret[pbsmetrics.AdapterErrorUnknown] = s
 		}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -239,6 +239,8 @@ func errorsToMetric(errs []error) map[pbsmetrics.AdapterError]struct{} {
 			ret[pbsmetrics.AdapterErrorBadInput] = s
 		case errortypes.BadServerResponseCode:
 			ret[pbsmetrics.AdapterErrorBadServerResponse] = s
+		case errortypes.FailedToRequestBidsCode:
+			ret[pbsmetrics.AdapterErrorFailedToBid] = s
 		default:
 			ret[pbsmetrics.AdapterErrorUnknown] = s
 		}

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -146,6 +146,7 @@ const (
 	AdapterErrorBadInput          AdapterError = "badinput"
 	AdapterErrorBadServerResponse AdapterError = "badserverresponse"
 	AdapterErrorTimeout           AdapterError = "timeout"
+	AdapterErrorFailedToBid       AdapterError = "failedtobid"
 	AdapterErrorUnknown           AdapterError = "unknown_error"
 )
 
@@ -154,6 +155,7 @@ func AdapterErrors() []AdapterError {
 		AdapterErrorBadInput,
 		AdapterErrorBadServerResponse,
 		AdapterErrorTimeout,
+		AdapterErrorFailedToBid,
 		AdapterErrorUnknown,
 	}
 }

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -143,11 +143,11 @@ func AdapterBids() []AdapterBid {
 
 // Adapter execution status
 const (
-	AdapterErrorBadInput          AdapterError = "badinput"
-	AdapterErrorBadServerResponse AdapterError = "badserverresponse"
-	AdapterErrorTimeout           AdapterError = "timeout"
-	AdapterErrorFailedToBid       AdapterError = "failedtobid"
-	AdapterErrorUnknown           AdapterError = "unknown_error"
+	AdapterErrorBadInput            AdapterError = "badinput"
+	AdapterErrorBadServerResponse   AdapterError = "badserverresponse"
+	AdapterErrorTimeout             AdapterError = "timeout"
+	AdapterErrorFailedToRequestBids AdapterError = "failedtorequestbid"
+	AdapterErrorUnknown             AdapterError = "unknown_error"
 )
 
 func AdapterErrors() []AdapterError {
@@ -155,7 +155,7 @@ func AdapterErrors() []AdapterError {
 		AdapterErrorBadInput,
 		AdapterErrorBadServerResponse,
 		AdapterErrorTimeout,
-		AdapterErrorFailedToBid,
+		AdapterErrorFailedToRequestBids,
 		AdapterErrorUnknown,
 	}
 }


### PR DESCRIPTION
Adapters should either generate one or more http requests to their bidder to get bids, or return errors indicating why they could not bid on the supplied bid request (or both). However this is not enforced. This PR adds a failedToBid error to catch this case, and signal that an adapter is misbehaving in this manner. This should hopefully never happen, but now we will be able to catch and debug if it ever does.