### PR TITLE
Improved error handling on Beachfront adapter

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -23,7 +23,7 @@ const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 
-const beachfrontAdapterName = "BF_PREBID_S2S1"
+const beachfrontAdapterName = "BF_PREBID_S2S"
 const beachfrontAdapterVersion = "0.3.0"
 
 type BeachfrontAdapter struct {

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,8 +16,7 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-const BannerEndpoint = "http://yourmomshouse.com/mock/display.php"
-// const BannerEndpoint = "https://display.bfmio.com/prebid_display"
+const BannerEndpoint = "https://ioms.bfmio.com/prebid_display"
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
@@ -401,7 +400,6 @@ func getVideoRequest(req *openrtb.BidRequest) (BeachfrontVideoRequest, []error, 
 func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	var bids []openrtb.Bid
 	var bidtype = getBidType(internalRequest)
-
 
 	bids, errs := postprocess(response, externalRequest, internalRequest.ID, bidtype)
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -18,14 +18,13 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-// const BannerEndpoint = "https://ioms.bfmio.com/prebid_display"
 const BannerEndpoint = "https://display.bfmio.com/prebid_display"
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
 
-const beachfrontAdapterName = "BF_PREBID_S2S"
-const beachfrontAdapterVersion = "0.2.2"
+const beachfrontAdapterName = "BF_PREBID_S2S1"
+const beachfrontAdapterVersion = "0.3.0"
 
 type BeachfrontAdapter struct {
 }
@@ -219,7 +218,6 @@ func getBannerRequest(req *openrtb.BidRequest) (BeachfrontBannerRequest, []error
 	var errs = make([]error, 0, len(req.Imp))
 	var imps = 0
 
-
 	// step through the prebid request "imp" and inject into the beachfront request.
 	for _, imp := range req.Imp {
 		if imp.Banner != nil {
@@ -405,8 +403,8 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	var bidtype = getBidType(internalRequest)
 
 	/*
-	Beachfront is now sending an empty array and 200 as their "no results" response. This should catch that.
- 	*/
+		Beachfront is now sending an empty array and 200 as their "no results" response. This should catch that.
+	*/
 
 	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 {
 		return nil, nil

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,7 +16,8 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-const BannerEndpoint = "https://ioms.bfmio.com/prebid_display"
+// const BannerEndpoint = "https://ioms.bfmio.com/prebid_display"
+const BannerEndpoint = "https://display.bfmio.com/prebid_display"
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
@@ -400,6 +401,33 @@ func getVideoRequest(req *openrtb.BidRequest) (BeachfrontVideoRequest, []error, 
 func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	var bids []openrtb.Bid
 	var bidtype = getBidType(internalRequest)
+
+	/*
+	Beachfront is now sending an empty array and 200 as their "no results" response. This should catch that.
+ 	*/
+
+ 	/*
+	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 && false {
+		glog.Info("Hit trigger")
+		return nil, nil
+	}
+
+	glog.Info("Missed trigger")
+
+	if response.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	if response.StatusCode == http.StatusBadRequest {
+		return nil, []error{&errortypes.BadInput{
+			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode),
+		}}
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, []error{fmt.Errorf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode)}
+	}
+	 */
 
 	bids, errs := postprocess(response, externalRequest, internalRequest.ID, bidtype)
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -16,7 +16,8 @@ import (
 const Seat = "beachfront"
 const BidCapacity = 5
 
-const BannerEndpoint = "https://display.bfmio.com/prebid_display"
+const BannerEndpoint = "http://yourmomshouse.com/mock/display.php"
+// const BannerEndpoint = "https://display.bfmio.com/prebid_display"
 const VideoEndpoint = "https://reachms.bfmio.com/bid.json?exchange_id="
 
 const VideoEndpointSuffix = "&prebidserver"
@@ -400,6 +401,11 @@ func getVideoRequest(req *openrtb.BidRequest) (BeachfrontVideoRequest, []error, 
 func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	var bids []openrtb.Bid
 	var bidtype = getBidType(internalRequest)
+
+
+	// glog.Info(response.Headers)
+	// response.Body = nil
+
 	bids, errs := postprocess(response, externalRequest, internalRequest.ID, bidtype)
 
 	if len(errs) != 0 {

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -3,6 +3,8 @@ package beachfront
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/prebid/prebid-server/errortypes"
 	"net/http"
 	"strconv"
 	"strings"
@@ -406,13 +408,9 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	Beachfront is now sending an empty array and 200 as their "no results" response. This should catch that.
  	*/
 
- 	/*
-	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 && false {
-		glog.Info("Hit trigger")
+	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 {
 		return nil, nil
 	}
-
-	glog.Info("Missed trigger")
 
 	if response.StatusCode == http.StatusNoContent {
 		return nil, nil
@@ -427,7 +425,6 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	if response.StatusCode != http.StatusOK {
 		return nil, []error{fmt.Errorf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode)}
 	}
-	 */
 
 	bids, errs := postprocess(response, externalRequest, internalRequest.ID, bidtype)
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -403,9 +403,6 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	var bidtype = getBidType(internalRequest)
 
 
-	// glog.Info(response.Headers)
-	// response.Body = nil
-
 	bids, errs := postprocess(response, externalRequest, internalRequest.ID, bidtype)
 
 	if len(errs) != 0 {

--- a/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
+++ b/adapters/beachfront/beachfronttest/exemplary/minimal-banner.json
@@ -56,7 +56,7 @@
           "dnt": 0,
           "ua": "",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.2.2",
+          "adapterVersion": "0.3.0",
           "user": {
           }
         }

--- a/adapters/beachfront/beachfronttest/exemplary/simple-video.json
+++ b/adapters/beachfront/beachfronttest/exemplary/simple-video.json
@@ -80,6 +80,7 @@
         }
         },
       "mockResponse": {
+        "status" : 200,
         "body": {
           "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
           "seatBid":[

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-banner-empty_array-200.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-banner-empty_array-200.json
@@ -1,9 +1,8 @@
 {
   "mockBidRequest": {
     "id": "some_test_ad",
-    "app": {
-      "domain": "yourmomshouse.com",
-      "id": "some-mobile-app"
+    "site": {
+      "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534"
     },
     "imp": [
       {
@@ -19,7 +18,7 @@
         "ext": {
           "bidder": {
             "bidfloor": 0.02,
-            "appId": "3b16770b-17af-4d22-daff-9606bdf2c9c3"
+            "appId": "00000000-1111-2222-3333-11111111111"
           }
         }
       }
@@ -34,7 +33,7 @@
           "slots": [
             {
               "slot": "",
-              "id": "3b16770b-17af-4d22-daff-9606bdf2c9c3",
+              "id": "00000000-1111-2222-3333-11111111111",
               "bidfloor": 0.02,
               "sizes": [
                 {
@@ -44,12 +43,12 @@
               ]
             }
           ],
-          "domain": "yourmomshouse.com",
-          "page": "some-mobile-app",
+          "domain": "test.opposingviews.com",
+          "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534",
           "referrer": "",
           "search": "",
-          "requestId": "some_test_ad",
           "secure": 0,
+          "requestId": "some_test_ad",
           "isMobile": 0,
           "ip": "",
           "deviceModel": "",
@@ -64,32 +63,10 @@
       },
       "mockResponse": {
         "status": 200,
-        "body": [
-          {
-            "crid":"crid_1",
-            "price":2.942808,
-            "w":300,
-            "h":250,
-            "slot":"div-gpt-ad-1460505748561-0",
-            "adm":"<div id=\"44861168\"><script>!function(){console.log\"Hello, ad.\";}();<\/script><\/div>"
-          }
-        ]
+        "body": []
       }
     }
   ],
 
-  "expectedBids": [
-    {
-      "Bid": {
-        "id": "12345678",
-        "impid": "test-slot",
-        "price": 2,
-        "adm": "\u003cdiv id=\"12345678\" style=\"width:300;height:250;background-color:black;color:white;\"\u003e300x250\u003c\\div\u003e",
-        "crid": "crid_1",
-        "w": 300,
-        "h": 250
-      },
-      "type": "banner"
-    }
-  ]
+  "expectedBids": []
 }

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-mobile-video.json
@@ -63,6 +63,7 @@
         }
       },
       "mockResponse": {
+        "status": 200,
         "body": {
           "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
           "seatBid":[

--- a/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/minimal-site-banner.json
@@ -56,7 +56,7 @@
             "dnt": 0,
             "ua": "",
             "adapterName": "BF_PREBID_S2S",
-            "adapterVersion": "0.2.2",
+            "adapterVersion": "0.3.0",
             "user": {
             }
           }

--- a/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-banner.json
@@ -96,7 +96,7 @@
           "dnt": 1,
           "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
           "adapterName": "BF_PREBID_S2S",
-          "adapterVersion": "0.2.2",
+          "adapterVersion": "0.3.0",
           "user": {
             "buyeruid": "some-buyer",
             "id": "some-user"

--- a/adapters/beachfront/beachfronttest/supplemental/multi-mix.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-mix.json
@@ -154,6 +154,7 @@
         }
         },
       "mockResponse": {
+        "status": 200,
         "body": {
           "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
           "seatBid":[

--- a/adapters/beachfront/beachfronttest/supplemental/multi-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/multi-video.json
@@ -106,6 +106,7 @@
         }
         },
       "mockResponse": {
+        "status": 200,
         "body": {
           "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
           "seatBid":[


### PR DESCRIPTION
Checking http statuses, in particular the possibility of a 200 with a empty array which should be treated as an empty response.