### PR TITLE
Configurable sync url

### DIFF
--- a/adapters/33across/usersync.go
+++ b/adapters/33across/usersync.go
@@ -11,7 +11,7 @@ import (
 )
 
 func New33AcrossSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/")
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	adapterConfig := cfg.Adapters[string(openrtb_ext.Bidder33Across)]
 	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dttx%26uid%3D33XUSERID33X"
 	syncerURL := adapterConfig.UserSyncURL + "/?ri=" + adapterConfig.PartnerId + "&ru=" + redirectURL

--- a/adapters/33across/usersync.go
+++ b/adapters/33across/usersync.go
@@ -13,7 +13,7 @@ import (
 func New33AcrossSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	adapterConfig := cfg.Adapters[string(openrtb_ext.Bidder33Across)]
-	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dttx%26uid%3D33XUSERID33X"
+	redirectURL := url.QueryEscape(externalURL) + "%3Fbidder%3Dttx%26uid%3D33XUSERID33X"
 	syncerURL := adapterConfig.UserSyncURL + "/?ri=" + adapterConfig.PartnerId + "&ru=" + redirectURL
 
 	if adapterConfig.PartnerId == "" {

--- a/adapters/33across/usersync_test.go
+++ b/adapters/33across/usersync_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func Test33AcrossSyncer(t *testing.T) {
 	ttx := New33AcrossSyncer(&config.Configuration{
-		ExternalURL: "localhost",
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
 		Adapters: map[string]config.Adapter{
 			"33across": {
 				UserSyncURL: "https://ssc-cms.33across.com/ps",

--- a/adapters/33across/usersync_test.go
+++ b/adapters/33across/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func Test33AcrossSyncer(t *testing.T) {
 	ttx := New33AcrossSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			"33across": {

--- a/adapters/adform/usersync.go
+++ b/adapters/adform/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewAdformSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderAdform)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("adform", 50, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/adform/usersync.go
+++ b/adapters/adform/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewAdformSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderAdform)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dadform%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("adform", 50, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/adform/usersync_test.go
+++ b/adapters/adform/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestAdformSyncer(t *testing.T) {
 	syncer := NewAdformSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderAdform): {

--- a/adapters/adform/usersync_test.go
+++ b/adapters/adform/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAdformSyncer(t *testing.T) {
-	syncer := NewAdformSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderAdform): {
-			UserSyncURL: "//cm.adform.net?return_url=",
+	syncer := NewAdformSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderAdform): {
+				UserSyncURL: "//cm.adform.net?return_url=",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("1", "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw")
 	assert.Equal(t, "//cm.adform.net?return_url=localhost%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D1%26gdpr_consent%3DBONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw%26uid%3D%24UID", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/adkernelAdn/usersync.go
+++ b/adapters/adkernelAdn/usersync.go
@@ -15,6 +15,6 @@ const adkernelGDPRVendorID = uint16(14)
 func NewAdkernelAdnSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	// Fixes #736
 	usersyncURL := cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderAdkernelAdn))].UserSyncURL
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/") + "/setuid?bidder=adkernelAdn&uid={UID}"
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/") + "/setuid?bidder=adkernelAdn&uid={UID}"
 	return adapters.NewSyncer("adkernelAdn", adkernelGDPRVendorID, adapters.ResolveMacros(usersyncURL+url.QueryEscape(externalURL)), adapters.SyncTypeRedirect)
 }

--- a/adapters/adkernelAdn/usersync.go
+++ b/adapters/adkernelAdn/usersync.go
@@ -15,6 +15,6 @@ const adkernelGDPRVendorID = uint16(14)
 func NewAdkernelAdnSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	// Fixes #736
 	usersyncURL := cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderAdkernelAdn))].UserSyncURL
-	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/") + "/setuid?bidder=adkernelAdn&uid={UID}"
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/") + "?bidder=adkernelAdn&uid={UID}"
 	return adapters.NewSyncer("adkernelAdn", adkernelGDPRVendorID, adapters.ResolveMacros(usersyncURL+url.QueryEscape(externalURL)), adapters.SyncTypeRedirect)
 }

--- a/adapters/adkernelAdn/usersync_test.go
+++ b/adapters/adkernelAdn/usersync_test.go
@@ -10,12 +10,16 @@ import (
 )
 
 func TestAdkernelAdnSyncer(t *testing.T) {
-	syncer := NewAdkernelAdnSyncer(&config.Configuration{ExternalURL: "https://localhost:8888", Adapters: map[string]config.Adapter{
-		// Prevents #736
-		strings.ToLower(string(openrtb_ext.BidderAdkernelAdn)): {
-			UserSyncURL: "https://tag.adkernel.com/syncr?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&r=",
+	syncer := NewAdkernelAdnSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "https://localhost:8888",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			// Prevents #736
+			strings.ToLower(string(openrtb_ext.BidderAdkernelAdn)): {
+				UserSyncURL: "https://tag.adkernel.com/syncr?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&r=",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("1", "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw")
 	assert.Equal(t, "https://tag.adkernel.com/syncr?gdpr=1&gdpr_consent=BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw&r=https%3A%2F%2Flocalhost%3A8888%2Fsetuid%3Fbidder%3DadkernelAdn%26uid%3D%7BUID%7D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/adkernelAdn/usersync_test.go
+++ b/adapters/adkernelAdn/usersync_test.go
@@ -12,7 +12,7 @@ import (
 func TestAdkernelAdnSyncer(t *testing.T) {
 	syncer := NewAdkernelAdnSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "https://localhost:8888",
+			BaseSyncURL: "https://localhost:8888/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			// Prevents #736

--- a/adapters/adtelligent/usersync.go
+++ b/adapters/adtelligent/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewAdtelligentSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%7Buid%7D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%7Buid%7D"
 	usersyncURL := "//sync.adtelligent.com/csync?t=p&ep=0&redir="
 	return adapters.NewSyncer("adtelligent", 0, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/adtelligent/usersync.go
+++ b/adapters/adtelligent/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewAdtelligentSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%7Buid%7D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dadtelligent%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%7Buid%7D"
 	usersyncURL := "//sync.adtelligent.com/csync?t=p&ep=0&redir="
 	return adapters.NewSyncer("adtelligent", 0, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/adtelligent/usersync_test.go
+++ b/adapters/adtelligent/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestAdtelligentSyncer(t *testing.T) {
 	syncer := NewAdtelligentSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("0", "")

--- a/adapters/adtelligent/usersync_test.go
+++ b/adapters/adtelligent/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAdtelligentSyncer(t *testing.T) {
-	syncer := NewAdtelligentSyncer(&config.Configuration{ExternalURL: "localhost"})
+	syncer := NewAdtelligentSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("0", "")
 	assert.Equal(t, "//sync.adtelligent.com/csync?t=p&ep=0&redir=localhost%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D0%26gdpr_consent%3D%26uid%3D%7Buid%7D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/appnexus/usersync.go
+++ b/adapters/appnexus/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewAppnexusSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dadnxs%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	usersyncURL := "//ib.adnxs.com/getuid?"
 	return adapters.NewSyncer("adnxs", 32, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/appnexus/usersync.go
+++ b/adapters/appnexus/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewAppnexusSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	usersyncURL := "//ib.adnxs.com/getuid?"
 	return adapters.NewSyncer("adnxs", 32, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/appnexus/usersync_test.go
+++ b/adapters/appnexus/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestAppNexusSyncer(t *testing.T) {
 	syncer := NewAppnexusSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "https://prebid.adnxs.com/pbs/v1",
+			BaseSyncURL: "https://prebid.adnxs.com/pbs/v1/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("", "")

--- a/adapters/appnexus/usersync_test.go
+++ b/adapters/appnexus/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAppNexusSyncer(t *testing.T) {
-	syncer := NewAppnexusSyncer(&config.Configuration{ExternalURL: "https://prebid.adnxs.com/pbs/v1"})
+	syncer := NewAppnexusSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "https://prebid.adnxs.com/pbs/v1",
+		},
+	})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "//ib.adnxs.com/getuid?https%3A%2F%2Fprebid.adnxs.com%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24UID", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/beachfront/usersync_test.go
+++ b/adapters/beachfront/usersync_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/adapters/brightroll/usersync.go
+++ b/adapters/brightroll/usersync.go
@@ -12,7 +12,7 @@ import (
 
 func NewBrightrollSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	userSyncURL := cfg.Adapters[string(openrtb_ext.BidderBrightroll)].UserSyncURL
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/")
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dbrightroll%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	return adapters.NewSyncer("brightroll", 25, adapters.ResolveMacros(userSyncURL+redirectURL), adapters.SyncTypeRedirect)
 }

--- a/adapters/brightroll/usersync.go
+++ b/adapters/brightroll/usersync.go
@@ -13,6 +13,6 @@ import (
 func NewBrightrollSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	userSyncURL := cfg.Adapters[string(openrtb_ext.BidderBrightroll)].UserSyncURL
 	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
-	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dbrightroll%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
+	redirectURL := url.QueryEscape(externalURL) + "%3Fbidder%3Dbrightroll%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	return adapters.NewSyncer("brightroll", 25, adapters.ResolveMacros(userSyncURL+redirectURL), adapters.SyncTypeRedirect)
 }

--- a/adapters/brightroll/usersync_test.go
+++ b/adapters/brightroll/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestBrightrollSyncer(t *testing.T) {
 	syncer := NewBrightrollSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderBrightroll): {

--- a/adapters/brightroll/usersync_test.go
+++ b/adapters/brightroll/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBrightrollSyncer(t *testing.T) {
-	syncer := NewBrightrollSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderBrightroll): {
-			UserSyncURL: "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr={{gdpr}}&euconsent={{gdpr_consent}}&url=",
+	syncer := NewBrightrollSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderBrightroll): {
+				UserSyncURL: "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr={{gdpr}}&euconsent={{gdpr_consent}}&url=",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "http://east-bid.ybp.yahoo.com/sync/appnexuspbs?gdpr=&euconsent=&url=localhost%2Fsetuid%3Fbidder%3Dbrightroll%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24%7BUID%7D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/conversant/usersync.go
+++ b/adapters/conversant/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewConversantSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderConversant)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dconversant%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
 	return adapters.NewSyncer("conversant", 24, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/conversant/usersync.go
+++ b/adapters/conversant/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewConversantSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderConversant)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
 	return adapters.NewSyncer("conversant", 24, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/conversant/usersync_test.go
+++ b/adapters/conversant/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConversantSyncer(t *testing.T) {
-	syncer := NewConversantSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderConversant): {
-			UserSyncURL: "usersync?rurl=",
+	syncer := NewConversantSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderConversant): {
+				UserSyncURL: "usersync?rurl=",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("0", "")
 	assert.Equal(t, "usersync?rurl=localhost%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D0%26gdpr_consent%3D%26uid%3D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/conversant/usersync_test.go
+++ b/adapters/conversant/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestConversantSyncer(t *testing.T) {
 	syncer := NewConversantSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderConversant): {

--- a/adapters/eplanning/usersync.go
+++ b/adapters/eplanning/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewEPlanningSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderEPlanning)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Deplanning%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Deplanning%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("eplanning", 0, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/eplanning/usersync.go
+++ b/adapters/eplanning/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewEPlanningSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderEPlanning)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Deplanning%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Deplanning%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("eplanning", 0, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/eplanning/usersync_test.go
+++ b/adapters/eplanning/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestEPlanningSyncer(t *testing.T) {
 	syncer := NewEPlanningSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderEPlanning): {

--- a/adapters/eplanning/usersync_test.go
+++ b/adapters/eplanning/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEPlanningSyncer(t *testing.T) {
-	syncer := NewEPlanningSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderEPlanning): {
-			UserSyncURL: "http://sync.e-planning.net/um?uid",
+	syncer := NewEPlanningSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderEPlanning): {
+				UserSyncURL: "http://sync.e-planning.net/um?uid",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "http://sync.e-planning.net/um?uidlocalhost%2Fsetuid%3Fbidder%3Deplanning%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24UID", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/lifestreet/usersync.go
+++ b/adapters/lifestreet/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewLifestreetSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dlifestreet%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%24visitor_cookie%24%24"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dlifestreet%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%24visitor_cookie%24%24"
 	usersyncURL := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl="
 	return adapters.NewSyncer("lifestreet", 67, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/lifestreet/usersync.go
+++ b/adapters/lifestreet/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewLifestreetSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dlifestreet%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%24visitor_cookie%24%24"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dlifestreet%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%24visitor_cookie%24%24"
 	usersyncURL := "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl="
 	return adapters.NewSyncer("lifestreet", 67, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/lifestreet/usersync_test.go
+++ b/adapters/lifestreet/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLifestreetSyncer(t *testing.T) {
-	syncer := NewLifestreetSyncer(&config.Configuration{ExternalURL: "localhost"})
+	syncer := NewLifestreetSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("0", "")
 	assert.Equal(t, "//ads.lfstmedia.com/idsync/137062?synced=1&ttl=1s&rurl=localhost%2Fsetuid%3Fbidder%3Dlifestreet%26gdpr%3D0%26gdpr_consent%3D%26uid%3D%24%24visitor_cookie%24%24", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/lifestreet/usersync_test.go
+++ b/adapters/lifestreet/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestLifestreetSyncer(t *testing.T) {
 	syncer := NewLifestreetSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("0", "")

--- a/adapters/openx/usersync.go
+++ b/adapters/openx/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewOpenxSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
-	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dopenx%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
+	redirectURL := url.QueryEscape(externalURL) + "%3Fbidder%3Dopenx%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	return adapters.NewSyncer("openx", 69, adapters.ResolveMacros("https://rtb.openx.net/sync/prebid?r="+redirectURL), adapters.SyncTypeRedirect)
 }

--- a/adapters/openx/usersync.go
+++ b/adapters/openx/usersync.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewOpenxSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/")
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dopenx%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	return adapters.NewSyncer("openx", 69, adapters.ResolveMacros("https://rtb.openx.net/sync/prebid?r="+redirectURL), adapters.SyncTypeRedirect)
 }

--- a/adapters/openx/usersync_test.go
+++ b/adapters/openx/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestOpenxSyncer(t *testing.T) {
 	syncer := NewOpenxSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("", "")

--- a/adapters/openx/usersync_test.go
+++ b/adapters/openx/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOpenxSyncer(t *testing.T) {
-	syncer := NewOpenxSyncer(&config.Configuration{ExternalURL: "localhost"})
+	syncer := NewOpenxSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "https://rtb.openx.net/sync/prebid?r=localhost%2Fsetuid%3Fbidder%3Dopenx%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24%7BUID%7D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/pubmatic/usersync.go
+++ b/adapters/pubmatic/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewPubmaticSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dpubmatic%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dpubmatic%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
 	usersyncURL := "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
 	return adapters.NewSyncer("pubmatic", 76, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeIframe)
 }

--- a/adapters/pubmatic/usersync.go
+++ b/adapters/pubmatic/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewPubmaticSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dpubmatic%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dpubmatic%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D"
 	usersyncURL := "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect="
 	return adapters.NewSyncer("pubmatic", 76, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeIframe)
 }

--- a/adapters/pubmatic/usersync_test.go
+++ b/adapters/pubmatic/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestPubmaticSyncer(t *testing.T) {
 	syncer := NewPubmaticSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("1", "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw")

--- a/adapters/pubmatic/usersync_test.go
+++ b/adapters/pubmatic/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPubmaticSyncer(t *testing.T) {
-	syncer := NewPubmaticSyncer(&config.Configuration{ExternalURL: "localhost"})
+	syncer := NewPubmaticSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("1", "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw")
 	assert.Equal(t, "//ads.pubmatic.com/AdServer/js/user_sync.html?predirect=localhost%2Fsetuid%3Fbidder%3Dpubmatic%26gdpr%3D1%26gdpr_consent%3DBONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw%26uid%3D", u.URL)
 	assert.Equal(t, "iframe", u.Type)

--- a/adapters/pulsepoint/usersync.go
+++ b/adapters/pulsepoint/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewPulsepointSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.ExternalURL) + "%2Fsetuid%3Fbidder%3Dpulsepoint%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%25%25VGUID%25%25"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dpulsepoint%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%25%25VGUID%25%25"
 	usersyncURL := "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl="
 	return adapters.NewSyncer("pulsepoint", 81, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/pulsepoint/usersync.go
+++ b/adapters/pulsepoint/usersync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewPulsepointSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dpulsepoint%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%25%25VGUID%25%25"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dpulsepoint%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%25%25VGUID%25%25"
 	usersyncURL := "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl="
 	return adapters.NewSyncer("pulsepoint", 81, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/pulsepoint/usersync_test.go
+++ b/adapters/pulsepoint/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPulsepointSyncer(t *testing.T) {
-	syncer := NewPulsepointSyncer(&config.Configuration{ExternalURL: "http://localhost"})
+	syncer := NewPulsepointSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "http://localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "//bh.contextweb.com/rtset?pid=561205&ev=1&rurl=http%3A%2F%2Flocalhost%2Fsetuid%3Fbidder%3Dpulsepoint%26gdpr%3D%26gdpr_consent%3D%26uid%3D%25%25VGUID%25%25", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/pulsepoint/usersync_test.go
+++ b/adapters/pulsepoint/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestPulsepointSyncer(t *testing.T) {
 	syncer := NewPulsepointSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "http://localhost",
+			BaseSyncURL: "http://localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("", "")

--- a/adapters/rhythmone/usersync.go
+++ b/adapters/rhythmone/usersync.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewRhythmoneSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/")
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	redirectURI := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Drhythmone%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%5BRX_UUID%5D"
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderRhythmone)].UserSyncURL
 	return adapters.NewSyncer("rhythmone", 36, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)

--- a/adapters/rhythmone/usersync.go
+++ b/adapters/rhythmone/usersync.go
@@ -12,7 +12,7 @@ import (
 
 func NewRhythmoneSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
-	redirectURI := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Drhythmone%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%5BRX_UUID%5D"
+	redirectURI := url.QueryEscape(externalURL) + "%3Fbidder%3Drhythmone%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%5BRX_UUID%5D"
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderRhythmone)].UserSyncURL
 	return adapters.NewSyncer("rhythmone", 36, adapters.ResolveMacros(usersyncURL+redirectURI), adapters.SyncTypeRedirect)
 

--- a/adapters/rhythmone/usersync_test.go
+++ b/adapters/rhythmone/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestRhythmoneSyncer(t *testing.T) {
 	syncer := NewRhythmoneSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderRhythmone): {

--- a/adapters/rhythmone/usersync_test.go
+++ b/adapters/rhythmone/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRhythmoneSyncer(t *testing.T) {
-	syncer := NewRhythmoneSyncer(&config.Configuration{ExternalURL: "localhost", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderRhythmone): {
-			UserSyncURL: "https://sync.1rx.io/usersync2/rmphb?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&redir=",
+	syncer := NewRhythmoneSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderRhythmone): {
+				UserSyncURL: "https://sync.1rx.io/usersync2/rmphb?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&redir=",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("1", "BOPVK28OVJoTBABABAENBs-AAAAhuAKAANAAoACwAGgAPAAxAB0AHgAQAAiABOADkA")
 	assert.Equal(t, "https://sync.1rx.io/usersync2/rmphb?gdpr=1&gdpr_consent=BOPVK28OVJoTBABABAENBs-AAAAhuAKAANAAoACwAGgAPAAxAB0AHgAQAAiABOADkA&redir=localhost%2Fsetuid%3Fbidder%3Drhythmone%26gdpr%3D1%26gdpr_consent%3DBOPVK28OVJoTBABABAENBs-AAAAhuAKAANAAoACwAGgAPAAxAB0AHgAQAAiABOADkA%26uid%3D%5BRX_UUID%5D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/somoaudience/usersync.go
+++ b/adapters/somoaudience/usersync.go
@@ -11,7 +11,7 @@ import (
 
 func NewSomoaudienceSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
-	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
+	redirectURL := url.QueryEscape(externalURL) + "%3Fbidder%3Dsomoaudience%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	usersyncURL := "//publisher-east.mobileadtrading.com/usersync?ru="
 	return adapters.NewSyncer("somoaudience", 341, adapters.ResolveMacros(usersyncURL+redirectURL), adapters.SyncTypeRedirect)
 }

--- a/adapters/somoaudience/usersync.go
+++ b/adapters/somoaudience/usersync.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewSomoaudienceSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	externalURL := strings.TrimRight(cfg.ExternalURL, "/")
+	externalURL := strings.TrimRight(cfg.HostCookie.BaseSyncURL, "/")
 	redirectURL := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24%7BUID%7D"
 	usersyncURL := "//publisher-east.mobileadtrading.com/usersync?ru="
 	return adapters.NewSyncer("somoaudience", 341, adapters.ResolveMacros(usersyncURL+redirectURL), adapters.SyncTypeRedirect)

--- a/adapters/somoaudience/usersync_test.go
+++ b/adapters/somoaudience/usersync_test.go
@@ -10,7 +10,7 @@ import (
 func TestSomoaudienceSyncer(t *testing.T) {
 	syncer := NewSomoaudienceSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "localhost",
+			BaseSyncURL: "localhost/setuid",
 		},
 	})
 	u := syncer.GetUsersyncInfo("", "")

--- a/adapters/somoaudience/usersync_test.go
+++ b/adapters/somoaudience/usersync_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSomoaudienceSyncer(t *testing.T) {
-	syncer := NewSomoaudienceSyncer(&config.Configuration{ExternalURL: "localhost"})
+	syncer := NewSomoaudienceSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "localhost",
+		},
+	})
 	u := syncer.GetUsersyncInfo("", "")
 	assert.Equal(t, "//publisher-east.mobileadtrading.com/usersync?ru=localhost%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24%7BUID%7D", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/sovrn/usersync.go
+++ b/adapters/sovrn/usersync.go
@@ -10,8 +10,7 @@ import (
 )
 
 func NewSovrnSyncer(cfg *config.Configuration) usersync.Usersyncer {
-	externalURL := cfg.ExternalURL
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderSovrn)].UserSyncURL
-	redirectURI := url.QueryEscape(externalURL) + "%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("sovrn", 13, adapters.ResolveMacros(usersyncURL+"redir="+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/sovrn/usersync.go
+++ b/adapters/sovrn/usersync.go
@@ -11,6 +11,6 @@ import (
 
 func NewSovrnSyncer(cfg *config.Configuration) usersync.Usersyncer {
 	usersyncURL := cfg.Adapters[string(openrtb_ext.BidderSovrn)].UserSyncURL
-	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
+	redirectURI := url.QueryEscape(cfg.HostCookie.BaseSyncURL) + "%3Fbidder%3Dsovrn%26gdpr%3D{{gdpr}}%26gdpr_consent%3D{{gdpr_consent}}%26uid%3D%24UID"
 	return adapters.NewSyncer("sovrn", 13, adapters.ResolveMacros(usersyncURL+"redir="+redirectURI), adapters.SyncTypeRedirect)
 }

--- a/adapters/sovrn/usersync_test.go
+++ b/adapters/sovrn/usersync_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSovrnSyncer(t *testing.T) {
-	syncer := NewSovrnSyncer(&config.Configuration{ExternalURL: "external.com", Adapters: map[string]config.Adapter{
-		string(openrtb_ext.BidderSovrn): {
-			UserSyncURL: "//ap.lijit.com/pixel?",
+	syncer := NewSovrnSyncer(&config.Configuration{
+		HostCookie: config.HostCookie{
+			BaseSyncURL: "external.com",
 		},
-	}})
+		Adapters: map[string]config.Adapter{
+			string(openrtb_ext.BidderSovrn): {
+				UserSyncURL: "//ap.lijit.com/pixel?",
+			},
+		}})
 	u := syncer.GetUsersyncInfo("0", "")
 	assert.Equal(t, "//ap.lijit.com/pixel?redir=external.com%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D0%26gdpr_consent%3D%26uid%3D%24UID", u.URL)
 	assert.Equal(t, "redirect", u.Type)

--- a/adapters/sovrn/usersync_test.go
+++ b/adapters/sovrn/usersync_test.go
@@ -11,7 +11,7 @@ import (
 func TestSovrnSyncer(t *testing.T) {
 	syncer := NewSovrnSyncer(&config.Configuration{
 		HostCookie: config.HostCookie{
-			BaseSyncURL: "external.com",
+			BaseSyncURL: "external.com/setuid",
 		},
 		Adapters: map[string]config.Adapter{
 			string(openrtb_ext.BidderSovrn): {

--- a/config/config.go
+++ b/config/config.go
@@ -243,7 +243,7 @@ func New(v *viper.Viper) (*Configuration, error) {
 		return nil, fmt.Errorf("viper failed to unmarshal app config: %v", err)
 	}
 	if c.HostCookie.BaseSyncURL == "" {
-		c.HostCookie.BaseSyncURL = c.ExternalURL
+		c.HostCookie.BaseSyncURL = c.ExternalURL + "/setuid"
 	}
 	glog.Info("Logging the resolved configuration:")
 	logGeneral(reflect.ValueOf(c), "  \t")

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type HostCookie struct {
 	CookieName   string `mapstructure:"cookie_name"`
 	OptOutURL    string `mapstructure:"opt_out_url"`
 	OptInURL     string `mapstructure:"opt_in_url"`
+	BaseSyncURL  string `mapstructure:"base_sync_url"`
 	OptOutCookie Cookie `mapstructure:"optout_cookie"`
 	// Cookie timeout in days
 	TTL int64 `mapstructure:"ttl_days"`
@@ -241,6 +242,9 @@ func New(v *viper.Viper) (*Configuration, error) {
 	if err := v.Unmarshal(&c); err != nil {
 		return nil, fmt.Errorf("viper failed to unmarshal app config: %v", err)
 	}
+	if c.HostCookie.BaseSyncURL == "" {
+		c.HostCookie.BaseSyncURL = c.ExternalURL
+	}
 	glog.Info("Logging the resolved configuration:")
 	logGeneral(reflect.ValueOf(c), "  \t")
 	if errs := c.validate(); len(errs) > 0 {
@@ -295,6 +299,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host_cookie.cookie_name", "")
 	v.SetDefault("host_cookie.opt_out_url", "")
 	v.SetDefault("host_cookie.opt_in_url", "")
+	v.SetDefault("host_cookie.base_sync_url", "")
 	v.SetDefault("host_cookie.optout_cookie.name", "")
 	v.SetDefault("host_cookie.value", "")
 	v.SetDefault("host_cookie.ttl_days", 90)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prebid/prebid-server/openrtb_ext"
-
 	"github.com/spf13/viper"
 )
 
@@ -26,6 +25,7 @@ func TestDefaults(t *testing.T) {
 	cmpInts(t, "host_cookie.ttl_days", int(cfg.HostCookie.TTL), 90)
 	cmpStrings(t, "datacache.type", cfg.DataCache.Type, "dummy")
 	cmpStrings(t, "adapters.pubmatic.endpoint", cfg.Adapters[string(openrtb_ext.BidderPubmatic)].Endpoint, "http://hbopenbid.pubmatic.com/translator?source=prebid-server")
+	cmpStrings(t, "host_cookie.base_sync_url", cfg.HostCookie.BaseSyncURL, "http://localhost:8000")
 }
 
 var fullConfig = []byte(`
@@ -38,6 +38,7 @@ host_cookie:
   domain: cookies.prebid.org
   opt_out_url: http://prebid.org/optout
   opt_in_url: http://prebid.org/optin
+  base_sync_url: http://sync.prebid.com
 external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
@@ -122,6 +123,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "cookie family", cfg.HostCookie.Family, "prebid")
 	cmpStrings(t, "opt out", cfg.HostCookie.OptOutURL, "http://prebid.org/optout")
 	cmpStrings(t, "opt in", cfg.HostCookie.OptInURL, "http://prebid.org/optin")
+	cmpStrings(t, "base sync url", cfg.HostCookie.BaseSyncURL, "http://sync.prebid.com")
 	cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid-server.prebid.org/")
 	cmpStrings(t, "host", cfg.Host, "prebid-server.prebid.org")
 	cmpInts(t, "port", cfg.Port, 1234)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ func TestDefaults(t *testing.T) {
 	cmpInts(t, "host_cookie.ttl_days", int(cfg.HostCookie.TTL), 90)
 	cmpStrings(t, "datacache.type", cfg.DataCache.Type, "dummy")
 	cmpStrings(t, "adapters.pubmatic.endpoint", cfg.Adapters[string(openrtb_ext.BidderPubmatic)].Endpoint, "http://hbopenbid.pubmatic.com/translator?source=prebid-server")
-	cmpStrings(t, "host_cookie.base_sync_url", cfg.HostCookie.BaseSyncURL, "http://localhost:8000")
+	cmpStrings(t, "host_cookie.base_sync_url", cfg.HostCookie.BaseSyncURL, "http://localhost:8000/setuid")
 }
 
 var fullConfig = []byte(`
@@ -38,7 +38,7 @@ host_cookie:
   domain: cookies.prebid.org
   opt_out_url: http://prebid.org/optout
   opt_in_url: http://prebid.org/optin
-  base_sync_url: http://sync.prebid.com
+  base_sync_url: http://sync.prebid.com/setuid
 external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
@@ -123,7 +123,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "cookie family", cfg.HostCookie.Family, "prebid")
 	cmpStrings(t, "opt out", cfg.HostCookie.OptOutURL, "http://prebid.org/optout")
 	cmpStrings(t, "opt in", cfg.HostCookie.OptInURL, "http://prebid.org/optin")
-	cmpStrings(t, "base sync url", cfg.HostCookie.BaseSyncURL, "http://sync.prebid.com")
+	cmpStrings(t, "base sync url", cfg.HostCookie.BaseSyncURL, "http://sync.prebid.com/setuid")
 	cmpStrings(t, "external url", cfg.ExternalURL, "http://prebid-server.prebid.org/")
 	cmpStrings(t, "host", cfg.Host, "prebid-server.prebid.org")
 	cmpInts(t, "port", cfg.Port, 1234)


### PR DESCRIPTION
Makes the cookie sync URL configurable. If the config value isn't defined, it defaults to the same external URL it uses today.