### PR TITLE
Cookie sync

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -64,7 +64,6 @@ type BeachfrontVideoImp struct {
 
 type BeachfrontVideoDevice struct {
 	UA         string `json:"ua"`
-	Devicetype int    `json:"deviceType"`
 	IP         string `json:"ip"`
 }
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -62,11 +62,12 @@ type BeachfrontVideoDevice struct {
 	Ip 			string `json:"ip"`
 }
 
+// Soooo close, but not quite openRTB
 type BeachfrontVideoImp struct {
 	Video    BeachfrontSize `json:"video"`
 	Bidfloor float64        `json:"bidfloor"`
-	Id       int            `json:"id"`
-	ImpId    string         `json:"impid"`
+	Id       int            `json:"id"`			// A sequential count of which imp on the page this is
+	ImpId    string         `json:"impid"`		// DNE in openRTB, would be "ID"
 	Secure	 int8			`json:"secure"`
 }
 
@@ -226,8 +227,6 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 				beachfrontReq.Slots[bannerImpsIndex].Sizes[j].W = imp.Banner.Format[j].W
 			}
 
-			beachfrontReq.Slots[bannerImpsIndex].Bidfloor = imp.BidFloor
-
 			var bidderExt adapters.ExtImpBidder
 			if err := json.Unmarshal(imp.Ext, &bidderExt); err != nil {
 				// possible banner error 2
@@ -252,6 +251,7 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 				}
 			}
 
+			beachfrontReq.Slots[bannerImpsIndex].Bidfloor = beachfrontExt.BidFloor
 			beachfrontReq.Slots[bannerImpsIndex].Slot = req.Imp[bannerImpsIndex].ID
 			beachfrontReq.Slots[bannerImpsIndex].Id = beachfrontExt.AppId
 		}

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,13 +16,11 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-const BannerEndpoint = "https://display.bfmio.com/prebid_display"
+// const BannerEndpoint = "https://display.bfmio.com/prebid_display"
+const BannerEndpoint = "https://qa.bfmio.com/prebid_display"
 
-// const BannerEndpoint = "https://qa.bfmio.com/prebid_display"
-
-const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
-
-// const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
+// const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
+const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -19,8 +19,8 @@ const BidCapacity = 5
 // const BannerEndpoint = "http://display.bfmio.com/prebid_display"
 const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
 
-// const VideoEndpoint = "http://reachms.bfmio.com/bid.json?exchange_id="
-const VideoEndpoint = "http://qa.bfmio.com/bid.json?exchange_id="
+// const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
+const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,11 +16,11 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-// const BannerEndpoint = "https://display.bfmio.com/prebid_display"
-const BannerEndpoint = "https://qa.bfmio.com/prebid_display"
+// const BannerEndpoint = "http://display.bfmio.com/prebid_display"
+const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
 
-// const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
-const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
+// const VideoEndpoint = "http://reachms.bfmio.com/bid.json?exchange_id="
+const VideoEndpoint = "http://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -65,6 +65,7 @@ type BeachfrontVideoImp struct {
 type BeachfrontVideoDevice struct {
 	UA         string `json:"ua"`
 	IP         string `json:"ip"`
+	JS		   string `json:"js"`
 }
 
 // ---------------------------------------------------
@@ -368,6 +369,7 @@ func getVideoRequest(req *openrtb.BidRequest) (BeachfrontVideoRequest, []error, 
 			if req.Device != nil {
 				beachfrontReq.Device.IP = req.Device.IP
 				beachfrontReq.Device.UA = req.Device.UA
+				beachfrontReq.Device.JS = "1"
 			}
 
 			beachfrontReq.AppId = beachfrontVideoExt.AppId

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,11 +16,11 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-// const BannerEndpoint = "http://display.bfmio.com/prebid_display"
-const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
+const BannerEndpoint = "http://display.bfmio.com/prebid_display"
+// const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
 
-// const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
-const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
+const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
+// const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -17,9 +17,11 @@ const Seat = "beachfront"
 const BidCapacity = 5
 
 const BannerEndpoint = "http://display.bfmio.com/prebid_display"
+
 // const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
 
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
+
 // const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
@@ -63,9 +65,9 @@ type BeachfrontVideoImp struct {
 }
 
 type BeachfrontVideoDevice struct {
-	UA         string `json:"ua"`
-	IP         string `json:"ip"`
-	JS		   string `json:"js"`
+	UA string `json:"ua"`
+	IP string `json:"ip"`
+	JS string `json:"js"`
 }
 
 // ---------------------------------------------------

--- a/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
+++ b/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
@@ -55,8 +55,9 @@
           "dnt": 0,
           "ua": "",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.1.1",
-          "user": ""
+          "adapterVersion": "0.2.1",
+          "user": {
+          }
         }
       },
       "mockResponse": {

--- a/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
+++ b/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
@@ -48,6 +48,7 @@
           "referrer": "",
           "search": "",
           "secure": 0,
+          "requestId": "some_test_ad",
           "isMobile": 0,
           "ip": "",
           "deviceModel": "",

--- a/adapters/beachfront/beachfronttest/exemplary/simple-video.json
+++ b/adapters/beachfront/beachfronttest/exemplary/simple-video.json
@@ -48,7 +48,6 @@
         "body": {
           "isPrebid": true,
           "appId": "11bc5dd5-7421-4dd8-c926-40fa653bec76",
-          "domain": "test.opposingviews.com",
           "id": "61b87329-8790-47b7-90dd-c53ae7ce1723",
           "imp": [
             {
@@ -57,19 +56,19 @@
                 "h": 250
               },
               "bidfloor": 0.01,
+              "secure" : 0,
               "id": 0,
               "impid": "video1"
             }
           ],
           "site": {
-            "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534"
+            "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534",
+            "domain": "test.opposingviews.com"
           },
           "device": {
             "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
             "deviceType": 0,
-            "geo": {
-              "ip": "127.0.0.1"
-            }
+            "ip": "127.0.0.1"
           },
           "cur": [
             "USD"

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
@@ -48,6 +48,7 @@
           "page": "some-mobile-app",
           "referrer": "",
           "search": "",
+          "requestId": "some_test_ad",
           "secure": 0,
           "isMobile": 0,
           "ip": "",

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
@@ -56,8 +56,9 @@
           "dnt": 0,
           "ua": "",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.1.1",
-          "user": ""
+          "adapterVersion": "0.2.1",
+          "user": {
+          }
         }
       },
       "mockResponse": {

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-video.json
@@ -2,7 +2,7 @@
   "mockBidRequest": {
     "id": "some_test_ad",
     "app": {
-      "domain": "yourmomshouse.com",
+      "domain": "some.app.com",
       "id": "some-mobile-app"
     },
     "imp": [
@@ -37,17 +37,15 @@
           ],
           "device": {
             "deviceType": 0,
-            "geo": {
-              "ip": ""
-            },
+            "ip": "",
             "ua": ""
           },
-          "domain": "yourmomshouse.com",
           "id": "some_test_ad",
           "imp": [
             {
               "bidfloor": 0.01,
               "id": 0,
+              "secure": 0,
               "impid": "video1",
               "video": {
                 "h": 250,
@@ -57,6 +55,7 @@
           ],
           "isPrebid": true,
           "site": {
+            "domain": "some.app.com",
             "page": "some-mobile-app"
           },
           "user": {

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
@@ -55,8 +55,9 @@
             "dnt": 0,
             "ua": "",
             "adapterName": "BF_PREBID_S2S",
-            "adapterVersion": "0.1.1",
-            "user": ""
+            "adapterVersion": "0.2.1",
+            "user": {
+            }
           }
         },
         "mockResponse": {

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
@@ -45,6 +45,7 @@
             ],
             "domain": "test.opposingviews.com",
             "page": "test.opposingviews.com",
+            "requestId": "some_test_ad",
             "referrer": "",
             "search": "",
             "secure": 0,

--- a/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
@@ -95,8 +95,11 @@
           "dnt": 1,
           "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.1.1",
-          "user": "some-buyer"
+          "adapterVersion": "0.2.1",
+          "user": {
+            "buyeruid": "some-buyer",
+            "id": "some-user"
+          }
         }
       },
       "mockResponse": {

--- a/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
@@ -86,6 +86,7 @@
           "domain": "test.opposingviews.com",
           "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534",
           "referrer": "",
+          "requestId": "fail_id",
           "search": "",
           "secure": 0,
           "isMobile": 0,

--- a/adapters/beachfront/beachfronttest/supplemental/multi-mix.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-mix.json
@@ -113,7 +113,6 @@
         "body": {
           "isPrebid": true,
           "appId": "11bc5dd5-7421-4dd8-c926-40fa653bec76",
-          "domain": "test.opposingviews.com",
           "id": "multi-mix-test",
           "imp": [
             {
@@ -123,7 +122,8 @@
               },
               "bidfloor": 0.01,
               "id": 0,
-              "impid": "video1"
+              "impid": "video1",
+              "secure": 0
             }, {
               "video": {
                 "w": 600,
@@ -131,18 +131,18 @@
               },
               "bidfloor": 0.01,
               "id": 1,
-              "impid": "video2"
+              "impid": "video2",
+              "secure": 0
             }
           ],
           "site": {
+            "domain": "test.opposingviews.com",
             "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534"
           },
           "device": {
             "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
             "deviceType": 0,
-            "geo": {
-              "ip": "127.0.0.1"
-            }
+            "ip": "127.0.0.1"
           },
           "cur": [
             "USD"

--- a/adapters/beachfront/beachfronttest/supplemental/multi-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-video.json
@@ -65,7 +65,6 @@
         "body": {
           "isPrebid": true,
           "appId": "11bc5dd5-7421-4dd8-c926-40fa653bec76",
-          "domain": "test.opposingviews.com",
           "id": "61b87329-8790-47b7-90dd-c53ae7ce1723",
           "imp": [
             {
@@ -75,7 +74,8 @@
               },
               "bidfloor": 0.01,
               "id": 0,
-              "impid": "video1"
+              "impid": "video1",
+              "secure": 0
             }, {
               "video": {
                 "w": 600,
@@ -83,18 +83,18 @@
               },
               "bidfloor": 0.01,
               "id": 1,
-              "impid": "video2"
+              "impid": "video2",
+              "secure": 0
             }
           ],
           "site": {
+            "domain": "test.opposingviews.com",
             "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534"
           },
           "device": {
             "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
             "deviceType": 0,
-            "geo": {
-              "ip": "127.0.0.1"
-            }
+            "ip": "127.0.0.1"
           },
           "cur": [
             "USD"

--- a/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-banner.json
@@ -29,6 +29,6 @@
 
   "expectedMakeRequestsErrors": [
     "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
-    "No valid impressions were found"
+    "no valid impressions were found"
   ]
 }

--- a/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-video.json
@@ -29,6 +29,6 @@
 
   "expectedMakeRequestsErrors": [
     "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
-    "No valid impressions were found"
+    "no valid impressions were found"
   ]
 }

--- a/adapters/beachfront/usersync.go
+++ b/adapters/beachfront/usersync.go
@@ -19,5 +19,5 @@ func NewBeachfrontSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	if len(usersyncURL) > 0 {
 		url = fmt.Sprintf("%s%s", usersyncURL, platformID)
 	}
-	return adapters.NewSyncer("beachfront", 0, adapters.ResolveMacros(url), adapters.SyncTypeRedirect)
+	return adapters.NewSyncer("beachfront", 0, adapters.ResolveMacros(url), adapters.SyncTypeIframe)
 }

--- a/adapters/beachfront/usersync.go
+++ b/adapters/beachfront/usersync.go
@@ -14,7 +14,7 @@ func NewBeachfrontSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	b := string(openrtb_ext.BidderBeachfront)
 	usersyncURL := cfg.Adapters[b].UserSyncURL
 	platformID := cfg.Adapters[b].PlatformID
-	// By default, beachfront has a platformID, but no URL. This is only useful if we have both
+
 	url := ""
 	if len(usersyncURL) > 0 {
 		url = fmt.Sprintf("%s%s", usersyncURL, platformID)

--- a/config/config.go
+++ b/config/config.go
@@ -354,7 +354,8 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.adform.endpoint", "http://adx.adform.net/adx")
 	v.SetDefault("adapters.adform.usersync_url", "//cm.adform.net/cookie?redirect_url=")
 	v.SetDefault("adapters.appnexus.endpoint", "http://ib.adnxs.com/openrtb2") // Docs: https://wiki.appnexus.com/display/supply/Incoming+Bid+Request+from+SSPs
-	v.SetDefault("adapters.beachfront.endpoint", "//sync.bfmio.com/syncb?pid=")
+	v.SetDefault("adapters.beachfront.endpoint", "https://display.bfmio.com/prebid_display")
+	v.SetDefault("adapters.beachfront.usersync_url", "//sync.bfmio.com/syncb?pid=")
 	v.SetDefault("adapters.beachfront.platform_id", "142")
 	v.SetDefault("adapters.brightroll.endpoint", "http://east-bid.ybp.yahoo.com/bid/appnexuspbs")
 	v.SetDefault("adapters.brightroll.usersync_url", "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr={{gdpr}}&euconsent={{gdpr_consent}}&url=")

--- a/config/config.go
+++ b/config/config.go
@@ -356,7 +356,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.appnexus.endpoint", "http://ib.adnxs.com/openrtb2") // Docs: https://wiki.appnexus.com/display/supply/Incoming+Bid+Request+from+SSPs
 	v.SetDefault("adapters.beachfront.endpoint", "https://display.bfmio.com/prebid_display")
 	v.SetDefault("adapters.beachfront.usersync_url", "//sync.bfmio.com/syncb?pid=")
-	v.SetDefault("adapters.beachfront.platform_id", "142")
+	v.SetDefault("adapters.beachfront.platform_id", "155")
 	v.SetDefault("adapters.brightroll.endpoint", "http://east-bid.ybp.yahoo.com/bid/appnexuspbs")
 	v.SetDefault("adapters.brightroll.usersync_url", "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr={{gdpr}}&euconsent={{gdpr_consent}}&url=")
 	v.SetDefault("adapters.conversant.endpoint", "http://api.hb.ad.cpe.dotomi.com/s2s/header/24")


### PR DESCRIPTION
I am not including the fix for issue #740 in this as, although by changing the expected message in the JSON I was able to pass validation while I was testing, the proper fix may involve changing the type to what is actually indicated ( ExtUser.consent ), or some other more involved fix.

What this does include are various bugs which were revealed in initial live testing, mostly related to cookie syncs and both the video and banner endpoint contracts. Where possible I've tried to use parts of the openRTB package structs instead of building custom structs, but still a lot of them are just different enough for that not to be possible. I've updated all validation to reflect these changes and checked coverage. I also set the default platform_id to 155 which indicates the appnexus server and points our cookie sync redirect to: https://prebid.adnxs.com/pbs/v1/setuid?