### PR TITLE
[godoc] properly format `Rev` doc

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Holds binary revision string
+// Rev holds binary revision string
 // Set manually at build time using:
 //    go build -ldflags "-X main.Rev=`git rev-parse --short HEAD`"
 // Populated automatically at build / release time via .travis.yml


### PR DESCRIPTION
Setup Field name into the comment so it's properly interpreted by godoc