### PR TITLE
Removed a stray/misleading info.yml file.

### DIFF
--- a/adapters/adform/info.yaml
+++ b/adapters/adform/info.yaml
@@ -1,2 +1,0 @@
-maintainer:
-  email: "scope.sspp@adform.com"


### PR DESCRIPTION
`static/bidder-info/{bidder}.yaml` is important. `adapters/{bidder}/info.yaml` isn't used anywhere.

This file confused a new adapter submission, so... deleting it: https://github.com/prebid/prebid-server/pull/655#discussion_r211582885