### PR TITLE
Adds support for parentAccount property

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -148,8 +148,17 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	} else {
 		labels.CookieFlag = pbsmetrics.CookieFlagYes
 	}
-	if req.Site != nil && req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
-		labels.PubID = req.Site.Publisher.ID
+	if req.Site != nil && req.Site.Publisher != nil {
+		if req.Site.Publisher.ID != "" {
+			labels.PubID = req.Site.Publisher.ID
+		}
+		var pubExt openrtb_ext.ExtPublisher
+		if req.Site.Ext != nil {
+			err := json.Unmarshal(req.Site.Ext, &pubExt)
+			if err == nil && pubExt.ParentAccount != nil {
+				labels.PubID = *pubExt.ParentAccount
+			}
+		}
 	}
 
 	response, err := deps.ex.HoldAuction(ctx, req, usersyncs, labels, &deps.categories)

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -148,18 +148,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	} else {
 		labels.CookieFlag = pbsmetrics.CookieFlagYes
 	}
-	if req.Site != nil && req.Site.Publisher != nil {
-		if req.Site.Publisher.ID != "" {
-			labels.PubID = req.Site.Publisher.ID
-		}
-		var pubExt openrtb_ext.ExtPublisher
-		if req.Site.Ext != nil {
-			err := json.Unmarshal(req.Site.Ext, &pubExt)
-			if err == nil && pubExt.ParentAccount != nil {
-				labels.PubID = *pubExt.ParentAccount
-			}
-		}
-	}
+	labels.PubID = effectivePubID(req.Site.Publisher)
 
 	response, err := deps.ex.HoldAuction(ctx, req, usersyncs, labels, &deps.categories)
 	ao.AuctionResponse = response

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1184,17 +1184,10 @@ func effectivePubID(pub *openrtb.Publisher) string {
 			err := json.Unmarshal(pub.Ext, &pubExt)
 			if err == nil && pubExt.ParentAccount != nil && *pubExt.ParentAccount != "" {
 				return *pubExt.ParentAccount
-			} else {
-				if pub.ID != "" {
-					return pub.ID
-				} else {
-					return pbsmetrics.PublisherUnknown
-				}
 			}
-		} else {
-			if pub.ID != "" {
-				return pub.ID
-			}
+		}
+		if pub.ID != "" {
+			return pub.ID
 		}
 	}
 	return pbsmetrics.PublisherUnknown

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -127,8 +127,17 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 	if req.App != nil {
 		labels.Source = pbsmetrics.DemandApp
 		labels.RType = pbsmetrics.ReqTypeORTB2App
-		if req.App.Publisher != nil && req.App.Publisher.ID != "" {
-			labels.PubID = req.App.Publisher.ID
+		if req.App.Publisher != nil {
+			if req.App.Publisher.ID != "" {
+				labels.PubID = req.App.Publisher.ID
+			}
+			var pubExt openrtb_ext.ExtPublisher
+			if req.App.Ext != nil {
+				err := json.Unmarshal(req.App.Ext, &pubExt)
+				if err == nil && pubExt.ParentAccount != nil {
+					labels.PubID = *pubExt.ParentAccount
+				}
+			}
 		}
 	} else { //req.Site != nil
 		labels.Source = pbsmetrics.DemandWeb
@@ -137,8 +146,17 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
-		if req.Site.Publisher != nil && req.Site.Publisher.ID != "" {
-			labels.PubID = req.Site.Publisher.ID
+		if req.Site.Publisher != nil {
+			if req.Site.Publisher.ID != "" {
+				labels.PubID = req.Site.Publisher.ID
+			}
+			var pubExt openrtb_ext.ExtPublisher
+			if req.Site.Ext != nil {
+				err := json.Unmarshal(req.Site.Ext, &pubExt)
+				if err == nil && pubExt.ParentAccount != nil {
+					labels.PubID = *pubExt.ParentAccount
+				}
+			}
 		}
 	}
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1194,12 +1194,8 @@ func effectivePubID(pub *openrtb.Publisher) string {
 		} else {
 			if pub.ID != "" {
 				return pub.ID
-			} else {
-				return pbsmetrics.PublisherUnknown
 			}
 		}
-	} else {
-		return pbsmetrics.PublisherUnknown
 	}
-
+	return pbsmetrics.PublisherUnknown
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -780,6 +780,16 @@ func TestValidateImpExtDisabledBidder(t *testing.T) {
 	assert.Equal(t, []error{&errortypes.BidderTemporarilyDisabled{Message: "The biddder 'unknownbidder' has been disabled."}}, errs)
 }
 
+func TestEffectivePubID(t *testing.T) {
+	var pub openrtb.Publisher
+	assert.Equal(t, pbsmetrics.PublisherUnknown, effectivePubID(nil), "effectivePubID failed for nil Publisher.")
+	assert.Equal(t, pbsmetrics.PublisherUnknown, effectivePubID(&pub), "effectivePubID failed for empty Publisher.")
+	pub.ID = "123"
+	assert.Equal(t, "123", effectivePubID(&pub), "effectivePubID failed for standard Publisher.")
+	pub.Ext = json.RawMessage(`{"parentAccount": "abc"}`)
+	assert.Equal(t, "abc", effectivePubID(&pub), "effectivePubID failed for parentAccount.")
+}
+
 func validRequest(t *testing.T, filename string) string {
 	requestData, err := ioutil.ReadFile("sample-requests/valid-whole/supplementary/" + filename)
 	if err != nil {

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -190,8 +190,17 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
 	if bidReq.App != nil {
 		labels.Source = pbsmetrics.DemandApp
-		if bidReq.App.Publisher != nil && bidReq.App.Publisher.ID != "" {
-			labels.PubID = bidReq.App.Publisher.ID
+		if bidReq.App.Publisher != nil {
+			if bidReq.App.Publisher.ID != "" {
+				labels.PubID = bidReq.App.Publisher.ID
+			}
+			var pubExt openrtb_ext.ExtPublisher
+			if bidReq.App.Ext != nil {
+				err := json.Unmarshal(bidReq.App.Ext, &pubExt)
+				if err == nil && pubExt.ParentAccount != nil {
+					labels.PubID = *pubExt.ParentAccount
+				}
+			}
 		}
 	} else { // both bidReq.App == nil and bidReq.Site != nil are true
 		labels.Source = pbsmetrics.DemandWeb
@@ -200,8 +209,17 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
-		if bidReq.Site.Publisher != nil && bidReq.Site.Publisher.ID != "" {
-			labels.PubID = bidReq.Site.Publisher.ID
+		if bidReq.Site.Publisher != nil {
+			if bidReq.Site.Publisher.ID != "" {
+				labels.PubID = bidReq.Site.Publisher.ID
+			}
+			var pubExt openrtb_ext.ExtPublisher
+			if bidReq.Site.Ext != nil {
+				err := json.Unmarshal(bidReq.Site.Ext, &pubExt)
+				if err == nil && pubExt.ParentAccount != nil {
+					labels.PubID = *pubExt.ParentAccount
+				}
+			}
 		}
 	}
 

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -190,18 +190,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	usersyncs := usersync.ParsePBSCookieFromRequest(r, &(deps.cfg.HostCookie))
 	if bidReq.App != nil {
 		labels.Source = pbsmetrics.DemandApp
-		if bidReq.App.Publisher != nil {
-			if bidReq.App.Publisher.ID != "" {
-				labels.PubID = bidReq.App.Publisher.ID
-			}
-			var pubExt openrtb_ext.ExtPublisher
-			if bidReq.App.Ext != nil {
-				err := json.Unmarshal(bidReq.App.Ext, &pubExt)
-				if err == nil && pubExt.ParentAccount != nil {
-					labels.PubID = *pubExt.ParentAccount
-				}
-			}
-		}
+		labels.PubID = effectivePubID(bidReq.App.Publisher)
 	} else { // both bidReq.App == nil and bidReq.Site != nil are true
 		labels.Source = pbsmetrics.DemandWeb
 		if usersyncs.LiveSyncCount() == 0 {
@@ -209,18 +198,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		} else {
 			labels.CookieFlag = pbsmetrics.CookieFlagYes
 		}
-		if bidReq.Site.Publisher != nil {
-			if bidReq.Site.Publisher.ID != "" {
-				labels.PubID = bidReq.Site.Publisher.ID
-			}
-			var pubExt openrtb_ext.ExtPublisher
-			if bidReq.Site.Ext != nil {
-				err := json.Unmarshal(bidReq.Site.Ext, &pubExt)
-				if err == nil && pubExt.ParentAccount != nil {
-					labels.PubID = *pubExt.ParentAccount
-				}
-			}
-		}
+		labels.PubID = effectivePubID(bidReq.Site.Publisher)
 	}
 
 	numImps = len(bidReq.Imp)

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -46,26 +46,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 			// Fixes #820
 			coreBidder := resolveBidder(bidder.String(), aliases)
 
-			var publisherID string = ""
-			var pubExt openrtb_ext.ExtPublisher
-			if bidReq.Site != nil && bidReq.Site.Publisher != nil {
-				publisherID = bidReq.Site.Publisher.ID
-				if bidReq.Site.Ext != nil {
-					err := json.Unmarshal(bidReq.Site.Ext, &pubExt)
-					if err == nil && pubExt.ParentAccount != nil {
-						publisherID = *pubExt.ParentAccount
-					}
-				}
-			}
-			if bidReq.App != nil && bidReq.App.Publisher != nil && publisherID == "" {
-				publisherID = bidReq.App.Publisher.ID
-				if bidReq.App.Ext != nil {
-					err := json.Unmarshal(bidReq.App.Ext, &pubExt)
-					if err == nil && pubExt.ParentAccount != nil {
-						publisherID = *pubExt.ParentAccount
-					}
-				}
-			}
+			var publisherID = labels.PubID
 			if ok, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, publisherID, consent); !ok && err == nil {
 				cleanPI(bidReq, labels.RType == pbsmetrics.ReqTypeAMP)
 			}

--- a/openrtb_ext/publisher.go
+++ b/openrtb_ext/publisher.go
@@ -1,0 +1,9 @@
+package openrtb_ext
+
+// ExtPublisher defines the contract for ...publisher.ext (found in both bidrequest.site and bidrequest.app)
+type ExtPublisher struct {
+
+	// parentAccount would define the legal entity (publisher owner or network) that has the direct relationship with the PBS
+	// host. As such, the definition depends on the PBS hosting entity.
+	ParentAccount *string `json:"parentAccount,omitempty"`
+}


### PR DESCRIPTION
This lets a PBS host have a "parent Account" to track the entity they do business with when `publisher.id` may be too granular. 