### PR TITLE
[Sharethrough] Implement Cookie Sync + misc improvements

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -23,6 +23,7 @@ type StrAdSeverParams struct {
 	Height             uint64
 	Width              uint64
 	TheTradeDeskUserId string
+	SharethroughUserId string
 }
 
 type StrOpenRTBInterface interface {
@@ -91,6 +92,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 			Width:              width,
 			InstantPlayCapable: s.Util.canAutoPlayVideo(request.Device.UA, s.UserAgentParsers),
 			TheTradeDeskUserId: userInfo.TtdUid,
+			SharethroughUserId: request.User.BuyerUID,
 		}),
 		Body:    nil,
 		Headers: headers,
@@ -150,6 +152,9 @@ func (h StrUriHelper) buildUri(params StrAdSeverParams) string {
 	if params.TheTradeDeskUserId != "" {
 		v.Set("ttduid", params.TheTradeDeskUserId)
 	}
+	if params.SharethroughUserId != "" {
+		v.Set("stxuid", params.SharethroughUserId)
+	}
 
 	v.Set("instant_play_capable", fmt.Sprintf("%t", params.InstantPlayCapable))
 	v.Set("stayInIframe", fmt.Sprintf("%t", params.Iframe))
@@ -157,7 +162,7 @@ func (h StrUriHelper) buildUri(params StrAdSeverParams) string {
 	v.Set("width", strconv.FormatUint(params.Width, 10))
 
 	v.Set("supplyId", supplyId)
-	v.Set("strVersion", strVersion)
+	v.Set("strVersion", strconv.FormatInt(strVersion, 10))
 
 	return h.BaseURI + "?" + v.Encode()
 }

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -167,7 +167,7 @@ func assertBidderResponseEquals(t *testing.T, testName string, expected adapters
 func TestSuccessResponseToOpenRTB(t *testing.T) {
 	tests := map[string]struct {
 		inputButlerReq  *adapters.RequestData
-		inputStrResp    openrtb_ext.ExtImpSharethroughResponse
+		inputStrResp    []byte
 		expectedSuccess *adapters.BidderResponse
 		expectedErrors  []error
 	}{
@@ -175,18 +175,7 @@ func TestSuccessResponseToOpenRTB(t *testing.T) {
 			inputButlerReq: &adapters.RequestData{
 				Uri: "http://uri.com?placement_key=pkey&bidId=bidid&height=20&width=30",
 			},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				AdServerRequestID: "arid",
-				BidID:             "bid",
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{{
-					CPM: 10,
-					Metadata: openrtb_ext.ExtImpSharethroughCreativeMetadata{
-						CampaignKey: "cmpKey",
-						CreativeKey: "creaKey",
-						DealID:      "dealId",
-					},
-				}},
-			},
+			inputStrResp: []byte(`{ "adserverRequestId": "arid", "bidId": "bid", "creatives": [{"cpm": 10, "creative": {"campaign_key": "cmpKey", "creative_key": "creaKey", "deal_id": "dealId"}}] }`),
 			expectedSuccess: &adapters.BidderResponse{
 				Bids: []*adapters.TypedBid{{
 					BidType: openrtb_ext.BidTypeNative,
@@ -220,15 +209,13 @@ func TestSuccessResponseToOpenRTB(t *testing.T) {
 func TestFailResponseToOpenRTB(t *testing.T) {
 	tests := map[string]struct {
 		inputButlerReq  *adapters.RequestData
-		inputStrResp    openrtb_ext.ExtImpSharethroughResponse
+		inputStrResp    []byte
 		expectedSuccess *adapters.BidderResponse
 		expectedErrors  []error
 	}{
 		"Returns nil if no creatives provided": {
-			inputButlerReq: &adapters.RequestData{},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{},
-			},
+			inputButlerReq:  &adapters.RequestData{},
+			inputStrResp:    []byte(`{}`),
 			expectedSuccess: nil,
 			expectedErrors: []error{
 				&errortypes.BadInput{Message: "No creative provided"},
@@ -238,12 +225,18 @@ func TestFailResponseToOpenRTB(t *testing.T) {
 			inputButlerReq: &adapters.RequestData{
 				Uri: "wrong format url",
 			},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{{}},
-			},
+			inputStrResp:    []byte(`{ "creatives": [{"creative": {}}] }`),
 			expectedSuccess: nil,
 			expectedErrors: []error{
 				&errortypes.BadInput{Message: `strconv.ParseUint: parsing "": invalid syntax`},
+			},
+		},
+		"Returns error if failed parsing body": {
+			inputButlerReq:  &adapters.RequestData{},
+			inputStrResp:    []byte(`{ wrong json`),
+			expectedSuccess: nil,
+			expectedErrors: []error{
+				&errortypes.BadInput{Message: "Unable to parse response JSON"},
 			},
 		},
 	}

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -84,6 +85,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 					IP: "127.0.0.1",
 				},
 				Site: &openrtb.Site{Page: "http://a.domain.com/page"},
+				User: &openrtb.User{},
 			},
 			inputDom: "http://a.domain.com",
 			expected: &adapters.RequestData{
@@ -287,6 +289,7 @@ func TestBuildUri(t *testing.T) {
 				Height:             20,
 				Width:              30,
 				TheTradeDeskUserId: "ttd123",
+				SharethroughUserId: "stx123",
 			},
 			expected: []string{
 				"http://abc.com?",
@@ -299,8 +302,9 @@ func TestBuildUri(t *testing.T) {
 				"height=20",
 				"width=30",
 				"supplyId=FGMrCMMc",
-				"strVersion=" + strVersion,
+				"strVersion=" + strconv.FormatInt(strVersion, 10),
 				"ttduid=ttd123",
+				"stxuid=stx123",
 			},
 		},
 	}

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -12,7 +12,7 @@ import (
 )
 
 const supplyId = "FGMrCMMc"
-const strVersion = "1.0.3"
+const strVersion = 4
 
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -1,12 +1,10 @@
 package sharethrough
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"regexp"
 )
@@ -68,10 +66,5 @@ func (a SharethroughAdapter) MakeBids(internalRequest *openrtb.BidRequest, exter
 		return nil, []error{fmt.Errorf("unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode)}
 	}
 
-	var strBidResp openrtb_ext.ExtImpSharethroughResponse
-	if err := json.Unmarshal(response.Body, &strBidResp); err != nil {
-		return nil, []error{err}
-	}
-
-	return a.AdServer.responseToOpenRTB(strBidResp, externalRequest)
+	return a.AdServer.responseToOpenRTB(response.Body, externalRequest)
 }

--- a/adapters/sharethrough/sharethrough_test.go
+++ b/adapters/sharethrough/sharethrough_test.go
@@ -5,7 +5,9 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
+	"github.com/stretchr/testify/assert"
 	"net/http"
+	"regexp"
 	"testing"
 )
 
@@ -37,6 +39,36 @@ func (m MockStrUriHelper) buildUri(params StrAdSeverParams) string {
 
 func (m MockStrUriHelper) parseUri(uri string) (*StrAdSeverParams, error) {
 	return m.mockParseUri()
+}
+
+func TestNewSharethroughBidder(t *testing.T) {
+	tests := map[string]struct {
+		input  string
+		output SharethroughAdapter
+	}{
+		"Creates Sharethrough adapter": {
+			input: "test endpoint",
+			output: SharethroughAdapter{
+				AdServer: StrOpenRTBTranslator{
+					UriHelper: StrUriHelper{BaseURI: "test endpoint"},
+					Util:      Util{},
+					UserAgentParsers: UserAgentParsers{
+						ChromeVersion:    regexp.MustCompile(`Chrome\/(?P<ChromeVersion>\d+)`),
+						ChromeiOSVersion: regexp.MustCompile(`CriOS\/(?P<chromeiOSVersion>\d+)`),
+						SafariVersion:    regexp.MustCompile(`Version\/(?P<safariVersion>\d+)`),
+					},
+				},
+			},
+		},
+	}
+
+	assert := assert.New(t)
+	for testName, test := range tests {
+		t.Logf("Test case: %s\n", testName)
+
+		actual := NewSharethroughBidder(test.input)
+		assert.Equal(actual, &test.output)
+	}
 }
 
 func TestSuccessMakeRequests(t *testing.T) {

--- a/adapters/sharethrough/sharethrough_test.go
+++ b/adapters/sharethrough/sharethrough_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"testing"
 )
@@ -21,7 +20,7 @@ func (m MockStrAdServer) requestFromOpenRTB(imp openrtb.Imp, request *openrtb.Bi
 	return m.mockRequestFromOpenRTB()
 }
 
-func (m MockStrAdServer) responseToOpenRTB(strResp openrtb_ext.ExtImpSharethroughResponse, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
+func (m MockStrAdServer) responseToOpenRTB(strRawResp []byte, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
 	return m.mockResponseToOpenRTB()
 }
 
@@ -208,13 +207,6 @@ func TestFailureMakeBids(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 			},
 			expected: []error{fmt.Errorf("unexpected status code: %d. Run with request.debug = 1 for more info", http.StatusInternalServerError)},
-		},
-		"Returns error if failed parsing body": {
-			inputResponse: &adapters.ResponseData{
-				StatusCode: http.StatusOK,
-				Body:       []byte(`{ wrong json`),
-			},
-			expected: []error{fmt.Errorf("invalid character 'w' looking for beginning of object key string")},
 		},
 		"Passes by errors from responseToOpenRTB": {
 			inputResponse: &adapters.ResponseData{

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -22,7 +22,7 @@ type UtilityInterface interface {
 	gdprApplies(*openrtb.BidRequest) bool
 	parseUserExt(*openrtb.User) userInfo
 
-	getAdMarkup(openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
+	getAdMarkup([]byte, openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
 	getPlacementSize([]openrtb.Format) (uint64, uint64)
 
 	canAutoPlayVideo(string, UserAgentParsers) bool
@@ -46,12 +46,8 @@ type userInfo struct {
 	TtdUid  string
 }
 
-func (u Util) getAdMarkup(strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
+func (u Util) getAdMarkup(strRawResp []byte, strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
 	strRespId := fmt.Sprintf("str_response_%s", strResp.BidID)
-	jsonPayload, err := json.Marshal(strResp)
-	if err != nil {
-		return "", err
-	}
 
 	tmplBody := `
 		<img src="//b.sharethrough.com/butler?type=s2s-win&arid={{.Arid}}" />
@@ -93,7 +89,7 @@ func (u Util) getAdMarkup(strResp openrtb_ext.ExtImpSharethroughResponse, params
 	var buf []byte
 	templatedBuf := bytes.NewBuffer(buf)
 
-	b64EncodedJson := base64.StdEncoding.EncodeToString(jsonPayload)
+	b64EncodedJson := base64.StdEncoding.EncodeToString(strRawResp)
 	err = tmpl.Execute(templatedBuf, struct {
 		Arid           template.JS
 		Pkey           string

--- a/config/config.go
+++ b/config/config.go
@@ -464,7 +464,7 @@ func (cfg *Configuration) setDerivedDefaults() {
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderRhythmone, "https://sync.1rx.io/usersync2/rmphb?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Drhythmone%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5BRX_UUID%5D")
 	// openrtb_ext.BidderRTBHouse doesn't have a good default.
 	// openrtb_ext.BidderRubicon doesn't have a good default.
-	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSharethrough, "https://sharethrough.adnxs.com/getuid?"+url.QueryEscape(externalURL)+"/setuid?bidder=sharethrough&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&uid=$UID")
+	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSharethrough, "https://match.sharethrough.com/FGMrCMMc/v1?redirectUri="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsharethrough%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSomoaudience, "https://publisher-east.mobileadtrading.com/usersync?ru="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsomoaudience%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUID%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSovrn, "https://ap.lijit.com/pixel?redir="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsovrn%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderSonobi, "https://sync.go.sonobi.com/us.gif?loc="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dsonobi%26consent_string%3D{{.GDPR}}%26gdpr%3D{{.GDPRConsent}}%26uid%3D%5BUID%5D")

--- a/openrtb_ext/imp_sharethrough.go
+++ b/openrtb_ext/imp_sharethrough.go
@@ -1,102 +1,25 @@
 package openrtb_ext
 
-import "encoding/json"
-
 type ExtImpSharethrough struct {
-	PlacementKey string `json:"pkey"`
-	Iframe       bool   `json:"iframe"`
+	Pkey       string `json:"pkey"`
+	Iframe     bool   `json:"iframe"`
+	IframeSize []int  `json:"iframeSize"`
 }
 
 // ExtImpSharethrough defines the contract for bidrequest.imp[i].ext.sharethrough
 type ExtImpSharethroughResponse struct {
 	AdServerRequestID string                       `json:"adserverRequestId"`
 	BidID             string                       `json:"bidId"`
-	CookieSyncUrls    []string                     `json:"cookieSyncUrls"`
 	Creatives         []ExtImpSharethroughCreative `json:"creatives"`
-	Placement         ExtImpSharethroughPlacement  `json:"placement"`
-	StxUserID         string                       `json:"stxUserId"`
 }
 type ExtImpSharethroughCreative struct {
 	AuctionWinID string                             `json:"auctionWinId"`
 	CPM          float64                            `json:"cpm"`
 	Metadata     ExtImpSharethroughCreativeMetadata `json:"creative"`
-	Version      int                                `json:"version"`
 }
 
 type ExtImpSharethroughCreativeMetadata struct {
-	Action                 string                            `json:"action"`
-	Advertiser             string                            `json:"advertiser"`
-	AdvertiserKey          string                            `json:"advertiser_key"`
-	Beacons                ExtImpSharethroughCreativeBeacons `json:"beacons"`
-	BrandLogoURL           string                            `json:"brand_logo_url"`
-	CampaignKey            string                            `json:"campaign_key"`
-	CreativeKey            string                            `json:"creative_key"`
-	CustomEngagementAction string                            `json:"custom_engagement_action"`
-	CustomEngagementLabel  string                            `json:"custom_engagement_label"`
-	CustomEngagementURL    string                            `json:"custom_engagement_url"`
-	DealID                 string                            `json:"deal_id"`
-	Description            string                            `json:"description"`
-	ForceClickToPlay       bool                              `json:"force_click_to_play"`
-	IconURL                string                            `json:"icon_url"`
-	ImpressionHTML         string                            `json:"impression_html"`
-	InstantPlayMobileCount int                               `json:"instant_play_mobile_count"`
-	InstantPlayMobileURL   string                            `json:"instant_play_mobile_url"`
-	MediaURL               string                            `json:"media_url"`
-	ShareURL               string                            `json:"share_url"`
-	SourceID               string                            `json:"source_id"`
-	ThumbnailURL           string                            `json:"thumbnail_url"`
-	Title                  string                            `json:"title"`
-	VariantKey             string                            `json:"variant_key"`
-}
-
-type ExtImpSharethroughCreativeBeacons struct {
-	Click           []string `json:"click"`
-	Impression      []string `json:"impression"`
-	Play            []string `json:"play"`
-	Visible         []string `json:"visible"`
-	WinNotification []string `json:"win-notification"`
-}
-
-type ExtImpSharethroughPlacement struct {
-	AllowInstantPlay      bool                                  `json:"allow_instant_play"`
-	ArticlesBeforeFirstAd int                                   `json:"articles_before_first_ad"`
-	ArticlesBetweenAds    int                                   `json:"articles_between_ads"`
-	Layout                string                                `json:"layout"`
-	Metadata              json.RawMessage                       `json:"metadata"`
-	PlacementAttributes   ExtImpSharethroughPlacementAttributes `json:"placementAttributes"`
-	Status                string                                `json:"status"`
-}
-
-type ExtImpSharethroughPlacementThirdPartyPartner struct {
-	Key string `json:"key"`
-	Tag string `json:"tag"`
-}
-
-type ExtImpSharethroughPlacementAttributes struct {
-	AdServerKey              string                                         `json:"ad_server_key"`
-	AdServerPath             string                                         `json:"ad_server_path"`
-	AllowDynamicCropping     bool                                           `json:"allow_dynamic_cropping"`
-	AppThirdPartyPartners    []string                                       `json:"app_third_party_partners"`
-	CustomCardCSS            string                                         `json:"custom_card_css"`
-	DFPPath                  string                                         `json:"dfp_path"`
-	DirectSellPromotedByText string                                         `json:"direct_sell_promoted_by_text"`
-	Domain                   string                                         `json:"domain"`
-	EnableLinkRedirection    bool                                           `json:"enable_link_redirection"`
-	FeaturedContent          json.RawMessage                                `json:"featured_content"`
-	MaxHeadlineLength        int                                            `json:"max_headline_length"`
-	MultiAdPlacement         bool                                           `json:"multi_ad_placement"`
-	PromotedByText           string                                         `json:"promoted_by_text"`
-	PublisherKey             string                                         `json:"publisher_key"`
-	RenderingPixelOffset     int                                            `json:"rendering_pixel_offset"`
-	SafeFrameSize            []int                                          `json:"safe_frame_size"`
-	SiteKey                  string                                         `json:"site_key"`
-	StrOptOutURL             string                                         `json:"str_opt_out_url"`
-	Template                 string                                         `json:"template"`
-	ThirdPartyPartners       []ExtImpSharethroughPlacementThirdPartyPartner `json:"third_party_partners"`
-}
-
-type ExtImpSharethroughExt struct {
-	Pkey       string `json:"pkey"`
-	Iframe     bool   `json:"iframe"`
-	IframeSize []int  `json:"iframeSize"`
+	CampaignKey string `json:"campaign_key"`
+	CreativeKey string `json:"creative_key"`
+	DealID      string `json:"deal_id"`
 }


### PR DESCRIPTION
### Implement Cookie Sync
- Change Cookie Sync Sharethrough URL with an actual URL (`config.go`)
- Send `request.User.BuyerUID` to the ad server

### Switch adapter version format
- Changing from `1.0.x` format to simple integer (here from `1.0.3` to `4`) for internal reason

### Ad Payload encoding
Before:
- Unmarshal JSON based on hardcoded ad payload schema (`imp_sharethrough.go`)
- Then re-Marshal it to JSON + B64 to put it in the ad markup

Now:
- JSON schema only has fields that actually matter in the adapter code
- the ad payload is kept raw so we can just B64-encode whatever we got back from the ad server