### PR TITLE
Configurable prometheus endpoint timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
 	errs = cfg.StoredRequests.validate(errs)
+	errs = cfg.Metrics.validate(errs)
 	if cfg.MaxRequestSize < 0 {
 		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))
 	}
@@ -185,6 +186,10 @@ type Metrics struct {
 	Prometheus PrometheusMetrics `mapstructure:"prometheus"`
 }
 
+func (cfg *Metrics) validate(errs configErrors) configErrors {
+	return cfg.Prometheus.validate(errs)
+}
+
 type InfluxMetrics struct {
 	Host     string `mapstructure:"host"`
 	Database string `mapstructure:"database"`
@@ -197,6 +202,13 @@ type PrometheusMetrics struct {
 	Namespace        string `mapstructure:"namespace"`
 	Subsystem        string `mapstructure:"subsystem"`
 	TimeoutMillisRaw int    `mapstructure:"timeout_ms"`
+}
+
+func (cfg *PrometheusMetrics) validate(errs configErrors) configErrors {
+	if cfg.Port > 0 && cfg.TimeoutMillisRaw <= 0 {
+		errs = append(errs, fmt.Errorf("metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got %d", cfg.Port))
+	}
+	return errs
 }
 
 func (m *PrometheusMetrics) Timeout() time.Duration {

--- a/config/config.go
+++ b/config/config.go
@@ -206,7 +206,7 @@ type PrometheusMetrics struct {
 
 func (cfg *PrometheusMetrics) validate(errs configErrors) configErrors {
 	if cfg.Port > 0 && cfg.TimeoutMillisRaw <= 0 {
-		errs = append(errs, fmt.Errorf("metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got %d", cfg.Port))
+		errs = append(errs, fmt.Errorf("metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got timeout=%d and port=%d", cfg.TimeoutMillisRaw, cfg.Port))
 	}
 	return errs
 }

--- a/config/config.go
+++ b/config/config.go
@@ -193,9 +193,14 @@ type InfluxMetrics struct {
 }
 
 type PrometheusMetrics struct {
-	Port      int    `mapstructure:"port"`
-	Namespace string `mapstructure:"namespace"`
-	Subsystem string `mapstructure:"subsystem"`
+	Port             int    `mapstructure:"port"`
+	Namespace        string `mapstructure:"namespace"`
+	Subsystem        string `mapstructure:"subsystem"`
+	TimeoutMillisRaw int    `mapstructure:"timeout_ms"`
+}
+
+func (m *PrometheusMetrics) Timeout() time.Duration {
+	return time.Duration(m.TimeoutMillisRaw) * time.Millisecond
 }
 
 type DataCache struct {
@@ -363,6 +368,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("metrics.prometheus.port", 0)
 	v.SetDefault("metrics.prometheus.namespace", "")
 	v.SetDefault("metrics.prometheus.subsystem", "")
+	v.SetDefault("metrics.prometheus.timeout_ms", 10000)
 	v.SetDefault("datacache.type", "dummy")
 	v.SetDefault("datacache.filename", "")
 	v.SetDefault("datacache.cache_size", 0)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaults(t *testing.T) {
@@ -178,37 +179,28 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestNegativeRequestSize(t *testing.T) {
-	cfg := Configuration{
-		MaxRequestSize: -1,
-	}
-
-	if err := cfg.validate(); err == nil {
-		t.Error("cfg.max_request_size should prevent negative values, but it doesn't")
-	}
+	cfg := newDefaultConfig(t)
+	cfg.MaxRequestSize = -1
+	assertOneError(t, cfg.validate(), "cfg.max_request_size must be >= 0. Got -1")
 }
 
 func TestNegativeVendorID(t *testing.T) {
-	cfg := Configuration{
-		GDPR: GDPR{
-			HostVendorID: -1,
-		},
-	}
+	cfg := newDefaultConfig(t)
+	cfg.GDPR.HostVendorID = -1
+	assertOneError(t, cfg.validate(), "gdpr.host_vendor_id must be in the range [0, 65535]. Got -1")
+}
 
-	if err := cfg.validate(); err == nil {
-		t.Error("cfg.gdpr.host_vendor_id should prevent negative values, but it doesn't")
-	}
+func TestNegativePrometheusTimeout(t *testing.T) {
+	cfg := newDefaultConfig(t)
+	cfg.Metrics.Prometheus.Port = 8001
+	cfg.Metrics.Prometheus.TimeoutMillisRaw = 0
+	assertOneError(t, cfg.validate(), "metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got 8001")
 }
 
 func TestOverflowedVendorID(t *testing.T) {
-	cfg := Configuration{
-		GDPR: GDPR{
-			HostVendorID: (0xffff) + 1,
-		},
-	}
-
-	if err := cfg.validate(); err == nil {
-		t.Errorf("cfg.gdpr.host_vendor_id should prevent values over %d, but it doesn't", 0xffff)
-	}
+	cfg := newDefaultConfig(t)
+	cfg.GDPR.HostVendorID = (0xffff) + 1
+	assertOneError(t, cfg.validate(), "gdpr.host_vendor_id must be in the range [0, 65535]. Got 65536")
 }
 
 func TestLimitTimeout(t *testing.T) {
@@ -217,7 +209,22 @@ func TestLimitTimeout(t *testing.T) {
 	doTimeoutTest(t, 5, 5, 10, 0)
 	doTimeoutTest(t, 15, 15, 0, 0)
 	doTimeoutTest(t, 15, 0, 20, 15)
+}
 
+func newDefaultConfig(t *testing.T) *Configuration {
+	v := viper.New()
+	SetupViper(v, "")
+	v.SetConfigType("yaml")
+	cfg, err := New(v)
+	assert.NoError(t, err)
+	return cfg
+}
+
+func assertOneError(t *testing.T, errs configErrors, message string) {
+	if !assert.Len(t, errs, 1) {
+		return
+	}
+	assert.EqualError(t, errs[0], message)
 }
 
 func doTimeoutTest(t *testing.T, expected int, requested int, max uint64, def uint64) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,7 +194,7 @@ func TestNegativePrometheusTimeout(t *testing.T) {
 	cfg := newDefaultConfig(t)
 	cfg.Metrics.Prometheus.Port = 8001
 	cfg.Metrics.Prometheus.TimeoutMillisRaw = 0
-	assertOneError(t, cfg.validate(), "metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got 8001")
+	assertOneError(t, cfg.validate(), "metrics.prometheus.timeout_ms must be positive if metrics.prometheus.port is defined. Got timeout=0 and port=8001")
 }
 
 func TestOverflowedVendorID(t *testing.T) {

--- a/server/prometheus.go
+++ b/server/prometheus.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -26,7 +25,7 @@ func newPrometheusServer(cfg *config.Configuration, metrics *metricsconfig.Detai
 		Handler: promhttp.HandlerFor(proMetrics.Registry, promhttp.HandlerOpts{
 			ErrorLog:            loggerForPrometheus{},
 			MaxRequestsInFlight: 5,
-			Timeout:             5 * time.Second,
+			Timeout:             cfg.Metrics.Prometheus.Timeout(),
 		}),
 	}
 }


### PR DESCRIPTION
Two changes here:

1. Make the prometheus timeout configurable rather than hardcoded
2. Fixes some bogus tests. These are in the same vein as the other ones @josephveach pointed out. They tested _that_ an error occurred... but not _which_ error occurred. Turns out that they _were_ passing for the wrong reasons. There were only a few of them, so... I fixed those too. 