### PR TITLE
Deleted the loadtype targeting key

### DIFF
--- a/docs/endpoints/openrtb2/amp.md
+++ b/docs/endpoints/openrtb2/amp.md
@@ -67,7 +67,6 @@ A sample response payload looks like this:
         "hb_bidder_appnexus": "appnexus",
         "hb_cache_id": "420d7329-30e8-4c4e-8eaa-fe937172e4e0",
         "hb_cache_id_appnexus": "420d7329-30e8-4c4e-8eaa-fe937172e4e0",
-        "hb_creative_loadtype": "html",
         "hb_pb": "0.50",
         "hb_pb_appnexus": "0.50",
         "hb_size": "300x250",

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"github.com/mssola/user_agent"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/config"
@@ -21,10 +24,6 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/usersync"
-
-	"github.com/golang/glog"
-	"github.com/julienschmidt/httprouter"
-	"github.com/mssola/user_agent"
 )
 
 type bidResult struct {
@@ -36,17 +35,10 @@ const defaultPriceGranularity = "med"
 
 // Constant keys for ad server targeting for responses to Prebid Mobile
 const hbpbConstantKey = "hb_pb"
-const hbCreativeLoadMethodConstantKey = "hb_creative_loadtype"
 const hbBidderConstantKey = "hb_bidder"
 const hbCacheIdConstantKey = "hb_cache_id"
 const hbDealIdConstantKey = "hb_deal"
 const hbSizeConstantKey = "hb_size"
-
-// hb_creative_loadtype key can be one of `demand_sdk` or `html`
-// default is `html` where the creative is loaded in the primary ad server's webview through AppNexus hosted JS
-// `demand_sdk` is for bidders who insist on their creatives being loaded in their own SDK's webview
-const hbCreativeLoadMethodHTML = "html"
-const hbCreativeLoadMethodDemandSDK = "demand_sdk"
 
 func min(x, y int) int {
 	if x < y {
@@ -485,11 +477,6 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				}
 				if hbSize != "" {
 					kvs[hbSizeConstantKey] = hbSize
-				}
-				if bid.BidderCode == "audienceNetwork" {
-					kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodDemandSDK
-				} else {
-					kvs[hbCreativeLoadMethodConstantKey] = hbCreativeLoadMethodHTML
 				}
 			}
 		}

--- a/endpoints/auction_test.go
+++ b/endpoints/auction_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/gdpr"
@@ -19,8 +20,6 @@ import (
 	metricsConf "github.com/prebid/prebid-server/pbsmetrics/config"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/usersync/usersyncers"
-
-	"github.com/mxmCherry/openrtb"
 	"github.com/spf13/viper"
 )
 
@@ -149,9 +148,6 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			t.Error("Ad server targeting should not be nil")
 		}
 		if bid.BidderCode == "audienceNetwork" {
-			if bid.AdServerTargeting["hb_creative_loadtype"] != "demand_sdk" {
-				t.Error("Facebook bid should have demand_sdk as hb_creative_loadtype in ad server targeting")
-			}
 			if bid.AdServerTargeting["hb_size"] != "300x250" {
 				t.Error("hb_size key was not parsed correctly")
 			}

--- a/exchange/exchangetest/targeting-cache-vast-banner.json
+++ b/exchange/exchangetest/targeting-cache-vast-banner.json
@@ -72,8 +72,7 @@
                   "hb_pb": "0.00",
                   "hb_pb_appnexus": "0.00",
                   "hb_size": "200x250",
-                  "hb_size_appnexus": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "200x250"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-cache-vast.json
+++ b/exchange/exchangetest/targeting-cache-vast.json
@@ -73,8 +73,7 @@
                   "hb_pb": "0.00",
                   "hb_pb_appnexus": "0.00",
                   "hb_size": "200x250",
-                  "hb_size_appnexus": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "200x250"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-cache-zero.json
+++ b/exchange/exchangetest/targeting-cache-zero.json
@@ -78,8 +78,7 @@
                   "hb_pb": "0.00",
                   "hb_pb_appnexus": "0.00",
                   "hb_size": "200x250",
-                  "hb_size_appnexus": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "200x250"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-mobile.json
+++ b/exchange/exchangetest/targeting-mobile.json
@@ -124,7 +124,6 @@
                   "hb_bidder_audienceNe": "audienceNetwork",
                   "hb_pb_audienceNetwor": "0.50",
                   "hb_size_audienceNetw": "200x250",
-                  "hb_creative_loadtype": "demand_sdk",
                   "hb_env_audienceNetwo": "mobile-app"
                 }
               }
@@ -151,8 +150,7 @@
                   "hb_size": "200x250",
                   "hb_size_appnexus": "200x250",
                   "hb_env": "mobile-app",
-                  "hb_env_appnexus": "mobile-app",
-                  "hb_creative_loadtype": "html"
+                  "hb_env_appnexus": "mobile-app"
                 }
               }
             }
@@ -188,8 +186,7 @@
                   "hb_size": "300x500",
                   "hb_size_appnexus": "300x500",
                   "hb_env": "mobile-app",
-                  "hb_env_appnexus": "mobile-app",
-                  "hb_creative_loadtype": "html"
+                  "hb_env_appnexus": "mobile-app"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-no-winners.json
+++ b/exchange/exchangetest/targeting-no-winners.json
@@ -125,8 +125,7 @@
                 "targeting": {
                   "hb_bidder_audienceNe": "audienceNetwork",
                   "hb_pb_audienceNetwor": "0.50",
-                  "hb_size_audienceNetw": "200x250",
-                  "hb_creative_loadtype": "demand_sdk"
+                  "hb_size_audienceNetw": "200x250"
                 }
               }
             }
@@ -147,8 +146,7 @@
                 "targeting": {
                   "hb_bidder_appnexus": "appnexus",
                   "hb_pb_appnexus": "0.70",
-                  "hb_size_appnexus": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "200x250"
                 }
               }
             }
@@ -179,8 +177,7 @@
                 "targeting": {
                   "hb_bidder_appnexus": "appnexus",
                   "hb_pb_appnexus": "0.60",
-                  "hb_size_appnexus": "300x500",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "300x500"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-only-winners.json
+++ b/exchange/exchangetest/targeting-only-winners.json
@@ -121,10 +121,7 @@
             "crid": "creative-4",
             "ext": {
               "prebid": {
-                "type": "video",
-                "targeting": {
-                  "hb_creative_loadtype": "demand_sdk"
-                }
+                "type": "video"
               }
             }
           }]
@@ -144,8 +141,7 @@
                 "targeting": {
                   "hb_bidder": "appnexus",
                   "hb_pb": "0.70",
-                  "hb_size": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size": "200x250"
                 }
               }
             }
@@ -176,8 +172,7 @@
                 "targeting": {
                   "hb_bidder": "appnexus",
                   "hb_pb": "0.60",
-                  "hb_size": "300x500",
-                  "hb_creative_loadtype": "html"
+                  "hb_size": "300x500"
                 }
               }
             }

--- a/exchange/exchangetest/targeting-with-winners.json
+++ b/exchange/exchangetest/targeting-with-winners.json
@@ -123,8 +123,7 @@
                 "targeting": {
                   "hb_bidder_audienceNe": "audienceNetwork",
                   "hb_pb_audienceNetwor": "0.50",
-                  "hb_size_audienceNetw": "200x250",
-                  "hb_creative_loadtype": "demand_sdk"
+                  "hb_size_audienceNetw": "200x250"
                 }
               }
             }
@@ -148,8 +147,7 @@
                   "hb_pb": "0.70",
                   "hb_pb_appnexus": "0.70",
                   "hb_size": "200x250",
-                  "hb_size_appnexus": "200x250",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "200x250"
                 }
               }
             }
@@ -183,8 +181,7 @@
                   "hb_pb": "0.60",
                   "hb_pb_appnexus": "0.60",
                   "hb_size": "300x500",
-                  "hb_size_appnexus": "300x500",
-                  "hb_creative_loadtype": "html"
+                  "hb_size_appnexus": "300x500"
                 }
               }
             }

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -54,12 +54,6 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool) {
 				targData.addKeys(targets, openrtb_ext.HbDealIdConstantKey, deal, bidderName, isOverallWinner)
 			}
 
-			if bidderName == "audienceNetwork" {
-				targets[string(openrtb_ext.HbCreativeLoadMethodConstantKey)] = openrtb_ext.HbCreativeLoadMethodDemandSDK
-			} else {
-				targets[string(openrtb_ext.HbCreativeLoadMethodConstantKey)] = openrtb_ext.HbCreativeLoadMethodHTML
-			}
-
 			if isApp {
 				targData.addKeys(targets, openrtb_ext.HbEnvKey, openrtb_ext.HbEnvKeyApp, bidderName, isOverallWinner)
 			}

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -80,12 +80,7 @@ const (
 	// HbBidderConstantKey is the name of the Bidder. For example, "appnexus" or "rubicon".
 	HbBidderConstantKey TargetingKey = "hb_bidder"
 	HbSizeConstantKey   TargetingKey = "hb_size"
-
-	// HbCreativeLoadMethodConstantKey is used exclusively by Prebid Mobile to accomodate Facebook.
-	// Facebook requires that ads from their network be loaded using their own SDK.
-	// Other demand sources are happy to let Prebid Mobile use a Webview.
-	HbCreativeLoadMethodConstantKey TargetingKey = "hb_creative_loadtype"
-	HbDealIdConstantKey             TargetingKey = "hb_deal"
+	HbDealIdConstantKey TargetingKey = "hb_deal"
 
 	// HbCacheKey and HbVastCacheKey store UUIDs which can be used to fetch things from prebid cache.
 	// Callers should *never* assume that either of these exist, since the call to the cache may always fail.
@@ -94,10 +89,6 @@ const (
 	// HbVastCacheKey will only ever exist for Video bids.
 	HbCacheKey     TargetingKey = "hb_cache_id"
 	HbVastCacheKey TargetingKey = "hb_uuid"
-
-	// These are not keys, but values used by hbCreativeLoadMethodConstantKey
-	HbCreativeLoadMethodHTML      string = "html"
-	HbCreativeLoadMethodDemandSDK string = "demand_sdk"
 
 	// This is not a key, but values used by the HbEnvKey
 	HbEnvKeyApp string = "mobile-app"


### PR DESCRIPTION
Fixes #749.

Prebid Mobile says they've given up trying to integrate Facebook in the SDK... so this key really doesn't serve any purpose anymore.