### PR TITLE
Using Site publisher or app publisher as account in openrtb

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -89,7 +89,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	start := time.Now()
 	labels := pbsmetrics.Labels{
-		Source:        pbsmetrics.DemandUnknown,
+		Source:        pbsmetrics.DemandWeb,
 		RType:         pbsmetrics.ReqTypeAMP,
 		PubID:         pbsmetrics.PublisherUnknown,
 		Browser:       pbsmetrics.BrowserOther,
@@ -143,13 +143,12 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	defer cancel()
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
-	labels.Source = pbsmetrics.DemandWeb
 	if usersyncs.LiveSyncCount() == 0 {
 		labels.CookieFlag = pbsmetrics.CookieFlagNo
 	} else {
 		labels.CookieFlag = pbsmetrics.CookieFlagYes
 	}
-	if req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
+	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 		labels.PubID = req.Site.Publisher.ID
 	}
 

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -149,7 +149,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	} else {
 		labels.CookieFlag = pbsmetrics.CookieFlagYes
 	}
-	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
+	if req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 		labels.PubID = req.Site.Publisher.ID
 	}
 

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -91,7 +91,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	labels := pbsmetrics.Labels{
 		Source:        pbsmetrics.DemandUnknown,
 		RType:         pbsmetrics.ReqTypeAMP,
-		PubID:         "",
+		PubID:         pbsmetrics.PublisherUnknown,
 		Browser:       pbsmetrics.BrowserOther,
 		CookieFlag:    pbsmetrics.CookieFlagUnknown,
 		RequestStatus: pbsmetrics.RequestStatusOK,
@@ -151,8 +151,6 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	}
 	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 		labels.PubID = req.Site.Publisher.ID
-	} else {
-		labels.PubID = "UNKNOWN"
 	}
 
 	response, err := deps.ex.HoldAuction(ctx, req, usersyncs, labels, &deps.categories)

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -143,16 +143,18 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	defer cancel()
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
-	if req.App != nil {
-		labels.Source = pbsmetrics.DemandApp
+	labels.Source = pbsmetrics.DemandWeb
+	if usersyncs.LiveSyncCount() == 0 {
+		labels.CookieFlag = pbsmetrics.CookieFlagNo
 	} else {
-		labels.Source = pbsmetrics.DemandWeb
-		if usersyncs.LiveSyncCount() == 0 {
-			labels.CookieFlag = pbsmetrics.CookieFlagNo
-		} else {
-			labels.CookieFlag = pbsmetrics.CookieFlagYes
-		}
+		labels.CookieFlag = pbsmetrics.CookieFlagYes
 	}
+	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
+		labels.PubID = req.Site.Publisher.ID
+	} else {
+		labels.PubID = "UNKNOWN"
+	}
+
 	response, err := deps.ex.HoldAuction(ctx, req, usersyncs, labels, &deps.categories)
 	ao.AuctionResponse = response
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -89,7 +89,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	labels := pbsmetrics.Labels{
 		Source:        pbsmetrics.DemandUnknown,
 		RType:         pbsmetrics.ReqTypeORTB2Web,
-		PubID:         "",
+		PubID:         pbsmetrics.PublisherUnknown,
 		Browser:       pbsmetrics.BrowserOther,
 		CookieFlag:    pbsmetrics.CookieFlagUnknown,
 		RequestStatus: pbsmetrics.RequestStatusOK,
@@ -139,9 +139,6 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 			labels.PubID = req.Site.Publisher.ID
 		}
-	}
-	if labels.PubID == "" {
-		labels.PubID = "UNKNOWN"
 	}
 
 	numImps = len(req.Imp)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -123,13 +123,15 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	defer cancel()
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
-	if req.Site != nil && req.Site.Publisher != nil {
+	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 		labels.PubID = req.Site.Publisher.ID
+	} else {
+		labels.PubID = "UNKNOWN"
 	}
 	if req.App != nil {
 		labels.Source = pbsmetrics.DemandApp
 		labels.RType = pbsmetrics.ReqTypeORTB2App
-		if req.App.Publisher != nil {
+		if labels.PubID == "UNKNOWN" && req.App.Publisher != nil && req.App.Publisher.ID != "" {
 			labels.PubID = req.App.Publisher.ID
 		}
 	} else {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -114,16 +114,6 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		return
 	}
 
-	if req.Site != nil && req.Site.Publisher != nil {
-		labels.PubID = req.Site.Publisher.ID
-	}
-	if req.App != nil {
-		labels.RType = pbsmetrics.ReqTypeORTB2App
-		if req.App.Publisher != nil {
-			labels.PubID = req.App.Publisher.ID
-		}
-	}
-
 	ctx := context.Background()
 	cancel := func() {}
 	timeout := deps.cfg.AuctionTimeouts.LimitAuctionTimeout(time.Duration(req.TMax) * time.Millisecond)
@@ -133,8 +123,15 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	defer cancel()
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
+	if req.Site != nil && req.Site.Publisher != nil {
+		labels.PubID = req.Site.Publisher.ID
+	}
 	if req.App != nil {
 		labels.Source = pbsmetrics.DemandApp
+		labels.RType = pbsmetrics.ReqTypeORTB2App
+		if req.App.Publisher != nil {
+			labels.PubID = req.App.Publisher.ID
+		}
 	} else {
 		labels.Source = pbsmetrics.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -123,15 +123,10 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	defer cancel()
 
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
-	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
-		labels.PubID = req.Site.Publisher.ID
-	} else {
-		labels.PubID = "UNKNOWN"
-	}
 	if req.App != nil {
 		labels.Source = pbsmetrics.DemandApp
 		labels.RType = pbsmetrics.ReqTypeORTB2App
-		if labels.PubID == "UNKNOWN" && req.App.Publisher != nil && req.App.Publisher.ID != "" {
+		if req.App.Publisher != nil && req.App.Publisher.ID != "" {
 			labels.PubID = req.App.Publisher.ID
 		}
 	} else {
@@ -141,6 +136,12 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
+		if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
+			labels.PubID = req.Site.Publisher.ID
+		}
+	}
+	if labels.PubID == "" {
+		labels.PubID = "UNKNOWN"
 	}
 
 	numImps = len(req.Imp)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -129,14 +129,14 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		if req.App.Publisher != nil && req.App.Publisher.ID != "" {
 			labels.PubID = req.App.Publisher.ID
 		}
-	} else {
+	} else { //req.Site != nil
 		labels.Source = pbsmetrics.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
 			labels.CookieFlag = pbsmetrics.CookieFlagNo
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
-		if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
+		if req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
 			labels.PubID = req.Site.Publisher.ID
 		}
 	}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -205,8 +205,6 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	}
 	if labels.PubID == "UNKNOWN" && bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
 		labels.PubID = bidReq.Site.Publisher.ID
-	} else {
-		labels.PubID = "UNKNOWN"
 	}
 
 	numImps = len(bidReq.Imp)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -190,8 +190,10 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
 	if bidReq.App != nil {
 		labels.Source = pbsmetrics.DemandApp
-		if bidReq.App.Publisher != nil {
+		if bidReq.App.Publisher != nil && bidReq.App.Publisher.ID != "" {
 			labels.PubID = bidReq.App.Publisher.ID
+		} else {
+			labels.PubID = "UNKNOWN"
 		}
 	} else {
 		labels.Source = pbsmetrics.DemandWeb
@@ -201,7 +203,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
 	}
-	if labels.PubID == "" && bidReq.Site != nil && bidReq.Site.Publisher != nil {
+	if labels.PubID == "UNKNOWN" && bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
 		labels.PubID = bidReq.Site.Publisher.ID
 	} else {
 		labels.PubID = "UNKNOWN"

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -190,6 +190,9 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
 	if bidReq.App != nil {
 		labels.Source = pbsmetrics.DemandApp
+		if bidReq.App.Publisher != nil {
+			labels.PubID = bidReq.App.Publisher.ID
+		}
 	} else {
 		labels.Source = pbsmetrics.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
@@ -197,6 +200,12 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
+	}
+	if labels.PubID == "" && bidReq.Site != nil && bidReq.Site.Publisher != nil {
+		labels.PubID = bidReq.Site.Publisher.ID
+	}
+	if labels.PubID == "" {
+		labels.PubID = "UNKNOWN"
 	}
 
 	numImps = len(bidReq.Imp)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -151,7 +151,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 			errL = []error{err}
 			return
 		} else if bidReq.App != nil && bidReq.Site != nil {
-			err = fmt.Errorf("Request seems to be sent with both 'Site' and 'App' values", err)
+			err = fmt.Errorf("Request specifies both 'Site' and 'App' values", err)
 			errL = []error{err}
 			return
 		} else if bidReq.App != nil {

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -200,10 +200,11 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
+		if bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
+			labels.PubID = bidReq.Site.Publisher.ID
+		}
 	}
-	if labels.PubID == "" && bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
-		labels.PubID = bidReq.Site.Publisher.ID
-	} else {
+	if labels.PubID == "" {
 		labels.PubID = "UNKNOWN"
 	}
 

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -192,8 +192,6 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		labels.Source = pbsmetrics.DemandApp
 		if bidReq.App.Publisher != nil && bidReq.App.Publisher.ID != "" {
 			labels.PubID = bidReq.App.Publisher.ID
-		} else {
-			labels.PubID = "UNKNOWN"
 		}
 	} else {
 		labels.Source = pbsmetrics.DemandWeb
@@ -203,8 +201,10 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
 	}
-	if labels.PubID == "UNKNOWN" && bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
+	if labels.PubID == "" && bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
 		labels.PubID = bidReq.Site.Publisher.ID
+	} else {
+		labels.PubID = "UNKNOWN"
 	}
 
 	numImps = len(bidReq.Imp)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -193,14 +193,14 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		if bidReq.App.Publisher != nil && bidReq.App.Publisher.ID != "" {
 			labels.PubID = bidReq.App.Publisher.ID
 		}
-	} else { //bidReq.App == nil
+	} else { // both bidReq.App == nil and bidReq.Site != nil are true
 		labels.Source = pbsmetrics.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
 			labels.CookieFlag = pbsmetrics.CookieFlagNo
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
-		if bidReq.Site != nil && bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
+		if bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
 			labels.PubID = bidReq.Site.Publisher.ID
 		}
 	}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -203,8 +203,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	}
 	if labels.PubID == "" && bidReq.Site != nil && bidReq.Site.Publisher != nil {
 		labels.PubID = bidReq.Site.Publisher.ID
-	}
-	if labels.PubID == "" {
+	} else {
 		labels.PubID = "UNKNOWN"
 	}
 

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -54,14 +54,15 @@ type AdapterError string
 // CacheResult : Cache hit/miss
 type CacheResult string
 
+// PublisherUnknown: Default value for Labels.PubID
+const PublisherUnknown = "unknown"
+
 // The demand sources
 const (
 	DemandWeb     DemandSource = "web"
 	DemandApp     DemandSource = "app"
 	DemandUnknown DemandSource = "unknown"
 )
-
-const PublisherUnknown = "unknown"
 
 func DemandTypes() []DemandSource {
 	return []DemandSource{

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -56,11 +56,12 @@ type CacheResult string
 
 // The demand sources
 const (
-	DemandWeb        DemandSource = "web"
-	DemandApp        DemandSource = "app"
-	DemandUnknown    DemandSource = "unknown"
-	PublisherUnknown DemandSource = "unknown"
+	DemandWeb     DemandSource = "web"
+	DemandApp     DemandSource = "app"
+	DemandUnknown DemandSource = "unknown"
 )
+
+const PublisherUnknown = "unknown"
 
 func DemandTypes() []DemandSource {
 	return []DemandSource{

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -59,7 +59,7 @@ const (
 	DemandWeb        DemandSource = "web"
 	DemandApp        DemandSource = "app"
 	DemandUnknown    DemandSource = "unknown"
-	PublisherUnknown DemandSource = "UNKNOWN"
+	PublisherUnknown DemandSource = "unknown"
 )
 
 func DemandTypes() []DemandSource {

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -56,9 +56,10 @@ type CacheResult string
 
 // The demand sources
 const (
-	DemandWeb     DemandSource = "web"
-	DemandApp     DemandSource = "app"
-	DemandUnknown DemandSource = "unknown"
+	DemandWeb        DemandSource = "web"
+	DemandApp        DemandSource = "app"
+	DemandUnknown    DemandSource = "unknown"
+	PublisherUnknown DemandSource = "UNKNOWN"
 )
 
 func DemandTypes() []DemandSource {


### PR DESCRIPTION
Currently we only track account for legacy requests. We are seeing issues now where it would be good to track accounts in `openrtb`. Unfortunately `openrtb` doesn't have this as a required field, but we can grab `request.site.publisher.id` or `request.app.publisher.id` as the account. We can use "UNKNOWN" for when this field is not populated.