### PR TITLE
Makes 'size' a required parameter for the ix adapter

### DIFF
--- a/static/bidder-params/ix.json
+++ b/static/bidder-params/ix.json
@@ -19,5 +19,5 @@
       "description": "An array of two integer containing the dimension"
     }
   },
-  "required": ["siteId"]
+  "required": ["siteId", "size"]
 }


### PR DESCRIPTION
Back in PR #747 in November, ix updated their adapter to require sizes. At the time we blocked updating `/bidders/params` to set `size` as required, as it would make all legacy configs (ix configs lacking a `size` parameter) fail the entire request, not just the ix adapter part. It has been 5 months now, publishers should have had plenty of time to update their configs.

@ix-certification : will be leaving this PR up unmerged for a couple of weeks in case anyone has an issue with this change.