### PR TITLE
PBS-348: fix cache expiration calculation

### DIFF
--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -72,8 +72,9 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 	for _, imp := range bidRequest.Imp {
 		expByImp[imp.ID] = imp.Exp
 	}
-	for impID, topBidsPerImp := range a.winningBidsByBidder {
+	for _, topBidsPerImp := range a.winningBidsByBidder {
 		for _, topBidPerBidder := range topBidsPerImp {
+			impID := topBidPerBidder.bid.ImpID
 			if bids {
 				if jsonBytes, err := json.Marshal(topBidPerBidder.bid); err == nil {
 					toCache = append(toCache, prebid_cache_client.Cacheable{

--- a/exchange/cachetest/defaultbanner.json
+++ b/exchange/cachetest/defaultbanner.json
@@ -1,14 +1,13 @@
 {
     "bidRequest": {
-		"imp": [
-			{
-				"id":  "oneImp"
-            }
-        ]
+        "imp": [{
+            "id":  "oneImp"
+        }]
     },
     "pbsBids": [{
         "bid":{
-            "id": "oneImp",
+            "id": "bidOne",
+            "impid": "oneImp",
             "price": 7.64,
             "exp":   600
         },
@@ -16,7 +15,8 @@
         "bidder": "appnexus"
     }, {
         "bid": {
-            "id": "oneImp",
+            "id": "bidTwo",
+            "impid": "oneImp",
             "price": 5.64
         },
         "bidType": "banner",

--- a/exchange/cachetest/defaultvideo.json
+++ b/exchange/cachetest/defaultvideo.json
@@ -1,24 +1,24 @@
 {
     "bidRequest": {
-		"imp": [
-			{
-				"id":  "oneImp",
-                "exp":   600
-            }, {
-				"id":  "twoImp"
-            }
-        ]
+        "imp": [{
+            "id":  "oneImp",
+            "exp":   600
+        }, {
+            "id":  "twoImp"
+        }]
     },
     "pbsBids": [{
         "bid":{
-            "id": "oneImp",
+            "id": "bidOne",
+            "impid": "oneImp",
             "price": 7.64
         },
         "bidType": "video",
         "bidder": "appnexus"
     }, {
         "bid": {
-            "id": "twoImp",
+            "id": "bidTwo",
+            "impid": "twoImp",
             "price": 5.64
         },
         "bidType": "video",

--- a/exchange/cachetest/multibid.json
+++ b/exchange/cachetest/multibid.json
@@ -1,18 +1,16 @@
 {
     "bidRequest": {
-		"imp": [
-			{
-				"id":  "oneImp",
-				"exp": 300
-			},
-			{
-				"id": "twoImp"
-			}
-        ]
+        "imp": [{
+            "id":  "oneImp",
+            "exp": 300
+        },{
+        "id": "twoImp"
+        }]
     },
     "pbsBids": [{
             "bid":{
-                "id": "oneImp",
+                "id": "bidOne",
+                "impid": "oneImp",
                 "price": 7.64,
                 "exp":   600
             },
@@ -20,7 +18,8 @@
             "bidder": "appnexus"
         }, {
             "bid": {
-                "id": "oneImp",
+                "id": "bidTwo",
+                "impid": "oneImp",
                 "price": 5.64,
                 "exp":   200
             },
@@ -28,21 +27,24 @@
             "bidder": "pubmatic"
         }, {
             "bid": {
-                "id": "oneImp",
+                "id": "bidThree",
+                "impid": "oneImp",
                 "price": 2.3
             },
             "bidType": "banner",
             "bidder": "openx"
         }, {
             "bid": {
-				"id": "twoImp",
+                "id": "bidFour",
+                "impid": "twoImp",
                 "price": 1.64
             },
             "bidType": "banner",
             "bidder": "appnexus"
         }, {
             "bid": {
-				"id": "twoImp",
+                "id": "bidFive",
+                "impid": "twoImp",
                 "price": 7.64,
                 "exp":   900
             },


### PR DESCRIPTION
This became more complicated than anticipated for a two-line fix.  The tests associated with the errant code were based on the same misunderstanding (using bid ID instead of imp ID) so they had to be updated as well.  I fixed all three tests even though only two (the tests with an impression expiration) were failing after the fix.  I also reformatted the test files for readability (there were tabs on some lines, not on others).