### PR TITLE
Removed gox until the before_deploy phase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
 before_install:
     - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
     - chmod +x $GOPATH/bin/dep
-    - go get github.com/mitchellh/gox
 
 install:
     - $GOPATH/bin/dep ensure
@@ -21,7 +20,6 @@ script:
 before_deploy:
     - go get github.com/mitchellh/gox
     - gox -os="linux" -arch="386" -output="{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...;
-
 
 deploy:
   provider: releases


### PR DESCRIPTION
I'm not sure how this line ended up in both the `before_install` and `before_deploy` sections... but we we don't use `gox` unless we're deploying. We shouldn't fetch it on every build if we don't need it.