### PR TITLE
PBS-64: Fix HTML-encoding errors

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1,6 +1,7 @@
 package exchange
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -300,8 +301,12 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 	bidResponse.SeatBid = seatBids
 
 	bidResponseExt := e.makeExtBidResponse(adapterBids, adapterExtra, bidRequest, resolvedRequest, errList)
-	ext, err := json.Marshal(bidResponseExt)
-	bidResponse.Ext = ext
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(bidResponseExt)
+	bidResponse.Ext = buffer.Bytes()
+
 	return bidResponse, err
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -78,9 +78,7 @@ func TestCharacterEscape(t *testing.T) {
 
 	/* 	2) Init new exchange with said configuration			*/
 	//Other parameters also needed to create exchange
-	handlerNoBidServer := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(204)
-	}
+	handlerNoBidServer := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(204) }
 	server := httptest.NewServer(http.HandlerFunc(handlerNoBidServer))
 	defer server.Close()
 
@@ -93,37 +91,21 @@ func TestCharacterEscape(t *testing.T) {
 
 	//adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid,
 	adapterBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid, 1)
-	adapterBids["appnexus"] = &pbsOrtbSeatBid{
-		currency: "USD",
-	}
+	adapterBids["appnexus"] = &pbsOrtbSeatBid{currency: "USD"}
 
 	//An openrtb.BidRequest struct as specified in https://github.com/prebid/prebid-server/issues/465
 	bidRequest := &openrtb.BidRequest{
 		ID: "some-request-id",
 		Imp: []openrtb.Imp{{
-			ID: "some-impression-id",
-			Banner: &openrtb.Banner{
-				Format: []openrtb.Format{{
-					W: 300,
-					H: 250,
-				}, {
-					W: 300,
-					H: 600,
-				}},
-			},
-			Ext: json.RawMessage(`{"appnexus": {"placementId": 10433394}}`),
+			ID:     "some-impression-id",
+			Banner: &openrtb.Banner{Format: []openrtb.Format{{W: 300, H: 250}, {W: 300, H: 600}}},
+			Ext:    json.RawMessage(`{"appnexus": {"placementId": 10433394}}`),
 		}},
-		Site: &openrtb.Site{
-			Page: "prebid.org",
-			Ext:  json.RawMessage(`{"amp":0}`),
-		},
-		Device: &openrtb.Device{
-			UA: "curl/7.54.0",
-			IP: "::1",
-		},
-		AT:   1,
-		TMax: 500,
-		Ext:  json.RawMessage(`{"id": "some-request-id","site": {"page": "prebid.org"},"imp": [{"id": "some-impression-id","banner": {"format": [{"w": 300,"h": 250},{"w": 300,"h": 600}]},"ext": {"appnexus": {"placementId": 10433394}}}],"tmax": 500}`),
+		Site:   &openrtb.Site{Page: "prebid.org", Ext: json.RawMessage(`{"amp":0}`)},
+		Device: &openrtb.Device{UA: "curl/7.54.0", IP: "::1"},
+		AT:     1,
+		TMax:   500,
+		Ext:    json.RawMessage(`{"id": "some-request-id","site": {"page": "prebid.org"},"imp": [{"id": "some-impression-id","banner": {"format": [{"w": 300,"h": 250},{"w": 300,"h": 600}]},"ext": {"appnexus": {"placementId": 10433394}}}],"tmax": 500}`),
 	}
 
 	//resolvedRequest json.RawMessage
@@ -133,12 +115,7 @@ func TestCharacterEscape(t *testing.T) {
 	adapterExtra := make(map[openrtb_ext.BidderName]*seatResponseExtra, 1)
 	adapterExtra["appnexus"] = &seatResponseExtra{
 		ResponseTimeMillis: 5,
-		Errors: []openrtb_ext.ExtBidderError{
-			{
-				Code:    999,
-				Message: "Post ib.adnxs.com/openrtb2?query1&query2: unsupported protocol scheme \"\"",
-			},
-		},
+		Errors:             []openrtb_ext.ExtBidderError{{Code: 999, Message: "Post ib.adnxs.com/openrtb2?query1&query2: unsupported protocol scheme \"\""}},
 	}
 
 	//errList []error
@@ -154,8 +131,6 @@ func TestCharacterEscape(t *testing.T) {
 	if len(errList) > 0 {
 		t.Errorf("exchange.buildBidResponse returned %d errors", len(errList))
 	}
-
-	//if bytes.Contains(bid_resp.Ext, []byte("&")) && !bytes.Contains(bid_resp.Ext, []byte("u0026")) {
 	if bytes.Contains(bid_resp.Ext, []byte("u0026")) {
 		t.Errorf("exchange.buildBidResponse() did not correctly print the '&' characters %s", string(bid_resp.Ext))
 	}

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -155,7 +155,8 @@ func TestCharacterEscape(t *testing.T) {
 		t.Errorf("exchange.buildBidResponse returned %d errors", len(errList))
 	}
 
-	if bytes.Contains(bid_resp.Ext, []byte("&")) {
+	//if bytes.Contains(bid_resp.Ext, []byte("&")) && !bytes.Contains(bid_resp.Ext, []byte("u0026")) {
+	if bytes.Contains(bid_resp.Ext, []byte("u0026")) {
 		t.Errorf("exchange.buildBidResponse() did not correctly print the '&' characters %s", string(bid_resp.Ext))
 	}
 }


### PR DESCRIPTION
Using the NewEncoder function that will help correct all '&', '<', and '>' characters. 