### PR TITLE
* added gzip support

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,6 +89,10 @@
   name = "github.com/prebid/go-gdpr"
   version = "^0.6.1"
 
+[[constraint]]
+  name = "github.com/NYTimes/gziphandler"
+  version = "~1.1.0"  
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	Port        int        `mapstructure:"port"`
 	Client      HTTPClient `mapstructure:"http_client"`
 	AdminPort   int        `mapstructure:"admin_port"`
+	EnableGzip  bool       `mapstructure:"enable_gzip"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
 	StatusResponse  string          `mapstructure:"status_response"`
@@ -364,6 +365,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host", "")
 	v.SetDefault("port", 8000)
 	v.SetDefault("admin_port", 6060)
+	v.SetDefault("enable_gzip", false)
 	v.SetDefault("status_response", "")
 	v.SetDefault("auction_timeouts_ms.default", 0)
 	v.SetDefault("auction_timeouts_ms.max", 0)

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/golang/glog"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -72,12 +73,18 @@ func newAdminServer(cfg *config.Configuration, handler http.Handler) *http.Serve
 }
 
 func newMainServer(cfg *config.Configuration, handler http.Handler) *http.Server {
+	var serverHandler = handler
+	if cfg.EnableGzip {
+		serverHandler = gziphandler.GzipHandler(handler)
+	}
+
 	return &http.Server{
 		Addr:         cfg.Host + ":" + strconv.Itoa(cfg.Port),
-		Handler:      handler,
+		Handler:      serverHandler,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 	}
+
 }
 
 func runServer(server *http.Server, name string, listener net.Listener) {


### PR DESCRIPTION
I would like to optionally add gzipped responses.
With this PR it's possible to set enable_gzip: true in the pbs.yml, which makes the server gzip the response when possible.
the default behavior is unchanged. 