### PR TITLE
Fixing a few stray issues

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -49,5 +49,6 @@ func serve(revision string, cfg *config.Configuration) error {
 	// Add cors support
 	corsRouter := router.SupportCORS(r)
 	server.Listen(cfg, router.NoCache{Handler: corsRouter}, router.Admin(revision), r.MetricsEngine)
+	r.Shutdown()
 	return nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -158,7 +158,7 @@ type Router struct {
 }
 
 func New(cfg *config.Configuration) (r *Router, err error) {
-	const bidderParamsDirectory = "./static/bidder-params"
+	const schemaDirectory = "./static/bidder-params"
 	r = &Router{
 		Router: httprouter.New(),
 	}
@@ -186,7 +186,7 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 	// Metrics engine
 	r.MetricsEngine = metricsConf.NewMetricsEngine(cfg, bidderList)
 
-	paramsValidator, err := openrtb_ext.NewBidderParamsValidator(bidderParamsDirectory)
+	paramsValidator, err := openrtb_ext.NewBidderParamsValidator(schemaDirectory)
 	if err != nil {
 		glog.Fatalf("Failed to create the bidder params validator. %v", err)
 	}
@@ -215,7 +215,7 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 	r.GET("/openrtb2/amp", ampEndpoint)
 	r.GET("/info/bidders", infoEndpoints.NewBiddersEndpoint())
 	r.GET("/info/bidders/:bidderName", infoEndpoints.NewBidderDetailsEndpoint(bidderInfos))
-	r.GET("/bidders/params", NewJsonDirectoryServer(bidderParamsDirectory, paramsValidator))
+	r.GET("/bidders/params", NewJsonDirectoryServer(schemaDirectory, paramsValidator))
 	r.POST("/cookie_sync", endpoints.NewCookieSyncEndpoint(syncers, cfg, gdprPerms, r.MetricsEngine, pbsAnalytics))
 	r.GET("/status", endpoints.NewStatusEndpoint(cfg.StatusResponse))
 	r.GET("/", serveIndex)

--- a/router/router.go
+++ b/router/router.go
@@ -191,7 +191,7 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 		glog.Fatalf("Failed to create the bidder params validator. %v", err)
 	}
 
-	p, _ := filepath.Abs("./static/bidder-info")
+	p, _ := filepath.Abs(schemaDirectory)
 	bidderInfos := adapters.ParseBidderInfos(p, openrtb_ext.BidderList())
 
 	syncers := usersyncers.NewSyncerMap(cfg)

--- a/router/router.go
+++ b/router/router.go
@@ -51,8 +51,6 @@ import (
 var dataCache cache.Cache
 var exchanges map[string]adapters.Adapter
 
-const schemaDirectory = "../static/bidder-params"
-
 // NewJsonDirectoryServer is used to serve .json files from a directory as a single blob. For example,
 // given a directory containing the files "a.json" and "b.json", this returns a Handle which serves JSON like:
 //
@@ -63,7 +61,7 @@ const schemaDirectory = "../static/bidder-params"
 //
 // This function stores the file contents in memory, and should not be used on large directories.
 // If the root directory, or any of the files in it, cannot be read, then the program will exit.
-func NewJsonDirectoryServer(validator openrtb_ext.BidderParamValidator) httprouter.Handle {
+func NewJsonDirectoryServer(schemaDirectory string, validator openrtb_ext.BidderParamValidator) httprouter.Handle {
 	// Slurp the files into memory first, since they're small and it minimizes request latency.
 	files, err := ioutil.ReadDir(schemaDirectory)
 	if err != nil {
@@ -160,6 +158,7 @@ type Router struct {
 }
 
 func New(cfg *config.Configuration) (r *Router, err error) {
+	const bidderParamsDirectory = "./static/bidder-params"
 	r = &Router{
 		Router: httprouter.New(),
 	}
@@ -187,12 +186,12 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 	// Metrics engine
 	r.MetricsEngine = metricsConf.NewMetricsEngine(cfg, bidderList)
 
-	paramsValidator, err := openrtb_ext.NewBidderParamsValidator(schemaDirectory)
+	paramsValidator, err := openrtb_ext.NewBidderParamsValidator(bidderParamsDirectory)
 	if err != nil {
 		glog.Fatalf("Failed to create the bidder params validator. %v", err)
 	}
 
-	p, _ := filepath.Abs("../static/bidder-info")
+	p, _ := filepath.Abs("./static/bidder-info")
 	bidderInfos := adapters.ParseBidderInfos(p, openrtb_ext.BidderList())
 
 	syncers := usersyncers.NewSyncerMap(cfg)
@@ -216,7 +215,7 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 	r.GET("/openrtb2/amp", ampEndpoint)
 	r.GET("/info/bidders", infoEndpoints.NewBiddersEndpoint())
 	r.GET("/info/bidders/:bidderName", infoEndpoints.NewBidderDetailsEndpoint(bidderInfos))
-	r.GET("/bidders/params", NewJsonDirectoryServer(paramsValidator))
+	r.GET("/bidders/params", NewJsonDirectoryServer(bidderParamsDirectory, paramsValidator))
 	r.POST("/cookie_sync", endpoints.NewCookieSyncEndpoint(syncers, cfg, gdprPerms, r.MetricsEngine, pbsAnalytics))
 	r.GET("/status", endpoints.NewStatusEndpoint(cfg.StatusResponse))
 	r.GET("/", serveIndex)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -38,7 +38,7 @@ func ensureHasKey(t *testing.T, data map[string]json.RawMessage, key string) {
 }
 
 func TestNewJsonDirectoryServer(t *testing.T) {
-	handler := NewJsonDirectoryServer(&testValidator{})
+	handler := NewJsonDirectoryServer("../static/bidder-params", &testValidator{})
 	recorder := httptest.NewRecorder()
 	request, _ := http.NewRequest("GET", "/whatever", nil)
 	handler(recorder, request, nil)


### PR DESCRIPTION
I found these during a last-minute review of #673.

Rather than bug @zachbadgett I just figured I'd change them right after merging. This fixes two issues:

1. `router.Shutdown()` was never called.
2. The schema directory only worked in tests, but not at runtime.

(2) is an issue because the tests run in the directory where they're defined, but the static binary gets output to the root directory... so the paths are actually different for each case.

Those changes stop PBS from crashing on startup.