### PR TITLE
Stop logging client write errors

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -196,7 +196,6 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(ampResponse); err != nil {
-		glog.Warningf("/openrtb2/amp Failed to send response: %v", err)
 		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
 		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/amp Failed to send response: %v", err))
 	}

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -147,7 +147,6 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
 	if err := enc.Encode(response); err != nil {
-		glog.Warningf("/openrtb2/auction Failed to send response: %v", err)
 		labels.RequestStatus = pbsmetrics.RequestStatusNetworkErr
 		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to send response: %v", err))
 	}


### PR DESCRIPTION
Taking another pass looking for low-hanging fruit to clean up the app logs.

Virtually all of these are either `i/o timeout` or `broken pipe`. We always _expect_ some baseline level of these errors... for example, if the client has a slow client connection, or the connection gets closed before we can respond.

I definitely see some value in logging them for metrics/analytics, so we can see major error spikes... but I don't see much value in spewing them to the app logs. If we remove them, this should cut our app logs in half.