### PR TITLE
Added the timeout to the response

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -10,10 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/text/currency"
-
 	"github.com/mxmCherry/openrtb"
-
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/errortypes"
@@ -21,6 +18,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid_cache_client"
+	"golang.org/x/text/currency"
 )
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
@@ -311,8 +309,9 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 // Extract all the data from the SeatBids and build the ExtBidResponse
 func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, req *openrtb.BidRequest, resolvedRequest json.RawMessage, errList []error) *openrtb_ext.ExtBidResponse {
 	bidResponseExt := &openrtb_ext.ExtBidResponse{
-		Errors:             make(map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError, len(adapterBids)),
-		ResponseTimeMillis: make(map[openrtb_ext.BidderName]int, len(adapterBids)),
+		Errors:               make(map[openrtb_ext.BidderName][]openrtb_ext.ExtBidderError, len(adapterBids)),
+		ResponseTimeMillis:   make(map[openrtb_ext.BidderName]int, len(adapterBids)),
+		RequestTimeoutMillis: req.TMax,
 	}
 	if req.Test == 1 {
 		bidResponseExt.Debug = &openrtb_ext.ExtResponseDebug{

--- a/exchange/exchangetest/tmax.json
+++ b/exchange/exchangetest/tmax.json
@@ -1,0 +1,71 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "tmax": 500,
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 1
+            }
+          }
+        }
+      ]
+    },
+    "usersyncs": {
+      "appnexus": "123"
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "expectRequest": {
+        "ortbRequest": {
+          "id": "some-request-id",
+          "site": {
+            "page": "test.somepage.com"
+          },
+          "user": {
+            "buyeruid": "123"
+          },
+          "tmax": 500,
+          "imp": [
+            {
+              "id": "my-imp-id",
+              "video": {
+                "mimes": ["video/mp4"]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 1
+                }
+              }
+            }
+          ]
+        },
+        "bidAdjustment": 1.0
+      },
+      "mockResponse": {
+        "errors": ["appnexus-error"]
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "ext": {
+        "requesttimeoutmillis": 500,
+        "errors": {
+          "appnexus": ["appnexus-error"]
+        }
+      }
+    }
+  }
+}

--- a/exchange/exchangetest/tmax.json
+++ b/exchange/exchangetest/tmax.json
@@ -61,7 +61,7 @@
     "bids": {
       "id": "some-request-id",
       "ext": {
-        "requesttimeoutmillis": 500,
+        "tmaxrequest": 500,
         "errors": {
           "appnexus": ["appnexus-error"]
         }

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -7,11 +7,15 @@ import (
 // ExtBidResponse defines the contract for bidresponse.ext
 type ExtBidResponse struct {
 	Debug *ExtResponseDebug `json:"debug,omitempty"`
-	// ExtResponseErrors defines the contract for bidresponse.ext.errors
+	// Errors defines the contract for bidresponse.ext.errors
 	Errors map[BidderName][]ExtBidderError `json:"errors,omitempty"`
-	// ExtResponseTimeMillis defines the contract for bidresponse.ext.responsetimemillis
+	// ResponseTimeMillis defines the contract for bidresponse.ext.responsetimemillis
 	ResponseTimeMillis map[BidderName]int `json:"responsetimemillis,omitempty"`
-	// ExtResponseUserSync defines the contract for bidresponse.ext.usersync
+	// RequestTimeoutMillis returns the timeout used in the auction.
+	// This is useful if the timeout is saved in the Stored Request on the server.
+	// Clients can run one auction, and then use this to set better connection timeouts on future auction requests.
+	RequestTimeoutMillis int64 `json:"requesttimeoutmillis,omitempty"`
+	// ResponseUserSync defines the contract for bidresponse.ext.usersync
 	Usersync map[BidderName]*ExtResponseSyncData `json:"usersync,omitempty"`
 }
 

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -14,7 +14,7 @@ type ExtBidResponse struct {
 	// RequestTimeoutMillis returns the timeout used in the auction.
 	// This is useful if the timeout is saved in the Stored Request on the server.
 	// Clients can run one auction, and then use this to set better connection timeouts on future auction requests.
-	RequestTimeoutMillis int64 `json:"requesttimeoutmillis,omitempty"`
+	RequestTimeoutMillis int64 `json:"tmaxrequest,omitempty"`
 	// ResponseUserSync defines the contract for bidresponse.ext.usersync
 	Usersync map[BidderName]*ExtResponseSyncData `json:"usersync,omitempty"`
 }


### PR DESCRIPTION
This was a request from @anwzhang over on Prebid Mobile.

The issue they need to solve is: "how long should the client wait for a response before it cancels the request?"

Ideally they want this to be `tmax + {buffer for latency}`... but  if `tmax` is defined on the server in a Stored Request, then the Mobile client has no way of accessing it today.

Their request was that we return this so that they can make a single auction request with a "long" timeout, and then use the value we return to tune future calls.