### PR TITLE
renaming yieldmo bidder param from placementid to placementId

### DIFF
--- a/adapters/yieldmo/params_test.go
+++ b/adapters/yieldmo/params_test.go
@@ -40,7 +40,7 @@ func TestInvalidParams(t *testing.T) {
 }
 
 var validParams = []string{
-	`{"placementid": "123"}`,
+	`{"placementId": "123"}`,
 }
 
 var invalidParams = []string{

--- a/adapters/yieldmo/yieldmotest/exemplary/simple-banner.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/simple-banner.json
@@ -14,7 +14,7 @@
         },
         "ext": {
           "bidder": {
-            "placementid": "123"
+            "placementId": "123"
           }
         }
       }

--- a/openrtb_ext/imp_yieldmo.go
+++ b/openrtb_ext/imp_yieldmo.go
@@ -2,5 +2,5 @@ package openrtb_ext
 
 // ExtImpYieldmo defines the contract for bidrequest.imp[i].ext.yieldmo
 type ExtImpYieldmo struct {
-	PlacementId string `json:"placementid"`
+	PlacementId string `json:"placementId"`
 }

--- a/static/bidder-params/yieldmo.json
+++ b/static/bidder-params/yieldmo.json
@@ -6,10 +6,10 @@
   
     "type": "object",
     "properties": {
-      "placementid": {
+      "placementId": {
         "type": "string",
         "description": "Internal Yieldmo Placement ID"
       }
     },
-    "required": ["placementid"]
+    "required": ["placementId"]
   }


### PR DESCRIPTION
The Yieldmo js adapter uses the bidder param placementId, and the Yieldmo server to server adapter to use placementid. This branch corrects that mistake and unifies them to both use placementId.