### PR TITLE
PBS-336: correct bad variable name

### DIFF
--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -199,16 +199,16 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 				}
 			}
 			sentBids++
-			bidderRunner := recoverSafely(func(bidder *pbs.PBSBidder, alabels pbsmetrics.AdapterLabels) {
+			bidderRunner := recoverSafely(func(bidder *pbs.PBSBidder, aLabels pbsmetrics.AdapterLabels) {
 				start := time.Now()
 				bidList, err := ex.Call(ctx, req, bidder)
-				a.metricsEngine.RecordAdapterTime(alabels, time.Since(start))
+				a.metricsEngine.RecordAdapterTime(aLabels, time.Since(start))
 				bidder.ResponseTime = int(time.Since(start) / time.Millisecond)
 				if err != nil {
 					var s struct{}
 					switch err {
 					case context.DeadlineExceeded:
-						alabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorTimeout: s}
+						aLabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorTimeout: s}
 						bidder.Error = "Timed out"
 					case context.Canceled:
 						fallthrough
@@ -216,12 +216,12 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 						bidder.Error = err.Error()
 						switch err.(type) {
 						case *errortypes.BadInput:
-							alabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadInput: s}
+							aLabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadInput: s}
 						case *errortypes.BadServerResponse:
-							alabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadServerResponse: s}
+							aLabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadServerResponse: s}
 						default:
 							glog.Warningf("Error from bidder %v. Ignoring all bids: %v", bidder.BidderCode, err)
-							alabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorUnknown: s}
+							aLabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorUnknown: s}
 						}
 					}
 				} else if bidList != nil {
@@ -229,18 +229,18 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 					bidder.NumBids = len(bidList)
 					for _, bid := range bidList {
 						var cpm = float64(bid.Price * 1000)
-						a.metricsEngine.RecordAdapterPrice(alabels, cpm)
+						a.metricsEngine.RecordAdapterPrice(aLabels, cpm)
 						switch bid.CreativeMediaType {
 						case "banner":
-							a.metricsEngine.RecordAdapterBidReceived(alabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
+							a.metricsEngine.RecordAdapterBidReceived(aLabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
 						case "video":
-							a.metricsEngine.RecordAdapterBidReceived(alabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
+							a.metricsEngine.RecordAdapterBidReceived(aLabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
 						}
 						bid.ResponseTime = bidder.ResponseTime
 					}
 				} else {
 					bidder.NoBid = true
-					alabels.AdapterBids = pbsmetrics.AdapterBidNone
+					aLabels.AdapterBids = pbsmetrics.AdapterBidNone
 				}
 
 				ch <- bidResult{
@@ -248,7 +248,7 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 					bidList: bidList,
 					// Bidder done, record bidder metrics
 				}
-				a.metricsEngine.RecordAdapterRequest(alabels)
+				a.metricsEngine.RecordAdapterRequest(aLabels)
 			})
 
 			go bidderRunner(bidder, blabels)

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -199,16 +199,16 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 				}
 			}
 			sentBids++
-			bidderRunner := recoverSafely(func(bidder *pbs.PBSBidder, blables pbsmetrics.AdapterLabels) {
+			bidderRunner := recoverSafely(func(bidder *pbs.PBSBidder, adapterlabels pbsmetrics.AdapterLabels) {
 				start := time.Now()
 				bidList, err := ex.Call(ctx, req, bidder)
-				a.metricsEngine.RecordAdapterTime(blabels, time.Since(start))
+				a.metricsEngine.RecordAdapterTime(adapterlabels, time.Since(start))
 				bidder.ResponseTime = int(time.Since(start) / time.Millisecond)
 				if err != nil {
 					var s struct{}
 					switch err {
 					case context.DeadlineExceeded:
-						blabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorTimeout: s}
+						adapterlabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorTimeout: s}
 						bidder.Error = "Timed out"
 					case context.Canceled:
 						fallthrough
@@ -216,12 +216,12 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 						bidder.Error = err.Error()
 						switch err.(type) {
 						case *errortypes.BadInput:
-							blabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadInput: s}
+							adapterlabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadInput: s}
 						case *errortypes.BadServerResponse:
-							blabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadServerResponse: s}
+							adapterlabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorBadServerResponse: s}
 						default:
 							glog.Warningf("Error from bidder %v. Ignoring all bids: %v", bidder.BidderCode, err)
-							blabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorUnknown: s}
+							adapterlabels.AdapterErrors = map[pbsmetrics.AdapterError]struct{}{pbsmetrics.AdapterErrorUnknown: s}
 						}
 					}
 				} else if bidList != nil {
@@ -229,18 +229,18 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 					bidder.NumBids = len(bidList)
 					for _, bid := range bidList {
 						var cpm = float64(bid.Price * 1000)
-						a.metricsEngine.RecordAdapterPrice(blables, cpm)
+						a.metricsEngine.RecordAdapterPrice(adapterlabels, cpm)
 						switch bid.CreativeMediaType {
 						case "banner":
-							a.metricsEngine.RecordAdapterBidReceived(blabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
+							a.metricsEngine.RecordAdapterBidReceived(adapterlabels, openrtb_ext.BidTypeBanner, bid.Adm != "")
 						case "video":
-							a.metricsEngine.RecordAdapterBidReceived(blabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
+							a.metricsEngine.RecordAdapterBidReceived(adapterlabels, openrtb_ext.BidTypeVideo, bid.Adm != "")
 						}
 						bid.ResponseTime = bidder.ResponseTime
 					}
 				} else {
 					bidder.NoBid = true
-					blabels.AdapterBids = pbsmetrics.AdapterBidNone
+					adapterlabels.AdapterBids = pbsmetrics.AdapterBidNone
 				}
 
 				ch <- bidResult{
@@ -248,7 +248,7 @@ func (a *auction) auction(w http.ResponseWriter, r *http.Request, _ httprouter.P
 					bidList: bidList,
 					// Bidder done, record bidder metrics
 				}
-				a.metricsEngine.RecordAdapterRequest(blabels)
+				a.metricsEngine.RecordAdapterRequest(adapterlabels)
 			})
 
 			go bidderRunner(bidder, blabels)


### PR DESCRIPTION
Simply a change of all the **blabel** and **blable** variable names passed as in the function argument to _recoverSafely_(), lines 202-252, to **adapterlabels**.

Since you're reviewing this, please consider the merits of the idea of moving this 50-line function call into a separate function.  I think this code is very confusing in its current form, which is that the call to _recoverSafely_() serves to simply insert some defer() code into the 50-line function passed to it, and then returns the same function.  Why not simply write a separate function with the defer() code already in place?  I can't spot a technical reason to not move the function out of calling function _auction_().  The benefits of moving it out are (1) the problem being fixed by this change would have been caught by the compiler and (2) it would be much easier for future maintenance to understand what's going on here.  If that's agreeable, we will open a separate, less urgent, ticket to address this change which also would be done for similar code in exchange/exchange.go's _getAllBids_() which calls its own _recoverySafely_().