### PR TITLE
Modify bidder info endpoint to be able to get all bidder details

### DIFF
--- a/endpoints/info/bidders.go
+++ b/endpoints/info/bidders.go
@@ -37,6 +37,12 @@ func NewBiddersEndpoint(aliases map[string]string) httprouter.Handle {
 
 // NewBidderDetailsEndpoint implements /info/bidders/*
 func NewBidderDetailsEndpoint(infos adapters.BidderInfos, aliases map[string]string) httprouter.Handle {
+	// Validate if there exist and alias with name "all". If it does error out because
+	// that will break the /info/bidders/all endpoint.
+	if _, ok := aliases["all"]; ok {
+		glog.Fatal("Default aliases shouldn't contain an alias with name \"all\". This will break the /info/bidders/all endpoint")
+	}
+
 	// Build a new map that's basically a copy of "infos" but will also contain
 	// alias bidder infos
 	var allBidderInfo = make(map[string]adapters.BidderInfo, len(infos)+len(aliases))

--- a/endpoints/info/bidders_test.go
+++ b/endpoints/info/bidders_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/endpoints/info"
@@ -37,32 +38,29 @@ func testGetBidders(t *testing.T, aliases map[string]string) {
 
 	req, err := http.NewRequest("GET", "http://prebid-server.com/info/bidders", strings.NewReader(""))
 	if err != nil {
-		t.Fatalf("Failed to create a GET /info/bidders request: %v", err)
+		assert.FailNow(t, "Failed to create a GET /info/bidders request: %v", err)
 	}
 
 	r := httptest.NewRecorder()
 	endpoint(r, req, nil)
-	if r.Code != http.StatusOK {
-		t.Errorf("GET /info/bidders returned bad status: %d", r.Code)
-	}
-	if r.Header().Get("Content-Type") != "application/json" {
-		t.Errorf("Bad /info/bidders content type. Expected application/json. Got %s", r.Header().Get("Content-Type"))
-	}
+
+	assert.Equal(t, http.StatusOK, r.Code, "GET /info/bidders returned bad status: %d", r.Code)
+	assert.Equal(t, "application/json", r.Header().Get("Content-Type"), "Bad /info/bidders content type. Expected application/json. Got %s", r.Header().Get("Content-Type"))
+
 	bodyBytes := r.Body.Bytes()
 	bidderSlice := make([]string, 0, len(openrtb_ext.BidderMap)+len(aliases))
-	if err := json.Unmarshal(bodyBytes, &bidderSlice); err != nil {
-		t.Errorf("Failed to unmarshal /info/bidders response: %v", err)
-	}
+	err = json.Unmarshal(bodyBytes, &bidderSlice)
+	assert.NoError(t, err, "Failed to unmarshal /info/bidders response: %v", err)
+
 	for _, bidderName := range bidderSlice {
 		if _, ok := openrtb_ext.BidderMap[bidderName]; !ok {
-			if _, aok := aliases[bidderName]; !aok {
-				t.Errorf("Response from /info/bidders contained unexpected BidderName: %s", bidderName)
-			}
+			assert.Contains(t, aliases, bidderName, "Response from /info/bidders contained unexpected BidderName: %s", bidderName)
 		}
 	}
-	if len(bidderSlice) != len(openrtb_ext.BidderMap)+len(aliases) {
-		t.Errorf("Response from /info/bidders did not match BidderMap. Expected %d elements. Got %d", len(openrtb_ext.BidderMap), len(bidderSlice))
-	}
+
+	assert.Len(t, bidderSlice, len(openrtb_ext.BidderMap)+len(aliases),
+		"Response from /info/bidders did not match BidderMap. Expected %d elements. Got %d",
+		len(openrtb_ext.BidderMap)+len(aliases), len(bidderSlice))
 }
 
 // TestGetSpecificBidders validates all the GET /info/bidders/{bidderName} endpoints
@@ -84,12 +82,8 @@ func TestGetSpecificBidders(t *testing.T) {
 
 		endpoint(r, req, params)
 
-		if r.Code != http.StatusOK {
-			t.Errorf("GET /info/bidders/"+bidderName+" returned a %d. Expected 200", r.Code)
-		}
-		if r.HeaderMap.Get("Content-Type") != "application/json" {
-			t.Errorf("GET /info/bidders/"+bidderName+" returned Content-Type %s. Expected application/json", r.HeaderMap.Get("Content-Type"))
-		}
+		assert.Equal(t, http.StatusOK, r.Code, "GET /info/bidders/"+bidderName+" returned a %d. Expected 200", r.Code)
+		assert.Equal(t, "application/json", r.HeaderMap.Get("Content-Type"), "GET /info/bidders/"+bidderName+" returned Content-Type %s. Expected application/json", r.HeaderMap.Get("Content-Type"))
 	}
 }
 
@@ -114,9 +108,7 @@ func testGetBidderAccuracy(t *testing.T, alias string) {
 
 	endpoint := info.NewBidderDetailsEndpoint(bidderInfos, aliases)
 	req, err := http.NewRequest("GET", "http://prebid-server.com/info/bidders/"+bidder, strings.NewReader(""))
-	if err != nil {
-		t.Fatalf("Failed to create a GET /info/bidders request: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create a GET /info/bidders request: %v", err)
 	params := []httprouter.Param{{
 		Key:   "bidderName",
 		Value: bidder,
@@ -127,43 +119,21 @@ func testGetBidderAccuracy(t *testing.T, alias string) {
 
 	var fileData adapters.BidderInfo
 	if err := json.Unmarshal(r.Body.Bytes(), &fileData); err != nil {
-		t.Fatalf("Failed to unmarshal JSON from endpoints/info/sample/someBidder.yaml: %v", err)
+		assert.FailNow(t, "Failed to unmarshal JSON from endpoints/info/sample/someBidder.yaml: %v", err)
 	}
 
-	if fileData.Maintainer.Email != "some-email@domain.com" {
-		t.Errorf("maintainer.email should be some-email@domain.com. Got %s", fileData.Maintainer.Email)
-	}
-
-	if len(fileData.Capabilities.App.MediaTypes) != 2 {
-		t.Fatalf("Expected 2 supported mediaTypes on app. Got %d", len(fileData.Capabilities.App.MediaTypes))
-	}
-	if fileData.Capabilities.App.MediaTypes[0] != "banner" {
-		t.Errorf("capabilities.app.mediaTypes[0] should be banner. Got %s", fileData.Capabilities.App.MediaTypes[0])
-	}
-	if fileData.Capabilities.App.MediaTypes[1] != "native" {
-		t.Errorf("capabilities.app.mediaTypes[1] should be native. Got %s", fileData.Capabilities.App.MediaTypes[1])
-	}
-
-	if len(fileData.Capabilities.Site.MediaTypes) != 3 {
-		t.Fatalf("Expected 3 supported mediaTypes on app. Got %d", len(fileData.Capabilities.Site.MediaTypes))
-	}
-	if fileData.Capabilities.Site.MediaTypes[0] != "banner" {
-		t.Errorf("capabilities.app.mediaTypes[0] should be banner. Got %s", fileData.Capabilities.Site.MediaTypes[0])
-	}
-	if fileData.Capabilities.Site.MediaTypes[1] != "video" {
-		t.Errorf("capabilities.app.mediaTypes[1] should be video. Got %s", fileData.Capabilities.Site.MediaTypes[1])
-	}
-	if fileData.Capabilities.Site.MediaTypes[2] != "native" {
-		t.Errorf("capabilities.app.mediaTypes[2] should be native. Got %s", fileData.Capabilities.Site.MediaTypes[2])
-	}
+	assert.Equal(t, "some-email@domain.com", fileData.Maintainer.Email, "maintainer.email should be some-email@domain.com. Got %s", fileData.Maintainer.Email)
+	assert.Len(t, fileData.Capabilities.App.MediaTypes, 2, "Expected 2 supported mediaTypes on app. Got %d", len(fileData.Capabilities.App.MediaTypes))
+	assert.Equal(t, openrtb_ext.BidType("banner"), fileData.Capabilities.App.MediaTypes[0], "capabilities.app.mediaTypes[0] should be banner. Got %s", fileData.Capabilities.App.MediaTypes[0])
+	assert.Equal(t, openrtb_ext.BidType("native"), fileData.Capabilities.App.MediaTypes[1], "capabilities.app.mediaTypes[1] should be native. Got %s", fileData.Capabilities.App.MediaTypes[1])
+	assert.Len(t, fileData.Capabilities.Site.MediaTypes, 3, "Expected 3 supported mediaTypes on app. Got %d", len(fileData.Capabilities.Site.MediaTypes))
+	assert.Equal(t, openrtb_ext.BidType("banner"), fileData.Capabilities.Site.MediaTypes[0], "capabilities.app.mediaTypes[0] should be banner. Got %s", fileData.Capabilities.Site.MediaTypes[0])
+	assert.Equal(t, openrtb_ext.BidType("video"), fileData.Capabilities.Site.MediaTypes[1], "capabilities.app.mediaTypes[1] should be video. Got %s", fileData.Capabilities.Site.MediaTypes[1])
+	assert.Equal(t, openrtb_ext.BidType("native"), fileData.Capabilities.Site.MediaTypes[2], "capabilities.app.mediaTypes[2] should be native. Got %s", fileData.Capabilities.Site.MediaTypes[2])
 	if len(alias) > 0 {
-		if fileData.AliasOf != "someBidder" {
-			t.Errorf("aliasOf should be \"someBidder\". Got \"%s\"", fileData.AliasOf)
-		}
+		assert.Equal(t, "someBidder", fileData.AliasOf, "aliasOf should be \"someBidder\". Got \"%s\"", fileData.AliasOf)
 	} else {
-		if len(fileData.AliasOf) != 0 {
-			t.Errorf("aliasOf should be empty. Got \"%s\"", fileData.AliasOf)
-		}
+		assert.Zero(t, len(fileData.AliasOf), "aliasOf should be empty. Got \"%s\"", fileData.AliasOf)
 	}
 }
 
@@ -172,7 +142,7 @@ func TestGetUnknownBidder(t *testing.T) {
 	endpoint := info.NewBidderDetailsEndpoint(bidderInfos, map[string]string{})
 	req, err := http.NewRequest("GET", "http://prebid-server.com/info/bidders/someUnknownBidder", strings.NewReader(""))
 	if err != nil {
-		t.Fatalf("Failed to create a GET /info/bidders/someUnknownBidder request: %v", err)
+		assert.FailNow(t, "Failed to create a GET /info/bidders/someUnknownBidder request: %v", err)
 	}
 
 	params := []httprouter.Param{{
@@ -182,50 +152,64 @@ func TestGetUnknownBidder(t *testing.T) {
 	r := httptest.NewRecorder()
 
 	endpoint(r, req, params)
-	if r.Code != http.StatusNotFound {
-		t.Errorf("GET /info/bidders/* should return a 404 on unknown bidders. Got %d", r.Code)
+	assert.Equal(t, http.StatusNotFound, r.Code, "GET /info/bidders/* should return a 404 on unknown bidders. Got %d", r.Code)
+}
+func TestGetAllBidders(t *testing.T) {
+	bidderInfos := adapters.ParseBidderInfos("../../static/bidder-info", openrtb_ext.BidderList())
+	endpoint := info.NewBidderDetailsEndpoint(bidderInfos, map[string]string{})
+	req, err := http.NewRequest("GET", "http://prebid-server.com/info/bidders/all", strings.NewReader(""))
+	if err != nil {
+		assert.FailNow(t, "Failed to create a GET /info/bidders/someUnknownBidder request: %v", err)
 	}
+	params := []httprouter.Param{{
+		Key:   "bidderName",
+		Value: "all",
+	}}
+	r := httptest.NewRecorder()
+
+	endpoint(r, req, params)
+	assert.Equal(t, http.StatusOK, r.Code, "GET /info/bidders/all returned a %d. Expected 200", r.Code)
+	assert.Equal(t, "application/json", r.HeaderMap.Get("Content-Type"), "GET /info/bidders/all returned Content-Type %s. Expected application/json", r.HeaderMap.Get("Content-Type"))
+
+	var resBidderInfos map[string]adapters.BidderInfo
+
+	if err := json.Unmarshal(r.Body.Bytes(), &resBidderInfos); err != nil {
+		assert.FailNow(t, "Failed to unmarshal JSON from endpoints/info/sample/someBidder.yaml: %v", err)
+	}
+
+	assert.Len(t, resBidderInfos, len(bidderInfos), "GET /info/bidders/all should respond with all bidders info")
 }
 
 // TestInfoFiles makes sure that static/bidder-info contains a .yaml file for every BidderName.
 func TestInfoFiles(t *testing.T) {
 	fileInfos, err := ioutil.ReadDir("../../static/bidder-info")
 	if err != nil {
-		t.Fatalf("Error reading the static/bidder-info directory: %v", err)
+		assert.FailNow(t, "Error reading the static/bidder-info directory: %v", err)
 	}
 
 	// Make sure that files exist for each BidderName
 	for bidderName := range openrtb_ext.BidderMap {
-		if _, err := os.Stat(fmt.Sprintf("../../static/bidder-info/%s.yaml", bidderName)); os.IsNotExist(err) {
-			t.Errorf("static/bidder-info/%s.yaml not found. Did you forget to create it?", bidderName)
-		}
+		_, err := os.Stat(fmt.Sprintf("../../static/bidder-info/%s.yaml", bidderName))
+		assert.False(t, os.IsNotExist(err), "static/bidder-info/%s.yaml not found. Did you forget to create it?", bidderName)
 	}
 
-	if len(fileInfos) != len(openrtb_ext.BidderMap) {
-		t.Errorf("static/bidder-info contains %d files, but the BidderMap has %d entries. These two should be in sync.", len(fileInfos), len(openrtb_ext.BidderMap))
-	}
+	assert.Len(t, fileInfos, len(openrtb_ext.BidderMap), "static/bidder-info contains %d files, but the BidderMap has %d entries. These two should be in sync.", len(fileInfos), len(openrtb_ext.BidderMap))
 
 	// Make sure that all the files have valid content
 	for _, fileInfo := range fileInfos {
 		infoFileData, err := os.Open(fmt.Sprintf("../../static/bidder-info/%s", fileInfo.Name()))
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-			continue
-		}
+		assert.NoError(t, err, "Unexpected error: %v", err)
 
 		content, err := ioutil.ReadAll(infoFileData)
-		if err != nil {
-			t.Errorf("Failed to read static/bidder-info/%s: %v", fileInfo.Name(), err)
-			continue
-		}
+		assert.NoError(t, err, "Failed to read static/bidder-info/%s: %v", fileInfo.Name(), err)
+
 		var fileInfoContent adapters.BidderInfo
-		if err := yaml.Unmarshal(content, &fileInfoContent); err != nil {
-			t.Errorf("Error interpreting content from static/bidder-info/%s: %v", fileInfo.Name(), err)
-			continue
-		}
-		if err := validateInfo(&fileInfoContent); err != nil {
-			t.Errorf("Invalid content in static/bidder-info/%s: %v", fileInfo.Name(), err)
-		}
+		err = yaml.Unmarshal(content, &fileInfoContent)
+		assert.NoError(t, err, "Error interpreting content from static/bidder-info/%s: %v", fileInfo.Name(), err)
+
+		err = validateInfo(&fileInfoContent)
+		assert.NoError(t, err, "Invalid content in static/bidder-info/%s: %v", fileInfo.Name(), err)
+
 	}
 }
 


### PR DESCRIPTION
- Add a fake bidderName "all" that responds with all bidder details
- Modify bidder_test file to use "testify/assert" package to do assertions

Docs PR for the same: https://github.com/prebid/prebid.github.io/pull/1297