### PR TITLE
Added a configurable "concurrent incoming connection" limter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -401,12 +401,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:33b9d71d1dde2106309484a388eb7ba53cd1f67014e34a71f7b3dbc20bd186e5"
+  digest = "1:302869097fc293e4260ac0256a1d71901759f8f685eb8c1f5720cd294ead9215"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
     "idna",
+    "netutil",
     "publicsuffix",
   ]
   pruneopts = "UT"
@@ -488,6 +489,7 @@
     "github.com/yudai/gojsondiff",
     "github.com/yudai/gojsondiff/formatter",
     "golang.org/x/net/context/ctxhttp",
+    "golang.org/x/net/netutil",
     "golang.org/x/net/publicsuffix",
     "golang.org/x/text/currency",
     "gopkg.in/yaml.v2",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/spf13/viper"
 )
 
@@ -38,6 +37,8 @@ host_cookie:
   domain: cookies.prebid.org
   opt_out_url: http://prebid.org/optout
   opt_in_url: http://prebid.org/optin
+main_server:
+  max_concurrent_connections: 200
 external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
@@ -137,6 +138,7 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
+	cmpInts(t, "main_server.max_concurrent_connections", cfg.MainServer.MaxConcurrentConnections, 200)
 	cmpStrings(t, "metrics.influxdb.host", cfg.Metrics.Influxdb.Host, "upstream:8232")
 	cmpStrings(t, "metrics.influxdb.database", cfg.Metrics.Influxdb.Database, "metricsdb")
 	cmpStrings(t, "metrics.influxdb.username", cfg.Metrics.Influxdb.Username, "admin")

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbsmetrics"
 	metricsconfig "github.com/prebid/prebid-server/pbsmetrics/config"
+	"golang.org/x/net/netutil"
 )
 
 // Listen blocks forever, serving PBS requests on the given port. This will block forever, until the process is shut down.
@@ -38,6 +39,9 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v", mainServer.Addr, err)
 		return
+	}
+	if cfg.MainServer.MaxConcurrentConnections > 0 {
+		mainListener = netutil.LimitListener(mainListener, cfg.MainServer.MaxConcurrentConnections)
 	}
 	adminListener, err := newListener(adminServer.Addr, nil)
 	if err != nil {


### PR DESCRIPTION
Use case here is to help protect against sudden traffic spikes. Without it, traffic spikes can grind things to a halt by causing us to open up many new connections to Bidders all at once.