### PR TITLE
[Currency] Changing the default currency rates URL

### DIFF
--- a/currencies/rates.go
+++ b/currencies/rates.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Rates holds data as represented on http://currency.prebid.org/latest.json
+// Rates holds data as represented on https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json
 // note that `DataAsOfRaw` field is needed when parsing remote JSON as the date format if not standard and requires
 // custom parsing to be properly set as Golang time.Time
 type Rates struct {


### PR DESCRIPTION
Following PrebidJS change regarding currenncy rates URL, any references
to it need to be updated to
`https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json`

More details at #785