### PR TITLE
Add support for Universal ID module (user.ext.tpid)

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -69,6 +69,7 @@ type rubiconUserExt struct {
 	RP        rubiconUserExtRP              `json:"rp"`
 	DigiTrust *openrtb_ext.ExtUserDigiTrust `json:"digitrust"`
 	Consent   string                        `json:"consent,omitempty"`
+	TpID      []openrtb_ext.ExtUserTpID     `json:"tpid,omitempty"`
 }
 
 type rubiconSiteExtRP struct {
@@ -593,6 +594,7 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.
 					userExtRP.DigiTrust = userExt.DigiTrust
 				}
 				userExtRP.Consent = userExt.Consent
+				userExtRP.TpID = userExt.TpID
 			}
 
 			userCopy.Ext, err = json.Marshal(&userExtRP)

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1031,11 +1031,18 @@ func TestOpenRTBRequest(t *testing.T) {
 		},
 		User: &openrtb.User{
 			Ext: json.RawMessage(`{"digitrust": {
-				"id": "some-digitrust-id",
-				"keyv": 1,
-				"pref": 0
-
-			}}`),
+                    "id": "some-digitrust-id",
+                    "keyv": 1,
+                    "pref": 0
+                },
+                "tpid": [{
+                    "source": "tdid",
+                    "uid": "3d50a262-bd8e-4be3-90b8-246291523907"
+                },{
+                    "source": "pubcid",
+                    "uid": "2402fc76-7b39-4f0e-bfc2-060ef7693648"
+                }]
+            }`),
 		},
 	}
 
@@ -1117,6 +1124,9 @@ func TestOpenRTBRequest(t *testing.T) {
 			}
 			if userExt.DigiTrust.ID != "some-digitrust-id" || userExt.DigiTrust.KeyV != 1 || userExt.DigiTrust.Pref != 0 {
 				t.Fatal("DigiTrust values are not as expected!")
+			}
+			if userExt.TpID == nil || len(userExt.TpID) != 2 {
+				t.Fatal("TpID values are not as expected!")
 			}
 		} else {
 			t.Fatalf("User.Ext object should not be nil since it contains a valid digitrust object.")

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -789,6 +789,20 @@ func validateUser(user *openrtb.User, aliases map[string]string) error {
 					}
 				}
 			}
+			// Check Universal User ID
+			if userExt.TpID != nil {
+				if len(userExt.TpID) == 0 {
+					return fmt.Errorf("request.user.ext.tpid must contain at least one element or be undefined")
+				}
+				for tpidIndex, tpid := range userExt.TpID {
+					if tpid.Source == "" {
+						return fmt.Errorf("request.user.ext.tpid[%d] missing required field: \"source\"", tpidIndex)
+					}
+					if tpid.UID == "" {
+						return fmt.Errorf("request.user.ext.tpid[%d] missing required field: \"uid\"", tpidIndex)
+					}
+				}
+			}
 		} else {
 			// Return error.
 			return fmt.Errorf("request.user.ext object is not valid: %v", err)

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-empty.json
@@ -1,0 +1,48 @@
+{
+  "message": "Invalid request: request.user.ext.tpid must contain at least one element or be undefined\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "tpid": []
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-source-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-source-empty.json
@@ -1,0 +1,50 @@
+{
+  "message": "Invalid request: request.user.ext.tpid[0] missing required field: \"source\"\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "tpid": [
+          {}
+        ]
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-uid-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-tpid-uid-empty.json
@@ -1,0 +1,52 @@
+{
+  "message": "Invalid request: request.user.ext.tpid[0] missing required field: \"uid\"\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "tpid": [
+          {
+            "source": "tpid-source1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/openrtb_ext/user.go
+++ b/openrtb_ext/user.go
@@ -2,7 +2,6 @@ package openrtb_ext
 
 // ExtUser defines the contract for bidrequest.user.ext
 type ExtUser struct {
-
 	// Consent is a GDPR consent string. See "Advised Extensions" of
 	// https://iabtechlab.com/wp-content/uploads/2018/02/OpenRTB_Advisory_GDPR_2018-02.pdf
 	Consent string `json:"consent,omitempty"`
@@ -13,6 +12,8 @@ type ExtUser struct {
 	// to match the recommendation from the broader digitrust community.
 	// For more info, see: https://github.com/digi-trust/dt-cdn/wiki/OpenRTB-extension#openrtb-2x
 	DigiTrust *ExtUserDigiTrust `json:"digitrust,omitempty"`
+
+	TpID []ExtUserTpID `json:"tpid,omitempty"`
 }
 
 // ExtUserPrebid defines the contract for bidrequest.user.ext.prebid
@@ -26,4 +27,11 @@ type ExtUserDigiTrust struct {
 	ID   string `json:"id"`   // Unique device identifier
 	KeyV int    `json:"keyv"` // Key version used to encrypt ID
 	Pref int    `json:"pref"` // User optout preference
+}
+
+// ExtUserTpID defines the contract for bidrequest.user.ext.tpid
+// Responsible for the Universal User ID support: establishing pseudonymous IDs for users.
+type ExtUserTpID struct {
+	Source string `json:"source"`
+	UID    string `json:"uid"`
 }


### PR DESCRIPTION
The **Universal User ID** module supports multiple ways of establishing pseudonymous IDs for users, which is an important way of increasing the value of header bidding. Instead of having several exchanges sync IDs with dozens of demand sources, a publisher can choose to integrate with one of these ID schemes:

- **Unified ID** – a simple cross-vendor approach – it calls out to a URL that responds with that user’s ID in one or more ID spaces (e.g. TradeDesk). The result is stored in the user’s browser for future requests and is passed to bidder adapters to pass it through to SSPs and DSPs that support the ID scheme.
- **PubCommon ID** – an ID is generated on the user’s browser and stored for later use on this publisher’s domain.

The OpenRTB request example:
```
{
  "user": {
    "ext": {
      "tpid": [{
        "source": "tdid",
        "uid": "19cfaea8-a429-48fc-9537-8a19a8eb4f0c"
      },
      {
        "source": "pubcid",
        "uid": "29cfaea8-a429-48fc-9537-8a19a8eb4f0d"
      }]
    }
  }
}
```
