### PR TITLE
[Currency] Introduce currencies conversions in PBS workflow

### DIFF
--- a/currencies/constant_rates.go
+++ b/currencies/constant_rates.go
@@ -1,0 +1,36 @@
+package currencies
+
+import (
+	"fmt"
+
+	"golang.org/x/text/currency"
+)
+
+// ConstantRates doesn't do any currency conversions and accepts only conversions where
+// both currencies (from and to) are the same.
+// If not the same currencies, it returns an error.
+type ConstantRates struct{}
+
+// NewConstantRates creates a new ConstantRates object holding currencies rates
+func NewConstantRates() *ConstantRates {
+	return &ConstantRates{}
+}
+
+// GetRate returns 1 if both currencies are the same.
+// If not, it will return an error.
+func (r *ConstantRates) GetRate(from string, to string) (float64, error) {
+	fromUnit, err := currency.ParseISO(from)
+	if err != nil {
+		return 0, err
+	}
+	toUnit, err := currency.ParseISO(to)
+	if err != nil {
+		return 0, err
+	}
+
+	if fromUnit.String() != toUnit.String() {
+		return 0, fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert '%s' => '%s'", fromUnit.String(), toUnit.String())
+	}
+
+	return 1, nil
+}

--- a/currencies/constant_rates_test.go
+++ b/currencies/constant_rates_test.go
@@ -1,0 +1,76 @@
+package currencies_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prebid/prebid-server/currencies"
+)
+
+func TestGetRate_ConstantRates(t *testing.T) {
+
+	// Setup:
+	rates := currencies.NewConstantRates()
+
+	testCases := []struct {
+		from         string
+		to           string
+		expectedRate float64
+		hasError     bool
+	}{
+		{from: "USD", to: "GBP", expectedRate: 0, hasError: true},
+		{from: "GBP", to: "USD", expectedRate: 0, hasError: true},
+		{from: "GBP", to: "EUR", expectedRate: 0, hasError: true},
+		{from: "CNY", to: "EUR", expectedRate: 0, hasError: true},
+		{from: "", to: "EUR", expectedRate: 0, hasError: true},
+		{from: "CNY", to: "", expectedRate: 0, hasError: true},
+		{from: "", to: "", expectedRate: 0, hasError: true},
+		{from: "USD", to: "USD", expectedRate: 1, hasError: false},
+		{from: "EUR", to: "EUR", expectedRate: 1, hasError: false},
+	}
+
+	for _, tc := range testCases {
+		// Execute:
+		rate, err := rates.GetRate(tc.from, tc.to)
+
+		// Verify:
+		if tc.hasError {
+			assert.NotNil(t, err, "err shouldn't be nil")
+			assert.Equal(t, float64(0), rate, "rate should be 0")
+		} else {
+			assert.Nil(t, err, "err should be nil")
+			assert.Equal(t, tc.expectedRate, rate, "rate doesn't match the expected one")
+		}
+	}
+}
+
+func TestGetRate_ConstantRates_NotValidISOCurrency(t *testing.T) {
+
+	// Setup:
+	rates := currencies.NewConstantRates()
+
+	testCases := []struct {
+		from         string
+		to           string
+		expectedRate float64
+		hasError     bool
+	}{
+		{from: "foo", to: "foo", expectedRate: 0, hasError: true},
+		{from: "bar", to: "foo", expectedRate: 0, hasError: true},
+	}
+
+	for _, tc := range testCases {
+		// Execute:
+		rate, err := rates.GetRate(tc.from, tc.to)
+
+		// Verify:
+		if tc.hasError {
+			assert.NotNil(t, err, "err shouldn't be nil")
+			assert.Equal(t, float64(0), rate, "rate should be 0")
+		} else {
+			assert.Nil(t, err, "err should be nil")
+			assert.Equal(t, tc.expectedRate, rate, "rate doesn't match the expected one")
+		}
+	}
+}

--- a/currencies/rate_converter_test.go
+++ b/currencies/rate_converter_test.go
@@ -39,7 +39,7 @@ func TestFetch_Success(t *testing.T) {
 
 	defer mockedHttpServer.Close()
 
-	expectedRates := currencies.Rates{
+	expectedRates := &currencies.Rates{
 		DataAsOf: time.Date(2018, time.September, 12, 0, 0, 0, 0, time.UTC),
 		Conversions: map[string]map[string]float64{
 			"USD": {
@@ -52,22 +52,20 @@ func TestFetch_Success(t *testing.T) {
 	}
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	beforeExecution := time.Now()
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	beforeExecution := time.Now()
-	err := rateConverter.Update()
 
 	// Verify:
 	assert.Equal(t, 1, len(calledURLs), "sync URL should have been called %d times but was %d", 1, len(calledURLs))
-	assert.Nil(t, err, "err should be nil")
-	assert.NotEqual(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() should return a time set")
-	assert.True(t, rateConverter.LastUpdated().After(beforeExecution), "LastUpdated() should be after last update")
-	rates := rateConverter.Rates()
+	assert.NotEqual(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() should return a time set")
+	assert.True(t, currencyConverter.LastUpdated().After(beforeExecution), "LastUpdated() should be after last update")
+	rates := currencyConverter.Rates()
 	assert.NotNil(t, rates, "Rates() should not return nil")
-	assert.Equal(t, expectedRates, *rates, "Rates() doesn't return expected rates")
+	assert.Equal(t, expectedRates, rates, "Rates() doesn't return expected rates")
 }
 
 func TestFetch_Fail404(t *testing.T) {
@@ -84,18 +82,16 @@ func TestFetch_Fail404(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	err := rateConverter.Update()
 
 	// Verify:
 	assert.Equal(t, 1, len(calledURLs), "sync URL should have been called %d times but was %d", 1, len(calledURLs))
-	assert.NotNil(t, err, "err shouldn't be nil")
-	assert.Equal(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
-	assert.Nil(t, rateConverter.Rates(), "Rates() should return nil")
+	assert.Equal(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
+	assert.Nil(t, currencyConverter.Rates(), "Rates() should return nil")
 }
 
 func TestFetch_FailErrorHttpClient(t *testing.T) {
@@ -112,18 +108,16 @@ func TestFetch_FailErrorHttpClient(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	err := rateConverter.Update()
 
 	// Verify:
 	assert.Equal(t, 1, len(calledURLs), "sync URL should have been called %d times but was %d", 1, len(calledURLs))
-	assert.NotNil(t, err, "err shouldn't be nil")
-	assert.Equal(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
-	assert.Nil(t, rateConverter.Rates(), "Rates() should return nil")
+	assert.Equal(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
+	assert.Nil(t, currencyConverter.Rates(), "Rates() should return nil")
 }
 
 func TestFetch_FailBadSyncURL(t *testing.T) {
@@ -131,17 +125,15 @@ func TestFetch_FailBadSyncURL(t *testing.T) {
 	// Setup:
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		"justaweirdurl",
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	err := rateConverter.Update()
 
 	// Verify:
-	assert.NotNil(t, err, "err shouldn't be nil")
-	assert.Equal(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
-	assert.Nil(t, rateConverter.Rates(), "Rates() should return nil")
+	assert.Equal(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
+	assert.Nil(t, currencyConverter.Rates(), "Rates() should return nil")
 }
 
 func TestFetch_FailBadJSON(t *testing.T) {
@@ -172,18 +164,16 @@ func TestFetch_FailBadJSON(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	err := rateConverter.Update()
 
 	// Verify:
 	assert.Equal(t, 1, len(calledURLs), "sync URL should have been called %d times but was %d", 1, len(calledURLs))
-	assert.NotNil(t, err, "err shouldn't be nil")
-	assert.Equal(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
-	assert.Nil(t, rateConverter.Rates(), "Rates() should return nil")
+	assert.Equal(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
+	assert.Nil(t, currencyConverter.Rates(), "Rates() should return nil")
 }
 
 func TestFetch_InvalidRemoteResponseContent(t *testing.T) {
@@ -201,18 +191,16 @@ func TestFetch_InvalidRemoteResponseContent(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0),
+		time.Duration(24)*time.Hour,
 	)
-	err := rateConverter.Update()
 
 	// Verify:
 	assert.Equal(t, 1, len(calledURLs), "sync URL should have been called %d times but was %d", 1, len(calledURLs))
-	assert.NotNil(t, err, "err shouldn't be nil")
-	assert.Equal(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
-	assert.Nil(t, rateConverter.Rates(), "Rates() should return nil")
+	assert.Equal(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated() shouldn't return a time set")
+	assert.Nil(t, currencyConverter.Rates(), "Rates() should return nil")
 }
 
 func TestInit(t *testing.T) {
@@ -241,7 +229,7 @@ func TestInit(t *testing.T) {
 	expectedTicks := 5
 	ticksTimes := []time.Time{}
 	ticks := make(chan int)
-	rateConverter := currencies.NewRateConverterWithNotifier(
+	currencyConverter := currencies.NewRateConverterWithNotifier(
 		&http.Client{},
 		mockedHttpServer.URL,
 		time.Duration(100)*time.Millisecond,
@@ -272,13 +260,13 @@ func TestInit(t *testing.T) {
 			assert.False(t, intervalDiff > float64(errorMargin*100), "Interval between ticks should be: %d but was: %d", expectedIntervalDuration, intervalDuration)
 		}
 
-		assert.NotNil(t, rateConverter.Rates(), "Rates shouldn't be nil")
-		assert.NotEqual(t, rateConverter.LastUpdated(), (time.Time{}), "LastUpdated should be set")
-		rates := rateConverter.Rates()
+		assert.NotNil(t, currencyConverter.Rates(), "Rates shouldn't be nil")
+		assert.NotEqual(t, currencyConverter.LastUpdated(), (time.Time{}), "LastUpdated should be set")
+		rates := currencyConverter.Rates()
 		assert.Equal(t, expectedRates, rates, "Conversions.Rates weren't the expected ones")
 
 		if ticksCount == expectedTicks {
-			rateConverter.StopPeriodicFetching()
+			currencyConverter.StopPeriodicFetching()
 			return
 		}
 	}
@@ -311,7 +299,7 @@ func TestStop(t *testing.T) {
 	// Execute:
 	expectedTicks := 2
 	ticks := make(chan int)
-	rateConverter := currencies.NewRateConverterWithNotifier(
+	currencyConverter := currencies.NewRateConverterWithNotifier(
 		&http.Client{},
 		mockedHttpServer.URL,
 		time.Duration(100)*time.Millisecond,
@@ -321,7 +309,7 @@ func TestStop(t *testing.T) {
 	// Let the currency converter fetch 5 times before stopping it
 	for ticksCount := range ticks {
 		if ticksCount == expectedTicks {
-			rateConverter.StopPeriodicFetching()
+			currencyConverter.StopPeriodicFetching()
 			break
 		}
 	}
@@ -331,7 +319,7 @@ func TestStop(t *testing.T) {
 	// Check for the next 1 second that no fetch was triggered
 	time.Sleep(1 * time.Second)
 
-	assert.False(t, rateConverter.LastUpdated().After(lastFetched), "LastUpdated() shouldn't be after `lastFetched` since the periodic fetching is stopped")
+	assert.False(t, currencyConverter.LastUpdated().After(lastFetched), "LastUpdated() shouldn't be after `lastFetched` since the periodic fetching is stopped")
 }
 
 func TestInitWithZeroDuration(t *testing.T) {
@@ -359,10 +347,10 @@ func TestInitWithZeroDuration(t *testing.T) {
 	)
 
 	// Execute:
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
-		time.Duration(0)*time.Millisecond,
+		time.Duration(0),
 	)
 
 	// Verify:
@@ -370,8 +358,9 @@ func TestInitWithZeroDuration(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	assert.Equal(t, 0, len(calledURLs), "sync URL shouldn't have been called but was called %d times", 0, len(calledURLs))
-	assert.Equal(t, (time.Time{}), rateConverter.LastUpdated(), "LastUpdated() shouldn't be set")
-	assert.Nil(t, rateConverter.Rates(), "Rates should be nil")
+	assert.Equal(t, (time.Time{}), currencyConverter.LastUpdated(), "LastUpdated() shouldn't be set")
+	_, ok := currencyConverter.Rates().(*currencies.ConstantRates)
+	assert.True(t, ok, "Rates should be type of `currencies.ConstantRates`")
 }
 
 func TestRates(t *testing.T) {
@@ -413,18 +402,18 @@ func TestRates(t *testing.T) {
 
 	// Execute:
 	ticks := make(chan int)
-	rateConverter := currencies.NewRateConverterWithNotifier(
+	currencyConverter := currencies.NewRateConverterWithNotifier(
 		&http.Client{},
 		mockedHttpServer.URL,
 		time.Duration(100)*time.Millisecond,
 		ticks,
 	)
-	rates := rateConverter.Rates()
+	rates := currencyConverter.Rates()
 
 	// Let the currency converter ticks 1 time before to stop it
 	select {
 	case <-ticks:
-		rateConverter.StopPeriodicFetching()
+		currencyConverter.StopPeriodicFetching()
 	}
 
 	// Verify:
@@ -454,13 +443,13 @@ func TestRates_EmptyRates(t *testing.T) {
 
 	// Execute:
 	// Will try to fetch directly on method call but will fail
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		&http.Client{},
 		mockedHttpServer.URL,
 		time.Duration(100)*time.Millisecond,
 	)
-	defer rateConverter.StopPeriodicFetching()
-	rates := rateConverter.Rates()
+	defer currencyConverter.StopPeriodicFetching()
+	rates := currencyConverter.Rates()
 
 	// Verify:
 	assert.Nil(t, rates, "rates should be nil")
@@ -493,12 +482,12 @@ func TestRace(t *testing.T) {
 	// Execute:
 
 	// Create a rate converter which will be fetching new values every 10 ms
-	rateConverter := currencies.NewRateConverter(
+	currencyConverter := currencies.NewRateConverter(
 		mockedHttpClient,
 		"currency.fake.com",
 		time.Duration(10)*time.Millisecond,
 	)
-	defer rateConverter.StopPeriodicFetching()
+	defer currencyConverter.StopPeriodicFetching()
 
 	// Create 50 clients asking for updates and rates conversion at random intervals
 	// from 1ms to 50ms for 10 seconds
@@ -519,10 +508,10 @@ func TestRace(t *testing.T) {
 					// based on the tick ms
 					tickMs := tickTime.UnixNano() / int64(time.Millisecond)
 					if tickMs%2 == 0 {
-						err := rateConverter.Update()
+						err := currencyConverter.Update()
 						assert.Nil(t, err)
 					} else {
-						rate, err := rateConverter.Rates().GetRate("USD", "GBP")
+						rate, err := currencyConverter.Rates().GetRate("USD", "GBP")
 						assert.Nil(t, err)
 						assert.Equal(t, float64(0.77208), rate)
 					}

--- a/currencies/rates_test.go
+++ b/currencies/rates_test.go
@@ -111,7 +111,6 @@ func TestUnMarshallRates(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		// Execute:
 		updatedRates := currencies.Rates{}
 		err := json.Unmarshal([]byte(tc.ratesJSON), &updatedRates)
@@ -149,10 +148,11 @@ func TestGetRate(t *testing.T) {
 		{from: "", to: "", expectedRate: 0, hasError: true},
 	}
 
-	// Verify:
 	for _, tc := range testCases {
+		// Execute:
 		rate, err := rates.GetRate(tc.from, tc.to)
 
+		// Verify:
 		if tc.hasError {
 			assert.NotNil(t, err, "err shouldn't be nil")
 			assert.Equal(t, float64(0), rate, "rate should be 0")
@@ -168,9 +168,40 @@ func TestGetRate_EmptyRates(t *testing.T) {
 	// Setup:
 	rates := currencies.NewRates(time.Time{}, nil)
 
-	// Verify:
+	// Execute:
 	rate, err := rates.GetRate("USD", "EUR")
 
+	// Verify:
 	assert.NotNil(t, err, "err shouldn't be nil")
 	assert.Equal(t, float64(0), rate, "rate should be 0")
+}
+
+func TestGetRate_NotValidISOCurrency(t *testing.T) {
+
+	// Setup:
+	rates := currencies.NewRates(time.Time{}, nil)
+
+	testCases := []struct {
+		from         string
+		to           string
+		expectedRate float64
+		hasError     bool
+	}{
+		{from: "foo", to: "foo", expectedRate: 0, hasError: true},
+		{from: "bar", to: "foo", expectedRate: 0, hasError: true},
+	}
+
+	for _, tc := range testCases {
+		// Execute:
+		rate, err := rates.GetRate(tc.from, tc.to)
+
+		// Verify:
+		if tc.hasError {
+			assert.NotNil(t, err, "err shouldn't be nil")
+			assert.Equal(t, float64(0), rate, "rate should be 0")
+		} else {
+			assert.Nil(t, err, "err should be nil")
+			assert.Equal(t, tc.expectedRate, rate, "rate doesn't match the expected one")
+		}
+	}
 }

--- a/docs/developers/currency-converter.md
+++ b/docs/developers/currency-converter.md
@@ -1,0 +1,51 @@
+**For the time being, currency conversion is not enabled, feature is still under dev (check #280).**
+
+# Currency Converter Mechanics
+
+Prebid server supports currency conversions when receiving bids.
+
+## Default currency
+
+The default currency is `USD`. It means that any bids coming without an explicit currency will be interpreted as being `USD`.
+
+## Setup
+
+By default, the currency converter uses https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json for currency conversion. This data is updated every 24 hours on prebid.org side.
+By default, currency conversions are updated from the endpoint every 30 minutes in prebid server.
+
+Default configuration:
+```
+v.SetDefault("currency_converter.fetch_url", "https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json")
+v.SetDefault("currency_converter.fetch_interval_seconds", 1800) // 30 minutes
+```
+
+This configuration can be changed:
+- currency_converter.fetch_url can be any URL exposing currency using the following JSON schema:
+  ```
+  {
+      "dataAsOf":"2018-09-12",
+      "conversions":{
+          "USD":{
+              "GBP":0.77208
+          },
+          "GBP":{
+              "USD":1.2952
+          }
+      }
+  }
+  ```
+- currency_converter.fetch_interval_seconds can be anything from 0 to max int.
+  **The currency conversion mechanism can be disable by setting it to 0, in this case, there will be no currency conversions at all and all bidders will need to provide bids as `USD`**
+
+ ## Examples
+
+ Here are couple examples showing the logic behind the currency converter:
+
+| Bidder bid price | Currency      | Rate to USD   | Rate converter is active | Converted bid price (USD) | Valid bid |
+| :--------------- | :------------ |:--------------| :------------------------| :-------------------------|:----------|
+| 1                | USD           |             1 | YES                      |                         1 | YES       |
+| 1                | N/A           |             1 | YES                      |                         1 | YES       |
+| 1                | USD           |             1 | NO                       |                         1 | YES       |
+| 1                | EUR           |          1.13 | YES                      |                      1.13 | YES       |
+| 1                | EUR           |           N/A | YES                      |                       N/A | NO        |
+| 1                | EUR           |          1.13 | NO                       |                       N/A | NO        |

--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -343,6 +343,13 @@ This adds two optional properties:
 
 These fields will be forwarded to each Bidder, so they can decide how to process them.
 
+### OpenRTB Ambiguities
+
+This section describes the ways in which Prebid Server **implements** OpenRTB spec ambiguous parts.
+
+- `request.cur`: If `request.cur` is not specified in the bid request, Prebid Server will consider it as being `USD` whereas OpenRTB spec doesn't mention any default currency for bid request.
+```request.cur: ['USD'] // Default value if not set```
+
 ### OpenRTB Differences
 
 This section describes the ways in which Prebid Server **breaks** the OpenRTB spec.

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -35,7 +35,18 @@ type AmpResponse struct {
 
 // NewAmpEndpoint modifies the OpenRTB endpoint to handle AMP requests. This will basically modify the parsing
 // of the request, and the return value, using the OpenRTB machinery to handle everything in between.
-func NewAmpEndpoint(ex exchange.Exchange, validator openrtb_ext.BidderParamValidator, requestsById stored_requests.Fetcher, cfg *config.Configuration, met pbsmetrics.MetricsEngine, pbsAnalytics analytics.PBSAnalyticsModule, disabledBidders map[string]string, defReqJSON []byte, bidderMap map[string]openrtb_ext.BidderName) (httprouter.Handle, error) {
+func NewAmpEndpoint(
+	ex exchange.Exchange,
+	validator openrtb_ext.BidderParamValidator,
+	requestsById stored_requests.Fetcher,
+	cfg *config.Configuration,
+	met pbsmetrics.MetricsEngine,
+	pbsAnalytics analytics.PBSAnalyticsModule,
+	disabledBidders map[string]string,
+	defReqJSON []byte,
+	bidderMap map[string]openrtb_ext.BidderName,
+) (httprouter.Handle, error) {
+
 	if ex == nil || validator == nil || requestsById == nil || cfg == nil || met == nil {
 		return nil, errors.New("NewAmpEndpoint requires non-nil arguments.")
 	}
@@ -43,6 +54,7 @@ func NewAmpEndpoint(ex exchange.Exchange, validator openrtb_ext.BidderParamValid
 	defRequest := defReqJSON != nil && len(defReqJSON) > 0
 
 	return httprouter.Handle((&endpointDeps{ex, validator, requestsById, cfg, met, pbsAnalytics, disabledBidders, defRequest, defReqJSON, bidderMap}).AmpAuction), nil
+
 }
 
 func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -39,7 +39,17 @@ func TestGoodAmpRequests(t *testing.T) {
 	// NewMetrics() will create a new go_metrics MetricsEngine, bypassing the need for a crafted configuration set to support it.
 	// As a side effect this gives us some coverage of the go_metrics piece of the metrics engine.
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	endpoint, _ := NewAmpEndpoint(&mockAmpExchange{}, newParamsValidator(t), &mockAmpStoredReqFetcher{goodRequests}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+	endpoint, _ := NewAmpEndpoint(
+		&mockAmpExchange{},
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{goodRequests},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 
 	for requestID := range goodRequests {
 		request := httptest.NewRequest("GET", fmt.Sprintf("/openrtb2/auction/amp?tag_id=%s", requestID), nil)
@@ -81,7 +91,18 @@ func TestAMPPageInfo(t *testing.T) {
 	}
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	exchange := &mockAmpExchange{}
-	endpoint, _ := NewAmpEndpoint(exchange, newParamsValidator(t), &mockAmpStoredReqFetcher{stored}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+
+	endpoint, _ := NewAmpEndpoint(
+		exchange,
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{stored},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 	request := httptest.NewRequest("GET", fmt.Sprintf("/openrtb2/auction/amp?tag_id=1&curl=%s", url.QueryEscape(page)), nil)
 	recorder := httptest.NewRecorder()
 	endpoint(recorder, request, nil)
@@ -102,7 +123,17 @@ func TestAMPSiteExt(t *testing.T) {
 	}
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	exchange := &mockAmpExchange{}
-	endpoint, _ := NewAmpEndpoint(exchange, newParamsValidator(t), &mockAmpStoredReqFetcher{stored}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), nil, nil, openrtb_ext.BidderMap)
+	endpoint, _ := NewAmpEndpoint(
+		exchange,
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{stored},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		nil,
+		nil,
+		openrtb_ext.BidderMap,
+	)
 	request, err := http.NewRequest("GET", "/openrtb2/auction/amp?tag_id=1", nil)
 	if !assert.NoError(t, err) {
 		return
@@ -130,7 +161,18 @@ func TestAmpBadRequests(t *testing.T) {
 	// NewMetrics() will create a new go_metrics MetricsEngine, bypassing the need for a crafted configuration set to support it.
 	// As a side effect this gives us some coverage of the go_metrics piece of the metrics engine.
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	endpoint, _ := NewEndpoint(&mockAmpExchange{}, newParamsValidator(t), &mockAmpStoredReqFetcher{badRequests}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+
+	endpoint, _ := NewEndpoint(
+		&mockAmpExchange{},
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{badRequests},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 	for requestID := range badRequests {
 		request := httptest.NewRequest("GET", fmt.Sprintf("/openrtb2/auction/amp?tag_id=%s", requestID), nil)
 		recorder := httptest.NewRecorder()
@@ -150,7 +192,17 @@ func TestAmpDebug(t *testing.T) {
 	}
 
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	endpoint, _ := NewAmpEndpoint(&mockAmpExchange{}, newParamsValidator(t), &mockAmpStoredReqFetcher{requests}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+	endpoint, _ := NewAmpEndpoint(
+		&mockAmpExchange{},
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{requests},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 
 	for requestID := range requests {
 		request := httptest.NewRequest("GET", fmt.Sprintf("/openrtb2/auction/amp?tag_id=%s&debug=1", requestID), nil)
@@ -211,7 +263,18 @@ func TestQueryParamOverrides(t *testing.T) {
 		"1": json.RawMessage(validRequest(t, "site.json")),
 	}
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	endpoint, _ := NewAmpEndpoint(&mockAmpExchange{}, newParamsValidator(t), &mockAmpStoredReqFetcher{requests}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+
+	endpoint, _ := NewAmpEndpoint(
+		&mockAmpExchange{},
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{requests},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 
 	requestID := "1"
 	curl := "http://example.com"
@@ -328,7 +391,17 @@ func (s formatOverrideSpec) execute(t *testing.T) {
 		"1": json.RawMessage(validRequest(t, "site.json")),
 	}
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
-	endpoint, _ := NewAmpEndpoint(&mockAmpExchange{}, newParamsValidator(t), &mockAmpStoredReqFetcher{requests}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+	endpoint, _ := NewAmpEndpoint(
+		&mockAmpExchange{},
+		newParamsValidator(t),
+		&mockAmpStoredReqFetcher{requests},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		openrtb_ext.BidderMap,
+	)
 
 	url := fmt.Sprintf("/openrtb2/auction/amp?tag_id=1&debug=1&w=%d&h=%d&ow=%d&oh=%d&ms=%s", s.width, s.height, s.overrideWidth, s.overrideHeight, s.multisize)
 	request := httptest.NewRequest("GET", url, nil)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -35,6 +35,7 @@ import (
 const storedRequestTimeoutMillis = 50
 
 func NewEndpoint(ex exchange.Exchange, validator openrtb_ext.BidderParamValidator, requestsById stored_requests.Fetcher, cfg *config.Configuration, met pbsmetrics.MetricsEngine, pbsAnalytics analytics.PBSAnalyticsModule, disabledBidders map[string]string, defReqJSON []byte, bidderMap map[string]openrtb_ext.BidderName) (httprouter.Handle, error) {
+
 	if ex == nil || validator == nil || requestsById == nil || cfg == nil || met == nil {
 		return nil, errors.New("NewEndpoint requires non-nil arguments.")
 	}

--- a/endpoints/openrtb2/auction_benchmark_test.go
+++ b/endpoints/openrtb2/auction_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/currencies"
 
 	analyticsConf "github.com/prebid/prebid-server/analytics/config"
 	"github.com/prebid/prebid-server/config"
@@ -67,7 +68,26 @@ func BenchmarkOpenrtbEndpoint(b *testing.B) {
 	if err != nil {
 		return
 	}
-	endpoint, _ := NewEndpoint(exchange.NewExchange(server.Client(), nil, &config.Configuration{}, theMetrics, infos, gdpr.AlwaysAllow{}), paramValidator, empty_fetcher.EmptyFetcher{}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, nil)
+
+	endpoint, _ := NewEndpoint(
+		exchange.NewExchange(
+			server.Client(),
+			nil,
+			&config.Configuration{},
+			theMetrics,
+			infos,
+			gdpr.AlwaysAllow{},
+			currencies.NewRateConverterDefault(),
+		),
+		paramValidator,
+		empty_fetcher.EmptyFetcher{},
+		&config.Configuration{MaxRequestSize: maxSize},
+		theMetrics,
+		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
+		map[string]string{},
+		[]byte{},
+		nil,
+	)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -94,6 +94,7 @@ func TestExplicitUserId(t *testing.T) {
 	// As a side effect this gives us some coverage of the go_metrics piece of the metrics engine.
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	endpoint, _ := NewEndpoint(ex, newParamsValidator(t), empty_fetcher.EmptyFetcher{}, cfg, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+
 	endpoint(httptest.NewRecorder(), request, nil)
 
 	if ex.lastRequest == nil {
@@ -129,6 +130,7 @@ func TestImplicitUserId(t *testing.T) {
 	// NewMetrics() will create a new go_metrics MetricsEngine, bypassing the need for a crafted configuration set to support it.
 	// As a side effect this gives us some coverage of the go_metrics piece of the metrics engine.
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
+
 	endpoint, _ := NewEndpoint(ex, newParamsValidator(t), empty_fetcher.EmptyFetcher{}, cfg, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
 	endpoint(httptest.NewRecorder(), request, nil)
 
@@ -429,6 +431,7 @@ func TestImplicitIPs(t *testing.T) {
 	// As a side effect this gives us some coverage of the go_metrics piece of the metrics engine.
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList())
 	endpoint, _ := NewEndpoint(ex, newParamsValidator(t), &mockStoredReqFetcher{}, &config.Configuration{MaxRequestSize: maxSize}, theMetrics, analyticsConf.NewPBSAnalytics(&config.Analytics{}), map[string]string{}, []byte{}, openrtb_ext.BidderMap)
+
 	httpReq := httptest.NewRequest("POST", "/openrtb2/auction", strings.NewReader(validRequest(t, "site.json")))
 	httpReq.Header.Set("X-Forwarded-For", "123.456.78.90")
 	recorder := httptest.NewRecorder()

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"golang.org/x/net/context/ctxhttp"
@@ -37,7 +38,7 @@ type adaptedBidder interface {
 	//
 	// Any errors will be user-facing in the API.
 	// Error messages should help publishers understand what might account for "bad" bids.
-	requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error)
+	requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions) (*pbsOrtbSeatBid, []error)
 }
 
 // pbsOrtbBid is a Bid returned by an adaptedBidder.
@@ -85,7 +86,7 @@ type bidderAdapter struct {
 	Client *http.Client
 }
 
-func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
+func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions) (*pbsOrtbSeatBid, []error) {
 	reqData, errs := bidder.Bidder.MakeRequests(request)
 
 	if len(reqData) == 0 {
@@ -109,13 +110,12 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 		}
 	}
 
+	defaultCurrency := "USD"
 	seatBid := &pbsOrtbSeatBid{
 		bids:      make([]*pbsOrtbBid, 0, len(reqData)),
-		currency:  "USD",
+		currency:  defaultCurrency,
 		httpCalls: make([]*openrtb_ext.ExtHttpCall, 0, len(reqData)),
 	}
-
-	firstHTTPCallCurrency := ""
 
 	// If the bidder made multiple requests, we still want them to enter as many bids as possible...
 	// even if the timeout occurs sometime halfway through.
@@ -134,24 +134,17 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 			if bidResponse != nil {
 
 				if bidResponse.Currency == "" {
-					bidResponse.Currency = "USD"
+					// Empty currency means default currency `USD`
+					bidResponse.Currency = defaultCurrency
 				}
 
-				// Related to #281 - currency support
-				// Prebid can't make sure that each HTTP call returns bids with the same currency as the others.
-				// If a Bidder makes two HTTP calls, and their servers respond with different currencies,
-				// we will consider the first call currency as standard currency and then reject others which contradict it.
-				if firstHTTPCallCurrency == "" { // First HTTP call
-					firstHTTPCallCurrency = bidResponse.Currency
-				}
-
-				// TODO: #281 - Once currencies rate conversion is out, this shouldn't be an issue anymore, we will only
-				// need to convert the bid price based on the currency.
-				if firstHTTPCallCurrency == bidResponse.Currency {
+				// Try to get a conversion rate
+				// TODO(#280): try to convert every to element of request.cur, and use the first one which succeeds
+				if conversionRate, err := conversions.GetRate(bidResponse.Currency, "USD"); err == nil {
+					// Conversion rate found, using it for conversion
 					for i := 0; i < len(bidResponse.Bids); i++ {
 						if bidResponse.Bids[i].Bid != nil {
-							// TODO #280: Convert the bid price
-							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment
+							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment * conversionRate
 						}
 						seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
 							bid:     bidResponse.Bids[i].Bid,
@@ -159,11 +152,8 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 						})
 					}
 				} else {
-					errs = append(errs, fmt.Errorf(
-						"Bid currencies mistmatch found. Expected all bids to have the same currencies. Expected '%s', was: '%s'",
-						firstHTTPCallCurrency,
-						bidResponse.Currency,
-					))
+					// If no conversions found, do not handle the bid
+					errs = append(errs, err)
 				}
 			}
 		} else {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2,15 +2,20 @@ package exchange
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSingleBidder makes sure that the following things work if the Bidder needs only one request.
@@ -56,7 +61,8 @@ func TestSingleBidder(t *testing.T) {
 		bidResponse: mockBidderResponse,
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", bidAdjustment)
+	currencyConverter := currencies.NewRateConverterDefault()
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", bidAdjustment, currencyConverter.Rates())
 
 	// Make sure the goodSingleBidder was called with the expected arguments.
 	if bidderImpl.httpResponse == nil {
@@ -140,7 +146,8 @@ func TestMultiBidder(t *testing.T) {
 		bidResponse: mockBidderResponse,
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0, currencyConverter.Rates())
 
 	if seatBid == nil {
 		t.Fatalf("SeatBid should exist, because bids exist.")
@@ -230,7 +237,12 @@ func TestConnectionClose(t *testing.T) {
 	}
 }
 
-// TestMultiCurrencies makes sure that bidderAdapter.requestBid returns errors if the bidder pass several currencies in case of multi HTTP calls.
+type bid struct {
+	currency string
+	price    float64
+}
+
+// TestMultiCurrencies rate converter is set / active.
 func TestMultiCurrencies(t *testing.T) {
 	// Setup:
 	respStatus := 200
@@ -238,70 +250,371 @@ func TestMultiCurrencies(t *testing.T) {
 	postRespBody := "{\"wasPost\":true}"
 
 	testCases := []struct {
-		bidRequestCurrencies           []string
-		bidCurrency                    []string
-		expectedBidsCount              uint
-		expectedBadCurrencyErrorsCount uint
+		bids                      []bid
+		rates                     currencies.Rates
+		expectedBids              []bid
+		expectedBadCurrencyErrors []error
 	}{
 		// Bidder respond with the same currency (default one) on all HTTP responses
 		{
-			bidCurrency:                    []string{"USD", "USD", "USD"},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "USD", price: 1.2},
+				{currency: "USD", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "USD", price: 1.2},
+				{currency: "USD", price: 1.3},
+			},
+			expectedBadCurrencyErrors: []error{},
+		},
+		// Bidder respond with no currency on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "", price: 1.1},
+				{currency: "", price: 1.2},
+				{currency: "", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "USD", price: 1.2},
+				{currency: "USD", price: 1.3},
+			},
+			expectedBadCurrencyErrors: []error{},
+		},
+		// Bidder respond with the same non default currency on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "EUR", price: 1.1},
+				{currency: "EUR", price: 1.2},
+				{currency: "EUR", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.1 * 1.1435678764},
+				{currency: "USD", price: 1.2 * 1.1435678764},
+				{currency: "USD", price: 1.3 * 1.1435678764},
+			},
+			expectedBadCurrencyErrors: []error{},
+		},
+		// Bidder respond with a mix of currencies on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "EUR", price: 1.2},
+				{currency: "GBP", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "USD", price: 1.2 * 1.1435678764},
+				{currency: "USD", price: 1.3 * 1.3050530256},
+			},
+			expectedBadCurrencyErrors: []error{},
+		},
+		// Bidder respond with a mix of currencies and no currency on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "", price: 1.1},
+				{currency: "EUR", price: 1.2},
+				{currency: "GBP", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.1},
+				{currency: "USD", price: 1.2 * 1.1435678764},
+				{currency: "USD", price: 1.3 * 1.3050530256},
+			},
+			expectedBadCurrencyErrors: []error{},
+		},
+		// Bidder respond with a mix of currencies and one unknown on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "JPY", price: 1.1},
+				{currency: "EUR", price: 1.2},
+				{currency: "GBP", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{
+				{currency: "USD", price: 1.2 * 1.1435678764},
+				{currency: "USD", price: 1.3 * 1.3050530256},
+			},
+			expectedBadCurrencyErrors: []error{
+				errors.New("Currency conversion rate not found: 'JPY' => 'USD'"),
+			},
+		},
+		// Bidder respond with currencies not having any rate on all HTTP responses
+		{
+			bids: []bid{
+				{currency: "JPY", price: 1.1},
+				{currency: "BZD", price: 1.2},
+				{currency: "DKK", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{},
+			expectedBadCurrencyErrors: []error{
+				errors.New("Currency conversion rate not found: 'JPY' => 'USD'"),
+				errors.New("Currency conversion rate not found: 'BZD' => 'USD'"),
+				errors.New("Currency conversion rate not found: 'DKK' => 'USD'"),
+			},
+		},
+		// Bidder respond with not existing currencies
+		{
+			bids: []bid{
+				{currency: "AAA", price: 1.1},
+				{currency: "BBB", price: 1.2},
+				{currency: "CCC", price: 1.3},
+			},
+			rates: currencies.Rates{
+				DataAsOf: time.Now(),
+				Conversions: map[string]map[string]float64{
+					"GBP": {
+						"USD": 1.3050530256,
+					},
+					"EUR": {
+						"USD": 1.1435678764,
+					},
+				},
+			},
+			expectedBids: []bid{},
+			expectedBadCurrencyErrors: []error{
+				errors.New("currency: tag is not a recognized currency"),
+				errors.New("currency: tag is not a recognized currency"),
+				errors.New("currency: tag is not a recognized currency"),
+			},
+		},
+	}
+
+	server := httptest.NewServer(mockHandler(respStatus, getRespBody, postRespBody))
+	defer server.Close()
+
+	for _, tc := range testCases {
+		mockBidderResponses := make([]*adapters.BidderResponse, len(tc.bids))
+		bidderImpl := &goodMultiHTTPCallsBidder{
+			bidResponses: mockBidderResponses,
+		}
+		bidderImpl.httpRequest = make([]*adapters.RequestData, len(tc.bids))
+
+		for i, bid := range tc.bids {
+
+			mockBidderResponses[i] = &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb.Bid{
+							Price: bid.price,
+						},
+						BidType: openrtb_ext.BidTypeBanner,
+					},
+				},
+				Currency: bid.currency,
+			}
+
+			bidderImpl.httpRequest[i] = &adapters.RequestData{
+				Method:  "POST",
+				Uri:     server.URL,
+				Body:    []byte("{\"key\":\"val\"}"),
+				Headers: http.Header{},
+			}
+		}
+
+		mockedHTTPServer := httptest.NewServer(http.HandlerFunc(
+			func(rw http.ResponseWriter, req *http.Request) {
+				b, err := json.Marshal(tc.rates)
+				if err == nil {
+					rw.WriteHeader(http.StatusOK)
+					rw.Write(b)
+				} else {
+					rw.WriteHeader(http.StatusInternalServerError)
+				}
+			}),
+		)
+
+		// Execute:
+		bidder := adaptBidder(bidderImpl, server.Client())
+		currencyConverter := currencies.NewRateConverter(
+			&http.Client{},
+			mockedHTTPServer.URL,
+			time.Duration(10)*time.Second,
+		)
+		seatBid, errs := bidder.requestBid(
+			context.Background(),
+			&openrtb.BidRequest{},
+			"test",
+			1,
+			currencyConverter.Rates(),
+		)
+
+		// Verify:
+		resultLightBids := make([]bid, len(seatBid.bids))
+		for i, b := range seatBid.bids {
+			resultLightBids[i] = bid{
+				price:    b.bid.Price,
+				currency: seatBid.currency,
+			}
+		}
+		assert.ElementsMatch(t, tc.expectedBids, resultLightBids, fmt.Sprintf("Case: %v", tc.bids))
+		assert.ElementsMatch(t, tc.expectedBadCurrencyErrors, errs, fmt.Sprintf("Case: %v", tc.bids))
+	}
+}
+
+// TestMultiCurrencies_RateConverterNotSet no rate converter is set / active.
+func TestMultiCurrencies_RateConverterNotSet(t *testing.T) {
+	// Setup:
+	respStatus := 200
+	getRespBody := "{\"wasPost\":false}"
+	postRespBody := "{\"wasPost\":true}"
+
+	testCases := []struct {
+		bidCurrency               []string
+		expectedBidsCount         uint
+		expectedBadCurrencyErrors []error
+	}{
+		// Bidder respond with the same currency (default one) on all HTTP responses
+		{
+			bidCurrency:               []string{"USD", "USD", "USD"},
+			expectedBidsCount:         3,
+			expectedBadCurrencyErrors: []error{},
 		},
 		// Bidder respond with the same currency (not default one) on all HTTP responses
 		{
-			bidCurrency:                    []string{"EUR", "EUR", "EUR"},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:       []string{"EUR", "EUR", "EUR"},
+			expectedBidsCount: 0,
+			expectedBadCurrencyErrors: []error{
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'EUR' => 'USD'"),
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'EUR' => 'USD'"),
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'EUR' => 'USD'"),
+			},
 		},
 		// Bidder responds with currency not set on all HTTP responses
 		{
-			bidCurrency:                    []string{"", "", ""},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:               []string{"", "", ""},
+			expectedBidsCount:         3,
+			expectedBadCurrencyErrors: []error{},
 		},
 		// Bidder responds with a mix of not set and default currency in HTTP responses
 		{
-			bidCurrency:                    []string{"", "USD", ""},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:               []string{"", "USD", ""},
+			expectedBidsCount:         3,
+			expectedBadCurrencyErrors: []error{},
 		},
 		// Bidder responds with a mix of not set and default currency in HTTP responses
 		{
-			bidCurrency:                    []string{"USD", "USD", ""},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:               []string{"USD", "USD", ""},
+			expectedBidsCount:         3,
+			expectedBadCurrencyErrors: []error{},
 		},
 		// Bidder responds with a mix of not set and default currency in HTTP responses
 		{
-			bidCurrency:                    []string{"", "", "USD"},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:               []string{"", "", "USD"},
+			expectedBidsCount:         3,
+			expectedBadCurrencyErrors: []error{},
 		},
 		// Bidder responds with a mix of not set, non default currency and default currency in HTTP responses
 		{
-			bidCurrency:                    []string{"EUR", "", "USD"},
-			expectedBidsCount:              1,
-			expectedBadCurrencyErrorsCount: 2,
+			bidCurrency:       []string{"EUR", "", "USD"},
+			expectedBidsCount: 2,
+			expectedBadCurrencyErrors: []error{
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'EUR' => 'USD'"),
+			},
 		},
 		// Bidder responds with a mix of not set, non default currency and default currency in HTTP responses
 		{
-			bidCurrency:                    []string{"GDB", "", "USD"},
-			expectedBidsCount:              1,
-			expectedBadCurrencyErrorsCount: 2,
+			bidCurrency:       []string{"GBP", "", "USD"},
+			expectedBidsCount: 2,
+			expectedBadCurrencyErrors: []error{
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'GBP' => 'USD'"),
+			},
 		},
-		// Bidder responds with a mix of not set and default currency in HTTP responses
+		// Bidder responds with a mix of not set and empty currencies (default currency) in HTTP responses
 		{
-			bidCurrency:                    []string{"GDB", "", ""},
-			expectedBidsCount:              1,
-			expectedBadCurrencyErrorsCount: 2,
+			bidCurrency:       []string{"GBP", "", ""},
+			expectedBidsCount: 2,
+			expectedBadCurrencyErrors: []error{
+				fmt.Errorf("Constant rates doesn't proceed to any conversions, cannot convert 'GBP' => 'USD'"),
+			},
 		},
-		// Bidder responds with a mix of not set and default currency in HTTP responses
+		// Bidder respond with not existing currencies
 		{
-			bidCurrency:                    []string{"GDB", "GDB", "GDB"},
-			expectedBidsCount:              3,
-			expectedBadCurrencyErrorsCount: 0,
+			bidCurrency:       []string{"AAA", "BBB", "CCC"},
+			expectedBidsCount: 0,
+			expectedBadCurrencyErrors: []error{
+				errors.New("currency: tag is not a recognized currency"),
+				errors.New("currency: tag is not a recognized currency"),
+				errors.New("currency: tag is not a recognized currency"),
+			},
 		},
 	}
 
@@ -337,24 +650,19 @@ func TestMultiCurrencies(t *testing.T) {
 
 		// Execute:
 		bidder := adaptBidder(bidderImpl, server.Client())
+		currencyConverter := currencies.NewRateConverterDefault()
 		seatBid, errs := bidder.requestBid(
 			context.Background(),
 			&openrtb.BidRequest{},
 			"test",
 			1,
+			currencyConverter.Rates(),
 		)
 
 		// Verify:
-		if seatBid == nil && tc.expectedBidsCount != 0 {
-			t.Errorf("Seatbid is nil but expected not to be nil")
-		}
-		if tc.expectedBidsCount != uint(len(seatBid.bids)) {
-			t.Errorf("Expected to have %d bids count but got %d", tc.expectedBidsCount, len(seatBid.bids))
-		}
-		if tc.expectedBadCurrencyErrorsCount != uint(len(errs)) {
-			t.Errorf("Expected to have %d errors count but got %d", tc.expectedBadCurrencyErrorsCount, len(errs))
-		}
-
+		assert.Equal(t, false, (seatBid == nil && tc.expectedBidsCount != 0), fmt.Sprint("Case:", strings.Join(tc.bidCurrency, ",")))
+		assert.Equal(t, tc.expectedBidsCount, uint(len(seatBid.bids)), fmt.Sprint("Case:", strings.Join(tc.bidCurrency, ",")))
+		assert.ElementsMatch(t, tc.expectedBadCurrencyErrors, errs, fmt.Sprint("Case:", strings.Join(tc.bidCurrency, ",")))
 	}
 }
 
@@ -447,10 +755,17 @@ func TestServerCallDebugging(t *testing.T) {
 		},
 	}
 	bidder := adaptBidder(bidderImpl, server.Client())
+	currencyConverter := currencies.NewRateConverterDefault()
 
-	bids, _ := bidder.requestBid(context.Background(), &openrtb.BidRequest{
-		Test: 1,
-	}, "test", 1.0)
+	bids, _ := bidder.requestBid(
+		context.Background(),
+		&openrtb.BidRequest{
+			Test: 1,
+		},
+		"test",
+		1.0,
+		currencyConverter.Rates(),
+	)
 
 	if len(bids.httpCalls) != 1 {
 		t.Errorf("We should log the server call if this is a test bid. Got %d", len(bids.httpCalls))
@@ -471,7 +786,8 @@ func TestServerCallDebugging(t *testing.T) {
 
 func TestErrorReporting(t *testing.T) {
 	bidder := adaptBidder(&bidRejector{}, nil)
-	bids, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	bids, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, "test", 1.0, currencyConverter.Rates())
 	if bids != nil {
 		t.Errorf("There should be no seatbid if no http requests are returned.")
 	}

--- a/exchange/bidder_validate_bids.go
+++ b/exchange/bidder_validate_bids.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"golang.org/x/text/currency"
 )
@@ -26,8 +27,8 @@ type validatedBidder struct {
 	bidder adaptedBidder
 }
 
-func (v *validatedBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
-	seatBid, errs := v.bidder.requestBid(ctx, request, name, bidAdjustment)
+func (v *validatedBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions) (*pbsOrtbSeatBid, []error) {
+	seatBid, errs := v.bidder.requestBid(ctx, request, name, bidAdjustment, conversions)
 	if validationErrors := removeInvalidBids(request, seatBid); len(validationErrors) > 0 {
 		errs = append(errs, validationErrors...)
 	}

--- a/exchange/bidder_validate_bids_test.go
+++ b/exchange/bidder_validate_bids_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,7 +41,7 @@ func TestAllValidBids(t *testing.T) {
 			},
 		},
 	})
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0)
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0, currencies.NewConstantRates())
 	assert.Len(t, seatBid.bids, 3)
 	assert.Len(t, errs, 0)
 }
@@ -81,7 +82,7 @@ func TestAllBadBids(t *testing.T) {
 			},
 		},
 	})
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0)
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0, currencies.NewConstantRates())
 	assert.Len(t, seatBid.bids, 0)
 	assert.Len(t, errs, 5)
 }
@@ -124,7 +125,7 @@ func TestMixedBids(t *testing.T) {
 			},
 		},
 	})
-	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0)
+	seatBid, errs := bidder.requestBid(context.Background(), &openrtb.BidRequest{}, openrtb_ext.BidderAppnexus, 1.0, currencies.NewConstantRates())
 	assert.Len(t, seatBid.bids, 2)
 	assert.Len(t, errs, 3)
 }
@@ -244,7 +245,7 @@ func TestCurrencyBids(t *testing.T) {
 			Cur: tc.brqCur,
 		}
 
-		seatBid, errs := bidder.requestBid(context.Background(), request, openrtb_ext.BidderAppnexus, 1.0)
+		seatBid, errs := bidder.requestBid(context.Background(), request, openrtb_ext.BidderAppnexus, 1.0, currencies.NewConstantRates())
 		assert.Len(t, seatBid.bids, expectedValidBids)
 		assert.Len(t, errs, expectedErrs)
 	}
@@ -255,6 +256,6 @@ type mockAdaptedBidder struct {
 	errorResponse []error
 }
 
-func (b *mockAdaptedBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
+func (b *mockAdaptedBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions) (*pbsOrtbSeatBid, []error) {
 	return b.bidResponse, b.errorResponse
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/openrtb_ext"
@@ -37,6 +38,7 @@ type exchange struct {
 	cache               prebid_cache_client.Client
 	cacheTime           time.Duration
 	gDPR                gdpr.Permissions
+	currencyConverter   *currencies.RateConverter
 	UsersyncIfAmbiguous bool
 	defaultTTLs         config.DefaultTTLs
 }
@@ -53,7 +55,7 @@ type bidResponseWrapper struct {
 	bidder       openrtb_ext.BidderName
 }
 
-func NewExchange(client *http.Client, cache prebid_cache_client.Client, cfg *config.Configuration, metricsEngine pbsmetrics.MetricsEngine, infos adapters.BidderInfos, gDPR gdpr.Permissions) Exchange {
+func NewExchange(client *http.Client, cache prebid_cache_client.Client, cfg *config.Configuration, metricsEngine pbsmetrics.MetricsEngine, infos adapters.BidderInfos, gDPR gdpr.Permissions, currencyConverter *currencies.RateConverter) Exchange {
 	e := new(exchange)
 
 	e.adapterMap = newAdapterMap(client, cfg, infos)
@@ -61,6 +63,7 @@ func NewExchange(client *http.Client, cache prebid_cache_client.Client, cfg *con
 	e.cacheTime = time.Duration(cfg.CacheURL.ExpectedTimeMillis) * time.Millisecond
 	e.me = metricsEngine
 	e.gDPR = gDPR
+	e.currencyConverter = currencyConverter
 	e.UsersyncIfAmbiguous = cfg.GDPR.UsersyncIfAmbiguous
 	e.defaultTTLs = cfg.CacheURL.DefaultTTLs
 	return e
@@ -127,7 +130,10 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 	auctionCtx, cancel := e.makeAuctionContext(ctx, shouldCacheBids)
 	defer cancel()
 
-	adapterBids, adapterExtra := e.getAllBids(auctionCtx, cleanRequests, aliases, bidAdjustmentFactors, blabels)
+	// Get currency rates conversions for the auction
+	conversions := e.currencyConverter.Rates()
+
+	adapterBids, adapterExtra := e.getAllBids(auctionCtx, cleanRequests, aliases, bidAdjustmentFactors, blabels, conversions)
 	auc := newAuction(adapterBids, len(bidRequest.Imp))
 	if targData != nil {
 		auc.setRoundedPrices(targData.priceGranularity)
@@ -153,7 +159,7 @@ func (e *exchange) makeAuctionContext(ctx context.Context, needsCache bool) (auc
 }
 
 // This piece sends all the requests to the bidder adapters and gathers the results.
-func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext.BidderName]*openrtb.BidRequest, aliases map[string]string, bidAdjustments map[string]float64, blabels map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels) (map[openrtb_ext.BidderName]*pbsOrtbSeatBid, map[openrtb_ext.BidderName]*seatResponseExtra) {
+func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext.BidderName]*openrtb.BidRequest, aliases map[string]string, bidAdjustments map[string]float64, blabels map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels, conversions currencies.Conversions) (map[openrtb_ext.BidderName]*pbsOrtbSeatBid, map[openrtb_ext.BidderName]*seatResponseExtra) {
 	// Set up pointers to the bid results
 	adapterBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid, len(cleanRequests))
 	adapterExtra := make(map[openrtb_ext.BidderName]*seatResponseExtra, len(cleanRequests))
@@ -162,7 +168,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 	for bidderName, req := range cleanRequests {
 		// Here we actually call the adapters and collect the bids.
 		coreBidder := resolveBidder(string(bidderName), aliases)
-		bidderRunner := recoverSafely(func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels) {
+		bidderRunner := recoverSafely(func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels, conversions currencies.Conversions) {
 			// Passing in aName so a doesn't change out from under the go routine
 			if bidlabels.Adapter == "" {
 				glog.Errorf("Exchange: bidlables for %s (%s) missing adapter string", aName, coreBidder)
@@ -180,7 +186,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			if givenAdjustment, ok := bidAdjustments[string(aName)]; ok {
 				adjustmentFactor = givenAdjustment
 			}
-			bids, err := e.adapterMap[coreBidder].requestBid(ctx, request, aName, adjustmentFactor)
+			bids, err := e.adapterMap[coreBidder].requestBid(ctx, request, aName, adjustmentFactor, conversions)
 
 			// Add in time reporting
 			elapsed := time.Since(start)
@@ -205,7 +211,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			}
 			chBids <- brw
 		}, chBids)
-		go bidderRunner(bidderName, coreBidder, req, blabels[coreBidder])
+		go bidderRunner(bidderName, coreBidder, req, blabels[coreBidder], conversions)
 	}
 	// Wait for the bidders to do their thing
 	for i := 0; i < len(cleanRequests); i++ {
@@ -217,8 +223,8 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 	return adapterBids, adapterExtra
 }
 
-func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels), chBids chan *bidResponseWrapper) func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels) {
-	return func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels) {
+func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels, currencies.Conversions), chBids chan *bidResponseWrapper) func(openrtb_ext.BidderName, openrtb_ext.BidderName, *openrtb.BidRequest, *pbsmetrics.AdapterLabels, currencies.Conversions) {
+	return func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels, conversions currencies.Conversions) {
 		defer func() {
 			if r := recover(); r != nil {
 				glog.Errorf("OpenRTB auction recovered panic from Bidder %s: %v. Stack trace is: %v", coreBidder, r, string(debug.Stack()))
@@ -228,7 +234,7 @@ func recoverSafely(inner func(openrtb_ext.BidderName, openrtb_ext.BidderName, *o
 				chBids <- brw
 			}
 		}()
-		inner(aName, coreBidder, request, bidlabels)
+		inner(aName, coreBidder, request, bidlabels, conversions)
 	}
 }
 

--- a/exchange/legacy.go
+++ b/exchange/legacy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/usersync"
@@ -32,7 +33,7 @@ type adaptedAdapter struct {
 //
 // This is not ideal. OpenRTB provides a superset of the legacy data structures.
 // For requests which use those features, the best we can do is respond with "no bid".
-func (bidder *adaptedAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64) (*pbsOrtbSeatBid, []error) {
+func (bidder *adaptedAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions) (*pbsOrtbSeatBid, []error) {
 	legacyRequest, legacyBidder, errs := bidder.toLegacyAdapterInputs(request, name)
 	if legacyRequest == nil || legacyBidder == nil {
 		return nil, errs

--- a/exchange/legacy_test.go
+++ b/exchange/legacy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/evanphx/json-patch"
 	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/usersync"
@@ -56,7 +57,8 @@ func TestSiteVideo(t *testing.T) {
 	mockAdapter := mockLegacyAdapter{}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0, currencyConverter.Rates())
 	if len(errs) > 0 {
 		t.Errorf("Unexpected error requesting bids: %v", errs)
 	}
@@ -89,7 +91,8 @@ func TestAppBanner(t *testing.T) {
 	mockAdapter := mockLegacyAdapter{}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0, currencyConverter.Rates())
 	if len(errs) > 0 {
 		t.Errorf("Unexpected error requesting bids: %v", errs)
 	}
@@ -134,7 +137,8 @@ func TestBidTransforms(t *testing.T) {
 	}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon, bidAdjustment)
+	currencyConverter := currencies.NewRateConverterDefault()
+	seatBid, errs := exchangeBidder.requestBid(context.Background(), newAppOrtbRequest(), openrtb_ext.BidderRubicon, bidAdjustment, currencyConverter.Rates())
 	if len(errs) != 1 {
 		t.Fatalf("Bad error count. Expected 1, got %d", len(errs))
 	}
@@ -282,7 +286,8 @@ func TestErrorResponse(t *testing.T) {
 	}
 
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	_, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderRubicon, 1.0, currencyConverter.Rates())
 	if len(errs) != 1 {
 		t.Fatalf("Bad error count. Expected 1, got %d", len(errs))
 	}
@@ -320,7 +325,8 @@ func TestWithTargeting(t *testing.T) {
 		}},
 	}
 	exchangeBidder := adaptLegacyAdapter(&mockAdapter)
-	bid, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderFacebook, 1.0)
+	currencyConverter := currencies.NewRateConverterDefault()
+	bid, errs := exchangeBidder.requestBid(context.Background(), ortbRequest, openrtb_ext.BidderFacebook, 1.0, currencyConverter.Rates())
 	if len(errs) != 0 {
 		t.Fatalf("This should not produce errors. Got %v", errs)
 	}

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prebid/prebid-server/currencies"
+
 	"github.com/prebid/prebid-server/gdpr"
 
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -74,6 +76,7 @@ func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*op
 		cache:               &wellBehavedCache{},
 		cacheTime:           time.Duration(0),
 		gDPR:                gdpr.AlwaysAllow{},
+		currencyConverter:   currencies.NewRateConverterDefault(),
 		UsersyncIfAmbiguous: false,
 	}
 


### PR DESCRIPTION
This CL allows to start using the rates converter.
The default currency remains `USD`.

By default, the rate converter will fetch every 30 minutes the official
prebid.org currencies rates at http://currency.prebid.org/latest.json.

The rate converter can be disabled by setting `rates_converter.fetch_url` to 0.

I will also do another PR to add a new endpoint in order to expose the rate converter settings along with the actual rates to ease debug and such if it's ok for you.

For more details on this feature, please refer to #280