### PR TITLE
Index the topBidsPerImp hash map by impID

### DIFF
--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -117,8 +117,8 @@ func loadCacheSpec(filename string) (*cacheSpec, error) {
 // finds the highest bid of every Imp.
 func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 	var bid *pbsOrtbBid
-	winningBidsByImp := make(map[string]*pbsOrtbBid)
-	winningBidsByBidder := make(map[string]map[openrtb_ext.BidderName]*pbsOrtbBid)
+	impsToTopBids := make(map[string]*pbsOrtbBid)
+	impsToBiddersTopBids := make(map[string]map[openrtb_ext.BidderName]*pbsOrtbBid)
 	roundedPrices := make(map[*pbsOrtbBid]string)
 	bidCategory := make(map[string]string)
 
@@ -131,20 +131,20 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 		cpm := bid.bid.Price
 
 		// Map this bid if it's the highest we've seen from this Imp so far
-		wbid, ok := winningBidsByImp[bid.bid.ImpID]
+		wbid, ok := impsToTopBids[bid.bid.ImpID]
 		if !ok || cpm > wbid.bid.Price {
-			winningBidsByImp[bid.bid.ImpID] = bid
+			impsToTopBids[bid.bid.ImpID] = bid
 		}
 
 		// Map this bid if it's the highest we've seen from this bidder so far
-		if _, ok := winningBidsByBidder[bid.bid.ImpID]; ok {
-			bestSoFar, ok := winningBidsByBidder[bid.bid.ImpID][pbsBid.Bidder]
+		if _, ok := impsToBiddersTopBids[bid.bid.ImpID]; ok {
+			bestSoFar, ok := impsToBiddersTopBids[bid.bid.ImpID][pbsBid.Bidder]
 			if !ok || cpm > bestSoFar.bid.Price {
-				winningBidsByBidder[bid.bid.ImpID][pbsBid.Bidder] = bid
+				impsToBiddersTopBids[bid.bid.ImpID][pbsBid.Bidder] = bid
 			}
 		} else {
-			winningBidsByBidder[bid.bid.ImpID] = make(map[openrtb_ext.BidderName]*pbsOrtbBid)
-			winningBidsByBidder[bid.bid.ImpID][pbsBid.Bidder] = bid
+			impsToBiddersTopBids[bid.bid.ImpID] = make(map[openrtb_ext.BidderName]*pbsOrtbBid)
+			impsToBiddersTopBids[bid.bid.ImpID][pbsBid.Bidder] = bid
 		}
 
 		if len(pbsBid.Bid.Cat) == 1 {
@@ -184,9 +184,9 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 	}
 
 	testAuction := &auction{
-		winningBids:         winningBidsByImp,
-		winningBidsByBidder: winningBidsByBidder,
-		roundedPrices:       roundedPrices,
+		impsToTopBids:        impsToTopBids,
+		impsToBiddersTopBids: impsToBiddersTopBids,
+		roundedPrices:        roundedPrices,
 	}
 	_ = testAuction.doCache(ctx, cache, targData, &specData.BidRequest, 60, &specData.DefaultTTLs, bidCategory)
 

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -31,8 +31,8 @@ type targetData struct {
 // it's ok if those stay in the auction. For now, this method implements a very naive cache strategy.
 // In the future, we should implement a more clever retry & backoff strategy to balance the success rate & performance.
 func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMapping map[string]string) {
-	for impId, topBidsPerImp := range auc.winningBidsByBidder {
-		overallWinner := auc.winningBids[impId]
+	for impId, topBidsPerImp := range auc.impsToBiddersTopBids {
+		overallWinner := auc.impsToTopBids[impId]
 		for bidderName, topBidPerBidder := range topBidsPerImp {
 			isOverallWinner := overallWinner == topBidPerBidder
 


### PR DESCRIPTION
### Issue description:
The `doCache` function found in `exchange/auction.go` must traverse this hash table by `ImpID` and not by `bidID` as it currently does.

### Implemented changes
Striving for readability and simplification, function `doCache` has been modified with no extra expense of time nor space complexity.  Names of two fields of the auction struct where also changed for the sake of readability