### PR TITLE
Remove hard coded targeting keys

### DIFF
--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -440,13 +440,13 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 
 			hbPbBidderKey := string(openrtb_ext.HbpbConstantKey) + "_" + bid.BidderCode
 			hbBidderBidderKey := string(openrtb_ext.HbBidderConstantKey) + "_" + bid.BidderCode
-			HbCacheIDBidderKey := string(openrtb_ext.HbCacheKey) + "_" + bid.BidderCode
+			hbCacheIDBidderKey := string(openrtb_ext.HbCacheKey) + "_" + bid.BidderCode
 			hbDealIDBidderKey := string(openrtb_ext.HbDealIDConstantKey) + "_" + bid.BidderCode
 			hbSizeBidderKey := string(openrtb_ext.HbSizeConstantKey) + "_" + bid.BidderCode
 			if pbs_req.MaxKeyLength != 0 {
 				hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
 				hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
-				HbCacheIDBidderKey = HbCacheIDBidderKey[:min(len(HbCacheIDBidderKey), int(pbs_req.MaxKeyLength))]
+				hbCacheIDBidderKey = hbCacheIDBidderKey[:min(len(hbCacheIDBidderKey), int(pbs_req.MaxKeyLength))]
 				hbDealIDBidderKey = hbDealIDBidderKey[:min(len(hbDealIDBidderKey), int(pbs_req.MaxKeyLength))]
 				hbSizeBidderKey = hbSizeBidderKey[:min(len(hbSizeBidderKey), int(pbs_req.MaxKeyLength))]
 			}
@@ -459,7 +459,7 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 
 			kvs[hbPbBidderKey] = roundedCpm
 			kvs[hbBidderBidderKey] = bid.BidderCode
-			kvs[HbCacheIDBidderKey] = bid.CacheID
+			kvs[hbCacheIDBidderKey] = bid.CacheID
 
 			if hbSize != "" {
 				kvs[hbSizeBidderKey] = hbSize

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -34,11 +34,6 @@ type bidResult struct {
 const defaultPriceGranularity = "med"
 
 // Constant keys for ad server targeting for responses to Prebid Mobile
-const hbpbConstantKey = "hb_pb"
-const hbBidderConstantKey = "hb_bidder"
-const hbCacheIdConstantKey = "hb_cache_id"
-const hbDealIdConstantKey = "hb_deal"
-const hbSizeConstantKey = "hb_size"
 
 func min(x, y int) int {
 	if x < y {
@@ -445,16 +440,16 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				hbSize = width + "x" + height
 			}
 
-			hbPbBidderKey := hbpbConstantKey + "_" + bid.BidderCode
-			hbBidderBidderKey := hbBidderConstantKey + "_" + bid.BidderCode
-			hbCacheIdBidderKey := hbCacheIdConstantKey + "_" + bid.BidderCode
-			hbDealIdBidderKey := hbDealIdConstantKey + "_" + bid.BidderCode
-			hbSizeBidderKey := hbSizeConstantKey + "_" + bid.BidderCode
+			hbPbBidderKey := string(openrtb_ext.HbpbConstantKey) + "_" + bid.BidderCode
+			hbBidderBidderKey := string(openrtb_ext.HbBidderConstantKey) + "_" + bid.BidderCode
+			hbCacheIDBidderKey := string(openrtb_ext.HbCacheKey) + "_" + bid.BidderCode
+			hbDealIDBidderKey := string(openrtb_ext.HbDealIdConstantKey) + "_" + bid.BidderCode
+			hbSizeBidderKey := string(openrtb_ext.HbSizeConstantKey) + "_" + bid.BidderCode
 			if pbs_req.MaxKeyLength != 0 {
 				hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
 				hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
-				hbCacheIdBidderKey = hbCacheIdBidderKey[:min(len(hbCacheIdBidderKey), int(pbs_req.MaxKeyLength))]
-				hbDealIdBidderKey = hbDealIdBidderKey[:min(len(hbDealIdBidderKey), int(pbs_req.MaxKeyLength))]
+				hbCacheIDBidderKey = hbCacheIDBidderKey[:min(len(hbCacheIDBidderKey), int(pbs_req.MaxKeyLength))]
+				hbDealIDBidderKey = hbDealIDBidderKey[:min(len(hbDealIDBidderKey), int(pbs_req.MaxKeyLength))]
 				hbSizeBidderKey = hbSizeBidderKey[:min(len(hbSizeBidderKey), int(pbs_req.MaxKeyLength))]
 			}
 
@@ -466,24 +461,24 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 
 			kvs[hbPbBidderKey] = roundedCpm
 			kvs[hbBidderBidderKey] = bid.BidderCode
-			kvs[hbCacheIdBidderKey] = bid.CacheID
+			kvs[hbCacheIDBidderKey] = bid.CacheID
 
 			if hbSize != "" {
 				kvs[hbSizeBidderKey] = hbSize
 			}
 			if bid.DealId != "" {
-				kvs[hbDealIdBidderKey] = bid.DealId
+				kvs[hbDealIDBidderKey] = bid.DealId
 			}
 			// For the top bid, we want to add the following additional keys
 			if i == 0 {
-				kvs[hbpbConstantKey] = roundedCpm
-				kvs[hbBidderConstantKey] = bid.BidderCode
-				kvs[hbCacheIdConstantKey] = bid.CacheID
+				kvs[string(openrtb_ext.HbpbConstantKey)] = roundedCpm
+				kvs[string(openrtb_ext.HbBidderConstantKey)] = bid.BidderCode
+				kvs[string(openrtb_ext.HbCacheKey)] = bid.CacheID
 				if bid.DealId != "" {
-					kvs[hbDealIdConstantKey] = bid.DealId
+					kvs[string(openrtb_ext.HbDealIdConstantKey)] = bid.DealId
 				}
 				if hbSize != "" {
-					kvs[hbSizeConstantKey] = hbSize
+					kvs[string(openrtb_ext.HbSizeConstantKey)] = hbSize
 				}
 			}
 		}

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -33,8 +33,6 @@ type bidResult struct {
 
 const defaultPriceGranularity = "med"
 
-// Constant keys for ad server targeting for responses to Prebid Mobile
-
 func min(x, y int) int {
 	if x < y {
 		return x

--- a/endpoints/auction.go
+++ b/endpoints/auction.go
@@ -440,13 +440,13 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 
 			hbPbBidderKey := string(openrtb_ext.HbpbConstantKey) + "_" + bid.BidderCode
 			hbBidderBidderKey := string(openrtb_ext.HbBidderConstantKey) + "_" + bid.BidderCode
-			hbCacheIDBidderKey := string(openrtb_ext.HbCacheKey) + "_" + bid.BidderCode
-			hbDealIDBidderKey := string(openrtb_ext.HbDealIdConstantKey) + "_" + bid.BidderCode
+			HbCacheIDBidderKey := string(openrtb_ext.HbCacheKey) + "_" + bid.BidderCode
+			hbDealIDBidderKey := string(openrtb_ext.HbDealIDConstantKey) + "_" + bid.BidderCode
 			hbSizeBidderKey := string(openrtb_ext.HbSizeConstantKey) + "_" + bid.BidderCode
 			if pbs_req.MaxKeyLength != 0 {
 				hbPbBidderKey = hbPbBidderKey[:min(len(hbPbBidderKey), int(pbs_req.MaxKeyLength))]
 				hbBidderBidderKey = hbBidderBidderKey[:min(len(hbBidderBidderKey), int(pbs_req.MaxKeyLength))]
-				hbCacheIDBidderKey = hbCacheIDBidderKey[:min(len(hbCacheIDBidderKey), int(pbs_req.MaxKeyLength))]
+				HbCacheIDBidderKey = HbCacheIDBidderKey[:min(len(HbCacheIDBidderKey), int(pbs_req.MaxKeyLength))]
 				hbDealIDBidderKey = hbDealIDBidderKey[:min(len(hbDealIDBidderKey), int(pbs_req.MaxKeyLength))]
 				hbSizeBidderKey = hbSizeBidderKey[:min(len(hbSizeBidderKey), int(pbs_req.MaxKeyLength))]
 			}
@@ -459,7 +459,7 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 
 			kvs[hbPbBidderKey] = roundedCpm
 			kvs[hbBidderBidderKey] = bid.BidderCode
-			kvs[hbCacheIDBidderKey] = bid.CacheID
+			kvs[HbCacheIDBidderKey] = bid.CacheID
 
 			if hbSize != "" {
 				kvs[hbSizeBidderKey] = hbSize
@@ -473,7 +473,7 @@ func sortBidsAddKeywordsMobile(bids pbs.PBSBidSlice, pbs_req *pbs.PBSRequest, pr
 				kvs[string(openrtb_ext.HbBidderConstantKey)] = bid.BidderCode
 				kvs[string(openrtb_ext.HbCacheKey)] = bid.CacheID
 				if bid.DealId != "" {
-					kvs[string(openrtb_ext.HbDealIdConstantKey)] = bid.DealId
+					kvs[string(openrtb_ext.HbDealIDConstantKey)] = bid.DealId
 				}
 				if hbSize != "" {
 					kvs[string(openrtb_ext.HbSizeConstantKey)] = hbSize

--- a/endpoints/auction_test.go
+++ b/endpoints/auction_test.go
@@ -148,56 +148,56 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			t.Error("Ad server targeting should not be nil")
 		}
 		if bid.BidderCode == "audienceNetwork" {
-			if bid.AdServerTargeting["hb_size"] != "300x250" {
-				t.Error("hb_size key was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbSizeConstantKey)] != "300x250" {
+				t.Error(string(openrtb_ext.HbSizeConstantKey) + " key was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_pb"] != "2.00" {
-				t.Error("hb_pb key was not parsed correctly ", bid.AdServerTargeting["hb_pb"])
+			if bid.AdServerTargeting[string(openrtb_ext.HbpbConstantKey)] != "2.00" {
+				t.Error(string(openrtb_ext.HbpbConstantKey)+" key was not parsed correctly ", bid.AdServerTargeting[string(openrtb_ext.HbpbConstantKey)])
 			}
 
-			if bid.AdServerTargeting["hb_cache_id"] != "test_cache_id1" {
-				t.Error("hb_cache_id key was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbCacheKey)] != "test_cache_id1" {
+				t.Error(string(openrtb_ext.HbCacheKey) + " key was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_bidder"] != "audienceNetwork" {
-				t.Error("hb_bidder key was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbBidderConstantKey)] != "audienceNetwork" {
+				t.Error(string(openrtb_ext.HbBidderConstantKey) + " key was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_deal"] != "2345" {
-				t.Error("hb_deal_id key was not parsed correctly ")
+			if bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)] != "2345" {
+				t.Error(string(openrtb_ext.HbDealIdConstantKey) + " key was not parsed correctly ")
 			}
 		}
 		if bid.BidderCode == "appnexus" {
-			if bid.AdServerTargeting["hb_size_appnexus"] != "320x50" {
-				t.Error("hb_size key for appnexus bidder was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbSizeConstantKey)+"_appnexus"] != "320x50" {
+				t.Error(string(openrtb_ext.HbSizeConstantKey) + " key for appnexus bidder was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_cache_id_appnexus"] != "test_cache_id2" {
-				t.Error("hb_cache_id key for appnexus bidder was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbCacheKey)+"_appnexus"] != "test_cache_id2" {
+				t.Error(string(openrtb_ext.HbCacheKey) + " key for appnexus bidder was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_bidder_appnexus"] != "appnexus" {
-				t.Error("hb_bidder key for appnexus bidder was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbBidderConstantKey)+"_appnexus"] != "appnexus" {
+				t.Error(string(openrtb_ext.HbBidderConstantKey) + " key for appnexus bidder was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_pb_appnexus"] != "1.00" {
-				t.Error("hb_pb key for appnexus bidder was not parsed correctly")
+			if bid.AdServerTargeting[string(openrtb_ext.HbpbConstantKey)+"_appnexus"] != "1.00" {
+				t.Error(string(openrtb_ext.HbpbConstantKey) + " key for appnexus bidder was not parsed correctly")
 			}
-			if bid.AdServerTargeting["hb_pb"] != "" {
-				t.Error("hb_pb key was parsed for two bidders")
+			if bid.AdServerTargeting[string(openrtb_ext.HbpbConstantKey)] != "" {
+				t.Error(string(openrtb_ext.HbpbConstantKey) + " key was parsed for two bidders")
 			}
-			if bid.AdServerTargeting["hb_deal_appnexus"] != "1234" {
-				t.Errorf("hb_deal_id_appnexus was not parsed correctly %v", bid.AdServerTargeting["hb_deal_id_appnexus"])
+			if bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_appnexus"] != "1234" {
+				t.Errorf(string(openrtb_ext.HbDealIdConstantKey)+"_appnexus was not parsed correctly %v", bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_appnexus"])
 			}
 		}
-		if bid.BidderCode == "rubicon" {
+		if bid.BidderCode == string(openrtb_ext.BidderRubicon) {
 			if bid.AdServerTargeting["rpfl_1001"] != "15_tier0100" {
 				t.Error("custom ad_server_targeting KVPs from adapter were not preserved")
 			}
 		}
 		if bid.BidderCode == "nosizebidder" {
-			if _, exists := bid.AdServerTargeting["hb_size_nosizebidder"]; exists {
-				t.Error("hb_size key for nosize bidder was not parsed correctly", bid.AdServerTargeting)
+			if _, exists := bid.AdServerTargeting[string(openrtb_ext.HbSizeConstantKey)+"_nosizebidder"]; exists {
+				t.Error(string(openrtb_ext.HbSizeConstantKey)+" key for nosize bidder was not parsed correctly", bid.AdServerTargeting)
 			}
 		}
 		if bid.BidderCode == "nodeal" {
-			if _, exists := bid.AdServerTargeting["hb_deal_nodeal"]; exists {
-				t.Error("hb_deal_id key for nodeal bidder was not parsed correctly")
+			if _, exists := bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_nodeal"]; exists {
+				t.Error(string(openrtb_ext.HbDealIdConstantKey) + " key for nodeal bidder was not parsed correctly")
 			}
 		}
 	}

--- a/endpoints/auction_test.go
+++ b/endpoints/auction_test.go
@@ -161,8 +161,8 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			if bid.AdServerTargeting[string(openrtb_ext.HbBidderConstantKey)] != "audienceNetwork" {
 				t.Error(string(openrtb_ext.HbBidderConstantKey) + " key was not parsed correctly")
 			}
-			if bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)] != "2345" {
-				t.Error(string(openrtb_ext.HbDealIdConstantKey) + " key was not parsed correctly ")
+			if bid.AdServerTargeting[string(openrtb_ext.HbDealIDConstantKey)] != "2345" {
+				t.Error(string(openrtb_ext.HbDealIDConstantKey) + " key was not parsed correctly ")
 			}
 		}
 		if bid.BidderCode == "appnexus" {
@@ -181,8 +181,8 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			if bid.AdServerTargeting[string(openrtb_ext.HbpbConstantKey)] != "" {
 				t.Error(string(openrtb_ext.HbpbConstantKey) + " key was parsed for two bidders")
 			}
-			if bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_appnexus"] != "1234" {
-				t.Errorf(string(openrtb_ext.HbDealIdConstantKey)+"_appnexus was not parsed correctly %v", bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_appnexus"])
+			if bid.AdServerTargeting[string(openrtb_ext.HbDealIDConstantKey)+"_appnexus"] != "1234" {
+				t.Errorf(string(openrtb_ext.HbDealIDConstantKey)+"_appnexus was not parsed correctly %v", bid.AdServerTargeting[string(openrtb_ext.HbDealIDConstantKey)+"_appnexus"])
 			}
 		}
 		if bid.BidderCode == string(openrtb_ext.BidderRubicon) {
@@ -196,8 +196,8 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 			}
 		}
 		if bid.BidderCode == "nodeal" {
-			if _, exists := bid.AdServerTargeting[string(openrtb_ext.HbDealIdConstantKey)+"_nodeal"]; exists {
-				t.Error(string(openrtb_ext.HbDealIdConstantKey) + " key for nodeal bidder was not parsed correctly")
+			if _, exists := bid.AdServerTargeting[string(openrtb_ext.HbDealIDConstantKey)+"_nodeal"]; exists {
+				t.Error(string(openrtb_ext.HbDealIDConstantKey) + " key for nodeal bidder was not parsed correctly")
 			}
 		}
 	}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -377,7 +377,7 @@ func buildVideoResponse(bidresponse *openrtb.BidResponse, podErrors []PodError) 
 			videoTargeting := openrtb_ext.VideoTargeting{
 				HbPb:       tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbpbConstantKey)],
 				HbPbCatDur: tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbCategoryDurationKey)],
-				HbCacheId:  tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbVastCacheKey)],
+				HbCacheID:  tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbVastCacheKey)],
 			}
 
 			adPod := findAdPod(podId, adPods)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -375,9 +375,9 @@ func buildVideoResponse(bidresponse *openrtb.BidResponse, podErrors []PodError) 
 			podId, _ := strconv.ParseInt(podNum, 0, 64)
 
 			videoTargeting := openrtb_ext.VideoTargeting{
-				Hb_pb:         tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbpbConstantKey)],
-				Hb_pb_cat_dur: tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbCategoryDurationKey)],
-				Hb_cache_id:   tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbVastCacheKey)],
+				HbPb:       tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbpbConstantKey)],
+				HbPbCatDur: tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbCategoryDurationKey)],
+				HbCacheId:  tempRespBidExt.Prebid.Targeting[string(openrtb_ext.HbVastCacheKey)],
 			}
 
 			adPod := findAdPod(podId, adPods)

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -54,7 +54,7 @@ func TestVideoEndpointImpressionsNumber(t *testing.T) {
 	assert.Len(t, resp.AdPods[3].Targeting, 1, "Incorrect Targeting data in response")
 	assert.Len(t, resp.AdPods[4].Targeting, 3, "Incorrect Targeting data in response")
 
-	assert.Equal(t, resp.AdPods[4].Targeting[0].Hb_pb_cat_dur, "20.00_395_30s", "Incorrect number of Ad Pods in response")
+	assert.Equal(t, resp.AdPods[4].Targeting[0].HbPbCatDur, "20.00_395_30s", "Incorrect number of Ad Pods in response")
 
 }
 
@@ -398,8 +398,8 @@ func TestVideoBuildVideoResponseMissedCacheForOneBid(t *testing.T) {
 	assert.NoError(t, err, "Should be no error")
 	assert.Len(t, bidRespVideo.AdPods, 1, "AdPods length should be 1")
 	assert.Len(t, bidRespVideo.AdPods[0].Targeting, 2, "AdPod Targeting length should be 2")
-	assert.Equal(t, "17.00_123_30s", bidRespVideo.AdPods[0].Targeting[0].Hb_pb_cat_dur, "AdPod Targeting first element hb_pb_cat_dur should be 17.00_123_30s")
-	assert.Equal(t, "17.00_456_30s", bidRespVideo.AdPods[0].Targeting[1].Hb_pb_cat_dur, "AdPod Targeting first element hb_pb_cat_dur should be 17.00_456_30s")
+	assert.Equal(t, "17.00_123_30s", bidRespVideo.AdPods[0].Targeting[0].HbPbCatDur, "AdPod Targeting first element hb_pb_cat_dur should be 17.00_123_30s")
+	assert.Equal(t, "17.00_456_30s", bidRespVideo.AdPods[0].Targeting[1].HbPbCatDur, "AdPod Targeting first element hb_pb_cat_dur should be 17.00_456_30s")
 }
 
 func TestVideoBuildVideoResponseMissedCacheForAllBids(t *testing.T) {

--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -73,11 +73,11 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 	toCache := make([]prebid_cache_client.Cacheable, 0, expectNumBids+expectNumVast)
 	expByImp := make(map[string]int64)
 	competitiveExclusion := false
-	var hbCacheID string
+	var HbCacheID string
 	if len(bidCategory) > 0 {
 		// assert:  category of winning bids never duplicated
 		if rawUuid, err := uuid.NewV4(); err == nil {
-			hbCacheID = rawUuid.String()
+			HbCacheID = rawUuid.String()
 			competitiveExclusion = true
 		} else {
 			errs = append(errs, errors.New("failed to create custom cache key"))
@@ -102,7 +102,7 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 				// set custom cache key for winning bid when competitive exclusion applies
 				catDur = bidCategory[topBidPerBidder.bid.ID]
 				if len(catDur) > 0 {
-					customCacheKey = fmt.Sprintf("%s_%s", catDur, hbCacheID)
+					customCacheKey = fmt.Sprintf("%s_%s", catDur, HbCacheID)
 					useCustomCacheKey = true
 				}
 			}
@@ -164,9 +164,9 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 		a.vastCacheIds = make(map[*openrtb.Bid]string, len(vastIndices))
 		for index, bid := range vastIndices {
 			if ids[index] != "" {
-				if competitiveExclusion && strings.HasSuffix(ids[index], hbCacheID) {
+				if competitiveExclusion && strings.HasSuffix(ids[index], HbCacheID) {
 					// omit the pb_cat_dur_ portion of cache ID
-					a.vastCacheIds[bid] = hbCacheID
+					a.vastCacheIds[bid] = HbCacheID
 				} else {
 					a.vastCacheIds[bid] = ids[index]
 				}

--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -73,11 +73,11 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 	toCache := make([]prebid_cache_client.Cacheable, 0, expectNumBids+expectNumVast)
 	expByImp := make(map[string]int64)
 	competitiveExclusion := false
-	var HbCacheID string
+	var hbCacheID string
 	if len(bidCategory) > 0 {
 		// assert:  category of winning bids never duplicated
 		if rawUuid, err := uuid.NewV4(); err == nil {
-			HbCacheID = rawUuid.String()
+			hbCacheID = rawUuid.String()
 			competitiveExclusion = true
 		} else {
 			errs = append(errs, errors.New("failed to create custom cache key"))
@@ -102,7 +102,7 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 				// set custom cache key for winning bid when competitive exclusion applies
 				catDur = bidCategory[topBidPerBidder.bid.ID]
 				if len(catDur) > 0 {
-					customCacheKey = fmt.Sprintf("%s_%s", catDur, HbCacheID)
+					customCacheKey = fmt.Sprintf("%s_%s", catDur, hbCacheID)
 					useCustomCacheKey = true
 				}
 			}
@@ -164,9 +164,9 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 		a.vastCacheIds = make(map[*openrtb.Bid]string, len(vastIndices))
 		for index, bid := range vastIndices {
 			if ids[index] != "" {
-				if competitiveExclusion && strings.HasSuffix(ids[index], HbCacheID) {
+				if competitiveExclusion && strings.HasSuffix(ids[index], hbCacheID) {
 					// omit the pb_cat_dur_ portion of cache ID
-					a.vastCacheIds[bid] = HbCacheID
+					a.vastCacheIds[bid] = hbCacheID
 				} else {
 					a.vastCacheIds[bid] = ids[index]
 				}

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -51,7 +51,7 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 				targData.addKeys(targets, openrtb_ext.HbVastCacheKey, vastID, bidderName, isOverallWinner)
 			}
 			if deal := topBidPerBidder.bid.DealID; len(deal) > 0 {
-				targData.addKeys(targets, openrtb_ext.HbDealIdConstantKey, deal, bidderName, isOverallWinner)
+				targData.addKeys(targets, openrtb_ext.HbDealIDConstantKey, deal, bidderName, isOverallWinner)
 			}
 
 			if isApp {

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -87,7 +87,7 @@ const (
 	// HbBidderConstantKey is the name of the Bidder. For example, "appnexus" or "rubicon".
 	HbBidderConstantKey TargetingKey = "hb_bidder"
 	HbSizeConstantKey   TargetingKey = "hb_size"
-	HbDealIdConstantKey TargetingKey = "hb_deal"
+	HbDealIDConstantKey TargetingKey = "hb_deal"
 
 	// HbCacheKey and HbVastCacheKey store UUIDs which can be used to fetch things from prebid cache.
 	// Callers should *never* assume that either of these exist, since the call to the cache may always fail.

--- a/openrtb_ext/bid_response_video.go
+++ b/openrtb_ext/bid_response_video.go
@@ -14,7 +14,7 @@ type AdPod struct {
 }
 
 type VideoTargeting struct {
-	Hb_pb         string `json:"hb_pb"`
-	Hb_pb_cat_dur string `json:"hb_pb_cat_dur"`
-	Hb_cache_id   string `json:"hb_cache_id"`
+	HbPb       string `json:"hb_pb"`
+	HbPbCatDur string `json:"hb_pb_cat_dur"`
+	HbCacheId  string `json:"hb_cache_id"`
 }

--- a/openrtb_ext/bid_response_video.go
+++ b/openrtb_ext/bid_response_video.go
@@ -16,5 +16,5 @@ type AdPod struct {
 type VideoTargeting struct {
 	HbPb       string `json:"hb_pb"`
 	HbPbCatDur string `json:"hb_pb_cat_dur"`
-	HbCacheId  string `json:"hb_cache_id"`
+	HbCacheID  string `json:"hb_cache_id"`
 }


### PR DESCRIPTION
This is a clean up PR that:
- Removes hardcoded targeting keys 
- Removes targeting key constants defined in multiple places
- Rename `VideoTargeting` struct fields to adhere to GoLang naming convention