### PR TITLE
PBS-353: caching changes for Sahara

### DIFF
--- a/exchange/cachetest/customcachekey.json
+++ b/exchange/cachetest/customcachekey.json
@@ -7,7 +7,7 @@
     },
     "pbsBids": [{
         "bid":{
-            "cat": ["sports"],
+            "cat": ["11_sports_22"],
             "id": "appbid001",
             "impid": "oneImp",
             "price": 7.64
@@ -16,7 +16,7 @@
         "bidder": "appnexus"
     }, {
         "bid": {
-            "cat": ["news"],
+            "cat": ["33_news_44"],
             "id": "pubbid001",
             "impid": "oneImp",
             "price": 5.64

--- a/exchange/customcachekeytest/customcachekey.json
+++ b/exchange/customcachekeytest/customcachekey.json
@@ -7,7 +7,7 @@
     },
     "pbsBids": [{
         "bid":{
-            "cat": ["sports"],
+            "cat": ["11_sports_22"],
             "id": "appbid001",
             "impid": "oneImp",
             "price": 7.64
@@ -16,7 +16,7 @@
         "bidder": "appnexus"
     }, {
         "bid": {
-            "cat": ["news"],
+            "cat": ["33_news_44"],
             "id": "pubbid001",
             "impid": "oneImp",
             "price": 5.64
@@ -28,7 +28,7 @@
         {
             "Type": "json",
             "TTLSeconds": 660,
-            "Key": "7.64_sports_"
+            "Key": "11_sports_22_"
         }, {
             "Type": "json",
             "TTLSeconds": 660


### PR DESCRIPTION
Two functional changes:
- back out the doCache() change that add pb portion of custom cache key
- save only the hbCacheID portion of the custom cache key in a.vastCacheIds[]

Had to update one of the tests to allow for doCache() no longer adding pb, so updated its sister test with a matching, more meaningful variable.