### PR TITLE
Bidder capabilities

### DIFF
--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"github.com/buger/jsonparser"
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -395,6 +396,7 @@ func openRtbToAdformRequest(request *openrtb.BidRequest) (*adformRequest, []erro
 			errors = append(errors, &errortypes.BadInput{
 				Message: fmt.Sprintf("Adform adapter supports only banner Imps for now. Ignoring Imp ID=%s", imp.ID),
 			})
+			glog.Warning("Adform CAPABILITY VIOLATION: no banner present")
 			continue
 		}
 

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/prebid/prebid-server/pbs"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -313,6 +314,7 @@ func keys(m map[string]bool) []string {
 func preprocess(imp *openrtb.Imp) (string, error) {
 	// We don't support audio imps yet.
 	if imp.Audio != nil {
+		glog.Warning("Appnexus CAPABILITY VIOLATION: audio Imps not supported")
 		return "", &errortypes.BadInput{
 			Message: fmt.Sprintf("Appnexus doesn't support audio Imps. Ignoring Imp ID=%s", imp.ID),
 		}

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -232,11 +233,13 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 			errs = append(errs, &errortypes.BadInput{
 				Message: fmt.Sprintf("Beachfront doesn't support audio Imps. Ignoring Imp ID=%s", imp.ID),
 			})
+			glog.Warning("Beachfront CAPABILITY VIOLATION: audio Imps not supported")
 			continue
 		} else if imp.Native != nil {
 			errs = append(errs, &errortypes.BadInput{
 				Message: fmt.Sprintf("Beachfront doesn't support native Imps. Ignoring Imp ID=%s", imp.ID),
 			})
+			glog.Warning("Beachfront CAPABILITY VIOLATION: native Imps not supported")
 			continue
 		} else if imp.Banner != nil {
 			beachfrontReq.Slots = append(beachfrontReq.Slots, BeachfrontSlot{})

--- a/adapters/brightroll/brightroll.go
+++ b/adapters/brightroll/brightroll.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -45,6 +46,7 @@ func (a *BrightrollAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapte
 			err := &errortypes.BadInput{
 				Message: fmt.Sprintf("Brightroll only supports banner and video imps. Ignoring imp id=%s", request.Imp[i].ID),
 			}
+			glog.Warning("Brightroll CAPABILITY VIOLATION: only banner and video Imps supported")
 			errs = append(errs, err)
 			request.Imp = append(request.Imp[:i], request.Imp[i+1:]...)
 			i--

--- a/adapters/eplanning/eplanning.go
+++ b/adapters/eplanning/eplanning.go
@@ -6,6 +6,7 @@ import (
 
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -91,6 +92,7 @@ func (adapter *EPlanningAdapter) MakeRequests(request *openrtb.BidRequest) ([]*a
 func verifyImp(imp *openrtb.Imp) (string, error) {
 	// We currently only support banner impressions
 	if imp.Banner == nil {
+		glog.Warning("EPlanning CAPABILITY VIOLATION: no banner present")
 		return "", &errortypes.BadInput{
 			Message: fmt.Sprintf("EPlanning only supports banner Imps. Ignoring Imp ID=%s", imp.ID),
 		}

--- a/adapters/info.go
+++ b/adapters/info.go
@@ -23,28 +23,28 @@ import (
 func EnforceBidderInfo(bidder Bidder, info BidderInfo) Bidder {
 	return &InfoAwareBidder{
 		Bidder: bidder,
-		info:   info,
+		info:   parseBidderInfo(info),
 	}
 }
 
 type InfoAwareBidder struct {
 	Bidder
-	info BidderInfo
+	info parsedBidderInfo
 }
 
 func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest) ([]*RequestData, []error) {
-	var allowedMediaTypes []openrtb_ext.BidType
+	var allowedMediaTypes parsedSupports
 	if request.Site != nil {
-		if i.info.Capabilities.Site == nil {
+		if i.info.site.enabled == false {
 			return nil, []error{BadInput("this bidder does not support site requests")}
 		}
-		allowedMediaTypes = i.info.Capabilities.Site.MediaTypes
+		allowedMediaTypes = i.info.site
 	}
 	if request.App != nil {
-		if i.info.Capabilities.App == nil {
+		if i.info.app.enabled == false {
 			return nil, []error{BadInput("this bidder does not support app requests")}
 		}
-		allowedMediaTypes = i.info.Capabilities.App.MediaTypes
+		allowedMediaTypes = i.info.app
 	}
 
 	// Filtering imps is quite expensive (array filter with large, non-pointer elements)... but should be rare,
@@ -64,24 +64,23 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest) ([]*RequestD
 
 // pruneImps trims invalid media types from each imp, and returns true if any of the
 // Imps have _no_ valid Media Types left.
-func (i *InfoAwareBidder) pruneImps(imps []openrtb.Imp, allowedTypes []openrtb_ext.BidType) (int, []error) {
-	allowBanner, allowVideo, allowAudio, allowNative := parseAllowedTypes(allowedTypes)
+func (i *InfoAwareBidder) pruneImps(imps []openrtb.Imp, allowedTypes parsedSupports) (int, []error) {
 	numToFilter := 0
 	var errs []error
 	for i := 0; i < len(imps); i++ {
-		if !allowBanner && imps[i].Banner != nil {
+		if !allowedTypes.banner && imps[i].Banner != nil {
 			imps[i].Banner = nil
 			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i)))
 		}
-		if !allowVideo && imps[i].Video != nil {
+		if !allowedTypes.video && imps[i].Video != nil {
 			imps[i].Video = nil
 			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i)))
 		}
-		if !allowAudio && imps[i].Audio != nil {
+		if !allowedTypes.audio && imps[i].Audio != nil {
 			imps[i].Audio = nil
 			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i)))
 		}
-		if !allowNative && imps[i].Native != nil {
+		if !allowedTypes.native && imps[i].Native != nil {
 			imps[i].Native = nil
 			errs = append(errs, BadInput(fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i)))
 		}
@@ -189,4 +188,31 @@ func containsMediaType(haystack []openrtb_ext.BidType, needle openrtb_ext.BidTyp
 		}
 	}
 	return false
+}
+
+// Structs to handle parsed bidder info, so we aren't reparsing every request
+type parsedBidderInfo struct {
+	app  parsedSupports
+	site parsedSupports
+}
+
+type parsedSupports struct {
+	enabled bool
+	banner  bool
+	video   bool
+	audio   bool
+	native  bool
+}
+
+func parseBidderInfo(info BidderInfo) parsedBidderInfo {
+	var parsedInfo parsedBidderInfo
+	if info.Capabilities.App != nil {
+		parsedInfo.app.enabled = true
+		parsedInfo.app.banner, parsedInfo.app.video, parsedInfo.app.audio, parsedInfo.app.native = parseAllowedTypes(info.Capabilities.App.MediaTypes)
+	}
+	if info.Capabilities.Site != nil {
+		parsedInfo.site.enabled = true
+		parsedInfo.site.banner, parsedInfo.site.video, parsedInfo.site.audio, parsedInfo.site.native = parseAllowedTypes(info.Capabilities.Site.MediaTypes)
+	}
+	return parsedInfo
 }

--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -41,6 +42,7 @@ func (a *OpenxAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.Re
 			err := &errortypes.BadInput{
 				Message: fmt.Sprintf("OpenX only supports banner and video imps. Ignoring imp id=%s", imp.ID),
 			}
+			glog.Warning("OpenX CAPABILITY VIOLATION: only supports banner and video imps")
 			errs = append(errs, err)
 		}
 	}

--- a/adapters/sovrn/sovrn.go
+++ b/adapters/sovrn/sovrn.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -268,6 +269,7 @@ func (s *SovrnAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalReq
 func preprocess(imp *openrtb.Imp) (string, error) {
 	// We currently only support banner impressions
 	if imp.Native != nil || imp.Audio != nil || imp.Video != nil {
+		glog.Warning("Sovrn CAPABILITY VIOLATION: no banner present")
 		return "", &errortypes.BadInput{
 			Message: fmt.Sprintf("Sovrn doesn't support audio, video, or native Imps. Ignoring Imp ID=%s", imp.ID),
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -237,7 +237,7 @@ func (cfg *Configuration) GetCachedAssetURL(uuid string) string {
 // Set the default config values for the viper object we are using.
 func SetupViper(v *viper.Viper, filename string) {
 	if filename != "" {
-		v.SetConfigName(name)
+		v.SetConfigName(filename)
 		v.AddConfigPath(".")
 		v.AddConfigPath("/etc/config")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -235,8 +235,8 @@ func (cfg *Configuration) GetCachedAssetURL(uuid string) string {
 }
 
 // Set the default config values for the viper object we are using.
-func SetupViper(v *viper.Viper) {
-	v.SetConfigName("pbs")
+func SetupViper(v *viper.Viper, name string) {
+	v.SetConfigName(name)
 	v.AddConfigPath(".")
 	v.AddConfigPath("/etc/config")
 

--- a/config/config.go
+++ b/config/config.go
@@ -235,11 +235,12 @@ func (cfg *Configuration) GetCachedAssetURL(uuid string) string {
 }
 
 // Set the default config values for the viper object we are using.
-func SetupViper(v *viper.Viper, name string) {
-	v.SetConfigName(name)
-	v.AddConfigPath(".")
-	v.AddConfigPath("/etc/config")
-
+func SetupViper(v *viper.Viper, filename string) {
+	if filename != "" {
+		v.SetConfigName(name)
+		v.AddConfigPath(".")
+		v.AddConfigPath("/etc/config")
+	}
 	// Fixes #475: Some defaults will be set just so they are accessable via environment variables
 	// (basically so viper knows they exist)
 	v.SetDefault("external_url", "http://localhost:8000")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDefaults(t *testing.T) {
 	v := viper.New()
-	SetupViper(v)
+	SetupViper(v, "abacadaeaf")
 	cfg, err := New(v)
 	if err != nil {
 		t.Error(err.Error())
@@ -104,7 +104,7 @@ func cmpBools(t *testing.T, key string, a bool, b bool) {
 
 func TestFullConfig(t *testing.T) {
 	v := viper.New()
-	SetupViper(v)
+	SetupViper(v, "abacadaeaf")
 	v.SetConfigType("yaml")
 	v.ReadConfig(bytes.NewBuffer(fullConfig))
 	cfg, err := New(v)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDefaults(t *testing.T) {
 	v := viper.New()
-	SetupViper(v, "abacadaeaf")
+	SetupViper(v, "")
 	cfg, err := New(v)
 	if err != nil {
 		t.Error(err.Error())
@@ -104,7 +104,7 @@ func cmpBools(t *testing.T, key string, a bool, b bool) {
 
 func TestFullConfig(t *testing.T) {
 	v := viper.New()
-	SetupViper(v, "abacadaeaf")
+	SetupViper(v, "")
 	v.SetConfigType("yaml")
 	v.ReadConfig(bytes.NewBuffer(fullConfig))
 	cfg, err := New(v)

--- a/endpoints/openrtb2/auction_benchmark_test.go
+++ b/endpoints/openrtb2/auction_benchmark_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prebid/prebid-server/adapters"
+
 	analyticsConf "github.com/prebid/prebid-server/analytics/config"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/exchange"
@@ -57,12 +59,14 @@ func BenchmarkOpenrtbEndpoint(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(dummyServer))
 	defer server.Close()
 
+	var infos adapters.BidderInfos
+	infos["appnexus"] = adapters.BidderInfo{Capabilities: &adapters.CapabilitiesInfo{Site: &adapters.PlatformInfo{MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner}}}}
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	paramValidator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
 	if err != nil {
 		return
 	}
-	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), nil, &config.Configuration{}, theMetrics), paramValidator, empty_fetcher.EmptyFetcher{}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}))
+	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), nil, &config.Configuration{}, theMetrics, infos), paramValidator, empty_fetcher.EmptyFetcher{}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}))
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -28,37 +28,37 @@ import (
 // The newAdapterMap function is segregated to its own file to make it a simple and clean location for each Adapter
 // to register itself. No wading through Exchange code to find it.
 
-func newAdapterMap(client *http.Client, cfg *config.Configuration) map[openrtb_ext.BidderName]adaptedBidder {
+func newAdapterMap(client *http.Client, cfg *config.Configuration, infos adapters.BidderInfos) map[openrtb_ext.BidderName]adaptedBidder {
 	return map[openrtb_ext.BidderName]adaptedBidder{
-		openrtb_ext.BidderAdform:      adaptBidder(adform.NewAdformBidder(client, cfg.Adapters[string(openrtb_ext.BidderAdform)].Endpoint), client),
-		openrtb_ext.BidderAdtelligent: adaptBidder(adtelligent.NewAdtelligentBidder(cfg.Adapters[string(openrtb_ext.BidderAdtelligent)].Endpoint), client),
-		openrtb_ext.BidderAppnexus:    adaptBidder(appnexus.NewAppNexusBidder(client, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint), client),
+		openrtb_ext.BidderAdform:      adaptBidder(adapters.EnforceBidderInfo(adform.NewAdformBidder(client, cfg.Adapters[string(openrtb_ext.BidderAdform)].Endpoint), infos[string(openrtb_ext.BidderAdform)]), client),
+		openrtb_ext.BidderAdtelligent: adaptBidder(adapters.EnforceBidderInfo(adtelligent.NewAdtelligentBidder(cfg.Adapters[string(openrtb_ext.BidderAdtelligent)].Endpoint), infos[string(openrtb_ext.BidderAdtelligent)]), client),
+		openrtb_ext.BidderAppnexus:    adaptBidder(adapters.EnforceBidderInfo(appnexus.NewAppNexusBidder(client, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint), infos[string(openrtb_ext.BidderAppnexus)]), client),
 		// TODO #615: Update the config setup so that the Beachfront URLs can be configured, and use those in TestRaceIntegration in exchange_test.go
-		openrtb_ext.BidderBeachfront: adaptBidder(beachfront.NewBeachfrontBidder(), client),
-		openrtb_ext.BidderBrightroll: adaptBidder(brightroll.NewBrightrollBidder(cfg.Adapters[string(openrtb_ext.BidderBrightroll)].Endpoint), client),
+		openrtb_ext.BidderBeachfront: adaptBidder(adapters.EnforceBidderInfo(beachfront.NewBeachfrontBidder(), infos[string(openrtb_ext.BidderBeachfront)]), client),
+		openrtb_ext.BidderBrightroll: adaptBidder(adapters.EnforceBidderInfo(brightroll.NewBrightrollBidder(cfg.Adapters[string(openrtb_ext.BidderBrightroll)].Endpoint), infos[string(openrtb_ext.BidderBrightroll)]), client),
 		// TODO #267: Upgrade the Conversant adapter
 		openrtb_ext.BidderConversant: adaptLegacyAdapter(conversant.NewConversantAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderConversant)].Endpoint)),
-		openrtb_ext.BidderEPlanning:  adaptBidder(eplanning.NewEPlanningBidder(client, cfg.Adapters[string(openrtb_ext.BidderEPlanning)].Endpoint), client),
+		openrtb_ext.BidderEPlanning:  adaptBidder(adapters.EnforceBidderInfo(eplanning.NewEPlanningBidder(client, cfg.Adapters[string(openrtb_ext.BidderEPlanning)].Endpoint), infos[string(openrtb_ext.BidderEPlanning)]), client),
 		// TODO #211: Upgrade the Facebook adapter
 		openrtb_ext.BidderFacebook: adaptLegacyAdapter(audienceNetwork.NewAdapterFromFacebook(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderFacebook))].PlatformID)),
 		// TODO #212: Upgrade the Index adapter
 		openrtb_ext.BidderIndex: adaptLegacyAdapter(indexExchange.NewIndexAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderIndex))].Endpoint)),
 		// TODO #213: Upgrade the Lifestreet adapter
 		openrtb_ext.BidderLifestreet: adaptLegacyAdapter(lifestreet.NewLifestreetAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderLifestreet)].Endpoint)),
-		openrtb_ext.BidderOpenx:      adaptBidder(openx.NewOpenxBidder(cfg.Adapters[string(openrtb_ext.BidderOpenx)].Endpoint), client),
+		openrtb_ext.BidderOpenx:      adaptBidder(adapters.EnforceBidderInfo(openx.NewOpenxBidder(cfg.Adapters[string(openrtb_ext.BidderOpenx)].Endpoint), infos[string(openrtb_ext.BidderOpenx)]), client),
 		// TODO #214: Upgrade the Pubmatic adapter
 		openrtb_ext.BidderPubmatic: adaptLegacyAdapter(pubmatic.NewPubmaticAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderPubmatic)].Endpoint)),
 		// TODO #215: Upgrade the Pulsepoint adapter
 		openrtb_ext.BidderPulsepoint: adaptLegacyAdapter(pulsepoint.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderPulsepoint)].Endpoint)),
-		openrtb_ext.BidderRubicon: adaptBidder(
+		openrtb_ext.BidderRubicon: adaptBidder(adapters.EnforceBidderInfo(
 			rubicon.NewRubiconBidder(
 				client,
 				cfg.Adapters[string(openrtb_ext.BidderRubicon)].Endpoint,
 				cfg.Adapters[string(openrtb_ext.BidderRubicon)].XAPI.Username,
 				cfg.Adapters[string(openrtb_ext.BidderRubicon)].XAPI.Password,
 				cfg.Adapters[string(openrtb_ext.BidderRubicon)].XAPI.Tracker),
-			client),
-		openrtb_ext.BidderSomoaudience: adaptBidder(somoaudience.NewSomoaudienceBidder(cfg.Adapters[string(openrtb_ext.BidderSomoaudience)].Endpoint), client),
-		openrtb_ext.BidderSovrn:        adaptBidder(sovrn.NewSovrnBidder(client, cfg.Adapters[string(openrtb_ext.BidderSovrn)].Endpoint), client),
+			infos[string(openrtb_ext.BidderRubicon)]), client),
+		openrtb_ext.BidderSomoaudience: adaptBidder(adapters.EnforceBidderInfo(somoaudience.NewSomoaudienceBidder(cfg.Adapters[string(openrtb_ext.BidderSomoaudience)].Endpoint), infos[string(openrtb_ext.BidderSomoaudience)]), client),
+		openrtb_ext.BidderSovrn:        adaptBidder(adapters.EnforceBidderInfo(sovrn.NewSovrnBidder(client, cfg.Adapters[string(openrtb_ext.BidderSovrn)].Endpoint), infos[string(openrtb_ext.BidderSovrn)]), client),
 	}
 }

--- a/exchange/adapter_map_test.go
+++ b/exchange/adapter_map_test.go
@@ -3,12 +3,13 @@ package exchange
 import (
 	"testing"
 
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
 func TestNewAdapterMap(t *testing.T) {
-	adapterMap := newAdapterMap(nil, &config.Configuration{})
+	adapterMap := newAdapterMap(nil, &config.Configuration{}, adapters.ParseBidderInfos("../static/bidder-info", openrtb_ext.BidderList()))
 	for _, bidderName := range openrtb_ext.BidderMap {
 		if bidder, ok := adapterMap[bidderName]; bidder == nil || !ok {
 			t.Errorf("adapterMap missing expected Bidder: %s", string(bidderName))

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
@@ -50,10 +51,10 @@ type bidResponseWrapper struct {
 	bidder       openrtb_ext.BidderName
 }
 
-func NewExchange(client *http.Client, cache prebid_cache_client.Client, cfg *config.Configuration, metricsEngine pbsmetrics.MetricsEngine) Exchange {
+func NewExchange(client *http.Client, cache prebid_cache_client.Client, cfg *config.Configuration, metricsEngine pbsmetrics.MetricsEngine, infos adapters.BidderInfos) Exchange {
 	e := new(exchange)
 
-	e.adapterMap = newAdapterMap(client, cfg)
+	e.adapterMap = newAdapterMap(client, cfg, infos)
 	e.cache = cache
 	e.cacheTime = time.Duration(cfg.CacheURL.ExpectedTimeMillis) * time.Millisecond
 	e.me = metricsEngine

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 
 	"github.com/buger/jsonparser"
@@ -40,7 +41,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}
 
-	e := NewExchange(server.Client(), nil, cfg, pbsmetrics.NewMetrics(metrics.NewRegistry(), knownAdapters)).(*exchange)
+	e := NewExchange(server.Client(), nil, cfg, pbsmetrics.NewMetrics(metrics.NewRegistry(), knownAdapters), adapters.ParseBidderInfos("../static/bidder-info", openrtb_ext.BidderList())).(*exchange)
 	for _, bidderName := range knownAdapters {
 		if _, ok := e.adapterMap[bidderName]; !ok {
 			t.Errorf("NewExchange produced an Exchange without bidder %s", bidderName)
@@ -80,7 +81,7 @@ func TestRaceIntegration(t *testing.T) {
 	}
 
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	ex := NewExchange(server.Client(), &wellBehavedCache{}, cfg, theMetrics)
+	ex := NewExchange(server.Client(), &wellBehavedCache{}, cfg, theMetrics, adapters.ParseBidderInfos("../static/bidder-info", openrtb_ext.BidderList()))
 	_, err := ex.HoldAuction(context.Background(), newRaceCheckingRequest(t), &emptyUsersync{}, pbsmetrics.Labels{})
 	if err != nil {
 		t.Errorf("HoldAuction returned unexpected error: %v", err)

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -634,7 +634,7 @@ func init() {
 
 func main() {
 	v := viper.New()
-	config.SetupViper(v)
+	config.SetupViper(v, "pbs")
 	cfg, err := config.New(v)
 	if err != nil {
 		glog.Fatalf("Configuration could not be loaded or did not pass validation: %v", err)

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -693,8 +693,10 @@ func serve(revision string, cfg *config.Configuration) error {
 		glog.Fatalf("Failed to create the bidder params validator. %v", err)
 	}
 
+	bidderInfos := adapters.ParseBidderInfos("./static/bidder-info", openrtb_ext.BidderList())
+
 	exchanges = newExchangeMap(cfg)
-	theExchange := exchange.NewExchange(theClient, pbc.NewClient(&cfg.CacheURL), cfg, metricsEngine)
+	theExchange := exchange.NewExchange(theClient, pbc.NewClient(&cfg.CacheURL), cfg, metricsEngine, bidderInfos)
 
 	openrtbEndpoint, err := openrtb2.NewEndpoint(theExchange, paramsValidator, fetcher, cfg, metricsEngine, pbsAnalytics)
 	if err != nil {
@@ -708,8 +710,6 @@ func serve(revision string, cfg *config.Configuration) error {
 
 	syncers := usersyncers.NewSyncerMap(cfg)
 	gdprPerms := gdpr.NewPermissions(context.Background(), cfg.GDPR, usersyncers.GDPRAwareSyncerIDs(syncers), theClient)
-
-	bidderInfos := adapters.ParseBidderInfos("./static/bidder-info", openrtb_ext.BidderList())
 
 	router.POST("/auction", (&auctionDeps{cfg, syncers, gdprPerms, metricsEngine}).auction)
 	router.POST("/openrtb2/auction", openrtbEndpoint)

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -350,7 +350,7 @@ func TestCacheVideoOnly(t *testing.T) {
 	ctx := context.TODO()
 	w := httptest.NewRecorder()
 	v := viper.New()
-	config.SetupViper(v)
+	config.SetupViper(v, "abacadaeaf")
 	cfg, err := config.New(v)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -655,14 +655,14 @@ func (validator *testValidator) Schema(name openrtb_ext.BidderName) string {
 // Test the viper setup
 func TestViperInit(t *testing.T) {
 	v := viper.New()
-	config.SetupViper(v)
+	config.SetupViper(v, "abacadaeaf")
 	compareStrings(t, "Viper error: external_url expected to be %s, found %s", "http://localhost:8000", v.Get("external_url").(string))
 	compareStrings(t, "Viper error: adapters.pulsepoint.endpoint expected to be %s, found %s", "http://bid.contextweb.com/header/s/ortb/prebid-s2s", v.Get("adapters.pulsepoint.endpoint").(string))
 }
 
 func TestViperEnv(t *testing.T) {
 	v := viper.New()
-	config.SetupViper(v)
+	config.SetupViper(v, "abacadaeaf")
 	port := forceEnv(t, "PBS_PORT", "7777")
 	defer port()
 

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -350,7 +350,7 @@ func TestCacheVideoOnly(t *testing.T) {
 	ctx := context.TODO()
 	w := httptest.NewRecorder()
 	v := viper.New()
-	config.SetupViper(v, "abacadaeaf")
+	config.SetupViper(v, "")
 	cfg, err := config.New(v)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -655,14 +655,14 @@ func (validator *testValidator) Schema(name openrtb_ext.BidderName) string {
 // Test the viper setup
 func TestViperInit(t *testing.T) {
 	v := viper.New()
-	config.SetupViper(v, "abacadaeaf")
+	config.SetupViper(v, "")
 	compareStrings(t, "Viper error: external_url expected to be %s, found %s", "http://localhost:8000", v.Get("external_url").(string))
 	compareStrings(t, "Viper error: adapters.pulsepoint.endpoint expected to be %s, found %s", "http://bid.contextweb.com/header/s/ortb/prebid-s2s", v.Get("adapters.pulsepoint.endpoint").(string))
 }
 
 func TestViperEnv(t *testing.T) {
 	v := viper.New()
-	config.SetupViper(v, "abacadaeaf")
+	config.SetupViper(v, "")
 	port := forceEnv(t, "PBS_PORT", "7777")
 	defer port()
 


### PR DESCRIPTION
This enforces the bidder capabilities listed in bidder-info.yaml. Server logging has been added to the redundant checks within the adapter code so we can verify they are not needed and remove them with a later PR. Note that this does not cover legacy adapters that have been wrapped with the legacy->openRTB adapter.