### PR TITLE
Fixed aAdkernelAdn usersync bug

### DIFF
--- a/adapters/adkernelAdn/usersync.go
+++ b/adapters/adkernelAdn/usersync.go
@@ -13,7 +13,8 @@ import (
 const adkernelGDPRVendorID = uint16(14)
 
 func NewAdkernelAdnSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderAdkernelAdn)].UserSyncURL
+	// Fixes #736
+	usersyncURL := cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderAdkernelAdn))].UserSyncURL
 	externalURL := strings.TrimRight(cfg.ExternalURL, "/") + "/setuid?bidder=adkernelAdn&uid={UID}"
 	return adapters.NewSyncer("adkernelAdn", adkernelGDPRVendorID, adapters.ResolveMacros(usersyncURL+url.QueryEscape(externalURL)), adapters.SyncTypeRedirect)
 }

--- a/adapters/adkernelAdn/usersync_test.go
+++ b/adapters/adkernelAdn/usersync_test.go
@@ -1,17 +1,18 @@
 package adkernelAdn
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAdkernelAdnSyncer(t *testing.T) {
 	syncer := NewAdkernelAdnSyncer(&config.Configuration{ExternalURL: "https://localhost:8888", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderAdkernelAdn): {
+		// Prevents #736
+		strings.ToLower(string(openrtb_ext.BidderAdkernelAdn)): {
 			UserSyncURL: "https://tag.adkernel.com/syncr?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&r=",
 		},
 	}})


### PR DESCRIPTION
Fixes #736.

This is subtle... but apparently Viper manages all config options as lowercase. I left some `// Fixes` and `// Prevents` comments because this looks like an easy bug to re-introduce later.