### PR TITLE
[fix][mispelling] fix mispelling in log

### DIFF
--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -20,18 +20,18 @@ func forceEnv(t *testing.T, key string, val string) func() {
 	orig, set := os.LookupEnv(key)
 	err := os.Setenv(key, val)
 	if err != nil {
-		t.Fatalf("Error setting evnvironment %s", key)
+		t.Fatalf("Error setting environment %s", key)
 	}
 	if set {
 		return func() {
 			if os.Setenv(key, orig) != nil {
-				t.Fatalf("Error unsetting evnvironment %s", key)
+				t.Fatalf("Error unsetting environment %s", key)
 			}
 		}
 	}
 	return func() {
 		if os.Unsetenv(key) != nil {
-			t.Fatalf("Error unsetting evnvironment %s", key)
+			t.Fatalf("Error unsetting environment %s", key)
 		}
 	}
 }


### PR DESCRIPTION
Following #991, fixing a mispelling found in log.