### PR TITLE
Check size match as per config before creating request

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -37,7 +37,8 @@ func (a *IxAdapter) SkipNoCookies() bool {
 }
 
 type indexParams struct {
-	SiteID string `json:"siteId"`
+	SiteID string    `json:"siteId"`
+	Size   [2]uint64 `json:"size"`
 }
 
 type ixBidResult struct {
@@ -52,6 +53,13 @@ type callOneObject struct {
 	requestJSON bytes.Buffer
 	width       uint64
 	height      uint64
+}
+
+func isValidIXSize(f openrtb.Format, s [2]uint64) bool {
+	if f.W != s[0] || f.H != s[1] {
+		return false
+	}
+	return true
 }
 
 func (a *IxAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
@@ -77,18 +85,24 @@ func (a *IxAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.P
 			break
 		}
 
-		for sizeIndex, format := range unit.Sizes {
-			var params indexParams
-			err := json.Unmarshal(unit.Params, &params)
-			if err != nil {
-				return nil, &errortypes.BadInput{
-					Message: fmt.Sprintf("unmarshal params '%s' failed: %v", unit.Params, err),
-				}
+		var params indexParams
+		err := json.Unmarshal(unit.Params, &params)
+		if err != nil {
+			return nil, &errortypes.BadInput{
+				Message: fmt.Sprintf("unmarshal params '%s' failed: %v", unit.Params, err),
 			}
-			if params.SiteID == "" {
-				return nil, &errortypes.BadInput{
-					Message: "Missing siteId param",
-				}
+		}
+
+		if params.SiteID == "" {
+			return nil, &errortypes.BadInput{
+				Message: "Missing siteId param",
+			}
+		}
+
+		for sizeIndex, format := range unit.Sizes {
+			// ensure request are sent only for valid size as specified in the params
+			if ok := isValidIXSize(format, params.Size); !ok {
+				continue
 			}
 
 			// Only grab this ad unit

--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -146,7 +146,7 @@ func (a *IxAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.P
 
 	if len(requests) == 0 {
 		return nil, &errortypes.BadInput{
-			Message: "Invalid ad unit/imp",
+			Message: "Invalid ad unit/imp/size",
 		}
 	}
 

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -31,7 +31,7 @@ func getAdUnit() pbs.PBSAdUnit {
 				H: 12,
 			},
 		},
-		Params: json.RawMessage("{\"siteId\": \"12\"}"),
+		Params: json.RawMessage("{\"siteId\":\"12\",\"size\":[10,12]}"),
 	}
 }
 
@@ -480,7 +480,7 @@ func TestIxInvalidParam(t *testing.T) {
 	}
 }
 
-func TestIxBasicResponse(t *testing.T) {
+func TestIxSingleSlotSingleValidSize(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(dummyIXServer),
@@ -507,7 +507,32 @@ func TestIxBasicResponse(t *testing.T) {
 	}
 }
 
-func TestIxTwoSlotResponse(t *testing.T) {
+func TestIxSingleSlotSingleInvalidSize(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(dummyIXServer),
+	)
+	defer server.Close()
+
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := NewIxAdapter(&conf, server.URL)
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	adUnit := getAdUnit()
+	adUnit.Params = json.RawMessage("{\"siteId\":\"1111\",\"size\":[8,10]}")
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			adUnit,
+		},
+	}
+	_, err := an.Call(ctx, &pbReq, &pbBidder)
+	if err == nil {
+		t.Fatalf("Should have gotten an error: %v", err)
+	}
+}
+
+func TestIxTwoSlotValidSize(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(dummyIXServer),
@@ -527,6 +552,8 @@ func TestIxTwoSlotResponse(t *testing.T) {
 			H: 10,
 		},
 	}
+	adUnit2.Params = json.RawMessage("{\"siteId\":\"1111\",\"size\":[8,10]}")
+
 	pbBidder := pbs.PBSBidder{
 		BidderCode: "bannerCode",
 		AdUnits: []pbs.PBSAdUnit{
@@ -554,7 +581,7 @@ func TestIxTwoSlotResponse(t *testing.T) {
 	}
 }
 
-func TestIxMultiSizeResponse(t *testing.T) {
+func TestIxTwoSlotMultiSizeOnlyValidIXSizeResponse(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(dummyIXServer),
@@ -580,14 +607,13 @@ func TestIxMultiSizeResponse(t *testing.T) {
 		t.Fatalf("Should not have gotten an error: %v", err)
 	}
 
-	if len(bids) != 2 {
-		t.Fatalf("Should have received 2 bids")
+	if len(bids) != 1 {
+		t.Fatalf("Should have received only 1 bids")
 	}
 
-	for _, v := range adUnit.Sizes {
-		if !bidResponseForSizeExist(bids, v.H, v.W) {
-			t.Fatalf("Missing bid for specified size %d and %d", v.W, v.H)
-		}
+	v := adUnit.Sizes[0]
+	if !bidResponseForSizeExist(bids, v.H, v.W) {
+		t.Fatalf("Missing bid for specified size %d and %d", v.W, v.H)
 	}
 }
 

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -480,6 +480,30 @@ func TestIxInvalidParam(t *testing.T) {
 	}
 }
 
+func TestIxEmptySize(t *testing.T) {
+
+	server := httptest.NewServer(
+		http.HandlerFunc(dummyIXServer),
+	)
+	defer server.Close()
+
+	conf := *adapters.DefaultHTTPAdapterConfig
+	an := NewIxAdapter(&conf, server.URL)
+	ctx := context.TODO()
+	pbReq := pbs.PBSRequest{}
+	adUnit := getAdUnit()
+	adUnit.Params = json.RawMessage("{\"siteId\":\"1111\"}")
+	pbBidder := pbs.PBSBidder{
+		BidderCode: "bannerCode",
+		AdUnits: []pbs.PBSAdUnit{
+			adUnit,
+		},
+	}
+	if _, err := an.Call(ctx, &pbReq, &pbBidder); err == nil {
+		t.Fatalf("Should have gotten error due to no valid bid request generated: %v", err)
+	}
+}
+
 func TestIxSingleSlotSingleValidSize(t *testing.T) {
 
 	server := httptest.NewServer(

--- a/static/bidder-params/ix.json
+++ b/static/bidder-params/ix.json
@@ -19,5 +19,5 @@
       "description": "An array of two integer containing the dimension"
     }
   },
-  "required": ["siteId", "size"]
+  "required": ["siteId"]
 }

--- a/static/bidder-params/ix.json
+++ b/static/bidder-params/ix.json
@@ -6,8 +6,18 @@
   "properties": {
     "siteId": {
       "type": "string",
+      "minLength": 1,
       "description": "An ID which identifies the site selling the impression"
+    },
+    "size": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 2,
+      "maxItems": 2,
+      "description": "An array of two integer containing the dimension"
     }
   },
-  "required": ["siteId"]
+  "required": ["siteId", "size"]
 }


### PR DESCRIPTION
Fixing a bug identified in the IX adapter where requests were being sent for sizes that were not present in the adapter config.

Additionally, some validation code was moved outside the loop containing it, because it did not need to be inside the loop.