### PR TITLE
Adding support for hb_source field in request made to AppNexus bidder…

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -26,6 +26,7 @@ type AppNexusAdapter struct {
 	http           *adapters.HTTPAdapter
 	URI            string
 	iabCategoryMap map[string]string
+	hbSource       int
 }
 
 // used for cookies and such
@@ -96,6 +97,7 @@ type appnexusReqExtAppnexus struct {
 	IncludeBrandCategory    *bool `json:"include_brand_category,omitempty"`
 	BrandCategoryUniqueness *bool `json:"brand_category_uniqueness,omitempty"`
 	IsAMP                   int   `json:"is_amp,omitempty"`
+	HeaderBiddingSource     int   `json:"hb_source,omitempty"`
 }
 
 // Full request extension including appnexus extension object
@@ -327,43 +329,35 @@ func (a *AppNexusAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *ada
 	}
 
 	// Add Appnexus request level extension
-	var isAMP int
+	var isAMP, isVIDEO int
 	if reqInfo.PbsEntryPoint == pbsmetrics.ReqTypeAMP {
 		isAMP = 1
-	} else {
-		isAMP = 0
+	} else if reqInfo.PbsEntryPoint == pbsmetrics.ReqTypeVideo {
+		isVIDEO = 1
 	}
+
 	var reqExt appnexusReqExt
 	if len(request.Ext) > 0 {
-		if err := json.Unmarshal(request.Ext, &reqExt); err == nil {
-			includeBrandCategory := reqExt.Prebid.Targeting != nil && reqExt.Prebid.Targeting.IncludeBrandCategory.PrimaryAdServer != 0
-			if includeBrandCategory {
-				if reqExt.Appnexus == nil {
-					reqExt.Appnexus = &appnexusReqExtAppnexus{}
-				}
-				reqExt.Appnexus.BrandCategoryUniqueness = &includeBrandCategory
-				reqExt.Appnexus.IncludeBrandCategory = &includeBrandCategory
-				reqExt.Appnexus.IsAMP = isAMP
-				request.Ext, err = json.Marshal(reqExt)
-				if err != nil {
-					errs = append(errs, err)
-					return nil, errs
-				}
-			}
-		} else {
+		if err := json.Unmarshal(request.Ext, &reqExt); err != nil {
 			errs = append(errs, err)
 			return nil, errs
 		}
-	} else if isAMP != 0 {
-		// if isAMP is 0, bidder doesn't need it included
-		var err error
+	}
+	if reqExt.Appnexus == nil {
 		reqExt.Appnexus = &appnexusReqExtAppnexus{}
-		reqExt.Appnexus.IsAMP = isAMP
-		request.Ext, err = json.Marshal(reqExt)
-		if err != nil {
-			errs = append(errs, err)
-			return nil, errs
-		}
+	}
+	includeBrandCategory := reqExt.Prebid.Targeting != nil && reqExt.Prebid.Targeting.IncludeBrandCategory.PrimaryAdServer != 0
+	if includeBrandCategory {
+		reqExt.Appnexus.BrandCategoryUniqueness = &includeBrandCategory
+		reqExt.Appnexus.IncludeBrandCategory = &includeBrandCategory
+	}
+	reqExt.Appnexus.IsAMP = isAMP
+	reqExt.Appnexus.HeaderBiddingSource = a.hbSource + isVIDEO
+	var err error
+	request.Ext, err = json.Marshal(reqExt)
+	if err != nil {
+		errs = append(errs, err)
+		return nil, errs
 	}
 
 	imps := request.Imp
@@ -596,11 +590,11 @@ func appendMemberId(uri string, memberId string) string {
 	return uri + "?member_id=" + memberId
 }
 
-func NewAppNexusAdapter(config *adapters.HTTPAdapterConfig, endpoint string) *AppNexusAdapter {
-	return NewAppNexusBidder(adapters.NewHTTPAdapter(config).Client, endpoint)
+func NewAppNexusAdapter(config *adapters.HTTPAdapterConfig, endpoint, platformID string) *AppNexusAdapter {
+	return NewAppNexusBidder(adapters.NewHTTPAdapter(config).Client, endpoint, platformID)
 }
 
-func NewAppNexusBidder(client *http.Client, endpoint string) *AppNexusAdapter {
+func NewAppNexusBidder(client *http.Client, endpoint, platformID string) *AppNexusAdapter {
 	a := &adapters.HTTPAdapter{Client: client}
 
 	// Load custom options for our adapter (currently just a lookup table to convert appnexus => iab categories)
@@ -614,9 +608,17 @@ func NewAppNexusBidder(client *http.Client, endpoint string) *AppNexusAdapter {
 		}
 	}
 
+	platid := 5
+	if len(platformID) > 0 {
+		if val, err := strconv.Atoi(platformID); err == nil {
+			platid = val
+		}
+	}
+
 	return &AppNexusAdapter{
 		http:           a,
 		URI:            endpoint,
 		iabCategoryMap: catmap,
+		hbSource:       platid,
 	}
 }

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -23,7 +23,11 @@ import (
 )
 
 func TestJsonSamples(t *testing.T) {
-	adapterstest.RunJSONBidderTest(t, "appnexustest", NewAppNexusBidder(nil, "http://ib.adnxs.com/openrtb2"))
+	adapterstest.RunJSONBidderTest(t, "appnexustest", NewAppNexusBidder(nil, "http://ib.adnxs.com/openrtb2", ""))
+}
+
+func TestVideoSamples(t *testing.T) {
+	adapterstest.RunJSONBidderTest(t, "appnexusplatformtest", NewAppNexusBidder(nil, "http://ib.adnxs.com/openrtb2", "8"))
 }
 
 func TestMemberQueryParam(t *testing.T) {
@@ -298,7 +302,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	}
 
 	conf := *adapters.DefaultHTTPAdapterConfig
-	an := NewAppNexusAdapter(&conf, server.URL)
+	an := NewAppNexusAdapter(&conf, server.URL, "")
 
 	pbin := pbs.PBSRequest{
 		AdUnits: make([]pbs.AdUnit, 2),

--- a/adapters/appnexus/appnexusplatformtest/exemplary/simple-auction.json
+++ b/adapters/appnexus/appnexusplatformtest/exemplary/simple-auction.json
@@ -29,10 +29,10 @@
 			"id": "test-request-id",
 			"ext": {
 				"appnexus": {
-				  "hb_source": 5
+				  "hb_source": 8
 				},
 				"prebid": {}
-			},
+			  },
 			"imp": [
 			  {
 				"id": "test-imp-id",
@@ -71,11 +71,12 @@
 				  "cid": "958",
 				  "crid": "29681110",
 				  "h": 250,
-				  "w": 300,
+					"w": 300,
+					"cat": ["IAB9-1"],
 				  "ext": {
 					"appnexus": {
-					  "brand_id": 99,
-						"brand_category_id": 99,
+					  "brand_id": 9,
+						"brand_category_id": 9,
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
@@ -109,10 +110,11 @@
 			  "crid": "29681110",
 			  "w": 300,
 			  "h": 250,
+			  "cat": ["IAB5-3"],
 			  "ext": {
 				"appnexus": {
-				  "brand_id": 99,
-					"brand_category_id": 99,
+				  "brand_id": 9,
+					"brand_category_id": 9,
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,

--- a/adapters/appnexus/appnexusplatformtest/video/simple-video.json
+++ b/adapters/appnexus/appnexusplatformtest/video/simple-video.json
@@ -29,10 +29,10 @@
 			"id": "test-request-id",
 			"ext": {
 				"appnexus": {
-				  "hb_source": 5
+				  "hb_source": 9
 				},
 				"prebid": {}
-			},
+			  },
 			"imp": [
 			  {
 				"id": "test-imp-id",
@@ -71,11 +71,12 @@
 				  "cid": "958",
 				  "crid": "29681110",
 				  "h": 250,
-				  "w": 300,
+					"w": 300,
+					"cat": ["IAB9-1"],
 				  "ext": {
 					"appnexus": {
-					  "brand_id": 99,
-						"brand_category_id": 99,
+					  "brand_id": 9,
+						"brand_category_id": 9,
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
@@ -109,10 +110,11 @@
 			  "crid": "29681110",
 			  "w": 300,
 			  "h": 250,
+			  "cat": ["IAB5-3"],
 			  "ext": {
 				"appnexus": {
-				  "brand_id": 99,
-					"brand_category_id": 99,
+				  "brand_id": 9,
+					"brand_category_id": 9,
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,

--- a/adapters/appnexus/appnexustest/amp/simple-banner.json
+++ b/adapters/appnexus/appnexustest/amp/simple-banner.json
@@ -32,7 +32,8 @@
         "body": {
           "ext": {
             "appnexus": {
-              "is_amp": 1
+              "is_amp": 1,
+              "hb_source": 5
             },
             "prebid": {
             }

--- a/adapters/appnexus/appnexustest/amp/simple-video.json
+++ b/adapters/appnexus/appnexustest/amp/simple-video.json
@@ -28,7 +28,8 @@
 		  "body": {
 			"ext": {
 				"appnexus": {
-					"is_amp": 1
+					"is_amp": 1,
+					"hb_source": 5
 				},
 				"prebid": {
 				}

--- a/adapters/appnexus/appnexustest/exemplary/native-1.1.json
+++ b/adapters/appnexus/appnexustest/exemplary/native-1.1.json
@@ -48,6 +48,12 @@
               }
             }
           ],
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
           "site": {
             "domain": "prebid.org",
             "page": "prebid.org"

--- a/adapters/appnexus/appnexustest/exemplary/optional-params.json
+++ b/adapters/appnexus/appnexustest/exemplary/optional-params.json
@@ -41,6 +41,12 @@
         "uri": "http://ib.adnxs.com/openrtb2?member_id=103",
         "body": {
           "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
           "imp": [
             {
               "id":"test-imp-id",

--- a/adapters/appnexus/appnexustest/exemplary/simple-banner.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-banner.json
@@ -31,6 +31,12 @@
         "uri": "http://ib.adnxs.com/openrtb2",
         "body": {
           "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
           "imp": [
             {
               "id": "test-imp-id",

--- a/adapters/appnexus/appnexustest/exemplary/simple-video.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-video.json
@@ -27,6 +27,12 @@
 		  "uri": "http://ib.adnxs.com/openrtb2",
 		  "body": {
 			"id": "test-request-id",
+			"ext": {
+				"appnexus": {
+				  "hb_source": 5
+				},
+				"prebid": {}
+			  },
 			"imp": [
 			  {
 				"id": "test-imp-id",

--- a/adapters/appnexus/appnexustest/supplemental/displaymanager-test.json
+++ b/adapters/appnexus/appnexustest/supplemental/displaymanager-test.json
@@ -47,7 +47,13 @@
                     }
                 }
               },
-                    "imp": [
+              "ext": {
+                "appnexus": {
+                  "hb_source": 5
+                },
+                "prebid": {}
+              },
+              "imp": [
               {
                 "id": "test-imp-id",
                 "banner": {

--- a/adapters/appnexus/appnexustest/supplemental/explicit-dimensions.json
+++ b/adapters/appnexus/appnexustest/supplemental/explicit-dimensions.json
@@ -28,6 +28,12 @@
         "uri": "http://ib.adnxs.com/openrtb2",
         "body": {
           "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
           "imp": [
             {
               "id": "test-imp-id",

--- a/adapters/appnexus/appnexustest/supplemental/multi-bid.json
+++ b/adapters/appnexus/appnexustest/supplemental/multi-bid.json
@@ -31,6 +31,12 @@
         "uri": "http://ib.adnxs.com/openrtb2",
         "body": {
           "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
           "imp": [
             {
               "id": "test-imp-id",

--- a/config/config.go
+++ b/config/config.go
@@ -584,6 +584,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.adtelligent.endpoint", "http://hb.adtelligent.com/auction")
 	v.SetDefault("adapters.adform.endpoint", "http://adx.adform.net/adx")
 	v.SetDefault("adapters.appnexus.endpoint", "http://ib.adnxs.com/openrtb2") // Docs: https://wiki.appnexus.com/display/supply/Incoming+Bid+Request+from+SSPs
+	v.SetDefault("adapters.appnexus.platform_id", "5")
 	v.SetDefault("adapters.advangelists.endpoint", "http://nep.advangelists.com/xp/get?pubid={{.PublisherID}}")
 	v.SetDefault("adapters.beachfront.endpoint", "https://display.bfmio.com/prebid_display")
 	v.SetDefault("adapters.beachfront.platform_id", "155")

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -55,7 +55,7 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration, infos adapter
 		openrtb_ext.BidderAdkernelAdn:  adkernelAdn.NewAdkernelAdnAdapter(cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderAdkernelAdn))].Endpoint),
 		openrtb_ext.BidderAdtelligent:  adtelligent.NewAdtelligentBidder(cfg.Adapters[string(openrtb_ext.BidderAdtelligent)].Endpoint),
 		openrtb_ext.BidderAdvangelists: advangelists.NewAdvangelistsBidder(cfg.Adapters[string(openrtb_ext.BidderAdvangelists)].Endpoint),
-		openrtb_ext.BidderAppnexus:     appnexus.NewAppNexusBidder(client, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint),
+		openrtb_ext.BidderAppnexus:     appnexus.NewAppNexusBidder(client, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].PlatformID),
 		// TODO #615: Update the config setup so that the Beachfront URLs can be configured, and use those in TestRaceIntegration in exchange_test.go
 		openrtb_ext.BidderBeachfront: beachfront.NewBeachfrontBidder(),
 		openrtb_ext.BidderBrightroll: brightroll.NewBrightrollBidder(cfg.Adapters[string(openrtb_ext.BidderBrightroll)].Endpoint),

--- a/router/router.go
+++ b/router/router.go
@@ -146,8 +146,8 @@ func loadDataCache(cfg *config.Configuration, db *sql.DB) (err error) {
 func newExchangeMap(cfg *config.Configuration) map[string]adapters.Adapter {
 	// These keys _must_ coincide with the bidder code in Prebid.js, if the adapter exists in both projects
 	return map[string]adapters.Adapter{
-		"appnexus":   appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint),
-		"districtm":  appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint),
+		"appnexus":   appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].PlatformID),
+		"districtm":  appnexus.NewAppNexusAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].Endpoint, cfg.Adapters[string(openrtb_ext.BidderAppnexus)].PlatformID),
 		"ix":         ix.NewIxAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderIx))].Endpoint),
 		"pubmatic":   pubmatic.NewPubmaticAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderPubmatic)].Endpoint),
 		"pulsepoint": pulsepoint.NewPulsePointAdapter(adapters.DefaultHTTPAdapterConfig, cfg.Adapters[string(openrtb_ext.BidderPulsepoint)].Endpoint),


### PR DESCRIPTION
…. The value for this comes from the "adapters.appnexus.platform_id" config option, and is incremented by one for requests that come from the longform video endpoint.