### PR TITLE
Gamoshi: Prebid server bidder adapter

### DIFF
--- a/adapters/gamoshi/gamoshi.go
+++ b/adapters/gamoshi/gamoshi.go
@@ -1,0 +1,185 @@
+package gamoshi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/errortypes"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type GamoshiAdapter struct {
+	URI string
+}
+
+func (a *GamoshiAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.RequestData, []error) {
+
+	errs := make([]error, 0, len(request.Imp))
+	if len(request.Imp) == 0 {
+		err := &errortypes.BadInput{
+			Message: "No impressions in the bid request",
+		}
+		errs = append(errs, err)
+		return nil, errs
+	}
+
+	// As of now, Gamoshi supports only banner and video impressions
+
+	validImpExists := false
+	for i := 0; i < len(request.Imp); i++ {
+		if request.Imp[i].Banner != nil {
+			bannerCopy := *request.Imp[i].Banner
+			if bannerCopy.W == nil && bannerCopy.H == nil && len(bannerCopy.Format) > 0 {
+				firstFormat := bannerCopy.Format[0]
+				bannerCopy.W = &(firstFormat.W)
+				bannerCopy.H = &(firstFormat.H)
+			}
+			request.Imp[i].Banner = &bannerCopy
+			validImpExists = true
+		} else if request.Imp[i].Video != nil {
+			validImpExists = true
+		} else {
+			err := &errortypes.BadInput{
+				Message: fmt.Sprintf("Gamoshi only supports banner and video media types. Ignoring imp id=%s", request.Imp[i].ID),
+			}
+			glog.Warning("Gamoshi SUPPORT VIOLATION: only banner and video media types supported")
+			errs = append(errs, err)
+			request.Imp = append(request.Imp[:i], request.Imp[i+1:]...)
+			i--
+		}
+	}
+
+	if !validImpExists {
+		err := &errortypes.BadInput{
+			Message: fmt.Sprintf("No valid impression in the bid request"),
+		}
+		errs = append(errs, err)
+		return nil, errs
+	}
+
+	reqJSON, err := json.Marshal(request)
+	if err != nil {
+		errs = append(errs, err)
+		return nil, errs
+	}
+	errors := make([]error, 0, 1)
+
+	var bidderExt adapters.ExtImpBidder
+	err = json.Unmarshal(request.Imp[0].Ext, &bidderExt)
+
+	if err != nil {
+		err = &errortypes.BadInput{
+			Message: "ext.bidder not provided",
+		}
+		errors = append(errors, err)
+		return nil, errors
+	}
+	var gamoshiExt openrtb_ext.ExtImpGamoshi
+	err = json.Unmarshal(bidderExt.Bidder, &gamoshiExt)
+	if err != nil {
+		err = &errortypes.BadInput{
+			Message: "ext.bidder.supplyPartnerId not provided",
+		}
+		errors = append(errors, err)
+		return nil, errors
+	}
+
+	if gamoshiExt.SupplyPartnerId == "" {
+		err = &errortypes.BadInput{
+			Message: "supplyPartnerId is empty",
+		}
+		errors = append(errors, err)
+		return nil, errors
+	}
+
+	thisURI := a.URI
+	if len(thisURI) == 0 {
+		thisURI = "https://rtb.gamoshi.io"
+	}
+	thisURI = thisURI + "/r/" + gamoshiExt.SupplyPartnerId + "/bidr"
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+	headers.Add("x-openrtb-version", "2.5")
+
+	if request.Device != nil {
+		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
+		addHeaderIfNonEmpty(headers, "X-Forwarded-For", request.Device.IP)
+		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
+		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+	}
+
+	return []*adapters.RequestData{{
+		Method:  "POST",
+		Uri:     thisURI,
+		Body:    reqJSON,
+		Headers: headers,
+	}}, errors
+}
+
+func (a *GamoshiAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+
+	if response.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	if response.StatusCode == http.StatusBadRequest {
+		return nil, []error{&errortypes.BadInput{
+			Message: fmt.Sprintf("Unexpected status code: %d. ", response.StatusCode),
+		}}
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode),
+		}}
+	}
+
+	var bidResp openrtb.BidResponse
+	if err := json.Unmarshal(response.Body, &bidResp); err != nil {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("bad server response: %d. ", err),
+		}}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(bidResp.SeatBid[0].Bid))
+	sb := bidResp.SeatBid[0]
+	for i := 0; i < len(sb.Bid); i++ {
+		bid := sb.Bid[i]
+		bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+			Bid:     &bid,
+			BidType: getMediaType(bid.ImpID, internalRequest.Imp),
+		})
+	}
+	return bidResponse, nil
+}
+
+// Adding header fields to request header
+func addHeaderIfNonEmpty(headers http.Header, headerName string, headerValue string) {
+	if len(headerValue) > 0 {
+		headers.Add(headerName, headerValue)
+	}
+}
+
+func getMediaType(impId string, imps []openrtb.Imp) openrtb_ext.BidType {
+	for _, imp := range imps {
+		if imp.ID == impId {
+			if imp.Video != nil {
+				return openrtb_ext.BidTypeVideo
+			}
+			return openrtb_ext.BidTypeBanner
+		}
+	}
+	return openrtb_ext.BidTypeBanner
+}
+
+func NewGamoshiBidder(endpoint string) *GamoshiAdapter {
+	return &GamoshiAdapter{
+		URI: endpoint,
+	}
+}

--- a/adapters/gamoshi/gamoshi.go
+++ b/adapters/gamoshi/gamoshi.go
@@ -143,7 +143,7 @@ func (a *GamoshiAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalR
 	var bidResp openrtb.BidResponse
 	if err := json.Unmarshal(response.Body, &bidResp); err != nil {
 		return nil, []error{&errortypes.BadServerResponse{
-			Message: fmt.Sprintf("bad server response: %d. ", err),
+			Message: fmt.Sprintf("bad server response: %v. ", err),
 		}}
 	}
 

--- a/adapters/gamoshi/gamoshi.go
+++ b/adapters/gamoshi/gamoshi.go
@@ -101,11 +101,11 @@ func (a *GamoshiAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.
 	if len(thisURI) == 0 {
 		thisURI = "https://rtb.gamoshi.io"
 	}
-	thisURI = thisURI + "/r/" + gamoshiExt.SupplyPartnerId + "/bidr"
+	thisURI = thisURI + "/r/" + gamoshiExt.SupplyPartnerId + "/bidr?reqformat=RTB_JSON"
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
-	headers.Add("x-openrtb-version", "2.5")
+	headers.Add("x-openrtb-version", "2.4")
 
 	if request.Device != nil {
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)

--- a/adapters/gamoshi/gamoshi_test.go
+++ b/adapters/gamoshi/gamoshi_test.go
@@ -1,0 +1,11 @@
+package gamoshi
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/adapters/adapterstest"
+)
+
+func TestJsonSamples(t *testing.T) {
+	adapterstest.RunJSONBidderTest(t, "gamoshitest", NewGamoshiBidder("https://rtb.gamoshi.io"))
+}

--- a/adapters/gamoshi/gamoshi_test.go
+++ b/adapters/gamoshi/gamoshi_test.go
@@ -8,4 +8,5 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	adapterstest.RunJSONBidderTest(t, "gamoshitest", NewGamoshiBidder("https://rtb.gamoshi.io"))
+	adapterstest.RunJSONBidderTest(t, "gamoshitest", NewGamoshiBidder(""))
 }

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-and-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-and-audio.json
@@ -1,0 +1,118 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-audio-imp",
+        "audio": {
+          "mimes": [
+            "video/mp4"
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ],
+                "w": 300,
+                "h": 250
+               },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["gamoshi.com"],
+                "cid": "958",
+                "crid": "29681110",
+                "h": 250,
+                "w": 300
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "7706636740145184841",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "adid": "29681110",
+        "adomain": ["gamoshi.com"],
+        "cid": "958",
+        "crid": "29681110",
+        "w": 300,
+        "h": 250
+      },
+      "type": "banner"
+    }
+  ]
+
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-and-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-and-audio.json
@@ -40,7 +40,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-and-video.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-and-video.json
@@ -1,0 +1,133 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "test-imp-video-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            },
+            {
+              "id": "test-imp-video-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-video-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["gamoshi.com"],
+                "cid": "958",
+                "crid": "29681110",
+                "h": 576,
+                "w": 1024
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "7706636740145184841",
+        "impid": "test-imp-video-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "adid": "29681110",
+        "adomain": ["gamoshi.com"],
+        "cid": "958",
+        "crid": "29681110",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-and-video.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-and-video.json
@@ -41,7 +41,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-native-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-native-audio.json
@@ -1,0 +1,130 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-native-imp",
+        "native": {
+          "ver": "1.1",
+          "request": "{\"ver\":\"1.1\",\"context\":1,\"contextsubtype\":11,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":500}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":1,\"hmin\":1}},{\"id\":3,\"required\":0,\"data\":{\"type\":1,\"len\":200}},{\"id\":4,\"required\":0,\"data\":{\"type\":2,\"len\":15000}},{\"id\":5,\"required\":0,\"data\":{\"type\":6,\"len\":40}},{\"id\":6,\"required\":0,\"data\":{\"type\":500}}]}"
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-audio-imp",
+        "audio": {
+          "mimes": [
+            "video/mp4"
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["gamoshi.com"],
+                "cid": "958",
+                "crid": "29681110",
+                "h": 250,
+                "w": 300
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "7706636740145184841",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "adid": "29681110",
+        "adomain": ["gamoshi.com"],
+        "cid": "958",
+        "crid": "29681110",
+        "w": 300,
+        "h": 250
+      },
+      "type": "banner"
+    }
+  ]
+
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-native-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-native-audio.json
@@ -52,7 +52,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-video-native.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-video-native.json
@@ -1,0 +1,145 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-native-imp",
+        "native": {
+          "ver": "1.1",
+          "request": "{\"ver\":\"1.1\",\"context\":1,\"contextsubtype\":11,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":500}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":1,\"hmin\":1}},{\"id\":3,\"required\":0,\"data\":{\"type\":1,\"len\":200}},{\"id\":4,\"required\":0,\"data\":{\"type\":2,\"len\":15000}},{\"id\":5,\"required\":0,\"data\":{\"type\":6,\"len\":40}},{\"id\":6,\"required\":0,\"data\":{\"type\":500}}]}"
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "test-imp-video-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            },
+            {
+              "id": "test-imp-video-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-video-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["gamoshi.com"],
+                "cid": "958",
+                "crid": "29681110",
+                "h": 576,
+                "w": 1024
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "7706636740145184841",
+        "impid": "test-imp-video-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "adid": "29681110",
+        "adomain": ["gamoshi.com"],
+        "cid": "958",
+        "crid": "29681110",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/banner-video-native.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/banner-video-native.json
@@ -53,7 +53,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/simple-banner.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/simple-banner.json
@@ -1,0 +1,105 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["yahoo.com"],
+                "cid": "958",
+                "crid": "29681110",
+                "h": 250,
+                "w": 300
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "7706636740145184841",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "adid": "29681110",
+        "adomain": ["gamoshi.com"],
+        "cid": "958",
+        "crid": "29681110",
+        "w": 300,
+        "h": 250
+      },
+      "type": "banner"
+    }
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/simple-banner.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/simple-banner.json
@@ -28,7 +28,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/simple-video.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/simple-video.json
@@ -1,0 +1,84 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "Gamoshi",
+              "bid": [{
+                "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adm": "some-test-ad",
+                "crid": "crid_10",
+                "w": 1024,
+                "h": 576
+              }]
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "crid": "crid_10",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/simple-video.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/simple-video.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/valid-extension.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/valid-extension.json
@@ -1,0 +1,84 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+           }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "gamoshi",
+              "bid": [{
+                "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adm": "some-test-ad",
+                "crid": "crid_10",
+                "w": 1024,
+                "h": 576
+              }]
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "crid": "crid_10",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/valid-extension.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/valid-extension.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/exemplary/valid-with-device.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/valid-with-device.json
@@ -1,0 +1,104 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "device": {
+      "ip": "3.0.0.0",
+      "ua": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.170 Safari/537.36"
+    },
+    "imp": [
+      {
+        "id": "test-imp-video-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-audio-imp",
+        "audio": {
+          "mimes": [
+            "video/mp4"
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
+        "body": {
+          "id": "test-request-id",
+          "device": {
+            "ip": "3.0.0.0",
+            "ua": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.170 Safari/537.36"
+          },
+          "imp": [
+            {
+              "id": "test-imp-video-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "gamoshi",
+              "bid": [{
+                "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                "impid": "test-imp-video-id",
+                "price": 0.500000,
+                "adm": "some-test-ad",
+                "crid": "crid_10",
+                "w": 1024,
+                "h": 576
+              }]
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+        "impid": "test-imp-video-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "crid": "crid_10",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/video-and-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/video-and-audio.json
@@ -1,0 +1,96 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-video-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      },
+      {
+        "id": "unsupported-audio-imp",
+        "audio": {
+          "mimes": [
+            "video/mp4"
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-video-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "gamoshi",
+              "bid": [{
+                "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                "impid": "test-imp-video-id",
+                "price": 0.500000,
+                "adm": "some-test-ad",
+                "crid": "crid_10",
+                "w": 1024,
+                "h": 576
+              }]
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+      "bid": {
+        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+        "impid": "test-imp-video-id",
+        "price": 0.5,
+        "adm": "some-test-ad",
+        "crid": "crid_10",
+        "w": 1024,
+        "h": 576
+      },
+      "type": "video"
+    }
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/exemplary/video-and-audio.json
+++ b/adapters/gamoshi/gamoshitest/exemplary/video-and-audio.json
@@ -34,7 +34,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://rtb.gamoshi.io/r/1707/bidr",
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/gamoshi/gamoshitest/params/race/banner.json
+++ b/adapters/gamoshi/gamoshitest/params/race/banner.json
@@ -1,0 +1,3 @@
+{
+  "supplyPartnerId": "1707"
+}

--- a/adapters/gamoshi/gamoshitest/params/race/video.json
+++ b/adapters/gamoshi/gamoshitest/params/race/video.json
@@ -1,0 +1,3 @@
+{
+  "supplyPartnerId": "1707"
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/audio.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/audio.json
@@ -1,0 +1,23 @@
+{
+  "mockBidRequest": {
+    "id": "unsupported-audio-request",
+    "imp": [
+      {
+        "id": "unsupported-audio-imp",
+        "audio": {
+          "mimes": ["video/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+
+  "expectedMakeRequestsErrors": [
+    "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
+    "No valid impression in the bid request"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-request-no-imps.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-request-no-imps.json
@@ -1,0 +1,7 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": []
+  },
+  "expectedMakeRequestsErrors": ["No impressions in the bid request"]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-request.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-request.json
@@ -1,0 +1,31 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "invalidbanner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    "Gamoshi only supports banner and video media types. Ignoring imp id=test-imp-id",
+    "No valid impression in the bid request"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-response-no-body.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-response-no-body.json
@@ -1,0 +1,54 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+           }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    "bad server response: unexpected end of JSON input. "
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-extension.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-extension.json
@@ -1,0 +1,28 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-invalid-ext-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+        }
+
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+       "ext.bidder.supplyPartnerId not provided"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-imp-no-supplyPartnerId.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-imp-no-supplyPartnerId.json
@@ -1,0 +1,20 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-request-imp",
+        "video": {
+          "mimes": ["video/mp4"]
+        },
+        "ext": {
+          "bidder": {
+          }
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    "supplyPartnerId is empty"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-imp.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-imp.json
@@ -1,0 +1,13 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "ext": {
+      "bidder": {
+        "supplyPartnerId": "1707"
+      }
+    }
+  },
+  "expectedMakeRequestsErrors": [
+    "No impressions in the bid request"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/missing-extension.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/missing-extension.json
@@ -1,0 +1,19 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-missing-ext-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+  "ext.bidder not provided"
+]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/missing-param.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/missing-param.json
@@ -1,0 +1,31 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-missing-req-param-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisher":""
+          }
+        }
+
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    "supplyPartnerId is empty"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/native.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/native.json
@@ -1,0 +1,23 @@
+{
+  "mockBidRequest": {
+    "id": "unsupported-native-request",
+    "imp": [
+      {
+        "id": "unsupported-native-imp",
+        "native": {
+          "ver": "1.1"
+        },
+        "ext": {
+          "bidder": {
+            "supplyPartnerId": "1707"
+          }
+        }
+      }
+    ]
+  },
+
+  "expectedMakeRequestsErrors": [
+    "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-native-imp",
+    "No valid impression in the bid request"
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/status-bad-request.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/status-bad-request.json
@@ -1,0 +1,55 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+           }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    "Unexpected status code: 400. "
+  ]
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/status-no-content.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/status-no-content.json
@@ -1,0 +1,53 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+           }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": []
+}

--- a/adapters/gamoshi/gamoshitest/supplemental/unexpected-status-code.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/unexpected-status-code.json
@@ -1,0 +1,55 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "ext":{
+          "bidder":{
+            "supplyPartnerId": "1707"
+           }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.gamoshi.io/r/1707/bidr?reqformat=RTB_JSON",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "ext": {
+                "bidder": {
+                  "supplyPartnerId": "1707"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    "unexpected status code: 500. Run with request.debug = 1 for more info"
+  ]
+}

--- a/adapters/gamoshi/params_test.go
+++ b/adapters/gamoshi/params_test.go
@@ -1,0 +1,59 @@
+package gamoshi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+// This file actually intends to test static/bidder-params/gamoshi.json
+//
+// These also validate the format of the external API: request.imp[i].ext.gamoshi
+
+// TestValidParams makes sure that the Gamoshi schema accepts all imp.ext fields which we intend to support.
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderGamoshi, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected Gamoshi params: %s", validParam)
+		}
+	}
+}
+
+// TestInvalidParams makes sure that the Gamoshi schema rejects all the imp.ext fields we don't support.
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderGamoshi, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"supplyPartnerId": "123"}`,
+	`{"supplyPartnerId": "test", "headerbidding": false}`,
+}
+
+var invalidParams = []string{
+	`{"supplyPartnerId": 100}`,
+	`{"supplyPartnerId": false}`,
+	`{"supplyPartnerId": true}`,
+	`{"supplyPartnerId": 123, "headerbidding": true}`,
+	``,
+	`null`,
+	`true`,
+	`9`,
+	`1.2`,
+	`[]`,
+	`{}`,
+}

--- a/adapters/gamoshi/usersync.go
+++ b/adapters/gamoshi/usersync.go
@@ -1,0 +1,12 @@
+package gamoshi
+
+import (
+	"text/template"
+
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/usersync"
+)
+
+func NewGamoshiSyncer(temp *template.Template) usersync.Usersyncer {
+	return adapters.NewSyncer("gamoshi", 0, temp, adapters.SyncTypeRedirect)
+}

--- a/adapters/gamoshi/usersync_test.go
+++ b/adapters/gamoshi/usersync_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestGamoshiSyncer(t *testing.T) {
-	temp := template.Must(template.New("sync-template").Parse("//rtb.gamoshi.io/getuid?https%3A%2F%2Frtb.gamoshi.io/%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID"))
+
+	temp := template.Must(template.New("sync-template").Parse("https://rtb.gamoshi.io/pix/1707/scm?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&rurl=localhost/setuid%3Fbidder%3Dgamoshi%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bgusr%5D"))
 	syncer := NewGamoshiSyncer(temp)
 	syncInfo, err := syncer.GetUsersyncInfo("", "")
 	assert.NoError(t, err)
-	assert.Equal(t, "//rtb.gamoshi.io/getuid?https%3A%2F%2Frtb.gamoshi.io%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24UID", syncInfo.URL)
+	assert.Equal(t, "https://rtb.gamoshi.io/pix/1707/scm?gdpr=&consent=&rurl=localhost/setuid%3Fbidder%3Dgamoshi%26gdpr%3D%26gdpr_consent%3D%26uid%3D%5Bgusr%5D", syncInfo.URL)
 	assert.Equal(t, "redirect", syncInfo.Type)
-	assert.EqualValues(t, 32, syncer.GDPRVendorID())
+	assert.EqualValues(t, 0, syncer.GDPRVendorID())
 	assert.Equal(t, false, syncInfo.SupportCORS)
 }

--- a/adapters/gamoshi/usersync_test.go
+++ b/adapters/gamoshi/usersync_test.go
@@ -1,0 +1,19 @@
+package gamoshi
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGamoshiSyncer(t *testing.T) {
+	temp := template.Must(template.New("sync-template").Parse("//rtb.gamoshi.io/getuid?https%3A%2F%2Frtb.gamoshi.io/%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID"))
+	syncer := NewGamoshiSyncer(temp)
+	syncInfo, err := syncer.GetUsersyncInfo("", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "//rtb.gamoshi.io/getuid?https%3A%2F%2Frtb.gamoshi.io%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dadnxs%26gdpr%3D%26gdpr_consent%3D%26uid%3D%24UID", syncInfo.URL)
+	assert.Equal(t, "redirect", syncInfo.Type)
+	assert.EqualValues(t, 32, syncer.GDPRVendorID())
+	assert.Equal(t, false, syncInfo.SupportCORS)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -341,6 +341,8 @@ func (cfg *Configuration) setDerivedDefaults() {
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSovrn, "https://ap.lijit.com/pixel?redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSonobi, "https://sync.go.sonobi.com/us.gif?loc="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsonobi%26consent_string%3D{{.GDPR}}%26gdpr%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderYieldmo, "https://ads.yieldmo.com/pbsync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&redirectUri="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dyieldmo%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderGamoshi, "https://rtb.gamoshi.io/pix/{{.supplyPartnerId}}/scm?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&rurl="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dgamoshi%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bgusr%5D")
+
 }
 
 func setDefaultUsersync(m map[string]Adapter, bidder openrtb_ext.BidderName, defaultValue string) {
@@ -464,6 +466,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.grid.endpoint", "http://grid.bidswitch.net/sp_bid?sp=prebid")
 	v.SetDefault("adapters.sonobi.endpoint", "https://apex.go.sonobi.com/bid?partnerid=71d9d3d8af")
 	v.SetDefault("adapters.yieldmo.endpoint", "http://ads.yieldmo.com/exchange/prebid-server")
+	v.SetDefault("adapters.gamoshi.endpoint", "https://rtb.gamoshi.io/r/{{.supplyPartnerId}}/bidr")
 
 	v.SetDefault("max_request_size", 1024*256)
 	v.SetDefault("analytics.file.filename", "")

--- a/config/config.go
+++ b/config/config.go
@@ -466,7 +466,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.grid.endpoint", "http://grid.bidswitch.net/sp_bid?sp=prebid")
 	v.SetDefault("adapters.sonobi.endpoint", "https://apex.go.sonobi.com/bid?partnerid=71d9d3d8af")
 	v.SetDefault("adapters.yieldmo.endpoint", "http://ads.yieldmo.com/exchange/prebid-server")
-	v.SetDefault("adapters.gamoshi.endpoint", "https://rtb.gamoshi.io/r/{{.supplyPartnerId}}/bidr")
+	v.SetDefault("adapters.gamoshi.endpoint", "https://rtb.gamoshi.io/r/{{.supplyPartnerId}}/bidr?reqformat=RTB_JSON")
 
 	v.SetDefault("max_request_size", 1024*256)
 	v.SetDefault("analytics.file.filename", "")

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/consumable"
 	"github.com/prebid/prebid-server/adapters/conversant"
 	"github.com/prebid/prebid-server/adapters/eplanning"
+	"github.com/prebid/prebid-server/adapters/gamoshi"
 	"github.com/prebid/prebid-server/adapters/grid"
 	"github.com/prebid/prebid-server/adapters/gumgum"
 	"github.com/prebid/prebid-server/adapters/ix"
@@ -64,6 +65,7 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration, infos adapter
 		openrtb_ext.BidderGrid:         grid.NewGridBidder(cfg.Adapters[string(openrtb_ext.BidderGrid)].Endpoint),
 		openrtb_ext.BidderSonobi:       sonobi.NewSonobiBidder(client, cfg.Adapters[string(openrtb_ext.BidderSonobi)].Endpoint),
 		openrtb_ext.BidderYieldmo:      yieldmo.NewYieldmoBidder(cfg.Adapters[string(openrtb_ext.BidderYieldmo)].Endpoint),
+		openrtb_ext.BidderGamoshi:      gamoshi.NewGamoshiBidder(cfg.Adapters[string(openrtb_ext.BidderGamoshi)].Endpoint),
 	}
 
 	legacyBidders := map[openrtb_ext.BidderName]adapters.Adapter{

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -44,6 +44,7 @@ const (
 	BidderSovrn        BidderName = "sovrn"
 	BidderSonobi       BidderName = "sonobi"
 	BidderYieldmo      BidderName = "yieldmo"
+	BidderGamoshi      BidderName = "gamoshi"
 )
 
 // BidderMap stores all the valid OpenRTB 2.x Bidders in the project. This map *must not* be mutated.
@@ -72,6 +73,7 @@ var BidderMap = map[string]BidderName{
 	"sovrn":           BidderSovrn,
 	"sonobi":          BidderSonobi,
 	"yieldmo":         BidderYieldmo,
+	"gamoshi":         BidderGamoshi,
 }
 
 // BidderList returns the values of the BidderMap

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -31,6 +31,7 @@ const (
 	BidderConversant   BidderName = "conversant"
 	BidderEPlanning    BidderName = "eplanning"
 	BidderFacebook     BidderName = "audienceNetwork"
+	BidderGamoshi      BidderName = "gamoshi"
 	BidderGrid         BidderName = "grid"
 	BidderGumGum       BidderName = "gumgum"
 	BidderIx           BidderName = "ix"
@@ -44,7 +45,6 @@ const (
 	BidderSovrn        BidderName = "sovrn"
 	BidderSonobi       BidderName = "sonobi"
 	BidderYieldmo      BidderName = "yieldmo"
-	BidderGamoshi      BidderName = "gamoshi"
 )
 
 // BidderMap stores all the valid OpenRTB 2.x Bidders in the project. This map *must not* be mutated.
@@ -60,6 +60,7 @@ var BidderMap = map[string]BidderName{
 	"consumable":      BidderConsumable,
 	"conversant":      BidderConversant,
 	"eplanning":       BidderEPlanning,
+	"gamoshi":         BidderGamoshi,
 	"grid":            BidderGrid,
 	"gumgum":          BidderGumGum,
 	"ix":              BidderIx,
@@ -73,7 +74,6 @@ var BidderMap = map[string]BidderName{
 	"sovrn":           BidderSovrn,
 	"sonobi":          BidderSonobi,
 	"yieldmo":         BidderYieldmo,
-	"gamoshi":         BidderGamoshi,
 }
 
 // BidderList returns the values of the BidderMap

--- a/openrtb_ext/imp_gamoshi.go
+++ b/openrtb_ext/imp_gamoshi.go
@@ -1,0 +1,7 @@
+package openrtb_ext
+
+// ExtImpGamoshi defines the contract for bidrequest.imp[i].ext.gamoshi
+type ExtImpGamoshi struct {
+	SupplyPartnerId  string `json:"supplyPartnerId"`
+	FavoredMediaType string `json:"favoredMediaType"`
+}

--- a/static/bidder-info/gamoshi.yaml
+++ b/static/bidder-info/gamoshi.yaml
@@ -1,0 +1,11 @@
+maintainer:
+  email: "moses@gamoshi.com"
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+  site:
+    mediaTypes:
+      - banner
+      - video

--- a/static/bidder-params/gamoshi.json
+++ b/static/bidder-params/gamoshi.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Gamoshi Adapter Params",
+  "description": "A schema which validates params accepted by Gamoshi adapter",
+  "type": "object",
+  "properties": {
+      "supplyPartnerId": {
+        "type": "string",
+        "description": "Supply partner id to use."
+    },
+    "favoredMediaType": {
+      "type": "string",
+      "description": "favored media type"
+    }
+  },
+  "required": ["supplyPartnerId"]
+}

--- a/usersync/usersyncers/syncer.go
+++ b/usersync/usersyncers/syncer.go
@@ -1,6 +1,7 @@
 package usersyncers
 
 import (
+	"github.com/prebid/prebid-server/adapters/gamoshi"
 	"strings"
 	"text/template"
 
@@ -64,6 +65,7 @@ func NewSyncerMap(cfg *config.Configuration) map[openrtb_ext.BidderName]usersync
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderSovrn, sovrn.NewSovrnSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderSonobi, sonobi.NewSonobiSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderYieldmo, yieldmo.NewYieldmoSyncer)
+	insertIntoMap(cfg, syncers, openrtb_ext.BidderGamoshi, gamoshi.NewGamoshiSyncer)
 
 	return syncers
 }

--- a/usersync/usersyncers/syncer_test.go
+++ b/usersync/usersyncers/syncer_test.go
@@ -38,6 +38,7 @@ func TestNewSyncerMap(t *testing.T) {
 			string(openrtb_ext.Bidder33Across):     syncConfig,
 			string(openrtb_ext.BidderSonobi):       syncConfig,
 			string(openrtb_ext.BidderYieldmo):      syncConfig,
+			string(openrtb_ext.BidderGamoshi):      syncConfig,
 		},
 	}
 	for bidder, config := range cfg.Adapters {


### PR DESCRIPTION
## Type of change
[x]  New prebid server bidder adapter

## Description of change

This is Gamoshi's a new prebid server adaptor. 
This adaptor follows openRTB2.5 specification for bid requests. 
This adaptor will reach out to Gamoshi's DSP platform to fetch bids during bidding process.

## Contact Info

Please contact moses@gamoshi.com for issues etc.