### PR TITLE
 Fixed "invalid BidType: " error for lifestreet adapter

### DIFF
--- a/adapters/lifestreet/lifestreet.go
+++ b/adapters/lifestreet/lifestreet.go
@@ -92,14 +92,14 @@ func (a *LifestreetAdapter) callOne(ctx context.Context, req *pbs.PBSRequest, re
 	}
 
 	result.Bid = &pbs.PBSBid{
-		AdUnitCode:  bid.ImpID,
-		Price:       bid.Price,
-		Adm:         bid.AdM,
-		Creative_id: bid.CrID,
-		Width:       bid.W,
-		Height:      bid.H,
-		DealId:      bid.DealID,
-		NURL:        bid.NURL,
+		AdUnitCode:        bid.ImpID,
+		Price:             bid.Price,
+		Adm:               bid.AdM,
+		Creative_id:       bid.CrID,
+		Width:             bid.W,
+		Height:            bid.H,
+		DealId:            bid.DealID,
+		NURL:              bid.NURL,
 		CreativeMediaType: t,
 	}
 	return


### PR DESCRIPTION
On the live traffic, we figured out that a client receives an error from our adapter:

`"errors": { "lifestreet": [{ "code": 999, "message": "invalid BidType: " }] },`

This change should fix the issue