### PR TITLE
Stop counting invalid bids in the metrics

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -204,7 +204,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 			ae.Errors = serr
 			brw.adapterExtra = ae
 			if bids != nil {
-				for _, bid := range bids.bids {
+				for _, bid := range brw.adapterBids.bids {
 					var cpm = float64(bid.bid.Price * 1000)
 					e.me.RecordAdapterPrice(*bidlabels, cpm)
 					e.me.RecordAdapterBidReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")


### PR DESCRIPTION
This isn't my priority at the moment... but I saw this line which looks, at first glance, like a bug.

Making this PR as a placeholder so it doesn't get forgotten. It seems like bids which are rejected as invalid are still being counted as valid in the metrics.

This needs some investigation, when there's more time. If it is really a bug, also needs a regression test (& maybe some refactoring to make it less likely in the future).