### PR TITLE
[Spelling fix] Fix spelling for go report card

### DIFF
--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -88,7 +88,7 @@ func TestIxInvalidCall(t *testing.T) {
 	pbBidder := pbs.PBSBidder{}
 	_, err := an.Call(ctx, &pbReq, &pbBidder)
 	if err == nil {
-		t.Fatalf("No error recived for invalid request")
+		t.Fatalf("No error received for invalid request")
 	}
 }
 
@@ -106,7 +106,7 @@ func TestIxInvalidCallReqAppNil(t *testing.T) {
 	_, err := an.Call(ctx, &pbReq, &pbBidder)
 
 	if err == nil {
-		t.Fatalf("No error recived for invalid request")
+		t.Fatalf("No error received for invalid request")
 	}
 }
 


### PR DESCRIPTION
This CL just to fix a spelling issue, allowing the Go report card to show 100% spelling report