### PR TITLE
Added a go import path to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - '1.10'
   - '1.11.1'
 
+go_import_path: github.com/prebid/prebid-server
+
 env:
   - DEP_VERSION="0.5.0"
 


### PR DESCRIPTION
hey @benjaminch, this one's for you.

A long while back, I remember you looking for ways to run CI in your fork without stray commits.

I stumbled on this in another repo, and it looks like a pretty clean solution: https://docs.travis-ci.com/user/languages/go#go-import-path

If you want to test it at some point, please let me know if it works. We can merge it and you can drop the `TRAVIS_REPO_SLUG` nastiness that you had to add to your fork. Official Go Modules will be coming very soon... so the Dep-specific solution will break in the near future anyway.