### PR TITLE
Use the correct labels for cache performance metric

### DIFF
--- a/pbsmetrics/prometheus/prometheus.go
+++ b/pbsmetrics/prometheus/prometheus.go
@@ -90,12 +90,12 @@ func NewMetrics(cfg config.PrometheusMetrics) *Metrics {
 	metrics.Registry.MustRegister(metrics.adaptBids)
 	metrics.storedReqCacheResult = newCounter(cfg, "stored_request_cache_performance",
 		"Number of stored request cache hits vs miss",
-		standardLabelNames,
+		[]string{"cache_result"},
 	)
 	metrics.Registry.MustRegister(metrics.storedReqCacheResult)
 	metrics.storedImpCacheResult = newCounter(cfg, "stored_imp_cache_performance",
 		"Number of stored imp cache hits vs miss",
-		standardLabelNames,
+		[]string{"cache_result"},
 	)
 	metrics.Registry.MustRegister(metrics.storedImpCacheResult)
 	metrics.adaptPrices = newHistogram(cfg, "adapter_prices",
@@ -365,6 +365,11 @@ func initializeTimeSeries(m *Metrics) {
 	for _, l := range cookieLabels {
 		_ = m.adaptCookieSync.With(l)
 	}
+	cacheLabels := addDimension([]prometheus.Labels{}, "cache_result", cacheResultAsString())
+	for _, l := range cacheLabels {
+		_ = m.storedImpCacheResult.With(l)
+		_ = m.storedReqCacheResult.With(l)
+	}
 }
 
 // addDimesion will expand a slice of labels to add the dimension of a new set of values for a new label name
@@ -456,6 +461,15 @@ func adapterBidsAsString() []string {
 
 func adapterErrorsAsString() []string {
 	list := pbsmetrics.AdapterErrors()
+	output := make([]string, len(list))
+	for i, s := range list {
+		output[i] = string(s)
+	}
+	return output
+}
+
+func cacheResultAsString() []string {
+	list := pbsmetrics.CacheResults()
 	output := make([]string, len(list))
 	for i, s := range list {
 		output[i] = string(s)

--- a/pbsmetrics/prometheus/prometheus_test.go
+++ b/pbsmetrics/prometheus/prometheus_test.go
@@ -279,6 +279,40 @@ func TestAdapterTimeMetrics(t *testing.T) {
 
 }
 
+func TestRecordStoredReqCacheResult(t *testing.T) {
+	proMetrics := newTestMetricsEngine()
+
+	metricCacheHit := dto.Metric{}
+	metricCacheMiss := dto.Metric{}
+
+	proMetrics.RecordStoredReqCacheResult(pbsmetrics.CacheHit, 2)
+	proMetrics.RecordStoredReqCacheResult(pbsmetrics.CacheHit, 0)
+	proMetrics.RecordStoredReqCacheResult(pbsmetrics.CacheMiss, 1)
+
+	proMetrics.storedReqCacheResult.WithLabelValues(string(pbsmetrics.CacheHit)).Write(&metricCacheHit)
+	proMetrics.storedReqCacheResult.WithLabelValues(string(pbsmetrics.CacheMiss)).Write(&metricCacheMiss)
+
+	assertCounterValue(t, "stored_request_cache_performance[hit]", &metricCacheHit, 2)
+	assertCounterValue(t, "stored_request_cache_performance[miss]", &metricCacheMiss, 1)
+}
+
+func TestRecordStoredImpCacheResult(t *testing.T) {
+	proMetrics := newTestMetricsEngine()
+
+	metricCacheHit := dto.Metric{}
+	metricCacheMiss := dto.Metric{}
+
+	proMetrics.RecordStoredImpCacheResult(pbsmetrics.CacheHit, 2)
+	proMetrics.RecordStoredImpCacheResult(pbsmetrics.CacheHit, 0)
+	proMetrics.RecordStoredImpCacheResult(pbsmetrics.CacheMiss, 1)
+
+	proMetrics.storedImpCacheResult.WithLabelValues(string(pbsmetrics.CacheHit)).Write(&metricCacheHit)
+	proMetrics.storedImpCacheResult.WithLabelValues(string(pbsmetrics.CacheMiss)).Write(&metricCacheMiss)
+
+	assertCounterValue(t, "stored_imp_cache_performance[hit]", &metricCacheHit, 2)
+	assertCounterValue(t, "stored_imp_cache_performance[miss]", &metricCacheMiss, 1)
+}
+
 func TestCookieMetrics(t *testing.T) {
 	proMetrics := newTestMetricsEngine()
 
@@ -332,6 +366,7 @@ func TestMetricsExist(t *testing.T) {
 
 	if err := proMetrics.Registry.Register(prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "prebid",
+		Subsystem: "server",
 		Name:      "active_connections",
 		Help:      "Current number of active (open) connections.",
 	})); err == nil {
@@ -343,7 +378,7 @@ func newTestMetricsEngine() *Metrics {
 	return NewMetrics(config.PrometheusMetrics{
 		Port:      8080,
 		Namespace: "prebid",
-		Subsystem: "",
+		Subsystem: "server",
 	})
 }
 


### PR DESCRIPTION
Cache performance metric for prometheus was using `standardLabels` where it should have been using only the `cache_result` label with values `hit` and `miss`. This PR rectifies that, adds a dimension for the cache performance metric with the cache_result label and unit tests to verify everything works as expected.