### PR TITLE
Allows sending user.buyerid for AMP requests

### DIFF
--- a/exchange/gdpr.go
+++ b/exchange/gdpr.go
@@ -49,12 +49,14 @@ type regsExt struct {
 }
 
 // cleanPI removes IP address last byte, device ID, buyer ID, and rounds off lattitude/longitude
-func cleanPI(bidRequest *openrtb.BidRequest) {
+func cleanPI(bidRequest *openrtb.BidRequest, isAMP bool) {
 	if bidRequest.User != nil {
 		// Need to duplicate pointer objects
 		user := *bidRequest.User
 		bidRequest.User = &user
-		bidRequest.User.BuyerUID = ""
+		if isAMP == false {
+			bidRequest.User.BuyerUID = ""
+		}
 		bidRequest.User.Geo = cleanGeo(bidRequest.User.Geo)
 	}
 	if bidRequest.Device != nil {

--- a/exchange/gdpr_test.go
+++ b/exchange/gdpr_test.go
@@ -48,7 +48,7 @@ func TestCleanPI(t *testing.T) {
 
 	bidReqCopy := bidReqOrig
 	// Make sure cleanIP handles the empty case
-	cleanPI(&bidReqCopy)
+	cleanPI(&bidReqCopy, false)
 
 	// Add values to clean
 	bidReqOrig.User = &openrtb.User{
@@ -66,7 +66,7 @@ func TestCleanPI(t *testing.T) {
 	// Make a shallow copy
 	bidReqCopy = bidReqOrig
 
-	cleanPI(&bidReqCopy)
+	cleanPI(&bidReqCopy, false)
 
 	// Verify cleaned values
 	assertStringEmpty(t, bidReqCopy.User.BuyerUID)
@@ -84,6 +84,40 @@ func TestCleanPI(t *testing.T) {
 	assert.Equal(t, 123.4567, bidReqOrig.Device.Geo.Lat)
 	assert.Equal(t, 7.9836, bidReqOrig.Device.Geo.Lon)
 
+}
+
+func TestCleanPIAmp(t *testing.T) {
+	bidReqOrig := openrtb.BidRequest{}
+
+	bidReqCopy := bidReqOrig
+	// Make sure cleanIP handles the empty case
+	cleanPI(&bidReqCopy, false)
+
+	// Add values to clean
+	bidReqOrig.User = &openrtb.User{
+		BuyerUID: "abc123",
+	}
+	bidReqOrig.Device = &openrtb.Device{
+		DIDMD5: "teapot",
+		IP:     "12.123.56.128",
+		IPv6:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		Geo: &openrtb.Geo{
+			Lat: 123.4567,
+			Lon: 7.9836,
+		},
+	}
+	// Make a shallow copy
+	bidReqCopy = bidReqOrig
+
+	cleanPI(&bidReqCopy, true)
+
+	// Verify cleaned values
+	assert.Equal(t, "abc123", bidReqCopy.User.BuyerUID)
+	assertStringEmpty(t, bidReqCopy.Device.DIDMD5)
+	assert.Equal(t, "12.123.56.000", bidReqCopy.Device.IP)
+	assert.Equal(t, "2001:0db8:85a3:0000:0000:8a2e:0370:0000", bidReqCopy.Device.IPv6)
+	assert.Equal(t, 123.46, bidReqCopy.Device.Geo.Lat)
+	assert.Equal(t, 7.98, bidReqCopy.Device.Geo.Lon)
 }
 
 func assertStringEmpty(t *testing.T, str string) {

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -37,7 +37,7 @@ func cleanOpenRTBRequests(ctx context.Context, orig *openrtb.BidRequest, usersyn
 	if gdpr == 1 {
 		for bidder, bidReq := range requestsByBidder {
 			if ok, err := gDPR.PersonalInfoAllowed(ctx, bidder, consent); !ok && err == nil {
-				cleanPI(bidReq)
+				cleanPI(bidReq, labels.RType == pbsmetrics.ReqTypeAMP)
 			}
 		}
 	}


### PR DESCRIPTION
DONT MERGE UNTIL #682 HAS BEEN TESTED AND DOES NOT RESOLVE THE ISSUE

AMP currently does not support generating/sending IAB consent strings. After merging #658 AMP performance tanked in the EU. This is likely due to the PR removing `user.buyerid` where consent is not set, and being impossible to set consent on AMP requests. We still leave in place the other PI information cleaning code.

This is intended as a patch for the AMP consent issue until AMP supports sending full consent information to 3rd party requests. Ideally they will support the IAB consent string, but we cannot discount that they may roll their own format.

The motivation behind allowing `user.buyerid` to go through is that we cannot know the user's consent, however if the ID exists then the user must have given consent for the bidder on at least one website that does prebid, we just can't confirm that the current website is also covered. Also, the `buyerid` is not itself personally identifying information, it can just be considered potentially identifying if the bidder already has some personal information associated with the user ID. So there exists an argument that sending the buyer ID does not violate the PI portion of the GDPR, but we mask it for non-AMP just to be safe.

The other GDPR pitfall is tracking consent. Prebid server does not log the `buyerid`, so it is not directly tracking the user. We send the bidder request with the GDPR flag set, but no consent string, so the bidder should consider no tracking consent has been given. So in theory no tracking data should be saved, but we do enable a bidder to track this user if the bidder is willing to violate the GDPR and the user has consent to tracking by this bidder, but not consented on this specific site in question. This should be a rare case.