### PR TITLE
Add a PI exemption environment variable to PBS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -122,6 +122,7 @@ type GDPR struct {
 	HostVendorID        int          `mapstructure:"host_vendor_id"`
 	UsersyncIfAmbiguous bool         `mapstructure:"usersync_if_ambiguous"`
 	Timeouts            GDPRTimeouts `mapstructure:"timeouts_ms"`
+	TrustVendors        []string     `mapstructure:"trust_vendors,flow"`
 }
 
 func (cfg *GDPR) validate(errs configErrors) configErrors {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ var fullConfig = []byte(`
 gdpr:
   host_vendor_id: 15
   usersync_if_ambiguous: true
+  trust_vendors: ["appbid001","pubbid001"]
 host_cookie:
   cookie_name: userid
   family: prebid
@@ -157,6 +158,8 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "http_client.idle_connection_timeout_seconds", cfg.Client.IdleConnTimeout, 30)
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
+	cmpStrings(t, "gdpr.trust_vendors", cfg.GDPR.TrustVendors[0], "appbid001")
+	cmpStrings(t, "gdpr.trust_vendors", cfg.GDPR.TrustVendors[1], "pubbid001")
 	cmpStrings(t, "currency_converter.fetch_url", cfg.CurrencyConverter.FetchURL, "https://currency.prebid.org")
 	cmpInts(t, "currency_converter.fetch_interval_seconds", cfg.CurrencyConverter.FetchIntervalSeconds, 1800)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -347,14 +347,12 @@ func (a *auction) shouldUsersync(ctx context.Context, bidder openrtb_ext.BidderN
 // cache video bids only for Web
 func cacheVideoOnly(bids pbs.PBSBidSlice, ctx context.Context, w http.ResponseWriter, deps *auction, labels *pbsmetrics.Labels) {
 	var cobjs []*pbc.CacheObject
-	var indexList []int
-	for i, bid := range bids {
+	for _, bid := range bids {
 		if bid.CreativeMediaType == "video" {
 			cobjs = append(cobjs, &pbc.CacheObject{
 				Value:   bid.Adm,
 				IsVideo: true,
 			})
-			indexList = append(indexList, i)
 		}
 	}
 	err := pbc.Put(ctx, cobjs)
@@ -363,13 +361,15 @@ func cacheVideoOnly(bids pbs.PBSBidSlice, ctx context.Context, w http.ResponseWr
 		labels.RequestStatus = pbsmetrics.RequestStatusErr
 		return
 	}
-	var cobjsIndex int = 0
-	for _, videoIndex := range indexList {
-		bids[videoIndex].CacheID = cobjs[cobjsIndex].UUID
-		bids[videoIndex].CacheURL = deps.cfg.GetCachedAssetURL(bids[videoIndex].CacheID)
-		bids[videoIndex].NURL = ""
-		bids[videoIndex].Adm = ""
-		cobjsIndex++
+	videoIndex := 0
+	for _, bid := range bids {
+		if bid.CreativeMediaType == "video" {
+			bid.CacheID = cobjs[videoIndex].UUID
+			bid.CacheURL = deps.cfg.GetCachedAssetURL(bid.CacheID)
+			bid.NURL = ""
+			bid.Adm = ""
+			videoIndex++
+		}
 	}
 }
 

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -41,6 +41,12 @@ func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 func (p *permissionsImpl) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
 	id, ok := p.vendorIDs[bidder]
 	if ok {
+		// Linear seach the bidderName in the GDPR TrustVendors array. These trusted vendors come from the configuration .yaml file
+		for _, trustedBidder := range p.cfg.TrustVendors {
+			if trustedBidder == string(bidder) {
+				return true, nil
+			}
+		}
 		return p.allowPI(ctx, id, consent)
 	}
 

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -182,6 +182,12 @@ func TestAllowPersonalInfo(t *testing.T) {
 	allowPI, err = perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderPubmatic, "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
 	assertNilErr(t, err)
 	assertBoolsEqual(t, true, allowPI)
+
+	// Assert that an item that otherwise would not be allowed PI access, gets approved because it is found in the GDPR.TrustVendor array
+	perms.cfg.TrustVendors = []string{string(openrtb_ext.BidderOpenx), string(openrtb_ext.BidderAppnexus)}
+	allowPI, err = perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderAppnexus, "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
+	assertNilErr(t, err)
+	assertBoolsEqual(t, true, allowPI)
 }
 
 func parseVendorListData(t *testing.T, data string) vendorlist.VendorList {


### PR DESCRIPTION
PBS internally determines if the impression from a sender includes the publisher_id RTB parameter, and if publisher_id is present in an ENV/config variable set by the PBS owner, skip the GDPR check internally but leave the gdpr=1/0 flag intact. 