### PR TITLE
Beachfront bidder - stop gap measure for cookie syncs for  live users

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -17,17 +17,12 @@ const Seat = "beachfront"
 const BidCapacity = 5
 
 const BannerEndpoint = "http://display.bfmio.com/prebid_display"
-
-// const BannerEndpoint = "http://qa.bfmio.com/prebid_display"
-
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
-
-// const VideoEndpoint = "https://qa.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 
 const beachfrontAdapterName = "BF_PREBID_S2S"
-const beachfrontAdapterVersion = "0.2.1"
+const beachfrontAdapterVersion = "0.2.2"
 
 type BeachfrontAdapter struct {
 }
@@ -44,8 +39,7 @@ type BeachfrontRequests struct {
 type BeachfrontVideoRequest struct {
 	IsPrebid bool   `json:"isPrebid"`
 	AppId    string `json:"appId"`
-	ID       string `json:"id"` // This ID is unique to this client page load and is sent by
-	// prebid.js. I'm sending it with banner requests as "requestId" for possible future reporting.
+	ID       string `json:"id"`
 	Imp    []BeachfrontVideoImp  `json:"imp"`
 	Site   openrtb.Site          `json:"site"`
 	Device BeachfrontVideoDevice `json:"device"`
@@ -57,10 +51,8 @@ type BeachfrontVideoRequest struct {
 type BeachfrontVideoImp struct {
 	Video    BeachfrontSize `json:"video"`
 	Bidfloor float64        `json:"bidfloor"`
-	Id       int            `json:"id"` // A sequential count of which imp on the page this is. Since the bfm
-	// 	video endpoint only returns one response for one imp, this is
-	//	never going to happen. This will always be 0. @TODO - Alex
-	ImpId  string `json:"impid"` // DNE in openRTB, would be "ID"
+	Id       int            `json:"id"`
+	ImpId  string `json:"impid"`
 	Secure int8   `json:"secure"`
 }
 
@@ -94,7 +86,7 @@ type BeachfrontBannerRequest struct {
 
 type BeachfrontSlot struct {
 	Slot     string           `json:"slot"`
-	Id       string           `json:"id"` // This is the AppID, aka, exchange id on platform.beachfront.com
+	Id       string           `json:"id"`
 	Bidfloor float64          `json:"bidfloor"`
 	Sizes    []BeachfrontSize `json:"sizes"`
 }
@@ -251,9 +243,9 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 				beachfrontReq.DeviceOs = req.Device.OS
 				beachfrontReq.Dnt = req.Device.DNT
 				if req.Device.UA != "" {
-					beachfrontReq.UA = req.Device.UA // The UA in the header that is sent to bfm is the Go
-				} // UA. I can set that to the same UA that is used here
-			} // if any logic is based off of that. @TODO - Alex
+					beachfrontReq.UA = req.Device.UA
+				}
+			}
 
 			beachfrontReq.Slots[bannerImpsIndex].Bidfloor = beachfrontExt.BidFloor
 			beachfrontReq.Slots[bannerImpsIndex].Slot = req.Imp[bannerImpsIndex].ID

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -37,14 +37,14 @@ type BeachfrontRequests struct {
 // ---------------------------------------------------
 
 type BeachfrontVideoRequest struct {
-	IsPrebid bool   `json:"isPrebid"`
-	AppId    string `json:"appId"`
-	ID       string `json:"id"`
-	Imp    []BeachfrontVideoImp  `json:"imp"`
-	Site   openrtb.Site          `json:"site"`
-	Device BeachfrontVideoDevice `json:"device"`
-	User   openrtb.User          `json:"user"`
-	Cur    []string              `json:"cur"`
+	IsPrebid bool                  `json:"isPrebid"`
+	AppId    string                `json:"appId"`
+	ID       string                `json:"id"`
+	Imp      []BeachfrontVideoImp  `json:"imp"`
+	Site     openrtb.Site          `json:"site"`
+	Device   BeachfrontVideoDevice `json:"device"`
+	User     openrtb.User          `json:"user"`
+	Cur      []string              `json:"cur"`
 }
 
 // Soooo close, but not quite openRTB
@@ -52,8 +52,8 @@ type BeachfrontVideoImp struct {
 	Video    BeachfrontSize `json:"video"`
 	Bidfloor float64        `json:"bidfloor"`
 	Id       int            `json:"id"`
-	ImpId  string `json:"impid"`
-	Secure int8   `json:"secure"`
+	ImpId    string         `json:"impid"`
+	Secure   int8           `json:"secure"`
 }
 
 type BeachfrontVideoDevice struct {

--- a/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
+++ b/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
@@ -56,7 +56,7 @@
           "dnt": 0,
           "ua": "",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.2.1",
+          "adapterVersion": "0.2.2",
           "user": {
           }
         }

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-banner.json
@@ -57,7 +57,7 @@
           "dnt": 0,
           "ua": "",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.2.1",
+          "adapterVersion": "0.2.2",
           "user": {
           }
         }

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
@@ -56,7 +56,7 @@
             "dnt": 0,
             "ua": "",
             "adapterName": "BF_PREBID_S2S",
-            "adapterVersion": "0.2.1",
+            "adapterVersion": "0.2.2",
             "user": {
             }
           }

--- a/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
@@ -96,7 +96,7 @@
           "dnt": 1,
           "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.2.1",
+          "adapterVersion": "0.2.2",
           "user": {
             "buyeruid": "some-buyer",
             "id": "some-user"

--- a/config/config.go
+++ b/config/config.go
@@ -308,9 +308,6 @@ func (cfg *Configuration) setDerivedDefaults() {
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdtelligent, "https://sync.adtelligent.com/csync?t=p&ep=0&redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7Buid%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdform, "https://cm.adform.net/cookie?redirect_url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAppnexus, "https://ib.adnxs.com/getuid?"+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
-	// openrtb_ext.BidderBeachfront - stop gap - this will work for now as our live users are currently
-	// using the appNexus server, which is what pid=155 points to. A new sync endpoint is in the works
-	// which will parse the other values and work on other servers.
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderBeachfront, "https://sync.bfmio.com/syncb?pid=155&gdpr={{.GDPR}}&gc={{.GDPRConsent}}&gce=1&url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dbeachfront%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bio_cid%5D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderBrightroll, "https://pr-bh.ybp.yahoo.com/sync/appnexuspbs?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dbrightroll%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUID%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderConversant, "https://prebid-match.dotomi.com/prebid/match?rurl="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D")

--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,7 @@ func (cfg *Configuration) GetCachedAssetURL(uuid string) string {
 func (cfg *Configuration) setDerivedDefaults() {
 	externalURL := cfg.ExternalURL
 	// openrtb_ext.Bidder33Across doesn't have a good default.
-	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdkernelAdn, "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3DadkernelAdn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUID%7D")
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdkernelAdn, "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3DadkernelAdn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7BUID%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdtelligent, "https://sync.adtelligent.com/csync?t=p&ep=0&redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7Buid%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdform, "https://cm.adform.net/cookie?redirect_url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAppnexus, "https://ib.adnxs.com/getuid?"+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")

--- a/config/config.go
+++ b/config/config.go
@@ -304,11 +304,14 @@ func (cfg *Configuration) GetCachedAssetURL(uuid string) string {
 func (cfg *Configuration) setDerivedDefaults() {
 	externalURL := cfg.ExternalURL
 	// openrtb_ext.Bidder33Across doesn't have a good default.
-	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdkernelAdn, "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3DadkernelAdn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7BUID%7D")
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdkernelAdn, "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3DadkernelAdn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUID%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdtelligent, "https://sync.adtelligent.com/csync?t=p&ep=0&redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadtelligent%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7Buid%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAdform, "https://cm.adform.net/cookie?redirect_url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadform%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderAppnexus, "https://ib.adnxs.com/getuid?"+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
-	// openrtb_ext.BidderBeachfront doesn't have a good default.
+	// openrtb_ext.BidderBeachfront - stop gap - this will work for now as our live users are currently
+	// using the appNexus server, which is what pid=155 points to. A new sync endpoint is in the works
+	// which will parse the other values and work on other servers.
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderBeachfront, "https://sync.bfmio.com/syncb?pid=155&gdpr={{.GDPR}}&gc={{.GDPRConsent}}&gce=1&url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dbeachfront%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bio_cid%5D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderBrightroll, "https://pr-bh.ybp.yahoo.com/sync/appnexuspbs?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&url="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dbrightroll%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUID%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderConversant, "https://prebid-match.dotomi.com/prebid/match?rurl="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dconversant%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderEPlanning, "https://sync.e-planning.net/um?uid"+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Deplanning%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")


### PR DESCRIPTION
This is a usable default for live users until we get a new sync endpoint set up. The new sync endpoint will behave as expected, reading the redirect url from the query string. The pid=155 is a temporary measure to make this work with the current sync endpoint, defaulting to point at https://prebid.adnxs.com/pbs/v1/setuid. The rest of the query parameters are ignored for now, but they are representative of what the new sync endpoint will be looking for.