### PR TITLE
Handle file paths in windows

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -113,7 +113,7 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get an absolute representation of the path: %s, %v", toOpen, err)
 		}
-		schemaLoader := gojsonschema.NewReferenceLoader("file:///" + toOpen)
+		schemaLoader := gojsonschema.NewReferenceLoader("file:///" + filepath.ToSlash(toOpen))
 		loadedSchema, err := gojsonschema.NewSchema(schemaLoader)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to load json schema at %s: %v", toOpen, err)


### PR DESCRIPTION
If you're adventurous, like I am, and want to run prebid-server on windows, you need to handle windows backward slashes in file paths. Adding .ToSlash in the included PR will make it possible to run prebid-server under windows at least for testing purposes.