### PR TITLE
Fixed a bug in the bidder limits

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -200,6 +200,9 @@ func (req *cookieSyncRequest) filterToLimit() {
 	if req.Limit <= 0 {
 		return
 	}
+	if req.Limit >= len(req.Bidders) {
+		return
+	}
 
 	// Modified Fisher and Yates' shuffle. We don't need the bidder list shuffled, so we stop shuffling once the final values beyond limit have been set.
 	// We also don't bother saving the values that should go into the entries beyond limit, as they will be discarded.

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -108,6 +108,14 @@ func TestCookieSyncWithLimit(t *testing.T) {
 	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
 }
 
+func TestCookieSyncWithLargeLimit(t *testing.T) {
+	syncers := syncersForTest()
+	rr := doPost(`{"limit":1000}`, nil, true, syncers)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Len(t, parseSyncs(t, rr.Body.Bytes()), len(syncers), "usersyncs")
+	assert.Equal(t, "no_cookie", parseStatus(t, rr.Body.Bytes()))
+}
+
 func doPost(body string, existingSyncs map[string]string, gdprHostConsent bool, gdprBidders map[openrtb_ext.BidderName]usersync.Usersyncer) *httptest.ResponseRecorder {
 	return doConfigurablePost(body, existingSyncs, gdprHostConsent, gdprBidders, config.GDPR{})
 }


### PR DESCRIPTION
I stumbled on this while testing other things.

If the limit is larger than the number of syncs, the code segfaults. This fixes + regression tests it.