### PR TITLE
patches the beachfront usersyncer to not return a URL when none is co…

### DIFF
--- a/adapters/beachfront/usersync.go
+++ b/adapters/beachfront/usersync.go
@@ -14,6 +14,10 @@ func NewBeachfrontSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	b := string(openrtb_ext.BidderBeachfront)
 	usersyncURL := cfg.Adapters[b].UserSyncURL
 	platformID := cfg.Adapters[b].PlatformID
-	url := fmt.Sprintf("%s%s", usersyncURL, platformID)
+	// By default, beachfront has a platformID, but no URL. This is only useful if we have both
+	url := ""
+	if len(usersyncURL) > 0 {
+		url = fmt.Sprintf("%s%s", usersyncURL, platformID)
+	}
 	return adapters.NewSyncer("beachfront", 0, adapters.ResolveMacros(url), adapters.SyncTypeRedirect)
 }

--- a/adapters/beachfront/usersync_test.go
+++ b/adapters/beachfront/usersync_test.go
@@ -21,3 +21,16 @@ func TestBeachfrontSyncer(t *testing.T) {
 	assert.Equal(t, uint16(0), syncer.GDPRVendorID())
 	assert.Equal(t, false, u.SupportCORS)
 }
+
+func TestBeachfrontNullSyncer(t *testing.T) {
+	syncer := NewBeachfrontSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
+		string(openrtb_ext.BidderBeachfront): {
+			PlatformID: "142",
+		},
+	}})
+	u := syncer.GetUsersyncInfo("0", "")
+	assert.Equal(t, "", u.URL)
+	assert.Equal(t, "redirect", u.Type)
+	assert.Equal(t, uint16(0), syncer.GDPRVendorID())
+	assert.Equal(t, false, u.SupportCORS)
+}

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -111,14 +111,17 @@ func (deps *cookieSyncDeps) Endpoint(w http.ResponseWriter, r *http.Request, _ h
 
 	csResp := cookieSyncResponse{
 		Status:       cookieSyncStatus(userSyncCookie.LiveSyncCount()),
-		BidderStatus: make([]*usersync.CookieSyncBidders, len(parsedReq.Bidders)),
+		BidderStatus: make([]*usersync.CookieSyncBidders, 0, len(parsedReq.Bidders)),
 	}
 	for i := 0; i < len(parsedReq.Bidders); i++ {
 		bidder := parsedReq.Bidders[i]
-		csResp.BidderStatus[i] = &usersync.CookieSyncBidders{
+		newSync := &usersync.CookieSyncBidders{
 			BidderCode:   bidder,
 			NoCookie:     true,
 			UsersyncInfo: deps.syncers[openrtb_ext.BidderName(bidder)].GetUsersyncInfo(gdprToString(parsedReq.GDPR), parsedReq.Consent),
+		}
+		if len(newSync.UsersyncInfo.URL) > 0 {
+			csResp.BidderStatus = append(csResp.BidderStatus, newSync)
 		}
 	}
 


### PR DESCRIPTION
…nfigured.

There is no default usersync URL for Beachfront. this will now return `""` as the syncer URL rather than the platform ID, which is more generally recognized as an unusable URL.