### PR TITLE
Install mtr in the runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/local/bin/
 COPY --from=build /go/src/github.com/prebid/prebid-server/prebid-server .
 COPY static static/
 COPY stored_requests/data stored_requests/data
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates mtr
 EXPOSE 8000
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/prebid-server"]


### PR DESCRIPTION
`mtr` helps collect and report on latency stats between two machines. Some docs are here: https://www.linode.com/docs/networking/diagnostics/diagnosing-network-issues-with-mtr/

It can be used to help debug latency issues, narrowing down whether a latency problem is caused by the code/config or the hardware/network.