### PR TITLE
PBS-335: Fix GDPR info lookup to use core bidder when aliases are used

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:af6e785bedb62fc2abb81977c58a7a44e5cf9f7e41b8d3c8dd4d872edea0ce08"
+  name = "github.com/NYTimes/gziphandler"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "dd0439581c7657cb652dfe5c71d7d48baf39541d"
+  version = "v1.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:5264e1bb1289de58fd25724e060fe45524a9c2b39bad8562a6fd9d6a62d7a3b6"
   name = "github.com/asaskevich/govalidator"
@@ -467,6 +475,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DATA-DOG/go-sqlmock",
+    "github.com/NYTimes/gziphandler",
     "github.com/asaskevich/govalidator",
     "github.com/blang/semver",
     "github.com/buger/jsonparser",

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -36,6 +36,7 @@ func cleanOpenRTBRequests(ctx context.Context, orig *openrtb.BidRequest, usersyn
 	consent := extractConsent(orig)
 	if gdpr == 1 {
 		for bidder, bidReq := range requestsByBidder {
+			// Fixes #820
 			coreBidder := resolveBidder(bidder.String(), aliases)
 			if ok, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, consent); !ok && err == nil {
 				cleanPI(bidReq, labels.RType == pbsmetrics.ReqTypeAMP)

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -36,7 +36,8 @@ func cleanOpenRTBRequests(ctx context.Context, orig *openrtb.BidRequest, usersyn
 	consent := extractConsent(orig)
 	if gdpr == 1 {
 		for bidder, bidReq := range requestsByBidder {
-			if ok, err := gDPR.PersonalInfoAllowed(ctx, bidder, consent); !ok && err == nil {
+			coreBidder := resolveBidder(bidder.String(), aliases)
+			if ok, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, consent); !ok && err == nil {
 				cleanPI(bidReq, labels.RType == pbsmetrics.ReqTypeAMP)
 			}
 		}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -1,10 +1,122 @@
 package exchange
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/pbsmetrics"
+	"github.com/stretchr/testify/assert"
 )
+
+// permissionsMock mocks the Permissions interface for tests
+//
+// It always disallows BrightRoll for GDPR consent
+type permissionsMock struct{}
+
+func (p *permissionsMock) HostCookiesAllowed(ctx context.Context, consent string) (bool, error) {
+	return true, nil
+}
+
+func (p *permissionsMock) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+	return true, nil
+}
+
+func (p *permissionsMock) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+	if bidder == "brightroll" {
+		return false, nil
+	}
+	return true, nil
+}
+
+func assertReqWithoutAliases(t *testing.T, reqByBidders map[openrtb_ext.BidderName]*openrtb.BidRequest) {
+	// assert individual bidder requests
+	assert.NotEqual(t, len(reqByBidders), 0, "cleanOpenRTBRequest should split request into individual bidder requests")
+
+	// assert for PI data
+	assert.Equal(t, reqByBidders["brightroll"].User.BuyerUID, "", "cleanOpenRTBRequest should clean PI data for a non-consented vendor")
+	assert.Equal(t, reqByBidders["brightroll"].Device.DIDMD5, "", "cleanOpenRTBRequest should clean PI data for a non-consented vendor")
+	assert.NotEqual(t, reqByBidders["appnexus"].User.BuyerUID, "", "cleanOpenRTBRequest shouldn't clean PI data for a consented vendor")
+}
+
+func assertReqWithAliases(t *testing.T, reqByBidders map[openrtb_ext.BidderName]*openrtb.BidRequest) {
+	// assert individual bidder requests
+	assert.NotEqual(t, reqByBidders, 0, "cleanOpenRTBRequest should split request into individual bidder requests")
+
+	// assert for PI data
+	assert.NotEqual(t, reqByBidders["brightroll"].User.BuyerUID, "", "cleanOpenRTBRequest shouldn't clean PI data for a consented vendor")
+	assert.NotEqual(t, reqByBidders["brightroll"].Device.DIDMD5, "", "cleanOpenRTBRequest shouldn't clean PI data for a consented vendor")
+	assert.NotEqual(t, reqByBidders["appnexus"].User.BuyerUID, "", "cleanOpenRTBRequest shouldn't clean PI data for a consented vendor")
+}
+
+func TestCleanOpenRTBRequests(t *testing.T) {
+	testCases := []struct {
+		req              *openrtb.BidRequest
+		bidReqAssertions func(t *testing.T, reqByBidders map[openrtb_ext.BidderName]*openrtb.BidRequest)
+		hasError         bool
+	}{
+		{req: newRaceCheckingRequest(t), bidReqAssertions: assertReqWithoutAliases, hasError: false},
+		{req: newAdapterAliasBidRequest(t), bidReqAssertions: assertReqWithAliases, hasError: false},
+	}
+
+	for _, test := range testCases {
+		reqByBidders, _, err := cleanOpenRTBRequests(context.Background(), test.req, &emptyUsersync{}, map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels{}, pbsmetrics.Labels{}, &permissionsMock{}, true)
+		if test.hasError {
+			assert.NotNil(t, err, "Error shouldn't be nil")
+		} else {
+			assert.Nil(t, err, "Err should be nil")
+			test.bidReqAssertions(t, reqByBidders)
+		}
+	}
+}
+
+// newAdapterAliasBidRequest builds a BidRequest with aliases
+func newAdapterAliasBidRequest(t *testing.T) *openrtb.BidRequest {
+	return &openrtb.BidRequest{
+		Site: &openrtb.Site{
+			Page:   "www.some.domain.com",
+			Domain: "domain.com",
+			Publisher: &openrtb.Publisher{
+				ID: "some-publisher-id",
+			},
+		},
+		Device: &openrtb.Device{
+			DIDMD5:   "some device ID hash",
+			UA:       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36",
+			IFA:      "ifa",
+			IP:       "132.173.230.74",
+			DNT:      1,
+			Language: "EN",
+		},
+		Source: &openrtb.Source{
+			TID: "61018dc9-fa61-4c41-b7dc-f90b9ae80e87",
+		},
+		User: &openrtb.User{
+			ID:       "our-id",
+			BuyerUID: "their-id",
+			Ext:      json.RawMessage(`{"consent":"BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw","digitrust":{"id":"digi-id","keyv":1,"pref":1}}`),
+		},
+		Regs: &openrtb.Regs{
+			Ext: json.RawMessage(`{"gdpr":1}`),
+		},
+		Imp: []openrtb.Imp{{
+			ID: "some-imp-id",
+			Banner: &openrtb.Banner{
+				Format: []openrtb.Format{{
+					W: 300,
+					H: 250,
+				}, {
+					W: 300,
+					H: 600,
+				}},
+			},
+			Ext: json.RawMessage(`{"appnexus": {"placementId": 10433394},"brightroll": {"placementId": 105}}`),
+		}},
+		Ext: json.RawMessage(`{"prebid":{"aliases":{"brightroll":"appnexus"}}}`),
+	}
+}
 
 func TestRandomizeList(t *testing.T) {
 	adapters := make([]openrtb_ext.BidderName, 3)

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -64,6 +64,7 @@ func assertReqWithAliases(t *testing.T, reqByBidders map[openrtb_ext.BidderName]
 	}
 }
 
+// Prevents #820
 func TestCleanOpenRTBRequests(t *testing.T) {
 	testCases := []struct {
 		req              *openrtb.BidRequest


### PR DESCRIPTION
This PR addresses #820 