### PR TITLE
Improved mixed media responses (related to Issue 862)

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -402,6 +402,7 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	var bids []openrtb.Bid
 	var bidtype = getBidType(internalRequest)
 
+	println("got here.")
 	/*
 		Beachfront is now sending an empty array and 200 as their "no results" response. This should catch that.
 	*/

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
@@ -391,7 +390,6 @@ func getVideoRequest(req *openrtb.BidRequest) (BeachfrontVideoRequest, []error, 
 			beachfrontReq.Imp[videoImpsIndex].Id = videoImpsIndex
 			beachfrontReq.Imp[videoImpsIndex].ImpId = imp.ID
 
-
 			beachfrontExt, err := getBeachfrontExtension(imp)
 			if err == nil {
 				beachfrontReq.AppId = beachfrontExt.AppId
@@ -474,7 +472,6 @@ func postprocess(response *adapters.ResponseData, externalRequest *adapters.Requ
 	var errs = make([]error, 0)
 
 	if bidtype == openrtb_ext.BidTypeVideo {
-		glog.Info("Video")
 		var openrtbResp openrtb.BidResponse
 		if err := json.Unmarshal(response.Body, &openrtbResp); err != nil {
 			errs = append(errs, err)
@@ -482,7 +479,6 @@ func postprocess(response *adapters.ResponseData, externalRequest *adapters.Requ
 		}
 		return postprocessVideo(openrtbResp.SeatBid[0].Bid, externalRequest, id)
 	} else {
-		glog.Info("Banner")
 		if err := json.Unmarshal(response.Body, &beachfrontResp); err != nil {
 			errs = append(errs, err)
 			return nil, errs

--- a/adapters/beachfront/beachfronttest/exemplary/simple-mix.json
+++ b/adapters/beachfront/beachfronttest/exemplary/simple-mix.json
@@ -66,7 +66,7 @@
               "bidfloor": 0.01,
               "secure" : 0,
               "id": 0,
-              "impid": "video1"
+              "impid": "mix1"
             }
           ],
           "site": {

--- a/adapters/beachfront/beachfronttest/exemplary/simple-mix.json
+++ b/adapters/beachfront/beachfronttest/exemplary/simple-mix.json
@@ -1,0 +1,159 @@
+{
+  "mockBidRequest":
+  {
+    "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
+    "tmax":1000,
+    "source":{
+      "tid":"61b87329-8790-47b7-90dd-c53ae7ce1723"
+    },
+    "imp":[
+      {
+        "id":"mix1",
+        "ext":{
+          "bidder":{
+            "bidfloor":0.01,
+            "appId":"11bc5dd5-7421-4dd8-c926-40fa653bec76"
+          }
+        },
+        "video":{
+          "mimes":[
+            "video/mp4"
+          ],
+          "context":"instream",
+          "w":300,
+          "h":250
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        }
+      }
+    ],
+    "site":{
+      "publisher":{
+        "id":"publisher1"
+      },
+      "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534"
+    },
+    "user": {
+      "id": "some-user",
+      "buyeruid": "some-buyer"
+    },
+    "device": {
+      "ip": "127.0.0.1",
+      "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16"
+    }
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://reachms.bfmio.com/bid.json?exchange_id=11bc5dd5-7421-4dd8-c926-40fa653bec76&prebidserver",
+        "body": {
+          "isPrebid": true,
+          "appId": "11bc5dd5-7421-4dd8-c926-40fa653bec76",
+          "id": "61b87329-8790-47b7-90dd-c53ae7ce1723",
+          "imp": [
+            {
+              "video": {
+                "w": 300,
+                "h": 250
+              },
+              "bidfloor": 0.01,
+              "secure" : 0,
+              "id": 0,
+              "impid": "video1"
+            }
+          ],
+          "site": {
+            "page": "https://test.opposingviews.com/i/society/republican-sen-collins-may-change-vote-tax-bill?cb=1234534",
+            "domain": "test.opposingviews.com"
+          },
+          "device": {
+            "js": "1",
+            "ua": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
+            "ip": "127.0.0.1"
+          },
+          "cur": [
+            "USD"
+          ],
+          "user": {
+            "id": "some-user",
+            "buyeruid": "some-buyer"
+          }
+        }
+      },
+      "mockResponse": {
+        "status" : 200,
+        "body": {
+          "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
+          "seatBid":[
+            {
+              "bid":[
+                {
+                  "w":0,
+                  "h":0,
+                  "id": "0",
+                  "impid":"",
+                  "price":0.01,
+                  "adid":"",
+                  "nurl":"https://evt.bfmio.com/getmu?aid=bid:0d32aea6-d199-4803-a188-bd7cf7be1e12:11bc5dd5-7421-4dd8-c926-40fa653bec76:0.01:0.01&v=1&dsp=5afda03c7c2d2bfaee55a3f0,0.01&i_type=pre",
+                  "adm":"",
+                  "adomain":[
+
+                  ],
+                  "iurl":"",
+                  "cid":"",
+                  "crid":"",
+                  "attr":[
+
+                  ],
+                  "ext":{
+
+                  },
+                  "cat":[
+
+                  ]
+                }
+              ],
+              "seat":"",
+              "group":0,
+              "ext":{
+
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBids": [
+    {
+
+      "bid":[
+        {
+          "id":"61b87329-8790-47b7-90dd-c53ae7ce1723",
+          "impid":"video1",
+          "price":9.605201,
+          "nurl":"https://evt.bfmio.com/getmu?aid=bid:0d32aea6-d199-4803-a188-bd7cf7be1e12:11bc5dd5-7421-4dd8-c926-40fa653bec76:0.01:0.01&v=1&dsp=5afda03c7c2d2bfaee55a3f0,0.01&i_type=pre",
+          "crid":"0d32aea6-d199-4803-a188-bd7cf7be1e12",
+          "w":1500,
+          "h":1280,
+          "ext":{
+            "prebid":{
+              "type":"video"
+            },
+            "bidder":{
+
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/bidders/beachfront.md
+++ b/docs/bidders/beachfront.md
@@ -5,33 +5,37 @@ account on [https://platform.beachfront.io](platform.beachfront.io).
 
 For further information, please contact adops@beachfront.com.
 
-The beachfront bidder is capable of delivering banner and video bids, but
-to get back both banner and video requires setting up some simple aliases. 
+## Some notes on mixed format requests
+Internally, the Beachfront adapter has to make display vs. video requests to two separate servers.
+A given request to the beachfront adapter can therefore return only display
+ads or only video ads. Also, a beachfront AppId can only be configured on
+[https://platform.beachfront.io](platform.beachfront.io) for one or the other. 
+This can be worked around by using aliases.
+
 In the example adUnit setup below, there is a placement for a banner ad
-and a placement for a video ad. It would also be possible to request
-both for a single placement slot.
+and a placement for a video ad. 
+
 ```javascript
+    var VIDEO_APPID = "11bc5dd5-7421-4dd8-c926-40fa653bec76";
+    var BANNER_APPID = "3b16770b-17af-4d22-daff-9606bdf2c9c3";
+
+    pbjs.aliasBidder("beachfront","beachfrontBanner");
     pbjs.aliasBidder("beachfront","beachfrontVideo");
     var adUnits = [
         {
-            code: "banner",
+            code: "bannerImp",
             sizes: [[728, 90], [468, 60]],
 
             bids: [
                 {
-                    bidder: "beachfront",
+                    bidder: "beachfrontBanner",
                     params: {
                         bidfloor: 3.01,
                         appId : BANNER_APPID
                     }
-                }, {
-                    bidder: "appnexus",
-                    params: {
-                       placementId: "13144370"
-                    }
                 } ]
         }, {
-            code: "video",
+            code: "videoImp",
             sizes: [500,380],
             mediaTypes: {
                 video: {
@@ -47,16 +51,6 @@ both for a single placement slot.
                     bidfloor: 0.06,
                     appId: VIDEO_APPID
                 }
-            }, {
-                bidder: "appnexusAst",
-                params: {
-                  placementId: '123456',
-                  video: {
-                    id: 123,
-                    skipppable: true,
-                    playback_method: ['auto_play_sound_off']
-                  }
-                }
             } ]
         }
     ];
@@ -64,4 +58,46 @@ both for a single placement slot.
 
 ```
 
+It is also possible to request both for a single placement slot. Notice the use of the "forceBanner" 
+flag on the banner request. If that were skipped, an attempt would be made on the Beachfront backend
+to get a video ad for that bid using a banner AppId, which will fail. The set up below will
+return both a banner and a video ad, each with it's correct "mediaType", which can then be handled 
+ programmatically by what ever criteria is appropriate. :
 
+```javascript
+    var VIDEO_APPID = "11bc5dd5-7421-4dd8-c926-40fa653bec76";
+    var BANNER_APPID = "3b16770b-17af-4d22-daff-9606bdf2c9c3";
+
+    pbjs.aliasBidder("beachfront","beachfrontBanner");
+    pbjs.aliasBidder("beachfront","beachfrontVideo");
+    var adUnit = {
+        code: 'mmTest',
+        mediaTypes: {
+            video: {
+                mimes: ["video/mp4"],
+                context : "instream"
+            },
+            banner: {
+                sizes: sizes
+            }
+        },
+
+        bids: [
+            {
+                bidder: 'beachfrontBanner',
+                params: {
+                    bidfloor: 0.03,
+                    appId : BANNER_APPID,
+                    forceBanner : true
+                }
+            }, {
+                bidder: "beachfrontVideo",
+                params: {
+                    bidfloor: 0.01,
+                    appId: VIDEO_APPID
+                }
+            }
+        ]
+    };
+
+```

--- a/docs/bidders/beachfront.md
+++ b/docs/bidders/beachfront.md
@@ -2,5 +2,66 @@
 
 To use the beachfront bidder you will need an appId from an exchange 
 account on [https://platform.beachfront.io](platform.beachfront.io).
+
 For further information, please contact adops@beachfront.com.
+
+The beachfront bidder is capable of delivering banner and video bids, but
+to get back both banner and video requires setting up some simple aliases. 
+In the example adUnit setup below, there is a placement for a banner ad
+and a placement for a video ad. It would also be possible to request
+both for a single placement slot.
+```javascript
+    pbjs.aliasBidder("beachfront","beachfrontVideo");
+    var adUnits = [
+        {
+            code: "banner",
+            sizes: [[728, 90], [468, 60]],
+
+            bids: [
+                {
+                    bidder: "beachfront",
+                    params: {
+                        bidfloor: 3.01,
+                        appId : BANNER_APPID
+                    }
+                }, {
+                    bidder: "appnexus",
+                    params: {
+                       placementId: "13144370"
+                    }
+                } ]
+        }, {
+            code: "video",
+            sizes: [500,380],
+            mediaTypes: {
+                video: {
+                    mimes: ["video/mp4"],
+                    w: 500,
+                    h: 380
+                }
+            },
+            bids: [
+            {
+                bidder: "beachfrontVideo",
+                params: {
+                    bidfloor: 0.06,
+                    appId: VIDEO_APPID
+                }
+            }, {
+                bidder: "appnexusAst",
+                params: {
+                  placementId: '123456',
+                  video: {
+                    id: 123,
+                    skipppable: true,
+                    playback_method: ['auto_play_sound_off']
+                  }
+                }
+            } ]
+        }
+    ];
+
+
+```
+
 

--- a/openrtb_ext/imp_beachfront.go
+++ b/openrtb_ext/imp_beachfront.go
@@ -1,7 +1,7 @@
 package openrtb_ext
 
 type ExtImpBeachfront struct {
-	AppId    string  `json:"appId"`
-	BidFloor float64 `json:"bidfloor"`
-	ForceBanner bool	 `json:"forceBanner"`
+	AppId       string  `json:"appId"`
+	BidFloor    float64 `json:"bidfloor"`
+	ForceBanner bool    `json:"forceBanner"`
 }

--- a/openrtb_ext/imp_beachfront.go
+++ b/openrtb_ext/imp_beachfront.go
@@ -3,4 +3,5 @@ package openrtb_ext
 type ExtImpBeachfront struct {
 	AppId    string  `json:"appId"`
 	BidFloor float64 `json:"bidfloor"`
+	ForceBanner bool	 `json:"forceBanner"`
 }

--- a/static/bidder-info/beachfront.yaml
+++ b/static/bidder-info/beachfront.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "jim@beachfront.com"
+  email: "prebid@beachfront.com"
 capabilities:
   app:
     mediaTypes:

--- a/static/bidder-params/beachfront.json
+++ b/static/bidder-params/beachfront.json
@@ -11,6 +11,10 @@
     "bidfloor": {
       "type": "number",
       "description": "The price floor for the bid"
+    },
+    "forceBanner" : {
+      "type": "boolean",
+      "description": "If a request is made that includes both banner and video in the same imp, the default behavior is to make a video request. If this is set to true, a banner request will be used instead. Combined with an alias, this makes it possible to request both banner and video ads from beachfront for a single imp."
     }
   },
 


### PR DESCRIPTION
Ii does not appear that beachfront specificity had a problem with returning the correct mediaTypes, but there were several problems with handling requests containing both video and banner media in a single imp. The default behavior was to return a video if there was video included in the request. There was also a problem with a cookie not getting sent with that video request which resulted in very low to no fill for video. 

Processing the multimedia request as a single request to Beachfront's servers is not possible as they have separate endpoints and contracts for banner vs. video. So what I have here is a compromise that adds the "forceBanner" flag. This along with an alias (and fixing the cookie bit) lets a request similar to the example in #862  work. This is using test AppIds for banner and video. A real request would have separate AppIds configured for banner vs. video on Beachfront's platform.

`{"id":"fe7e9b35-4ae7-495b-834f-2e4a877271d9","source":{"tid":"fe7e9b35-4ae7-495b-834f-2e4a877271d9"},"tmax":1800,"imp":[{"id":"AdThrive_Content_1_phone","ext":{"beachfront":{"appId":"3b16770b-17af-4d22-daff-9606bdf2c9c3","bidfloor":0.1,"forceBanner":true},"beachfrontVideo":{"appId":"11bc5dd5-7421-4dd8-c926-40fa653bec76","bidfloor":0.1},"brightroll":{"publisher":"adthrive"},"districtm":{"use_pmt_rule":false,"placement_id":13239211,"allow_smaller_sizes":true}},"banner":{"format":[{"w":300,"h":250},{"w":320,"h":50},{"w":336,"h":280},{"w":300,"h":50},{"w":320,"h":100},{"w":250,"h":250},{"w":120,"h":240},{"w":1,"h":1},{"w":300,"h":300}]},"video":{"context":"outstream","mimes":["video/mp4"]}}],"test":1,"site":{"publisher":{"id":"72409f4d-9858-41ac-bf45-be255b82de89"},"page":"https://damndelicious.net/2014/04/11/garlic-butter-shrimp/"},"device":{"w":425,"h":976},"ext":{"prebid":{"aliases":{"districtm":"appnexus","beachfrontVideo":"beachfront"}}}}`

I've also updated the documentation with examples of multi media requests.