### PR TITLE
Update mxmCherry from v10 to v11

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:af6e785bedb62fc2abb81977c58a7a44e5cf9f7e41b8d3c8dd4d872edea0ce08"
+  name = "github.com/NYTimes/gziphandler"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "dd0439581c7657cb652dfe5c71d7d48baf39541d"
+  version = "v1.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:5264e1bb1289de58fd25724e060fe45524a9c2b39bad8562a6fd9d6a62d7a3b6"
   name = "github.com/asaskevich/govalidator"
@@ -467,6 +475,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DATA-DOG/go-sqlmock",
+    "github.com/NYTimes/gziphandler",
     "github.com/asaskevich/govalidator",
     "github.com/blang/semver",
     "github.com/buger/jsonparser",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -207,7 +207,7 @@
   version = "v0.4.1"
 
 [[projects]]
-  digest = "1:201a3deb0bbd1b035114a920ad932d656e6e9133825118902f6264914d72286c"
+  digest = "1:46119a7cf1745644cc6871b4d037e6ad453001fe74b067b7e50c43058af05fc9"
   name = "github.com/mxmCherry/openrtb"
   packages = [
     ".",
@@ -215,8 +215,8 @@
     "native/request",
   ]
   pruneopts = "UT"
-  revision = "e642f66bd4f9b51c99b0c7b51188b751969465cb"
-  version = "v10.0.0"
+  revision = "39d0e974b2f73eedac8ea9799c6625df7735a47d"
+  version = "v11.0.0"
 
 [[projects]]
   digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,7 +59,7 @@
 
 [[constraint]]
   name = "github.com/mxmCherry/openrtb"
-  version = "~10.0.0"
+  version = "~11.0.0"
 
 [[constraint]]
   name = "github.com/rs/cors"

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -241,7 +241,9 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 				beachfrontReq.IP = req.Device.IP
 				beachfrontReq.DeviceModel = req.Device.Model
 				beachfrontReq.DeviceOs = req.Device.OS
-				beachfrontReq.Dnt = req.Device.DNT
+				if req.Device.DNT != nil {
+					beachfrontReq.Dnt = *req.Device.DNT
+				}
 				if req.Device.UA != "" {
 					beachfrontReq.UA = req.Device.UA
 				}

--- a/adapters/brightroll/brightroll.go
+++ b/adapters/brightroll/brightroll.go
@@ -109,7 +109,9 @@ func (a *BrightrollAdapter) MakeRequests(requestIn *openrtb.BidRequest) ([]*adap
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
 		addHeaderIfNonEmpty(headers, "X-Forwarded-For", request.Device.IP)
 		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
-		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+		if request.Device.DNT != nil {
+			addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(*request.Device.DNT)))
+		}
 	}
 
 	return []*adapters.RequestData{{

--- a/adapters/eplanning/eplanning.go
+++ b/adapters/eplanning/eplanning.go
@@ -98,7 +98,9 @@ func (adapter *EPlanningAdapter) MakeRequests(request *openrtb.BidRequest) ([]*a
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
 		addHeaderIfNonEmpty(headers, "X-Forwarded-For", ip)
 		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
-		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+		if request.Device.DNT != nil {
+			addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(*request.Device.DNT)))
+		}
 	}
 
 	var pageURL string

--- a/adapters/gamoshi/gamoshi.go
+++ b/adapters/gamoshi/gamoshi.go
@@ -111,7 +111,9 @@ func (a *GamoshiAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
 		addHeaderIfNonEmpty(headers, "X-Forwarded-For", request.Device.IP)
 		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
-		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+		if request.Device.DNT != nil {
+			addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(*request.Device.DNT)))
+		}
 	}
 
 	return []*adapters.RequestData{{

--- a/adapters/rhythmone/rhythmonetest/exemplary/banner-and-video-app.json
+++ b/adapters/rhythmone/rhythmonetest/exemplary/banner-and-video-app.json
@@ -145,6 +145,7 @@
 		"os": "iOS",
 		"osv": "6.1",
 		"js": 1,
+		"dnt": 0,
 		"language": "en",
 		"carrier": "VERIZON",
 		"connectiontype": 3,

--- a/adapters/somoaudience/somoaudience.go
+++ b/adapters/somoaudience/somoaudience.go
@@ -119,7 +119,9 @@ func (a *SomoaudienceAdapter) makeRequest(request *openrtb.BidRequest) (*adapter
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
 		addHeaderIfNonEmpty(headers, "X-Forwarded-For", request.Device.IP)
 		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
-		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+		if request.Device.DNT != nil {
+			addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(*request.Device.DNT)))
+		}
 	}
 	return &adapters.RequestData{
 		Method:  "POST",

--- a/adapters/somoaudience/somoaudiencetest/exemplary/no-bid.json
+++ b/adapters/somoaudience/somoaudiencetest/exemplary/no-bid.json
@@ -97,6 +97,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           }
         }

--- a/adapters/somoaudience/somoaudiencetest/supplemental/gdpr.json
+++ b/adapters/somoaudience/somoaudiencetest/supplemental/gdpr.json
@@ -94,6 +94,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           },
           "regs": {

--- a/adapters/sovrn/sovrn.go
+++ b/adapters/sovrn/sovrn.go
@@ -86,7 +86,9 @@ func (s *SovrnAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pb
 		addHeaderIfNonEmpty(httpReq.Header, "User-Agent", sReq.Device.UA)
 		addHeaderIfNonEmpty(httpReq.Header, "X-Forwarded-For", sReq.Device.IP)
 		addHeaderIfNonEmpty(httpReq.Header, "Accept-Language", sReq.Device.Language)
-		addHeaderIfNonEmpty(httpReq.Header, "DNT", strconv.Itoa(int(sReq.Device.DNT)))
+		if sReq.Device.DNT != nil {
+			addHeaderIfNonEmpty(httpReq.Header, "DNT", strconv.Itoa(int(*sReq.Device.DNT)))
+		}
 	}
 	if sReq.User != nil {
 		userID := strings.TrimSpace(sReq.User.BuyerUID)
@@ -199,7 +201,9 @@ func (s *SovrnAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.Re
 		addHeaderIfNonEmpty(headers, "User-Agent", request.Device.UA)
 		addHeaderIfNonEmpty(headers, "X-Forwarded-For", request.Device.IP)
 		addHeaderIfNonEmpty(headers, "Accept-Language", request.Device.Language)
-		addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(request.Device.DNT)))
+		if request.Device.DNT != nil {
+			addHeaderIfNonEmpty(headers, "DNT", strconv.Itoa(int(*request.Device.DNT)))
+		}
 	}
 
 	if request.User != nil {

--- a/adapters/sovrn/sovrn_test.go
+++ b/adapters/sovrn/sovrn_test.go
@@ -136,8 +136,10 @@ func checkHttpRequest(req http.Request, t *testing.T) {
 }
 
 func SampleSovrnRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
+	dnt := int8(0)
 	device := openrtb.Device{
 		Language: "murican",
+		DNT:      &dnt,
 	}
 
 	user := openrtb.User{

--- a/adapters/sovrn/sovrntest/exemplary/no-bid.json
+++ b/adapters/sovrn/sovrntest/exemplary/no-bid.json
@@ -100,6 +100,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           }
         }

--- a/adapters/sovrn/sovrntest/exemplary/simple-banner.json
+++ b/adapters/sovrn/sovrntest/exemplary/simple-banner.json
@@ -85,6 +85,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           }
         }

--- a/adapters/sovrn/sovrntest/supplemental/blank-device.json
+++ b/adapters/sovrn/sovrntest/supplemental/blank-device.json
@@ -38,8 +38,7 @@
       "expectedRequest": {
         "headers": {
           "Content-Type": ["application/json"],
-          "Cookie": ["ljt_reader=test_reader_id"],
-          "Dnt": ["0"]
+          "Cookie": ["ljt_reader=test_reader_id"]
         },
         "uri": "http://sovrn.com/test/endpoint",
         "body": {

--- a/adapters/sovrn/sovrntest/supplemental/camel-case-tagId.json
+++ b/adapters/sovrn/sovrntest/supplemental/camel-case-tagId.json
@@ -85,6 +85,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           }
         }

--- a/adapters/sovrn/sovrntest/supplemental/gdpr.json
+++ b/adapters/sovrn/sovrntest/supplemental/gdpr.json
@@ -96,6 +96,7 @@
           "device": {
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
+            "dnt": 0,
             "language": "en"
           },
           "regs": {

--- a/adapters/sovrn/sovrntest/supplemental/no-user.json
+++ b/adapters/sovrn/sovrntest/supplemental/no-user.json
@@ -76,6 +76,7 @@
             "page": "http://www.publisher.com/awesome/site"
           },
           "device": {
+            "dnt": 0,
             "ua": "test-user-agent",
             "ip": "123.123.123.123",
             "language": "en"

--- a/config/config.go
+++ b/config/config.go
@@ -428,7 +428,7 @@ func (cfg *Configuration) setDerivedDefaults() {
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSovrn, "https://ap.lijit.com/pixel?redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSonobi, "https://sync.go.sonobi.com/us.gif?loc="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsonobi%26consent_string%3D{{.GDPR}}%26gdpr%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderYieldmo, "https://ads.yieldmo.com/pbsync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&redirectUri="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dyieldmo%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
-	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderGamoshi, "https://rtb.gamoshi.io/pix/{{.supplyPartnerId}}/scm?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&rurl="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dgamoshi%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bgusr%5D")
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderGamoshi, "https://rtb.gamoshi.io/pix/0000/scm?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&rurl="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dgamoshi%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5Bgusr%5D")
 
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -94,6 +94,7 @@ func TestRaceIntegration(t *testing.T) {
 // newRaceCheckingRequest builds a BidRequest from all the params in the
 // adapters/{bidder}/{bidder}test/params/race/*.json files
 func newRaceCheckingRequest(t *testing.T) *openrtb.BidRequest {
+	dnt := int8(1)
 	return &openrtb.BidRequest{
 		Site: &openrtb.Site{
 			Page:   "www.some.domain.com",
@@ -106,7 +107,7 @@ func newRaceCheckingRequest(t *testing.T) *openrtb.BidRequest {
 			UA:       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36",
 			IFA:      "ifa",
 			IP:       "132.173.230.74",
-			DNT:      1,
+			DNT:      &dnt,
 			Language: "EN",
 		},
 		Source: &openrtb.Source{


### PR DESCRIPTION
I updated mxmCherry to the latest stable version for better OpenRTB support in the future.
v11 fixed the empty Lmt&Dnt problem which is required to identify if `LMT`/`DNT` are 0 or empty.

I'll close the previous one and update it till v12 consolidated.
https://github.com/prebid/prebid-server/pull/828

This pull depends on the following fix: https://github.com/prebid/prebid-server/pull/837