### PR TITLE
Formalizing support for `site.ext.amp`

### DIFF
--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -80,7 +80,11 @@ The only exception here is the top-level `BidResponse`, because it's bidder-inde
 `ext.{anyBidderCode}` and `ext.bidder` extensions are defined by bidders.
 `ext.prebid` extensions are defined by Prebid Server.
 
-Exceptions are made for DigiTrust and GDPR, so that we define `ext` according to the official recommendations.
+Exceptions are made for extensions with "standard" recommendations:
+
+- `request.user.ext.digitrust` -- To support Digitrust support
+- `request.regs.ext.gdpr` and `request.user.ext.consent` -- To support GDPR
+- `request.site.ext.amp` -- To identify AMP as the request source
 
 #### Bid Adjustments
 
@@ -254,7 +258,7 @@ For example, a request may return this in `response.ext`
     ],
     "rubicon": [
       {
-        "code": 1, 
+        "code": 1,
         "message": "The request exceeded the timeout allocated"
       }
     ]

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buger/jsonparser"
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mxmCherry/openrtb"
@@ -460,4 +461,16 @@ func defaultRequestExt(req *openrtb.BidRequest) (errs []error) {
 	}
 
 	return
+}
+
+func setAmpExt(site *openrtb.Site, value string) {
+	if len(site.Ext) > 0 {
+		if _, dataType, _, _ := jsonparser.Get(site.Ext, "amp"); dataType == jsonparser.NotExist {
+			if val, err := jsonparser.Set(site.Ext, []byte(value), "amp"); err == nil {
+				site.Ext = val
+			}
+		}
+	} else {
+		site.Ext = json.RawMessage(`{"amp":` + value + `}`)
+	}
 }

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -325,6 +325,11 @@ func (deps *endpointDeps) overrideWithParams(httpRequest *http.Request, req *ope
 			req.Site.Domain = domain
 		}
 	}
+	if data, err := json.Marshal(openrtb_ext.ExtSite{
+		AMP: 1,
+	}); err != nil {
+		req.Site.Ext = data
+	}
 
 	slot := httpRequest.FormValue("slot")
 	if slot != "" {

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -147,7 +147,6 @@ func TestAmpBadRequests(t *testing.T) {
 // TestAmpDebug makes sure we get debug information back when requested
 func TestAmpDebug(t *testing.T) {
 	requests := map[string]json.RawMessage{
-		"1": json.RawMessage(validRequest(t, "app.json")),
 		"2": json.RawMessage(validRequest(t, "site.json")),
 	}
 

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -30,12 +30,10 @@ func TestGoodAmpRequests(t *testing.T) {
 	goodRequests := map[string]json.RawMessage{
 		"1": json.RawMessage(validRequest(t, "aliased-buyeruids.json")),
 		"2": json.RawMessage(validRequest(t, "aliases.json")),
-		"3": json.RawMessage(validRequest(t, "app.json")),
 		"4": json.RawMessage(validRequest(t, "digitrust.json")),
 		"5": json.RawMessage(validRequest(t, "gdpr-no-consentstring.json")),
 		"6": json.RawMessage(validRequest(t, "gdpr.json")),
 		"7": json.RawMessage(validRequest(t, "site.json")),
-		"8": json.RawMessage(validRequest(t, "timeout.json")),
 		"9": json.RawMessage(validRequest(t, "user.json")),
 	}
 
@@ -97,6 +95,29 @@ func TestAMPPageInfo(t *testing.T) {
 	}
 	assert.Equal(t, page, exchange.lastRequest.Site.Page)
 	assert.Equal(t, "test.somepage.co.uk", exchange.lastRequest.Site.Domain)
+}
+
+func TestAMPSiteExt(t *testing.T) {
+	stored := map[string]json.RawMessage{
+		"1": json.RawMessage(validRequest(t, "site.json")),
+	}
+	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
+	exchange := &mockAmpExchange{}
+	endpoint, _ := NewAmpEndpoint(exchange, newParamsValidator(t), &mockAmpStoredReqFetcher{stored}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}))
+	request, err := http.NewRequest("GET", "/openrtb2/auction/amp?tag_id=1", nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+	recorder := httptest.NewRecorder()
+	endpoint(recorder, request, nil)
+
+	if !assert.NotNil(t, exchange.lastRequest, "Endpoint responded with %d: %s", recorder.Code, recorder.Body.String()) {
+		return
+	}
+	if !assert.NotNil(t, exchange.lastRequest.Site) {
+		return
+	}
+	assert.JSONEq(t, `{"amp":1}`, string(exchange.lastRequest.Site.Ext))
 }
 
 // TestBadRequests makes sure we return 400's on bad requests.

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -681,7 +681,11 @@ func (deps *endpointDeps) validateAliases(aliases map[string]string) error {
 }
 
 func (deps *endpointDeps) validateSite(site *openrtb.Site) error {
-	if site != nil && site.ID == "" && site.Page == "" {
+	if site == nil {
+		return nil
+	}
+
+	if site.ID == "" && site.Page == "" {
 		return errors.New("request.site should include at least one of request.site.id or request.site.page.")
 	}
 	if len(site.Ext) > 0 {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -778,13 +778,13 @@ func setAuctionTypeImplicitly(bidReq *openrtb.BidRequest) {
 
 // setSiteImplicitly uses implicit info from httpReq to populate bidReq.Site
 func setSiteImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
-	if bidReq.Site == nil {
-		bidReq.Site = &openrtb.Site{}
-	}
-	if bidReq.Site.Page == "" || bidReq.Site.Domain == "" {
+	if bidReq.Site == nil || bidReq.Site.Page == "" || bidReq.Site.Domain == "" {
 		referrerCandidate := httpReq.Referer()
 		if parsedUrl, err := url.Parse(referrerCandidate); err == nil {
 			if domain, err := publicsuffix.EffectiveTLDPlusOne(parsedUrl.Host); err == nil {
+				if bidReq.Site == nil {
+					bidReq.Site = &openrtb.Site{}
+				}
 				if bidReq.Site.Domain == "" {
 					bidReq.Site.Domain = domain
 				}
@@ -797,7 +797,9 @@ func setSiteImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
 			}
 		}
 	}
-	setAmpExt(bidReq.Site, "0")
+	if bidReq.Site != nil {
+		setAmpExt(bidReq.Site, "0")
+	}
 }
 
 func setAmpExt(site *openrtb.Site, value string) {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -802,18 +802,6 @@ func setSiteImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
 	}
 }
 
-func setAmpExt(site *openrtb.Site, value string) {
-	if len(site.Ext) > 0 {
-		if _, dataType, _, _ := jsonparser.Get(site.Ext, "amp"); dataType == jsonparser.NotExist {
-			if val, err := jsonparser.Set(site.Ext, []byte(value), "amp"); err == nil {
-				site.Ext = val
-			}
-		}
-	} else {
-		site.Ext = json.RawMessage(`{"amp":` + value + `}`)
-	}
-}
-
 func setImpsImplicitly(httpReq *http.Request, imps []openrtb.Imp) {
 	secure := int8(1)
 	for i := 0; i < len(imps); i++ {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -793,14 +793,18 @@ func setSiteImplicitly(httpReq *http.Request, bidReq *openrtb.BidRequest) {
 			}
 		}
 	}
-	if len(bidReq.Site.Ext) > 0 {
-		if _, dataType, _, _ := jsonparser.Get(bidReq.Site.Ext, "amp"); dataType == jsonparser.NotExist {
-			if val, err := jsonparser.Set(bidReq.Site.Ext, []byte("0"), "amp"); err == nil {
-				bidReq.Site.Ext = val
+	setAmpExt(bidReq.Site, "0")
+}
+
+func setAmpExt(site *openrtb.Site, value string) {
+	if len(site.Ext) > 0 {
+		if _, dataType, _, _ := jsonparser.Get(site.Ext, "amp"); dataType == jsonparser.NotExist {
+			if val, err := jsonparser.Set(site.Ext, []byte(value), "amp"); err == nil {
+				site.Ext = val
 			}
 		}
 	} else {
-		bidReq.Site.Ext = json.RawMessage(`{"amp":0}`)
+		site.Ext = json.RawMessage(`{"amp":` + value + `}`)
 	}
 }
 

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -497,7 +497,9 @@ func TestImplicitAMPNoExt(t *testing.T) {
 		return
 	}
 
-	var bidReq openrtb.BidRequest
+	bidReq := openrtb.BidRequest{
+		Site: &openrtb.Site{},
+	}
 	setSiteImplicitly(httpReq, &bidReq)
 	assert.JSONEq(t, `{"amp":0}`, string(bidReq.Site.Ext))
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -491,6 +491,28 @@ func TestTimeoutParser(t *testing.T) {
 	}
 }
 
+func TestImplicitAMP(t *testing.T) {
+	httpReq, err := http.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site.json")))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var bidReq openrtb.BidRequest
+	setSiteImplicitly(httpReq, &bidReq)
+	assert.JSONEq(t, `{"amp":0}`, string(bidReq.Site.Ext))
+}
+
+func TestExplicitAMP(t *testing.T) {
+	httpReq, err := http.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site-amp.json")))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var bidReq openrtb.BidRequest
+	setSiteImplicitly(httpReq, &bidReq)
+	assert.JSONEq(t, `{"amp":1}`, string(bidReq.Site.Ext))
+}
+
 // TestContentType prevents #328
 func TestContentType(t *testing.T) {
 	endpoint, _ := NewEndpoint(

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -491,7 +491,7 @@ func TestTimeoutParser(t *testing.T) {
 	}
 }
 
-func TestImplicitAMP(t *testing.T) {
+func TestImplicitAMPNoExt(t *testing.T) {
 	httpReq, err := http.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site.json")))
 	if !assert.NoError(t, err) {
 		return
@@ -502,13 +502,32 @@ func TestImplicitAMP(t *testing.T) {
 	assert.JSONEq(t, `{"amp":0}`, string(bidReq.Site.Ext))
 }
 
+func TestImplicitAMPOtherExt(t *testing.T) {
+	httpReq, err := http.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site.json")))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	bidReq := openrtb.BidRequest{
+		Site: &openrtb.Site{
+			Ext: json.RawMessage(`{"other":true}`),
+		},
+	}
+	setSiteImplicitly(httpReq, &bidReq)
+	assert.JSONEq(t, `{"amp":0,"other":true}`, string(bidReq.Site.Ext))
+}
+
 func TestExplicitAMP(t *testing.T) {
 	httpReq, err := http.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site-amp.json")))
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	var bidReq openrtb.BidRequest
+	bidReq := openrtb.BidRequest{
+		Site: &openrtb.Site{
+			Ext: json.RawMessage(`{"amp":1}`),
+		},
+	}
 	setSiteImplicitly(httpReq, &bidReq)
 	assert.JSONEq(t, `{"amp":1}`, string(bidReq.Site.Ext))
 }

--- a/endpoints/openrtb2/sample-requests/invalid-whole/site-ext-amp.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/site-ext-amp.json
@@ -1,43 +1,46 @@
 {
-  "id": "some-request-id",
-  "site": {
-    "page": "test.somepage.com",
-    "ext": {
-      "amp": 2
-    }
-  },
-  "imp": [
-    {
-      "id": "my-imp-id",
-      "banner": {
-        "format": [
-          {
-            "w": 300,
-            "h": 600
-          }
-        ]
-      },
-      "pmp": {
-        "deals": [
-          {
-            "id": "some-deal-id"
-          }
-        ]
-      },
+  "message": "Invalid request: request.site.ext.amp must be either 1, 0, or undefined\n",
+  "requestPayload": {
+    "id": "some-request-id",
+    "site": {
+      "page": "test.somepage.com",
       "ext": {
-        "appnexus": {
-          "placementId": 10433394
+        "amp": 2
+      }
+    },
+    "imp": [
+      {
+        "id": "my-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "pmp": {
+          "deals": [
+            {
+              "id": "some-deal-id"
+            }
+          ]
+        },
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
         }
       }
-    }
-  ],
-  "ext": {
-    "prebid": {
-      "targeting": {
-        "pricegranularity": "low"
-      },
-      "cache": {
-        "bids": {}
+    ],
+    "ext": {
+      "prebid": {
+        "targeting": {
+          "pricegranularity": "low"
+        },
+        "cache": {
+          "bids": {}
+        }
       }
     }
   }

--- a/endpoints/openrtb2/sample-requests/invalid-whole/site-ext-amp.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/site-ext-amp.json
@@ -1,0 +1,44 @@
+{
+  "id": "some-request-id",
+  "site": {
+    "page": "test.somepage.com",
+    "ext": {
+      "amp": 2
+    }
+  },
+  "imp": [
+    {
+      "id": "my-imp-id",
+      "banner": {
+        "format": [
+          {
+            "w": 300,
+            "h": 600
+          }
+        ]
+      },
+      "pmp": {
+        "deals": [
+          {
+            "id": "some-deal-id"
+          }
+        ]
+      },
+      "ext": {
+        "appnexus": {
+          "placementId": 10433394
+        }
+      }
+    }
+  ],
+  "ext": {
+    "prebid": {
+      "targeting": {
+        "pricegranularity": "low"
+      },
+      "cache": {
+        "bids": {}
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/site-amp.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/site-amp.json
@@ -1,0 +1,44 @@
+{
+  "id": "some-request-id",
+  "site": {
+    "page": "test.somepage.com",
+    "ext": {
+      "amp": 1
+    }
+  },
+  "imp": [
+    {
+      "id": "my-imp-id",
+      "banner": {
+        "format": [
+          {
+            "w": 300,
+            "h": 600
+          }
+        ]
+      },
+      "pmp": {
+        "deals": [
+          {
+            "id": "some-deal-id"
+          }
+        ]
+      },
+      "ext": {
+        "appnexus": {
+          "placementId": 10433394
+        }
+      }
+    }
+  ],
+  "ext": {
+    "prebid": {
+      "targeting": {
+        "pricegranularity": "low"
+      },
+      "cache": {
+        "bids": {}
+      }
+    }
+  }
+}

--- a/openrtb_ext/site.go
+++ b/openrtb_ext/site.go
@@ -1,0 +1,34 @@
+package openrtb_ext
+
+import (
+	"errors"
+
+	"github.com/buger/jsonparser"
+)
+
+// ExtSite defines the contract for bidrequest.site.ext
+type ExtSite struct {
+	// AMP should be 1 if the request comes from an AMP page, and 0 if not.
+	AMP int8 `json:"amp"`
+}
+
+func (es *ExtSite) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return errors.New("request.site.ext must have some data in it")
+	}
+	if value, dataType, _, _ := jsonparser.Get(b, "amp"); dataType != jsonparser.NotExist && dataType != jsonparser.Number {
+		return errors.New(`request.site.ext.amp must be either 1, 0, or undefined`)
+	} else if len(value) != 1 {
+		return errors.New(`request.site.ext.amp must be either 1, 0, or undefined`)
+	} else {
+		switch value[0] {
+		case byte(48): // 0
+			es.AMP = 0
+		case byte(49): // 1
+			es.AMP = 1
+		default:
+			return errors.New(`request.site.ext.amp must be either 1, 0, or undefined`)
+		}
+	}
+	return nil
+}

--- a/openrtb_ext/site_test.go
+++ b/openrtb_ext/site_test.go
@@ -1,0 +1,24 @@
+package openrtb_ext_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidSiteExt(t *testing.T) {
+	var s openrtb_ext.ExtSite
+	assert.EqualError(t, json.Unmarshal([]byte(`{"amp":-1}`), &s), "request.site.ext.amp must be either 1, 0, or undefined")
+	assert.EqualError(t, json.Unmarshal([]byte(`{"amp":2}`), &s), "request.site.ext.amp must be either 1, 0, or undefined")
+	assert.EqualError(t, json.Unmarshal([]byte(`{"amp":true}`), &s), "request.site.ext.amp must be either 1, 0, or undefined")
+	assert.EqualError(t, json.Unmarshal([]byte(`{"amp":null}`), &s), "request.site.ext.amp must be either 1, 0, or undefined")
+	assert.EqualError(t, json.Unmarshal([]byte(`{"amp":"1"}`), &s), "request.site.ext.amp must be either 1, 0, or undefined")
+}
+
+func TestValidSiteExt(t *testing.T) {
+	var s openrtb_ext.ExtSite
+	assert.NoError(t, json.Unmarshal([]byte(`{"amp":0}`), &s))
+	assert.NoError(t, json.Unmarshal([]byte(`{"amp":1}`), &s))
+}

--- a/openrtb_ext/site_test.go
+++ b/openrtb_ext/site_test.go
@@ -20,5 +20,9 @@ func TestInvalidSiteExt(t *testing.T) {
 func TestValidSiteExt(t *testing.T) {
 	var s openrtb_ext.ExtSite
 	assert.NoError(t, json.Unmarshal([]byte(`{"amp":0}`), &s))
+	assert.EqualValues(t, 0, s.AMP)
 	assert.NoError(t, json.Unmarshal([]byte(`{"amp":1}`), &s))
+	assert.EqualValues(t, 1, s.AMP)
+	assert.NoError(t, json.Unmarshal([]byte(`{"amp":      1   }`), &s))
+	assert.EqualValues(t, 1, s.AMP)
 }


### PR DESCRIPTION
This fixes #708

Technically the `ext` was already going to the bidders... so this just adds input validation & documents it.

Along the way, I found that our AMP tests were testing lots of payloads with `request.app` defined. Since AMP implies `site`, these tests don't make sense. I added an explicit check for `request.app` in the code.

This seems like a breaking change... but I don't think it is, because a _real_ AMP page would send the `curl` query param, and there was already code which defined `site` in that case. If the Stored Request already defined `app`, then it would cause both to be defined, which would make the request invalid anyway.