### PR TITLE
PubMatic Adslot validation

### DIFF
--- a/adapters/pubmatic/params_test.go
+++ b/adapters/pubmatic/params_test.go
@@ -40,6 +40,9 @@ func TestInvalidParams(t *testing.T) {
 }
 
 var validParams = []string{
+	`{"publisherId":"7890"}`,
+	`{"adSlot":"","publisherId":"7890"}`,
+	`{"adSlot":"AdTag_Div1","publisherId":"7890"}`,
 	`{"adSlot":"AdTag_Div1@728x90","publisherId":"7890"}`,
 	`{"adSlot":"AdTag_Div1@728x90","publisherId":"7890","keywords":[{"key": "pmZoneID", "value":["zone1"]},{"key": "dctr", "value":[ "v1","v2"]}]}`,
 	`{"adSlot":"AdTag_Div1@728x90","publisherId":"7890","keywords":[{"key": "pmZoneID", "value":["zone1", "zone2"]}], "wrapper":{"profile":5123}}`,
@@ -53,7 +56,6 @@ var invalidParams = []string{
 	`4.2`,
 	`[]`,
 	`{}`,
-	`{"publisherId":"7890"}`,
 	`{"adSlot":"AdTag_Div1@728x90:0"}`,
 	`{"adSlot":"AdTag_Div1@728x90:0","publisherId":1}`,
 	`{"adSlot":123,"publisherId":"7890"}`,

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -368,37 +368,38 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters
 	}}, errs
 }
 
-// validateAdslot validate the adslot object
+// validateAdslot validate the optional adslot string
 // valid formats are 'adslot@WxH', 'adslot' and no adslot
 func validateAdSlot(adslot string, imp *openrtb.Imp) error {
-	if len(adslot) == 0 {
-		return nil
-	}
-
-	if !strings.Contains(adslot, "@") {
-		imp.TagID = strings.TrimSpace(adslot)
-		return nil
-	}
-
 	adSlotStr := strings.TrimSpace(adslot)
+
+	if len(adSlotStr) == 0 {
+		return nil
+	}
+
+	if !strings.Contains(adSlotStr, "@") {
+		imp.TagID = adSlotStr
+		return nil
+	}
+
 	adSlot := strings.Split(adSlotStr, "@")
 	if len(adSlot) == 2 && adSlot[0] != "" && adSlot[1] != "" {
 		imp.TagID = strings.TrimSpace(adSlot[0])
 
 		adSize := strings.Split(strings.ToLower(strings.TrimSpace(adSlot[1])), "x")
 		if len(adSize) != 2 {
-			return errors.New(fmt.Sprintf("Invalid size provided in adSlot %v for ImpID = %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid size provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
 		}
 
 		width, err := strconv.Atoi(strings.TrimSpace(adSize[0]))
 		if err != nil {
-			return errors.New(fmt.Sprintf("Invalid width provided in adSlot %v for ImpID = %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid width provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
 		}
 
 		heightStr := strings.Split(strings.TrimSpace(adSize[1]), ":")
 		height, err := strconv.Atoi(strings.TrimSpace(heightStr[0]))
 		if err != nil {
-			return errors.New(fmt.Sprintf("Invalid height provided in adSlot %v for ImpID = %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid height provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
 		}
 
 		//In case of video, size could be derived from the player size
@@ -407,7 +408,7 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 			imp.Banner.W = openrtb.Uint64Ptr(uint64(width))
 		}
 	} else {
-		return errors.New(fmt.Sprintf("Invalid adSlot provided %v", adSlot))
+		return errors.New(fmt.Sprintf("Invalid adSlot %v for ImpID %v", adSlotStr, imp.ID))
 	}
 
 	return nil
@@ -449,12 +450,7 @@ func parseImpressionObject(imp *openrtb.Imp, wrapExt *string, pubID *string) err
 	}
 
 	if err := validateAdSlot(strings.TrimSpace(pubmaticExt.AdSlot), imp); err != nil {
-		fmt.Printf("Error __parin1__ %v", err.Error())
-		glog.Info(fmt.Sprintf("Error __parin1__ %v", err.Error()))
 		return err
-	} else {
-		fmt.Printf("Valid Adslot __parin2__ %v", pubmaticExt.AdSlot)
-		glog.Info(fmt.Sprintf("Valid Adslot __parin2__ %v", pubmaticExt.AdSlot))
 	}
 
 	if pubmaticExt.Keywords != nil && len(pubmaticExt.Keywords) != 0 {

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -388,18 +388,18 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 
 		adSize := strings.Split(strings.ToLower(strings.TrimSpace(adSlot[1])), "x")
 		if len(adSize) != 2 {
-			return errors.New(fmt.Sprintf("Invalid size provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid size provided in adSlot %v", adSlotStr))
 		}
 
 		width, err := strconv.Atoi(strings.TrimSpace(adSize[0]))
 		if err != nil {
-			return errors.New(fmt.Sprintf("Invalid width provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid width provided in adSlot %v", adSlotStr))
 		}
 
 		heightStr := strings.Split(strings.TrimSpace(adSize[1]), ":")
 		height, err := strconv.Atoi(strings.TrimSpace(heightStr[0]))
 		if err != nil {
-			return errors.New(fmt.Sprintf("Invalid height provided in adSlot %v for ImpID %v", adSlotStr, imp.ID))
+			return errors.New(fmt.Sprintf("Invalid height provided in adSlot %v", adSlotStr))
 		}
 
 		//In case of video, size could be derived from the player size
@@ -408,7 +408,7 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 			imp.Banner.W = openrtb.Uint64Ptr(uint64(width))
 		}
 	} else {
-		return errors.New(fmt.Sprintf("Invalid adSlot %v for ImpID %v", adSlotStr, imp.ID))
+		return errors.New(fmt.Sprintf("Invalid adSlot %v", adSlotStr))
 	}
 
 	return nil

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -386,7 +386,7 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 	if len(adSlot) == 2 && adSlot[0] != "" && adSlot[1] != "" {
 		imp.TagID = strings.TrimSpace(adSlot[0])
 
-		adSize := strings.Split(strings.ToLower(strings.TrimSpace(adSlot[1])), "x")
+		adSize := strings.Split(strings.ToLower(adSlot[1]), "x")
 		if len(adSize) != 2 {
 			return errors.New(fmt.Sprintf("Invalid size provided in adSlot %v", adSlotStr))
 		}
@@ -396,7 +396,7 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 			return errors.New(fmt.Sprintf("Invalid width provided in adSlot %v", adSlotStr))
 		}
 
-		heightStr := strings.Split(strings.TrimSpace(adSize[1]), ":")
+		heightStr := strings.Split(adSize[1], ":")
 		height, err := strconv.Atoi(strings.TrimSpace(heightStr[0]))
 		if err != nil {
 			return errors.New(fmt.Sprintf("Invalid height provided in adSlot %v", adSlotStr))

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -414,6 +414,27 @@ func validateAdSlot(adslot string, imp *openrtb.Imp) error {
 	return nil
 }
 
+func assignBannerSize(banner *openrtb.Banner) error {
+	if banner == nil {
+		return nil
+	}
+
+	if banner.W != nil && banner.H != nil {
+		return nil
+	}
+
+	if len(banner.Format) == 0 {
+		return errors.New(fmt.Sprintf("No sizes provided for Banner %v", banner.Format))
+	}
+
+	banner.W = new(uint64)
+	*banner.W = banner.Format[0].W
+	banner.H = new(uint64)
+	*banner.H = banner.Format[0].H
+
+	return nil
+}
+
 // parseImpressionObject parse the imp to get it ready to send to pubmatic
 func parseImpressionObject(imp *openrtb.Imp, wrapExt *string, pubID *string) error {
 	// PubMatic supports banner and video impressions.
@@ -451,6 +472,12 @@ func parseImpressionObject(imp *openrtb.Imp, wrapExt *string, pubID *string) err
 
 	if err := validateAdSlot(strings.TrimSpace(pubmaticExt.AdSlot), imp); err != nil {
 		return err
+	}
+
+	if imp.Banner != nil {
+		if err := assignBannerSize(imp.Banner); err != nil {
+			return err
+		}
 	}
 
 	if pubmaticExt.Keywords != nil && len(pubmaticExt.Keywords) != 0 {

--- a/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
@@ -11,7 +11,7 @@
             },
             "ext": {
                 "bidder": {
-                    "adSlot": "AdTag_Div1",
+                    "adSlot": "AdTag_Div1@",
                     "publisherId": "999"
                 }
             }
@@ -58,6 +58,34 @@
                     "publisherId": "999"
                 }
             }
+        },{
+            "id": "test-imp-id-5",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {
+                    "adSlot": "AdTag_Div1@300x",
+                    "publisherId": "999"
+                }
+            }
+        },{
+            "id": "test-imp-id-6",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {
+                    "adSlot": "AdTag_Div1@x250",
+                    "publisherId": "999"
+                }
+            }
         }],
         "site": {
 			"id": "siteID",
@@ -68,9 +96,11 @@
     },
   
     "expectedMakeRequestsErrors": [
-        "Invalid adSlot provided",
-        "Invalid size provided in adSlot",
-        "Invalid width provided in adSlot",
-        "Invalid height provided in adSlot"
+        "Invalid adSlot AdTag_Div1@ for ImpID test-imp-id-1",
+        "Invalid size provided in adSlot AdTag_Div1@300 for ImpID test-imp-id-2",
+        "Invalid width provided in adSlot AdTag_Div1@valx250 for ImpID test-imp-id-3",
+        "Invalid height provided in adSlot AdTag_Div1@300xval for ImpID test-imp-id-4",
+        "Invalid height provided in adSlot AdTag_Div1@300x for ImpID test-imp-id-5",
+        "Invalid width provided in adSlot AdTag_Div1@x250 for ImpID test-imp-id-6"
       ]
   }

--- a/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
@@ -96,11 +96,11 @@
     },
   
     "expectedMakeRequestsErrors": [
-        "Invalid adSlot AdTag_Div1@ for ImpID test-imp-id-1",
-        "Invalid size provided in adSlot AdTag_Div1@300 for ImpID test-imp-id-2",
-        "Invalid width provided in adSlot AdTag_Div1@valx250 for ImpID test-imp-id-3",
-        "Invalid height provided in adSlot AdTag_Div1@300xval for ImpID test-imp-id-4",
-        "Invalid height provided in adSlot AdTag_Div1@300x for ImpID test-imp-id-5",
-        "Invalid width provided in adSlot AdTag_Div1@x250 for ImpID test-imp-id-6"
+        "Invalid adSlot AdTag_Div1@",
+        "Invalid size provided in adSlot AdTag_Div1@300",
+        "Invalid width provided in adSlot AdTag_Div1@valx250",
+        "Invalid height provided in adSlot AdTag_Div1@300xval",
+        "Invalid height provided in adSlot AdTag_Div1@300x",
+        "Invalid width provided in adSlot AdTag_Div1@x250"
       ]
   }

--- a/openrtb_ext/imp_pubmatic.go
+++ b/openrtb_ext/imp_pubmatic.go
@@ -3,7 +3,8 @@ package openrtb_ext
 import "encoding/json"
 
 // ExtImpPubmatic defines the contract for bidrequest.imp[i].ext.pubmatic
-// PublisherId and adSlot are mandatory parameters, others are optional parameters
+// PublisherId is mandatory parameters, others are optional parameters
+// AdSlot is identifier for specific ad placement or ad tag
 // Keywords is bid specific parameter,
 // WrapExt needs to be sent once per bid request
 
@@ -14,7 +15,7 @@ type ExtImpPubmatic struct {
 	Keywords    []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
 }
 
-// ExtImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.appnexus.keywords[i]
+// ExtImpPubmaticKeyVal defines the contract for bidrequest.imp[i].ext.pubmatic.keywords[i]
 type ExtImpPubmaticKeyVal struct {
 	Key    string   `json:"key,omitempty"`
 	Values []string `json:"value,omitempty"`

--- a/static/bidder-params/pubmatic.json
+++ b/static/bidder-params/pubmatic.json
@@ -49,5 +49,5 @@
 			}
 		  }
 	},
-	"required": ["publisherId", "adSlot"]
+	"required": ["publisherId"]
 }


### PR DESCRIPTION
Make AdSlot as optional parameter and make changes in adslot validation. The valid format for the optional string adslot are :  'adslot@WxH' and 'adslot'

If Width and Height parameters are not present for Banner, assign them to the Banner object from the first size in the array format sizes.