### PR TITLE
Add adapter errors to the AMP response

### DIFF
--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -73,11 +73,21 @@ A sample response payload looks like this:
         "hb_size": "300x250",
         "hb_size_appnexus": "300x250"
     }
+    "errors": {
+        "openx":[
+            {
+               "code": 1, 
+               "message": "The request exceeded the timeout allocated"
+            }
+        ]
+    }
 }
 ```
 
 In [the typical AMP setup](http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html),
 these targeting params will be sent to DFP.
+
+Note that "errors" will only appear if there were any errors generated. They are identical to the "errors" field in the response.ext of the OpenRTB endpoint.
 
 ### Query Parameters
 

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -254,7 +254,8 @@ For example, a request may return this in `response.ext`
     ],
     "rubicon": [
       {
-        "code": 1, "The request exceeded the timeout allocated"
+        "code": 1, 
+        "message": "The request exceeded the timeout allocated"
       }
     ]
   }

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -167,7 +167,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	var extResponse openrtb_ext.ExtBidResponse
 	eRErr := json.Unmarshal(response.Ext, &extResponse)
 	if eRErr != nil {
-		ao.Errors = append(ao.Errors, fmt.Errorf("AMP response: failed to unpack OpenRTB response.ext: %v", eRErr))
+		ao.Errors = append(ao.Errors, fmt.Errorf("AMP response: failed to unpack OpenRTB response.ext, debug info cannot be forwarded: %v", eRErr))
 	}
 
 	// Now JSONify the targets for the AMP response.

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -165,19 +165,15 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	}
 	// Extract any errors
 	var extResponse openrtb_ext.ExtBidResponse
-	var respErrors map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError
 	eRErr := json.Unmarshal(response.Ext, &extResponse)
 	if eRErr != nil {
-		glog.Errorf("AMP response: failed to unpack OpenRTB response.ext: %v", eRErr)
 		ao.Errors = append(ao.Errors, fmt.Errorf("AMP response: failed to unpack OpenRTB response.ext: %v", eRErr))
-	} else {
-		respErrors = extResponse.Errors
 	}
 
 	// Now JSONify the targets for the AMP response.
 	ampResponse := AmpResponse{
 		Targeting: targets,
-		Errors:    respErrors,
+		Errors:    extResponse.Errors,
 	}
 
 	ao.AmpTargetingValues = targets

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -26,11 +26,12 @@ import (
 const defaultAmpRequestTimeoutMillis = 900
 
 type AmpResponse struct {
-	Targeting map[string]string             `json:"targeting"`
-	Debug     *openrtb_ext.ExtResponseDebug `json:"debug,omitempty"`
+	Targeting map[string]string                                       `json:"targeting"`
+	Debug     *openrtb_ext.ExtResponseDebug                           `json:"debug,omitempty"`
+	Errors    map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError `json:"errors,omitempty"`
 }
 
-// We need to modify the OpenRTB endpoint to handle AMP requests. This will basically modify the parsing
+// NewAmpEndpoint modifies the OpenRTB endpoint to handle AMP requests. This will basically modify the parsing
 // of the request, and the return value, using the OpenRTB machinery to handle everything inbetween.
 func NewAmpEndpoint(ex exchange.Exchange, validator openrtb_ext.BidderParamValidator, requestsById stored_requests.Fetcher, cfg *config.Configuration, met pbsmetrics.MetricsEngine, pbsAnalytics analytics.PBSAnalyticsModule) (httprouter.Handle, error) {
 	if ex == nil || validator == nil || requestsById == nil || cfg == nil || met == nil {
@@ -162,17 +163,28 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 			}
 		}
 	}
+	// Extract any errors
+	var extResponse openrtb_ext.ExtBidResponse
+	var respErrors map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError
+	eRErr := json.Unmarshal(response.Ext, &extResponse)
+	if eRErr != nil {
+		glog.Errorf("AMP response: failed to unpack OpenRTB response.ext: %v", eRErr)
+		ao.Errors = append(ao.Errors, fmt.Errorf("AMP response: failed to unpack OpenRTB response.ext: %v", eRErr))
+	} else {
+		respErrors = extResponse.Errors
+	}
+
 	// Now JSONify the targets for the AMP response.
 	ampResponse := AmpResponse{
 		Targeting: targets,
+		Errors:    respErrors,
 	}
 
 	ao.AmpTargetingValues = targets
 
 	// add debug information if requested
-	if req.Test == 1 {
-		var extResponse openrtb_ext.ExtBidResponse
-		if err := json.Unmarshal(response.Ext, &extResponse); err == nil && extResponse.Debug != nil {
+	if req.Test == 1 && eRErr == nil {
+		if extResponse.Debug != nil {
 			ampResponse.Debug = extResponse.Debug
 		} else {
 			glog.Errorf("Test set on request but debug not present in response: %v", err)

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -68,6 +68,9 @@ func TestGoodAmpRequests(t *testing.T) {
 		if response.Debug != nil {
 			t.Errorf("Debug present but not requested")
 		}
+		if _, ok := response.Errors[openrtb_ext.BidderOpenx]; !ok {
+			t.Errorf("OpenX error message is not present. (%v)", response.Errors)
+		}
 	}
 }
 
@@ -333,6 +336,7 @@ func (m *mockAmpExchange) HoldAuction(ctx context.Context, bidRequest *openrtb.B
 				Ext: openrtb.RawJSON(`{ "prebid": {"targeting": { "hb_pb": "1.20", "hb_appnexus_pb": "1.20", "hb_cache_id": "some_id"}}}`),
 			}},
 		}},
+		Ext: openrtb.RawJSON(`{ "errors": {"openx":[ { "code": 1, "message": "The request exceeded the timeout allocated" } ] } }`),
 	}
 
 	if bidRequest.Test == 1 {


### PR DESCRIPTION
AMP should ignore the field, but allows for debugging without trying to turn the request into an openrtb request. Fixes #616 