### PR TITLE
Corrected redundant append bug, and fixed Gopkg.lock corruption from previous PR

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -442,7 +442,7 @@ func postprocessBanner(beachfrontResp []BeachfrontResponseSlot, id string) ([]op
 	for i := range beachfrontResp {
 		crid := extractBannerCrid(beachfrontResp[i].Adm)
 
-		bids = append(bids, openrtb.Bid{
+		bids[i] = openrtb.Bid{
 			CrID:  crid,
 			ImpID: beachfrontResp[i].Slot,
 			Price: beachfrontResp[i].Price,
@@ -450,7 +450,7 @@ func postprocessBanner(beachfrontResp []BeachfrontResponseSlot, id string) ([]op
 			AdM:   beachfrontResp[i].Adm,
 			H:     beachfrontResp[i].H,
 			W:     beachfrontResp[i].W,
-		})
+		}
 	}
 
 	// Am not adding any errors


### PR DESCRIPTION
When I did git diff to origin, there where problems. The Gopkg.lock was formatted differently. I just did a fresh clone from origin, and redid my trivial change in beachfront.go. A diff with origin now looks right.