### PR TITLE
[Sharethrough] Improved Headers in ad server request

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -55,6 +55,8 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	headers.Add("Content-Type", "text/plain;charset=utf-8")
 	headers.Add("Accept", "application/json")
 	headers.Add("Origin", domain)
+	headers.Add("X-Forwarded-For", request.Device.IP)
+	headers.Add("User-Agent", request.Device.UA)
 
 	var strImpExt adapters.ExtImpBidder
 	if err := json.Unmarshal(imp.Ext, &strImpExt); err != nil {

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -52,6 +52,9 @@ func assertRequestDataEquals(t *testing.T, testName string, expected *adapters.R
 	if len(expected.Body) != len(actual.Body) {
 		t.Errorf("Body mismatch: expected %s got %s\n", expected.Body, actual.Body)
 	}
+	if len(expected.Headers) != len(actual.Headers) {
+		t.Errorf("Number of headers mismatch: expected %d got %d\n", len(expected.Headers), len(actual.Headers))
+	}
 	for headerIndex, expectedHeader := range expected.Headers {
 		if expectedHeader[0] != actual.Headers[headerIndex][0] {
 			t.Errorf("Header %s mismatch: expected %s got %s\n", headerIndex, expectedHeader[0], actual.Headers[headerIndex][0])
@@ -78,17 +81,20 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				App: &openrtb.App{Ext: []byte(`{}`)},
 				Device: &openrtb.Device{
 					UA: "Android Chome/60",
+					IP: "127.0.0.1",
 				},
 			},
-			inputDom: "a.domain.com",
+			inputDom: "http://a.domain.com",
 			expected: &adapters.RequestData{
 				Method: "POST",
 				Uri:    "http://abc.com",
 				Body:   nil,
 				Headers: http.Header{
-					"Content-Type": []string{"text/plain;charset=utf-8"},
-					"Accept":       []string{"application/json"},
-					"Origin":       []string{"a.domain.com"},
+					"Content-Type":    []string{"text/plain;charset=utf-8"},
+					"Accept":          []string{"application/json"},
+					"Origin":          []string{"http://a.domain.com"},
+					"User-Agent":      []string{"Android Chome/60"},
+					"X-Forwarded-For": []string{"127.0.0.1"},
 				},
 			},
 		},
@@ -290,7 +296,7 @@ func TestBuildUri(t *testing.T) {
 				"height=20",
 				"width=30",
 				"supplyId=FGMrCMMc",
-				"strVersion=1.0.0",
+				"strVersion=" + strVersion,
 			},
 		},
 	}

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -12,7 +12,7 @@ import (
 )
 
 const supplyId = "FGMrCMMc"
-const strVersion = "1.0.0"
+const strVersion = "1.0.1"
 
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -206,6 +206,10 @@ func (u Util) parseDomain(fullUrl string) string {
 		} else {
 			domain = uri.Host
 		}
+
+		if domain != "" {
+			domain = uri.Scheme + "://" + domain
+		}
 	}
 
 	return domain

--- a/adapters/sharethrough/utils_test.go
+++ b/adapters/sharethrough/utils_test.go
@@ -416,11 +416,11 @@ func TestParseDomain(t *testing.T) {
 	}{
 		"Parses domain without port": {
 			input:    "http://a.domain.com/page?param=value",
-			expected: "a.domain.com",
+			expected: "http://a.domain.com",
 		},
 		"Parses domain with port": {
-			input:    "http://a.domain.com:8000/page?param=value",
-			expected: "a.domain.com",
+			input:    "https://a.domain.com:8000/page?param=value",
+			expected: "https://a.domain.com",
 		},
 		"Returns empty string if cannot parse the domain": {
 			input:    "abc",


### PR DESCRIPTION
This is forwarding more data to the Sharethrough ad server in order to bid more accurately:
- add scheme to `Origin` header
- add `X-Forwarded-For` header
- add `User-Agent` header