### PR TITLE
Set the /cookie_sync Content-Type to application/json

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/buger/jsonparser"
-
 	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/config"
@@ -129,6 +128,7 @@ func (deps *cookieSyncDeps) Endpoint(w http.ResponseWriter, r *http.Request, _ h
 		co.BidderStatus = append(co.BidderStatus, csResp.BidderStatus...)
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.Encode(csResp)

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buger/jsonparser"
+	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-server/adapters/appnexus"
 	"github.com/prebid/prebid-server/adapters/audienceNetwork"
 	"github.com/prebid/prebid-server/adapters/lifestreet"
@@ -18,47 +20,48 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 	metricsConf "github.com/prebid/prebid-server/pbsmetrics/config"
 	"github.com/prebid/prebid-server/usersync"
-
-	"github.com/buger/jsonparser"
-	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCookieSyncNoCookies(t *testing.T) {
 	rr := doPost(`{"bidders":["appnexus", "audienceNetwork", "random"]}`, nil, true, syncersForTest())
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes(), "appnexus", "audienceNetwork")
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.ElementsMatch(t, []string{"appnexus", "audienceNetwork"}, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func TestGDPRPreventsCookie(t *testing.T) {
 	rr := doPost(`{"bidders":["appnexus", "pubmatic"]}`, nil, false, syncersForTest())
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-
-	assertSyncsExist(t, rr.Body.Bytes())
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func TestGDPRPreventsBidders(t *testing.T) {
 	rr := doPost(`{"gdpr":1,"bidders":["appnexus", "pubmatic", "lifestreet"],"gdpr_consent":"BOONs2HOONs2HABABBENAGgAAAAPrABACGA"}`, nil, true, map[openrtb_ext.BidderName]usersync.Usersyncer{
 		openrtb_ext.BidderLifestreet: lifestreet.NewLifestreetSyncer(&config.Configuration{ExternalURL: "someurl.com"}),
 	})
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes(), "lifestreet")
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.ElementsMatch(t, []string{"lifestreet"}, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func TestGDPRIgnoredIfZero(t *testing.T) {
 	rr := doPost(`{"gdpr":0,"bidders":["appnexus", "pubmatic"]}`, nil, false, nil)
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-
-	assertSyncsExist(t, rr.Body.Bytes(), "appnexus", "pubmatic")
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.ElementsMatch(t, []string{"appnexus", "pubmatic"}, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func TestGDPRConsentRequired(t *testing.T) {
 	rr := doPost(`{"gdpr":1,"bidders":["appnexus", "pubmatic"]}`, nil, false, nil)
-	assertIntsMatch(t, http.StatusBadRequest, rr.Code)
-	assertStringsMatch(t, "gdpr_consent is required if gdpr=1\n", rr.Body.String())
+	assert.Equal(t, rr.Header().Get("Content-Type"), "text/plain; charset=utf-8")
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Equal(t, "gdpr_consent is required if gdpr=1\n", rr.Body.String())
 }
 
 func TestCookieSyncHasCookies(t *testing.T) {
@@ -66,32 +69,36 @@ func TestCookieSyncHasCookies(t *testing.T) {
 		"adnxs":           "1234",
 		"audienceNetwork": "2345",
 	}, true, syncersForTest())
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes())
-	assertStatus(t, rr.Body.Bytes(), "ok")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "ok", parseStatus(t, rr.Body.Bytes()))
 }
 
 // Make sure that an empty bidders array returns no syncs
 func TestCookieSyncEmptyBidders(t *testing.T) {
 	rr := doPost(`{"bidders": []}`, nil, true, syncersForTest())
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes())
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 // Make sure that all syncs are returned if "bidders" isn't a key
 func TestCookieSyncNoBidders(t *testing.T) {
 	rr := doPost("{}", nil, true, syncersForTest())
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes(), "appnexus", "audienceNetwork", "lifestreet", "pubmatic")
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.ElementsMatch(t, []string{"appnexus", "audienceNetwork", "lifestreet", "pubmatic"}, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func TestCookieSyncNoCookiesBrokenGDPR(t *testing.T) {
 	rr := doConfigurablePost(`{"bidders":["appnexus", "audienceNetwork", "random"],"gdpr_consent":"GLKHGKGKKGK"}`, nil, true, map[openrtb_ext.BidderName]usersync.Usersyncer{}, config.GDPR{UsersyncIfAmbiguous: true})
-	assertIntsMatch(t, http.StatusOK, rr.Code)
-	assertSyncsExist(t, rr.Body.Bytes(), "appnexus", "audienceNetwork")
-	assertStatus(t, rr.Body.Bytes(), "no_cookie")
+	assert.Equal(t, rr.Header().Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.ElementsMatch(t, []string{"appnexus", "audienceNetwork"}, parseSyncs(t, rr.Body.Bytes()))
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
 func doPost(body string, existingSyncs map[string]string, gdprHostConsent bool, gdprBidders map[openrtb_ext.BidderName]usersync.Usersyncer) *httptest.ResponseRecorder {
@@ -133,21 +140,13 @@ func syncersForTest() map[openrtb_ext.BidderName]usersync.Usersyncer {
 	}
 }
 
-func assertSyncsExist(t *testing.T, responseBody []byte, expectedBidders ...string) {
-	t.Helper()
-	assertSameElements(t, expectedBidders, parseSyncs(t, responseBody))
-}
-
-func assertStatus(t *testing.T, responseBody []byte, expected string) {
+func parseStatus(t *testing.T, responseBody []byte) string {
 	t.Helper()
 	val, err := jsonparser.GetString(responseBody, "status")
 	if err != nil {
-		t.Errorf("response.status was not a string. Error was %v", err)
-		return
+		t.Fatalf("response.status was not a string. Error was %v", err)
 	}
-	if val != expected {
-		t.Errorf("response.status was %s, but expected %s", val, expected)
-	}
+	return val
 }
 
 func parseSyncs(t *testing.T, response []byte) []string {
@@ -164,26 +163,6 @@ func parseSyncs(t *testing.T, response []byte) []string {
 		}
 	}, "bidder_status")
 	return syncs
-}
-
-func assertSameElements(t *testing.T, expected []string, actual []string) {
-	t.Helper()
-	if len(expected) != len(actual) {
-		t.Errorf("expected %v, but got %v.", expected, actual)
-		return
-	}
-	for _, expectedVal := range expected {
-		seen := false
-		for _, actualVal := range actual {
-			if expectedVal == actualVal {
-				seen = true
-				break
-			}
-		}
-		if !seen {
-			t.Errorf("Expected sync from %s, but it wasn't in the response.", expectedVal)
-		}
-	}
 }
 
 func mockPermissions(allowHost bool, allowedBidders map[openrtb_ext.BidderName]usersync.Usersyncer) gdpr.Permissions {


### PR DESCRIPTION
Small bugfix... we never set the `Content-Type` to `application/json` on the `/cookie_sync` URL.

I added some regression tests... but also noticed that these tests came from the days before `testify`. Figured I'd clean up some of the duplicate helper methods while I was in there.