### PR TITLE
Add message_go1.11 to fix test failing on go1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ go:
 env:
   - DEP_VERSION="0.5.0"
 
-matrix:
-  allow_failures:
-    - go: '1.11'
-
 before_install:
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -251,15 +251,6 @@ func getRequestPayload(t *testing.T, example []byte) []byte {
 	return nil
 }
 
-func getMessage(t *testing.T, example []byte) []byte {
-	if value, err := jsonparser.GetString(example, "message"); err != nil {
-		t.Fatalf("Error parsing root.message from request: %v.", err)
-	} else {
-		return []byte(value)
-	}
-	return nil
-}
-
 // TestNilExchange makes sure we fail when given nil for the Exchange.
 func TestNilExchange(t *testing.T) {
 	// NewMetrics() will create a new go_metrics MetricsEngine, bypassing the need for a crafted configuration set to support it.

--- a/endpoints/openrtb2/openrtb2_go111_test.go
+++ b/endpoints/openrtb2/openrtb2_go111_test.go
@@ -1,0 +1,23 @@
+// +build go1.11
+
+package openrtb2
+
+import (
+	"testing"
+
+	"github.com/buger/jsonparser"
+)
+
+func getMessage(t *testing.T, example []byte) []byte {
+	// Hack to get tests passing in go1.11, see: https://github.com/golang/go/issues/27275
+	// todo: remove this hack when go1.11.1 is released
+	if value, _ := jsonparser.GetString(example, "message_go1.11"); value != "" {
+		return []byte(value)
+	}
+	if value, err := jsonparser.GetString(example, "message"); err != nil {
+		t.Fatalf("Error parsing root.message from request: %v.", err)
+	} else {
+		return []byte(value)
+	}
+	return nil
+}

--- a/endpoints/openrtb2/openrtb2_test.go
+++ b/endpoints/openrtb2/openrtb2_test.go
@@ -1,0 +1,18 @@
+// +build !go1.11
+
+package openrtb2
+
+import (
+	"testing"
+
+	"github.com/buger/jsonparser"
+)
+
+func getMessage(t *testing.T, example []byte) []byte {
+	if value, err := jsonparser.GetString(example, "message"); err != nil {
+		t.Fatalf("Error parsing root.message from request: %v.", err)
+	} else {
+		return []byte(value)
+	}
+	return nil
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-consent-int.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-consent-int.json
@@ -1,5 +1,6 @@
 {
   "message": "Invalid request: request.user.ext object is not valid: json: cannot unmarshal number into Go struct field ExtUser.consent of type string\n",
+  "message_go1.11": "Invalid request: request.user.ext object is not valid: json: cannot unmarshal number into Go value of type string\n",
   "requestPayload": {
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
     "site": {


### PR DESCRIPTION
Unfortunately, the build flags (at least from what I can tell), do not allow specifying minor versions. When `go1.11.1` is released we can remove the hack and possibly add a warning in the README explaining why `go1.11` is not supported/why the tests fail on that specific version.