### PR TITLE
Implements metrics to record GDPR status of cookie sync requests

### DIFF
--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -6,9 +6,9 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
-	"github.com/prebid/prebid-server/pbsmetrics/prometheus"
-	"github.com/rcrowley/go-metrics"
-	"github.com/vrischmann/go-metrics-influxdb"
+	prometheusmetrics "github.com/prebid/prebid-server/pbsmetrics/prometheus"
+	metrics "github.com/rcrowley/go-metrics"
+	influxdb "github.com/vrischmann/go-metrics-influxdb"
 )
 
 // NewMetricsEngine reads the configuration and returns the appropriate metrics engine
@@ -132,6 +132,13 @@ func (me *MultiMetricsEngine) RecordCookieSync(labels pbsmetrics.Labels) {
 	}
 }
 
+// RecordAdapterCookieSync across all engines
+func (me *MultiMetricsEngine) RecordAdapterCookieSync(adapter openrtb_ext.BidderName, gdprBlocked bool) {
+	for _, thisME := range *me {
+		thisME.RecordAdapterCookieSync(adapter, gdprBlocked)
+	}
+}
+
 // RecordUserIDSet across all engines
 func (me *MultiMetricsEngine) RecordUserIDSet(userLabels pbsmetrics.UserLabels) {
 	for _, thisME := range *me {
@@ -189,6 +196,11 @@ func (me *DummyMetricsEngine) RecordAdapterTime(labels pbsmetrics.AdapterLabels,
 
 // RecordCookieSync as a noop
 func (me *DummyMetricsEngine) RecordCookieSync(labels pbsmetrics.Labels) {
+	return
+}
+
+// RecordAdapterCookieSync as a noop
+func (me *DummyMetricsEngine) RecordAdapterCookieSync(adapter openrtb_ext.BidderName, gdprBlocked bool) {
 	return
 }
 

--- a/pbsmetrics/go_metrics_test.go
+++ b/pbsmetrics/go_metrics_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/openrtb_ext"
-	"github.com/rcrowley/go-metrics"
+	metrics "github.com/rcrowley/go-metrics"
 )
 
 func TestNewMetrics(t *testing.T) {
@@ -19,6 +19,9 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "amp_no_cookie_requests", m.AmpNoCookieMeter)
 	ensureContainsAdapterMetrics(t, registry, "adapter.appnexus", m.AdapterMetrics["appnexus"])
 	ensureContainsAdapterMetrics(t, registry, "adapter.rubicon", m.AdapterMetrics["rubicon"])
+	ensureContains(t, registry, "cookie_sync_requests", m.CookieSyncMeter)
+	ensureContains(t, registry, "cookie_sync.appnexus.gen", m.CookieSyncGen["appnexus"])
+	ensureContains(t, registry, "cookie_sync.appnexus.gdpr_prevent", m.CookieSyncGDPRPrevent["appnexus"])
 	ensureContains(t, registry, "usersync.appnexus.gdpr_prevent", m.userSyncGDPRPrevent["appnexus"])
 	ensureContains(t, registry, "usersync.rubicon.gdpr_prevent", m.userSyncGDPRPrevent["rubicon"])
 	ensureContains(t, registry, "usersync.unknown.gdpr_prevent", m.userSyncGDPRPrevent["unknown"])

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -195,6 +195,7 @@ type MetricsEngine interface {
 	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)
 	RecordAdapterTime(labels AdapterLabels, length time.Duration)
-	RecordCookieSync(labels Labels)        // May ignore all labels
+	RecordCookieSync(labels Labels) // May ignore all labels
+	RecordAdapterCookieSync(adapter openrtb_ext.BidderName, gdprBlocked bool)
 	RecordUserIDSet(userLabels UserLabels) // Function should verify bidder values
 }

--- a/pbsmetrics/prometheus/prometheus.go
+++ b/pbsmetrics/prometheus/prometheus.go
@@ -12,19 +12,20 @@ import (
 
 // Defines the actual Prometheus metrics we will be using. Satisfies interface MetricsEngine
 type Metrics struct {
-	Registry      *prometheus.Registry
-	connCounter   prometheus.Gauge
-	connError     *prometheus.CounterVec
-	imps          *prometheus.CounterVec
-	requests      *prometheus.CounterVec
-	reqTimer      *prometheus.HistogramVec
-	adaptRequests *prometheus.CounterVec
-	adaptTimer    *prometheus.HistogramVec
-	adaptBids     *prometheus.CounterVec
-	adaptPrices   *prometheus.HistogramVec
-	adaptErrors   *prometheus.CounterVec
-	cookieSync    prometheus.Counter
-	userID        *prometheus.CounterVec
+	Registry        *prometheus.Registry
+	connCounter     prometheus.Gauge
+	connError       *prometheus.CounterVec
+	imps            *prometheus.CounterVec
+	requests        *prometheus.CounterVec
+	reqTimer        *prometheus.HistogramVec
+	adaptRequests   *prometheus.CounterVec
+	adaptTimer      *prometheus.HistogramVec
+	adaptBids       *prometheus.CounterVec
+	adaptPrices     *prometheus.HistogramVec
+	adaptErrors     *prometheus.CounterVec
+	cookieSync      prometheus.Counter
+	adaptCookieSync *prometheus.CounterVec
+	userID          *prometheus.CounterVec
 }
 
 // NewMetrics constructs the appropriate options for the Prometheus metrics. Needs to be fed the promethus config
@@ -91,6 +92,11 @@ func NewMetrics(cfg config.PrometheusMetrics) *Metrics {
 	metrics.Registry.MustRegister(metrics.adaptErrors)
 	metrics.cookieSync = newCookieSync(cfg)
 	metrics.Registry.MustRegister(metrics.cookieSync)
+	metrics.adaptCookieSync = newCounter(cfg, "adapter_cookie_sync",
+		"Number of syncs generated for a bidder, and if they were subsequently blocked.",
+		[]string{"adapter", "gdpr_blocked"},
+	)
+	metrics.Registry.MustRegister(metrics.adaptCookieSync)
 	metrics.userID = newCounter(cfg, "usersync_total",
 		"Number of user ID syncs performed",
 		[]string{"action", "bidder"},
@@ -197,6 +203,18 @@ func (me *Metrics) RecordCookieSync(labels pbsmetrics.Labels) {
 	me.cookieSync.Inc()
 }
 
+func (me *Metrics) RecordAdapterCookieSync(adapter openrtb_ext.BidderName, gdprBlocked bool) {
+	labels := prometheus.Labels{
+		"adapter": string(adapter),
+	}
+	if gdprBlocked {
+		labels["gdpr_blocked"] = "true"
+	} else {
+		labels["gdpr_blocked"] = "false"
+	}
+	me.adaptCookieSync.With(labels).Inc()
+}
+
 func (me *Metrics) RecordUserIDSet(userLabels pbsmetrics.UserLabels) {
 	me.userID.With(resolveUserSyncLabels(userLabels)).Inc()
 }
@@ -300,6 +318,11 @@ func initializeTimeSeries(m *Metrics) {
 	labels = addDimension(errorLabels, "adapter_error", adapterErrorsAsString())
 	for _, l := range labels {
 		_ = m.adaptErrors.With(l)
+	}
+	cookieLabels := addDimension([]prometheus.Labels{}, "adapter", adaptersAsString())
+	cookieLabels = addDimension(cookieLabels, "gdpr_blocked", []string{"true", "false"})
+	for _, l := range cookieLabels {
+		_ = m.adaptCookieSync.With(l)
 	}
 }
 

--- a/pbsmetrics/prometheus/prometheus.go
+++ b/pbsmetrics/prometheus/prometheus.go
@@ -92,12 +92,12 @@ func NewMetrics(cfg config.PrometheusMetrics) *Metrics {
 	metrics.Registry.MustRegister(metrics.adaptErrors)
 	metrics.cookieSync = newCookieSync(cfg)
 	metrics.Registry.MustRegister(metrics.cookieSync)
-	metrics.adaptCookieSync = newCounter(cfg, "adapter_cookie_sync",
+	metrics.adaptCookieSync = newCounter(cfg, "cookie_sync_returns",
 		"Number of syncs generated for a bidder, and if they were subsequently blocked.",
 		[]string{"adapter", "gdpr_blocked"},
 	)
 	metrics.Registry.MustRegister(metrics.adaptCookieSync)
-	metrics.userID = newCounter(cfg, "usersync_total",
+	metrics.userID = newCounter(cfg, "setuid_calls",
 		"Number of user ID syncs performed",
 		[]string{"action", "bidder"},
 	)


### PR DESCRIPTION
We can see per adapter how often an adapter user sync is GDPR blocked in the `/cookie-sync` endpoint.