### PR TITLE
Custom cache key support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,6 +106,14 @@
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6b08a5c5172ba18946672b49749cde22873dd7c2"
+  version = "v3.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
@@ -483,6 +491,7 @@
     "github.com/coocood/freecache",
     "github.com/erikstmartin/go-testdb",
     "github.com/evanphx/json-patch",
+    "github.com/gofrs/uuid",
     "github.com/golang/glog",
     "github.com/julienschmidt/httprouter",
     "github.com/lib/pq",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,3 +104,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/asaskevich/govalidator"
+
+[[constraint]]
+  name = "github.com/gofrs/uuid"
+  version = "^3.2.0"

--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -73,11 +73,11 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 	toCache := make([]prebid_cache_client.Cacheable, 0, expectNumBids+expectNumVast)
 	expByImp := make(map[string]int64)
 	competitiveExclusion := false
-	var hbCacheId string
+	var hbCacheID string
 	if len(bidCategory) > 0 {
 		// assert:  category of winning bids never duplicated
 		if rawUuid, err := uuid.NewV4(); err == nil {
-			hbCacheId = rawUuid.String()
+			hbCacheID = rawUuid.String()
 			competitiveExclusion = true
 		} else {
 			errs = append(errs, errors.New("failed to create custom cache key"))
@@ -101,11 +101,7 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 				if len(catDur) > 0 {
 					pb = a.roundedPrices[topBidPerBidder]
 					if len(pb) > 0 {
-<<<<<<< HEAD
-						customCacheKey = fmt.Sprintf("%s_%s_%s", pb, catDur, hbCacheId)
-=======
-						customCacheKey = fmt.Sprintf("%s_%s_%s", pb, catDur, hb_cache_id)
->>>>>>> 8c2b1ac7e912a5d24c3395d5215df75258245617
+						customCacheKey = fmt.Sprintf("%s_%s_%s", pb, catDur, hbCacheID)
 						useCustomCacheKey = true
 					}
 				}

--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/prebid_cache_client"
-	uuid "github.com/satori/go.uuid"
 )
 
 func newAuction(seatBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, numImps int) *auction {

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -55,6 +55,8 @@ func TestCacheJSON(t *testing.T) {
 
 			runCacheSpec(t, fileDisplayName, specData, true, false)
 		}
+	} else {
+		t.Fatalf("Failed to read contents of directory exchange/cachetest/: %v", err)
 	}
 }
 
@@ -72,6 +74,8 @@ func TestCustomCacheKeyJSON(t *testing.T) {
 
 			runCacheSpec(t, fileDisplayName, specData, false, true)
 		}
+	} else {
+		t.Fatalf("Failed to read contents of directory exchange/customcachekeytest/: %v", err)
 	}
 }
 

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
@@ -111,8 +112,31 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 
 	for _, cExpected := range specData.ExpectedCacheables {
 		for _, cFound := range cache.items {
+			// make sure Data section matches exactly
 			eq := jsonpatch.Equal(cExpected.Data, cFound.Data)
-			if cExpected.TTLSeconds == cFound.TTLSeconds && eq {
+			if !eq {
+				continue
+			}
+
+			// make sure Key value is as expected
+			keymatch := false
+			if len(cExpected.Key) > 0 {
+				// can only verify prefix; remainder is random
+				if strings.HasPrefix(cFound.Key, cExpected.Key) {
+					keymatch = true
+				}
+			} else {
+				if len(cExpected.Key) == 0 {
+					// Key is expected to be empty
+					keymatch = true
+				}
+			}
+			if !keymatch {
+				continue
+			}
+
+			// make sure TTLSeconds section matches exactly
+			if cExpected.TTLSeconds == cFound.TTLSeconds {
 				found++
 			}
 		}

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -102,9 +102,9 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 	cache := &mockCache{}
 
 	testAuction := &auction{
-		winningBids: winningBids,
+		winningBids:         winningBids,
 		winningBidsByBidder: winningBidsByBidder,
-		roundedPrices: roundedPrices,
+		roundedPrices:       roundedPrices,
 	}
 	_ = testAuction.doCache(ctx, cache, true, false, &specData.BidRequest, 60, &specData.DefaultTTLs, bidCategory)
 	found := 0

--- a/exchange/cachetest/customcachekey.json
+++ b/exchange/cachetest/customcachekey.json
@@ -1,0 +1,43 @@
+{
+    "bidRequest": {
+        "imp": [{
+            "id":  "oneImp",
+           "exp":   600
+        }]
+    },
+    "pbsBids": [{
+        "bid":{
+            "cat": ["sports"],
+            "id": "appbid001",
+            "impid": "oneImp",
+            "price": 7.64
+        },
+        "bidType": "video",
+        "bidder": "appnexus"
+    }, {
+        "bid": {
+            "cat": ["news"],
+            "id": "pubbid001",
+            "impid": "oneImp",
+            "price": 5.64
+        },
+        "bidType": "video",
+        "bidder": "pubmatic"
+    }],
+    "expectedCacheables": [
+        {
+            "Type": "json",
+            "TTLSeconds": 660,
+            "Key": "7.64_sports_"
+        }, {
+            "Type": "json",
+            "TTLSeconds": 660
+        }
+    ],
+    "defaultTTLs": {
+        "banner": 300,
+        "video": 3600,
+        "audio": 1800,
+        "native": 300
+    }
+}

--- a/exchange/customcachekeytest/customcachekey.json
+++ b/exchange/customcachekeytest/customcachekey.json
@@ -27,7 +27,8 @@
     "expectedCacheables": [
         {
             "Type": "json",
-            "TTLSeconds": 660
+            "TTLSeconds": 660,
+            "Key": "7.64_sports_"
         }, {
             "Type": "json",
             "TTLSeconds": 660

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -144,7 +144,7 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 
 	if targData != nil && adapterBids != nil {
 		auc.setRoundedPrices(targData.priceGranularity)
-		cacheErrs := auc.doCache(ctx, e.cache, targData.includeCacheBids, targData.includeCacheVast, bidRequest, 60, &e.defaultTTLs)
+		cacheErrs := auc.doCache(ctx, e.cache, targData.includeCacheBids, targData.includeCacheVast, bidRequest, 60, &e.defaultTTLs, bidCategory)
 		if len(cacheErrs) > 0 {
 			errs = append(errs, cacheErrs...)
 		}
@@ -373,7 +373,6 @@ func applyCategoryMapping(requestExt openrtb_ext.ExtRequest, seatBids *map[openr
 					return res, err
 				}
 				duration = bidderExt.CreativeInfo.Video.Duration
-
 			}
 
 			bidIabCat := bid.Cat

--- a/prebid_cache_client/client.go
+++ b/prebid_cache_client/client.go
@@ -36,6 +36,7 @@ type Cacheable struct {
 	Type       PayloadType
 	Data       json.RawMessage
 	TTLSeconds int64
+	Key        string
 }
 
 func NewClient(conf *config.Cache) Client {
@@ -149,6 +150,11 @@ func encodeValueToBuffer(value Cacheable, leadingComma bool, buffer *bytes.Buffe
 		buffer.WriteString(`","value":`)
 	}
 	buffer.Write(value.Data)
+	if len(value.Key) > 0 {
+		buffer.WriteString(`,"key":"`)
+		buffer.WriteString(string(value.Key))
+		buffer.WriteString(`"`)
+	}
 	buffer.WriteByte('}')
 	return nil
 }


### PR DESCRIPTION
When using category exclusion for video, force cache key for winning bids to be <pb>_<cat>_<dur>_<hb_cache_id> where:
pb == price bucket
cat == brand category
dur == ad duration
hb_cache_id == random cache id shared by all impressions in request

Separate changes will ensure:
- no duplicated bid IDs from separate bidders
- do duplicated categories among impressions