### PR TITLE
[Go 1.9] deprecate 1.9 & 1.10 versions and introduce 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - '1.9'
-  - '1.10'
   - '1.11.1'
+  - '1.12'
 
 go_import_path: github.com/prebid/prebid-server
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information, see:
 
 ## Installation
 
-First install [Go 1.9.1](https://golang.org/doc/install) or later and [dep](https://golang.github.io/dep/docs/installation.html). Note that dep requires an explicit GOPATH to be set.
+First install [Go 1.11](https://golang.org/doc/install) or later and [dep](https://golang.github.io/dep/docs/installation.html). Note that dep requires an explicit GOPATH to be set.
 
 ```bash
 export GOPATH=$(go env GOPATH)

--- a/validate.sh
+++ b/validate.sh
@@ -57,18 +57,7 @@ if [ "$RACE" -ne "0" ]; then
 fi
 
 if $VET; then
-  # Fix for the go 1.10 vet bug (https://github.com/w0rp/ale/issues/1358)
-  COMMAND="go tool vet -source *.go"
+  COMMAND="go vet"
   echo "Running: $COMMAND"
   `$COMMAND`
-  for SOURCE in $GOGLOB ; do
-    # default call for wildcards and directories
-    COMMAND="go tool vet -source $SOURCE"
-    if [ -f $SOURCE ]; then
-      # file
-      COMMAND="go vet -source $SOURCE"
-    fi
-    echo "Running: $COMMAND"
-    `$COMMAND`
-  done
 fi


### PR DESCRIPTION
This CL deprecates Go 1.9 version removing it from the CI along updating
the installation instructions.

This PR probably needs to be flagged as important change so people using Go 1.9 will be aware of this change from now on.

Issue: #920