### PR TITLE
Add a PI exemption environment variable to PBS

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ var fullConfig = []byte(`
 gdpr:
   host_vendor_id: 15
   usersync_if_ambiguous: true
+  trusted_publishers: ["siteID","fake-site-id","appID","agltb3B1Yi1pbmNyDAsSA0FwcBiJkfIUDA"]
 host_cookie:
   cookie_name: userid
   family: prebid
@@ -157,6 +158,22 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "http_client.idle_connection_timeout_seconds", cfg.Client.IdleConnTimeout, 30)
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
+
+	//Assert the TrustedPublisherList was correctly unmarshalled
+	cmpStrings(t, "gdpr.trusted_publishers", cfg.GDPR.TrustedPublisherList[0], "siteID")
+	cmpStrings(t, "gdpr.trusted_publishers", cfg.GDPR.TrustedPublisherList[1], "fake-site-id")
+	cmpStrings(t, "gdpr.trusted_publishers", cfg.GDPR.TrustedPublisherList[2], "appID")
+	cmpStrings(t, "gdpr.trusted_publishers", cfg.GDPR.TrustedPublisherList[3], "agltb3B1Yi1pbmNyDAsSA0FwcBiJkfIUDA")
+
+	//Assert the TrustedPublisherMap hash table was built correctly
+	var found bool
+	for i := 0; i < len(cfg.GDPR.TrustedPublisherList); i++ {
+		_, found = cfg.GDPR.TrustedPublisherMap[cfg.GDPR.TrustedPublisherList[i]]
+		cmpBools(t, "cfg.GDPR.TrustedPublisherMap", found, true)
+	}
+	_, found = cfg.GDPR.TrustedPublisherMap["appnexus"]
+	cmpBools(t, "cfg.GDPR.TrustedPublisherMap", found, false)
+
 	cmpStrings(t, "currency_converter.fetch_url", cfg.CurrencyConverter.FetchURL, "https://currency.prebid.org")
 	cmpInts(t, "currency_converter.fetch_interval_seconds", cfg.CurrencyConverter.FetchIntervalSeconds, 1800)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")

--- a/endpoints/auction_test.go
+++ b/endpoints/auction_test.go
@@ -409,7 +409,7 @@ func (m *auctionMockPermissions) BidderSyncAllowed(ctx context.Context, bidder o
 	return m.allowBidderSync, nil
 }
 
-func (m *auctionMockPermissions) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (m *auctionMockPermissions) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return m.allowPI, nil
 }
 

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -198,6 +198,6 @@ func (g *gdprPerms) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.Bi
 	return ok, nil
 }
 
-func (g *gdprPerms) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (g *gdprPerms) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return true, nil
 }

--- a/endpoints/setuid_test.go
+++ b/endpoints/setuid_test.go
@@ -193,6 +193,6 @@ func (g *mockPermsSetUID) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return false, nil
 }
 
-func (g *mockPermsSetUID) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (g *mockPermsSetUID) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return g.allowPI, nil
 }

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -45,7 +45,16 @@ func cleanOpenRTBRequests(ctx context.Context,
 		for bidder, bidReq := range requestsByBidder {
 			// Fixes #820
 			coreBidder := resolveBidder(bidder.String(), aliases)
-			if ok, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, consent); !ok && err == nil {
+
+			var publisher_id string
+			if bidReq.Site != nil && bidReq.Site.ID != "" {
+				publisher_id = bidReq.Site.ID
+			} else if bidReq.App != nil {
+				publisher_id = bidReq.App.ID
+			} else {
+				publisher_id = ""
+			}
+			if ok, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, publisher_id, consent); !ok && err == nil {
 				cleanPI(bidReq, labels.RType == pbsmetrics.ReqTypeAMP)
 			}
 		}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -24,7 +24,7 @@ func (p *permissionsMock) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return true, nil
 }
 
-func (p *permissionsMock) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (p *permissionsMock) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	if bidder == "appnexus" {
 		return true, nil
 	}

--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -22,7 +22,7 @@ type Permissions interface {
 	// Determines whether or not to send PI information to a bidder, or mask it out.
 	//
 	// If the consent string was nonsenical, the returned error will be an ErrorMalformedConsent.
-	PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error)
+	PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error)
 }
 
 // NewPermissions gets an instance of the Permissions for use elsewhere in the project.

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -38,7 +38,12 @@ func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return false, nil
 }
 
-func (p *permissionsImpl) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (p *permissionsImpl) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
+	_, ok := p.cfg.TrustedPublisherMap[PublisherID]
+	if ok {
+		return true, nil
+	}
+
 	id, ok := p.vendorIDs[bidder]
 	if ok {
 		return p.allowPI(ctx, id, consent)
@@ -125,6 +130,6 @@ func (a AlwaysAllow) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.B
 	return true, nil
 }
 
-func (a AlwaysAllow) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, consent string) (bool, error) {
+func (a AlwaysAllow) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return true, nil
 }

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -175,11 +175,21 @@ func TestAllowPersonalInfo(t *testing.T) {
 	}
 
 	// PI needs both purposes to succeed
-	allowPI, err := perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderAppnexus, "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
+	allowPI, err := perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderAppnexus, "", "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
 	assertNilErr(t, err)
 	assertBoolsEqual(t, false, allowPI)
 
-	allowPI, err = perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderPubmatic, "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
+	allowPI, err = perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderPubmatic, "", "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
+	assertNilErr(t, err)
+	assertBoolsEqual(t, true, allowPI)
+
+	// Assert that an item that otherwise would not be allowed PI access, gets approved because it is found in the GDPR.TrustedPublisherList array
+	perms.cfg.TrustedPublisherList = []string{"siteID", "fake-site-id", "appNexusAppID"}
+	perms.cfg.TrustedPublisherMap = make(map[string]int)
+	for _, publisher_id := range perms.cfg.TrustedPublisherList {
+		perms.cfg.TrustedPublisherMap[publisher_id] = 1
+	}
+	allowPI, err = perms.PersonalInfoAllowed(context.Background(), openrtb_ext.BidderAppnexus, "appNexusAppID", "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA")
 	assertNilErr(t, err)
 	assertBoolsEqual(t, true, allowPI)
 }


### PR DESCRIPTION
**This pull request substitutes #897**
PBS internally determines if the impression from a sender includes the publisher_id RTB parameter, and if publisher_id is present in an ENV/config variable set by the PBS owner, skip the GDPR check internally but leave the gdpr=1/0 flag intact. This ticket is intended to substitute PBS-372 since it was rejected in favor of this approach.