### PR TITLE
Fixes requests hanging on adapter panic

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -222,6 +222,7 @@ func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *o
 				glog.Errorf("OpenRTB auction recovered panic from Bidder %s: %v. Stack trace is: %v", coreBidder, r, string(debug.Stack()))
 				// Let the master request know that there is no data here
 				brw := new(bidResponseWrapper)
+				brw.adapterExtra = new(seatResponseExtra)
 				chBids <- brw
 			}
 		}()

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -202,7 +202,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 				}
 			}
 			chBids <- brw
-		})
+		}, chBids)
 		go bidderRunner(bidderName, coreBidder, req, blabels[coreBidder])
 	}
 	// Wait for the bidders to do their thing
@@ -215,11 +215,14 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 	return adapterBids, adapterExtra
 }
 
-func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels)) func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels) {
+func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels), chBids chan *bidResponseWrapper) func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels) {
 	return func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels) {
 		defer func() {
 			if r := recover(); r != nil {
 				glog.Errorf("OpenRTB auction recovered panic from Bidder %s: %v. Stack trace is: %v", coreBidder, r, string(debug.Stack()))
+				// Let the master request know that there is no data here
+				brw := new(bidResponseWrapper)
+				chBids <- brw
 			}
 		}()
 		inner(aName, coreBidder, request, bidlabels)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -143,10 +143,11 @@ func newRaceCheckingRequest(t *testing.T) *openrtb.BidRequest {
 }
 
 func TestPanicRecovery(t *testing.T) {
+	chBids := make(chan *bidResponseWrapper, 1)
 	panicker := func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels) {
 		panic("panic!")
 	}
-	recovered := recoverSafely(panicker)
+	recovered := recoverSafely(panicker, chBids)
 	recovered(openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, nil, nil)
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -175,6 +175,61 @@ func buildImpExt(t *testing.T, jsonFilename string) openrtb.RawJSON {
 	return openrtb.RawJSON(toReturn)
 }
 
+func TestPanicRecoveryHighLevel(t *testing.T) {
+	noBidServer := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}
+	server := httptest.NewServer(http.HandlerFunc(noBidServer))
+	defer server.Close()
+
+	cfg := &config.Configuration{
+		Adapters: make(map[string]config.Adapter, len(openrtb_ext.BidderMap)),
+	}
+	for _, bidder := range openrtb_ext.BidderList() {
+		cfg.Adapters[strings.ToLower(string(bidder))] = config.Adapter{
+			Endpoint: server.URL,
+		}
+	}
+	e := NewExchange(server.Client(), nil, cfg, pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList()), adapters.ParseBidderInfos("../static/bidder-info", openrtb_ext.BidderList())).(*exchange)
+
+	e.adapterMap[openrtb_ext.BidderBeachfront] = panicingAdapter{}
+	e.adapterMap[openrtb_ext.BidderAppnexus] = panicingAdapter{}
+
+	request := &openrtb.BidRequest{
+		Site: &openrtb.Site{
+			Page:   "www.some.domain.com",
+			Domain: "domain.com",
+			Publisher: &openrtb.Publisher{
+				ID: "some-publisher-id",
+			},
+		},
+		User: &openrtb.User{
+			ID:       "our-id",
+			BuyerUID: "their-id",
+			Ext:      openrtb.RawJSON(`{"consent":"BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw","digitrust":{"id":"digi-id","keyv":1,"pref":1}}`),
+		},
+		Imp: []openrtb.Imp{{
+			ID: "some-imp-id",
+			Banner: &openrtb.Banner{
+				Format: []openrtb.Format{{
+					W: 300,
+					H: 250,
+				}, {
+					W: 300,
+					H: 600,
+				}},
+			},
+			Ext: buildImpExt(t, "banner"),
+		}},
+	}
+
+	_, err := e.HoldAuction(context.Background(), request, &emptyUsersync{}, pbsmetrics.Labels{})
+	if err != nil {
+		t.Errorf("HoldAuction returned unexpected error: %v", err)
+	}
+
+}
+
 func TestTimeoutComputation(t *testing.T) {
 	cacheTimeMillis := 10
 	ex := exchange{
@@ -536,4 +591,10 @@ type mockUsersync struct {
 func (e *mockUsersync) GetId(bidder openrtb_ext.BidderName) (id string, exists bool) {
 	id, exists = e.syncs[string(bidder)]
 	return
+}
+
+type panicingAdapter struct{}
+
+func (panicingAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (posb *pbsOrtbSeatBid, errs []error) {
+	panic("Panic! Panic! The world is ending!")
 }

--- a/validate.sh
+++ b/validate.sh
@@ -45,7 +45,7 @@ fi
 if $COVERAGE; then
   ./scripts/check_coverage.sh
 else
-  go test $(go list ./... | grep -v /vendor/)
+  go test -timeout 120s $(go list ./... | grep -v /vendor/)
 fi
 
 # Then run the race condition tests. These only run on tests named TestRace.* for two reasons.


### PR DESCRIPTION
We use the `chBids` channel to collect all the bids from the adapters. However if an adapter goroutine panics, we never send a result. This causes the whole request to hang waiting for the bids from this adapter.

This change has the `recoverSafely()` function send an empty bid response on the `chBids` channel so that the main thread knows to continue.