### PR TITLE
Made connection pools configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,10 +14,11 @@ import (
 
 // Configuration
 type Configuration struct {
-	ExternalURL string `mapstructure:"external_url"`
-	Host        string `mapstructure:"host"`
-	Port        int    `mapstructure:"port"`
-	AdminPort   int    `mapstructure:"admin_port"`
+	ExternalURL string     `mapstructure:"external_url"`
+	Host        string     `mapstructure:"host"`
+	Port        int        `mapstructure:"port"`
+	Client      HTTPClient `mapstructure:"http_client"`
+	AdminPort   int        `mapstructure:"admin_port"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
 	StatusResponse  string          `mapstructure:"status_response"`
@@ -36,6 +37,12 @@ type Configuration struct {
 	Analytics            Analytics          `mapstructure:"analytics"`
 	AMPTimeoutAdjustment int64              `mapstructure:"amp_timeout_adjustment_ms"`
 	GDPR                 GDPR               `mapstructure:"gdpr"`
+}
+
+type HTTPClient struct {
+	MaxIdleConns        int `mapstructure:"max_idle_connections"`
+	MaxIdleConnsPerHost int `mapstructure:"max_idle_connections_per_host"`
+	IdleConnTimeout     int `mapstructure:"idle_connection_timeout_seconds"`
 }
 
 type configErrors []error
@@ -263,6 +270,9 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host_cookie.optout_cookie.name", "")
 	v.SetDefault("host_cookie.value", "")
 	v.SetDefault("host_cookie.ttl_days", 90)
+	v.SetDefault("http_client.max_idle_connections", 400)
+	v.SetDefault("http_client.max_idle_connections_per_host", 10)
+	v.SetDefault("http_client.idle_connection_timeout_seconds", 60)
 	// no metrics configured by default (metrics{host|database|username|password})
 	v.SetDefault("metrics.influxdb.host", "")
 	v.SetDefault("metrics.influxdb.database", "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,10 @@ cache:
   scheme: http
   host: prebidcache.net
   query: uuid=%PBS_CACHE_UUID%
+http_client:
+  max_idle_connections: 500
+  max_idle_connections_per_host: 20
+  idle_connection_timeout_seconds: 30
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   influxdb:
@@ -127,6 +131,9 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")
 	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "prebidcache.net")
 	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")
+	cmpInts(t, "http_client.max_idle_connections", cfg.Client.MaxIdleConns, 500)
+	cmpInts(t, "http_client.max_idle_connections_per_host", cfg.Client.MaxIdleConnsPerHost, 20)
+	cmpInts(t, "http_client.idle_connection_timeout_seconds", cfg.Client.IdleConnTimeout, 30)
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")

--- a/router/router.go
+++ b/router/router.go
@@ -165,9 +165,9 @@ func New(cfg *config.Configuration) (r *Router, err error) {
 	}
 	theClient := &http.Client{
 		Transport: &http.Transport{
-			MaxIdleConns:        400,
-			MaxIdleConnsPerHost: 10,
-			IdleConnTimeout:     60 * time.Second,
+			MaxIdleConns:        cfg.Client.MaxIdleConns,
+			MaxIdleConnsPerHost: cfg.Client.MaxIdleConnsPerHost,
+			IdleConnTimeout:     time.Duration(cfg.Client.IdleConnTimeout) * time.Second,
 			TLSClientConfig:     &tls.Config{RootCAs: ssl.GetRootCAPool()},
 		},
 	}


### PR DESCRIPTION
These should definitely change from one deploy to another, depending on the incoming traffic... so moving them into the configs.