### PR TITLE
Add mapping of user.ext.eids[] for TDID in Rubicon bidder

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -65,11 +65,17 @@ type rubiconUserExtRP struct {
 	Target json.RawMessage `json:"target"`
 }
 
+type rubiconExtUserTpID struct {
+	Source string `json:"source"`
+	UID    string `json:"uid"`
+}
+
 type rubiconUserExt struct {
-	RP        rubiconUserExtRP              `json:"rp"`
-	DigiTrust *openrtb_ext.ExtUserDigiTrust `json:"digitrust"`
 	Consent   string                        `json:"consent,omitempty"`
-	TpID      []openrtb_ext.ExtUserTpID     `json:"tpid,omitempty"`
+	DigiTrust *openrtb_ext.ExtUserDigiTrust `json:"digitrust"`
+	Eids      []openrtb_ext.ExtUserEid      `json:"eids,omitempty"`
+	TpID      []rubiconExtUserTpID          `json:"tpid,omitempty"`
+	RP        rubiconUserExtRP              `json:"rp"`
 }
 
 type rubiconSiteExtRP struct {
@@ -590,11 +596,30 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 					})
 					continue
 				}
+				userExtRP.Consent = userExt.Consent
 				if userExt.DigiTrust != nil {
 					userExtRP.DigiTrust = userExt.DigiTrust
 				}
-				userExtRP.Consent = userExt.Consent
-				userExtRP.TpID = userExt.TpID
+				userExtRP.Eids = userExt.Eids
+
+				// set user.ext.tpid
+				if len(userExt.Eids) > 0 {
+					tpIds := make([]rubiconExtUserTpID, 0)
+					for _, eid := range userExt.Eids {
+						if eid.Source == "adserver.org" {
+							uids := eid.Uids
+							if len(uids) > 0 {
+								uid := uids[0]
+								if uid.Ext != nil && uid.Ext.RtiPartner == "TDID" {
+									tpIds = append(tpIds, rubiconExtUserTpID{Source: "tdid", UID: uid.ID})
+								}
+							}
+						}
+					}
+					if len(tpIds) > 0 {
+						userExtRP.TpID = tpIds
+					}
+				}
 			}
 
 			userCopy.Ext, err = json.Marshal(&userExtRP)

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1035,13 +1035,19 @@ func TestOpenRTBRequest(t *testing.T) {
                     "keyv": 1,
                     "pref": 0
                 },
-                "tpid": [{
-                    "source": "tdid",
-                    "uid": "3d50a262-bd8e-4be3-90b8-246291523907"
-                },{
+				"eids": [{
+                    "source": "adserver.org",
+                    "uids": [{
+                        "id": "3d50a262-bd8e-4be3-90b8-246291523907",
+                        "ext": {
+                            "rtiPartner": "TDID"
+                        }
+                    }]
+                },
+                {
                     "source": "pubcid",
-                    "uid": "2402fc76-7b39-4f0e-bfc2-060ef7693648"
-                }]
+                    "id": "2402fc76-7b39-4f0e-bfc2-060ef7693648"
+				}]
             }`),
 		},
 		Ext: json.RawMessage(`{"prebid": {}}`),
@@ -1129,7 +1135,10 @@ func TestOpenRTBRequest(t *testing.T) {
 			if userExt.DigiTrust.ID != "some-digitrust-id" || userExt.DigiTrust.KeyV != 1 || userExt.DigiTrust.Pref != 0 {
 				t.Fatal("DigiTrust values are not as expected!")
 			}
-			if userExt.TpID == nil || len(userExt.TpID) != 2 {
+			if userExt.Eids == nil || len(userExt.Eids) != 2 {
+				t.Fatal("Eids values are not as expected!")
+			}
+			if userExt.TpID == nil || len(userExt.TpID) != 1 {
 				t.Fatal("TpID values are not as expected!")
 			}
 		} else {

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-eids-uids-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-eids-uids-empty.json
@@ -1,0 +1,53 @@
+{
+  "message": "Invalid request: request.user.ext.eids[0].uids must contain at least one element or be undefined\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "eids": [
+          {
+            "source": "source1",
+            "uids": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-empty.json
@@ -1,5 +1,5 @@
 {
-  "message": "Invalid request: request.user.ext.tpid[0] missing required field: \"source\"\n",
+  "message": "Invalid request: request.user.ext.eids must contain at least one element or be undefined\n",
   "requestPayload": {
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
     "site": {
@@ -41,9 +41,7 @@
     },
     "user": {
       "ext": {
-        "tpid": [
-          {}
-        ]
+        "eids": []
       }
     }
   }

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-id-uids-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-id-uids-empty.json
@@ -1,5 +1,5 @@
 {
-  "message": "Invalid request: request.user.ext.tpid must contain at least one element or be undefined\n",
+  "message": "Invalid request: request.user.ext.eids[0] must contain either \"id\" or \"uids\" field\n",
   "requestPayload": {
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
     "site": {
@@ -41,7 +41,11 @@
     },
     "user": {
       "ext": {
-        "tpid": []
+        "eids": [
+          {
+            "source": "source1"
+          }
+        ]
       }
     }
   }

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-source-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-source-empty.json
@@ -1,0 +1,50 @@
+{
+  "message": "Invalid request: request.user.ext.eids[0] missing required field: \"source\"\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "eids": [
+          {}
+        ]
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-source-unique.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-source-unique.json
@@ -1,0 +1,57 @@
+{
+  "message": "Invalid request: request.user.ext.eids must contain unique sources\n",
+  "requestPayload": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 10433394
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "user": {
+      "ext": {
+        "eids": [
+          {
+            "source": "source1",
+            "id": "id1"
+          },
+          {
+            "source": "source1",
+            "id": "id2"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-uids-id-empty.json
+++ b/endpoints/openrtb2/sample-requests/invalid-whole/user-ext-eids-uids-id-empty.json
@@ -1,5 +1,5 @@
 {
-  "message": "Invalid request: request.user.ext.tpid[0] missing required field: \"uid\"\n",
+  "message": "Invalid request: request.user.ext.eids[0].uids[0] missing required field: \"id\"\n",
   "requestPayload": {
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
     "site": {
@@ -41,9 +41,12 @@
     },
     "user": {
       "ext": {
-        "tpid": [
+        "eids": [
           {
-            "source": "tpid-source1"
+            "source": "source1",
+            "uids": [
+              {}
+            ]
           }
         ]
       }

--- a/openrtb_ext/user.go
+++ b/openrtb_ext/user.go
@@ -13,7 +13,7 @@ type ExtUser struct {
 	// For more info, see: https://github.com/digi-trust/dt-cdn/wiki/OpenRTB-extension#openrtb-2x
 	DigiTrust *ExtUserDigiTrust `json:"digitrust,omitempty"`
 
-	TpID []ExtUserTpID `json:"tpid,omitempty"`
+	Eids []ExtUserEid `json:"eids,omitempty"`
 }
 
 // ExtUserPrebid defines the contract for bidrequest.user.ext.prebid
@@ -29,9 +29,22 @@ type ExtUserDigiTrust struct {
 	Pref int    `json:"pref"` // User optout preference
 }
 
-// ExtUserTpID defines the contract for bidrequest.user.ext.tpid
+// ExtUserEid defines the contract for bidrequest.user.ext.eids
 // Responsible for the Universal User ID support: establishing pseudonymous IDs for users.
-type ExtUserTpID struct {
-	Source string `json:"source"`
-	UID    string `json:"uid"`
+// See https://github.com/prebid/Prebid.js/issues/3900 for details.
+type ExtUserEid struct {
+	Source string          `json:"source"`
+	ID     string          `json:"id,omitempty"`
+	Uids   []ExtUserEidUid `json:"uids,omitempty"`
+}
+
+// ExtUserEidUid defines the contract for bidrequest.user.ext.eids[i].uids[j]
+type ExtUserEidUid struct {
+	ID  string            `json:"id"`
+	Ext *ExtUserEidUidExt `json:"ext,omitempty"`
+}
+
+// ExtUserEidUidExt defines the contract for bidrequest.user.ext.eids[i].uids[j].ext
+type ExtUserEidUidExt struct {
+	RtiPartner string `json:"rtiPartner,omitempty"`
 }


### PR DESCRIPTION
Added mapping:
- Loop through user.ext.eids[]
- If user.ext.eids[n].source is "adserver.org" and user.ext.eids[n].uids[0].ext.rtiPartner =="TDID", then copy user.ext.eids[n].uids[0].id to a new array entry in user.ext.tpid[] with this structure:
```
"source": "tdid", // hardcoded
"uid": "19cfaea8-a429-48fc-9537-8a19a8eb4f0c" // copy from user.ext.eids.uids[0].id
```

Example OpenRTB request:
```
  "user": {
    "ext": {
      "eids": [
        {
          "source": "adserver.org",
          "uids": [
            {
              "id": "cd96870f-f53d-4986-a08e-cd1612fb13b0",
              "ext": {
                "rtiPartner": "TDID"
              }
            }
          ]
        },
        {
          "source": "pubcid",
          "id": "29cfaea8-a429-48fc-9537-8a19a8eb4f0d"
        }
      ]
    }
  }
```

To Rubicon XAPI request:
```
  "user": {
    "ext": {
      "tpid": [
        {
          "source": "tdid",
          "uid": "cd96870f-f53d-4986-a08e-cd1612fb13b0"
        }
      ],
      "eids": [
        {
          "source": "adserver.org",
          "uids": [
            {
              "id": "cd96870f-f53d-4986-a08e-cd1612fb13b0",
              "ext": {
                "rtiPartner": "TDID"
              }
            }
          ]
        },
        {
          "source": "pubcid",
          "id": "29cfaea8-a429-48fc-9537-8a19a8eb4f0d"
        }
      ]
    }
  }
```
