### PR TITLE
Removed mobile support listing from audience network.

### DIFF
--- a/static/bidder-info/audienceNetwork.yaml
+++ b/static/bidder-info/audienceNetwork.yaml
@@ -1,9 +1,6 @@
 maintainer:
   email: "info@prebid.org"
 capabilities:
-  app:
-    mediaTypes:
-      - banner
   site:
     mediaTypes:
       - banner


### PR DESCRIPTION
@mjacobsonny tells me that mobile doesn't work with audience network... so removing it here.