### PR TITLE
Sets an explicit path on the cookies

### DIFF
--- a/usersync/cookie.go
+++ b/usersync/cookie.go
@@ -118,6 +118,7 @@ func (cookie *PBSCookie) ToHTTPCookie(ttl time.Duration) *http.Cookie {
 		Name:    UID_COOKIE_NAME,
 		Value:   b64,
 		Expires: time.Now().Add(ttl),
+		Path:    "/",
 	}
 }
 


### PR DESCRIPTION
This should lead to more predictable cookie behavior.