### PR TITLE
Required some size to exist on banner requests

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -355,6 +355,11 @@ func validateBanner(banner *openrtb.Banner, impIndex int) error {
 		return fmt.Errorf("request.imp[%d].banner uses unsupported property: \"hmax\". Use the \"format\" array instead.", impIndex)
 	}
 
+	hasRootSize := banner.H != nil && banner.W != nil
+	if !hasRootSize && len(banner.Format) == 0 {
+		return fmt.Errorf("request.imp[%d].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements.", impIndex)
+	}
+
 	for fmtIndex, format := range banner.Format {
 		if err := validateFormat(&format, impIndex, fmtIndex); err != nil {
 			return err

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -355,7 +355,7 @@ func validateBanner(banner *openrtb.Banner, impIndex int) error {
 		return fmt.Errorf("request.imp[%d].banner uses unsupported property: \"hmax\". Use the \"format\" array instead.", impIndex)
 	}
 
-	hasRootSize := banner.H != nil && banner.W != nil
+	hasRootSize := banner.H != nil && banner.W != nil && *banner.H > 0 && *banner.W > 0
 	if !hasRootSize && len(banner.Format) == 0 {
 		return fmt.Errorf("request.imp[%d].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements.", impIndex)
 	}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/banner-h-only.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/banner-h-only.json
@@ -7,9 +7,9 @@
     },
     "imp": [
       {
-        "id": "imp-id",
-        "banner": {
-          "format": []
+        "id":"imp-id",
+        "banner":{
+          "h": 300
         },
         "ext": {
           "appnexus": {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/banner-h-zero.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/banner-h-zero.json
@@ -7,9 +7,10 @@
     },
     "imp": [
       {
-        "id": "imp-id",
-        "banner": {
-          "format": []
+        "id":"imp-id",
+        "banner":{
+          "h": 0,
+          "w": 250
         },
         "ext": {
           "appnexus": {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/banner-w-only.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/banner-w-only.json
@@ -7,9 +7,9 @@
     },
     "imp": [
       {
-        "id": "imp-id",
-        "banner": {
-          "format": []
+        "id":"imp-id",
+        "banner":{
+          "w": 50
         },
         "ext": {
           "appnexus": {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/banner-w-zero.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/banner-w-zero.json
@@ -9,7 +9,8 @@
       {
         "id": "imp-id",
         "banner": {
-          "format": []
+          "h": 300,
+          "w": 0
         },
         "ext": {
           "appnexus": {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/format-empty-array.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/format-empty-array.json
@@ -1,12 +1,20 @@
 {
-  "message": "Invalid request: request.imp[0].ext is required\n",
+  "message": "Invalid request: request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements.\n",
   "requestPayload": {
     "id":"req-id",
+    "site": {
+      "id": "some-site"
+    },
     "imp": [
       {
         "id":"imp-id",
         "banner":{
           "format":[]
+        },
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
         }
       }
     ]


### PR DESCRIPTION
In #644, I found this test which wasn't testing what it thought it was.

It intended to make sure we reject sizeless banners... but it was failing for other reasons.

Unfortunately, this is now a breaking change :(. Still probably better late than never. We can measure its true impact whenever we release it.