### PR TITLE
Implement ability to require a publisher/account ID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,8 @@ type Configuration struct {
 	// Array of blacklisted accounts that is used to create the hash table BlacklistedAcctMap so Account.ID's can be instantly accessed.
 	BlacklistedAccts   []string `mapstructure:"blacklisted_accts,flow"`
 	BlacklistedAcctMap map[string]bool
+	// Is publisher/account ID required to be submitted in the OpenRTB2 request
+	AccountRequired bool `mapstructure:"account_required"`
 }
 
 type HTTPClient struct {
@@ -660,6 +662,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("default_request.alias_info", false)
 	v.SetDefault("blacklisted_apps", []string{""})
 	v.SetDefault("blacklisted_accts", []string{""})
+	v.SetDefault("account_required", false)
 
 	// Set environment variable support:
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func TestDefaults(t *testing.T) {
 	cmpStrings(t, "adapters.pubmatic.endpoint", cfg.Adapters[string(openrtb_ext.BidderPubmatic)].Endpoint, "http://hbopenbid.pubmatic.com/translator?source=prebid-server")
 	cmpInts(t, "currency_converter.fetch_interval_seconds", cfg.CurrencyConverter.FetchIntervalSeconds, 1800)
 	cmpStrings(t, "currency_converter.fetch_url", cfg.CurrencyConverter.FetchURL, "https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json")
+	cmpBools(t, "account_required", cfg.AccountRequired, false)
 }
 
 var fullConfig = []byte(`
@@ -90,6 +91,7 @@ adapters:
   adkerneladn:
      usersync_url: https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r=
 blacklisted_apps: ["spamAppID","sketchy-app-id"]
+account_required: true
 `)
 
 var invalidAdapterEndpointConfig = []byte(`
@@ -213,6 +215,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "adapters.adkerneladn.usersync_url", cfg.Adapters[strings.ToLower(string(openrtb_ext.BidderAdkernelAdn))].UserSyncURL, "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r=")
 	cmpStrings(t, "adapters.rhythmone.endpoint", cfg.Adapters[string(openrtb_ext.BidderRhythmone)].Endpoint, "http://tag.1rx.io/rmp")
 	cmpStrings(t, "adapters.rhythmone.usersync_url", cfg.Adapters[string(openrtb_ext.BidderRhythmone)].UserSyncURL, "https://sync.1rx.io/usersync2/rmphb?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&redir=http%3A%2F%2Fprebid-server.prebid.org%2F%2Fsetuid%3Fbidder%3Drhythmone%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%5BRX_UUID%5D")
+	cmpBools(t, "account_required", cfg.AccountRequired, true)
 }
 
 func TestValidConfig(t *testing.T) {

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/config"
-	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -150,8 +149,8 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	}
 	labels.PubID = effectivePubID(req.Site.Publisher)
 	// Blacklist account now that we have resolved the value
-	if _, found := deps.cfg.BlacklistedAcctMap[labels.PubID]; found {
-		errL = append(errL, &errortypes.BlacklistedAcct{Message: fmt.Sprintf("Prebid-server has blacklisted Account ID: %s, pleaase reach out to the prebid server host.", labels.PubID)})
+	if acctIdErr := validateAccount(deps.cfg, labels.PubID); acctIdErr != nil {
+		errL = append(errL, acctIdErr)
 		w.WriteHeader(http.StatusBadRequest)
 		for _, err := range errL {
 			w.Write([]byte(fmt.Sprintf("Invalid request format: %s\n", err.Error())))

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/exchange"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
@@ -151,12 +152,17 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	// Blacklist account now that we have resolved the value
 	if acctIdErr := validateAccount(deps.cfg, labels.PubID); acctIdErr != nil {
 		errL = append(errL, acctIdErr)
-		w.WriteHeader(http.StatusBadRequest)
+		erVal := errortypes.DecodeError(acctIdErr)
+		if erVal == errortypes.BlacklistedAppCode || erVal == errortypes.BlacklistedAcctCode {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else { //erVal == errortypes.AcctRequiredCode
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
 		for _, err := range errL {
 			w.Write([]byte(fmt.Sprintf("Invalid request format: %s\n", err.Error())))
 		}
 		ao.Errors = append(ao.Errors, errL...)
-		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
 		return
 	}
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1184,13 +1184,11 @@ func validateAccount(cfg *config.Configuration, pubID string) error {
 	var err error = nil
 	// If specified in the configuration, discard requests that don't come with an account ID.
 	if cfg.AccountRequired && pubID == pbsmetrics.PublisherUnknown {
-		//return errortypes.AcctRequired{Message: fmt.Sprintf("Prebid-server has been configured to discard requests that don't come with an Account ID. Please reach out to the prebid server host.")}
 		err = error(&errortypes.AcctRequired{Message: fmt.Sprintf("Prebid-server has been configured to discard requests that don't come with an Account ID. Please reach out to the prebid server host.")})
 	}
 
 	// Blacklist account now that we have resolved the value
 	if _, found := cfg.BlacklistedAcctMap[pubID]; found {
-		//return errortypes.BlacklistedAcct{Message: fmt.Sprintf("Prebid-server has blacklisted Account ID: %s, please reach out to the prebid server host.", labels.PubID)}
 		err = error(&errortypes.BlacklistedAcct{Message: fmt.Sprintf("Prebid-server has blacklisted Account ID: %s, please reach out to the prebid server host.", pubID)})
 	}
 	return err

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -107,8 +107,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	req, errL := deps.parseRequest(r)
 
-	if fatalError(errL) && writeError(errL, w) {
-		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
+	if fatalError(errL) && writeError(errL, w, &labels) {
 		return
 	}
 
@@ -138,8 +137,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	if acctIdErr := validateAccount(deps.cfg, labels.PubID); acctIdErr != nil {
 		errL = append(errL, acctIdErr)
-		writeError(errL, w)
-		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
+		writeError(errL, w, &labels)
 		return
 	}
 
@@ -1141,9 +1139,18 @@ func checkSafari(r *http.Request) (isSafari bool) {
 }
 
 // Write(return) errors to the client, if any. Returns true if errors were found.
-func writeError(errs []error, w http.ResponseWriter) bool {
+func writeError(errs []error, w http.ResponseWriter, labels *pbsmetrics.Labels) bool {
 	if len(errs) > 0 {
-		w.WriteHeader(http.StatusBadRequest)
+		httpStatus := http.StatusBadRequest
+		metricsStatus := pbsmetrics.RequestStatusBadInput
+		for _, err := range errs {
+			erVal := errortypes.DecodeError(err)
+			if erVal == errortypes.BlacklistedAppCode || erVal == errortypes.BlacklistedAcctCode {
+				httpStatus = http.StatusServiceUnavailable
+			}
+		}
+		w.WriteHeader(httpStatus)
+		labels.RequestStatus = metricsStatus
 		for _, err := range errs {
 			w.Write([]byte(fmt.Sprintf("Invalid request: %s\n", err.Error())))
 		}
@@ -1182,13 +1189,11 @@ func effectivePubID(pub *openrtb.Publisher) string {
 
 func validateAccount(cfg *config.Configuration, pubID string) error {
 	var err error = nil
-	// If specified in the configuration, discard requests that don't come with an account ID.
 	if cfg.AccountRequired && pubID == pbsmetrics.PublisherUnknown {
+		// If specified in the configuration, discard requests that don't come with an account ID.
 		err = error(&errortypes.AcctRequired{Message: fmt.Sprintf("Prebid-server has been configured to discard requests that don't come with an Account ID. Please reach out to the prebid server host.")})
-	}
-
-	// Blacklist account now that we have resolved the value
-	if _, found := cfg.BlacklistedAcctMap[pubID]; found {
+	} else if _, found := cfg.BlacklistedAcctMap[pubID]; found {
+		// Blacklist account now that we have resolved the value
 		err = error(&errortypes.BlacklistedAcct{Message: fmt.Sprintf("Prebid-server has blacklisted Account ID: %s, please reach out to the prebid server host.", pubID)})
 	}
 	return err

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1142,7 +1142,6 @@ func checkSafari(r *http.Request) (isSafari bool) {
 func writeError(errs []error, w http.ResponseWriter, labels *pbsmetrics.Labels) bool {
 	if len(errs) > 0 {
 		httpStatus := http.StatusBadRequest
-		metricsStatus := pbsmetrics.RequestStatusBadInput
 		for _, err := range errs {
 			erVal := errortypes.DecodeError(err)
 			if erVal == errortypes.BlacklistedAppCode || erVal == errortypes.BlacklistedAcctCode {
@@ -1150,7 +1149,7 @@ func writeError(errs []error, w http.ResponseWriter, labels *pbsmetrics.Labels) 
 			}
 		}
 		w.WriteHeader(httpStatus)
-		labels.RequestStatus = metricsStatus
+		labels.RequestStatus = pbsmetrics.RequestStatusBadInput
 		for _, err := range errs {
 			w.Write([]byte(fmt.Sprintf("Invalid request: %s\n", err.Error())))
 		}

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -45,6 +45,7 @@ type getResponseFromDirectory struct {
 	disabledBidders []string
 	adaptersConfig  map[string]config.Adapter
 	accountReq      bool
+	description     string
 }
 
 // TestExplicitUserId makes sure that the cookie's ID doesn't override an explicit value sent in the request.
@@ -223,7 +224,7 @@ func TestBlacklistRequests(t *testing.T) {
 		dir:           "sample-requests/blacklisted",
 		payloadGetter: getRequestPayload,
 		messageGetter: getMessage,
-		expectedCode:  http.StatusBadRequest,
+		expectedCode:  http.StatusServiceUnavailable,
 		aliased:       false,
 	}
 	tests.assert(t)
@@ -232,8 +233,9 @@ func TestBlacklistRequests(t *testing.T) {
 // TestRejectAccountRequired asserts we return a 400 code on a request that comes with no user id nor app id
 // if the `AccountRequired` field in the `config.Configuration` structure is set to true
 func TestRejectAccountRequired(t *testing.T) {
-	tests := map[string]*getResponseFromDirectory{
-		"8.1) Not required and not provided. Since not provided, not blacklisted": {
+	tests := []*getResponseFromDirectory{
+		{
+			// Account not required and not provided in prebid request
 			dir:           "sample-requests/account-required",
 			file:          "no-acct.json",
 			payloadGetter: getRequestPayload,
@@ -241,7 +243,8 @@ func TestRejectAccountRequired(t *testing.T) {
 			expectedCode:  http.StatusOK,
 			accountReq:    false,
 		},
-		"8.2) Required, not provided and in consequence, not blacklisted": {
+		{
+			// Account was required but not provided in prebid request
 			dir:           "sample-requests/account-required",
 			file:          "no-acct.json",
 			payloadGetter: getRequestPayload,
@@ -249,7 +252,8 @@ func TestRejectAccountRequired(t *testing.T) {
 			expectedCode:  http.StatusBadRequest,
 			accountReq:    true,
 		},
-		"8.3) Required, provided and not blacklisted": {
+		{
+			// Account is required, was provided and is not in the blacklisted accounts map
 			dir:           "sample-requests/account-required",
 			file:          "with-acct.json",
 			payloadGetter: getRequestPayload,
@@ -258,12 +262,13 @@ func TestRejectAccountRequired(t *testing.T) {
 			aliased:       true,
 			accountReq:    true,
 		},
-		"8.4) Required, provided and blacklisted": {
+		{
+			// Account is required, was provided in request and is found in the  blacklisted accounts map
 			dir:           "sample-requests/blacklisted",
 			file:          "blacklisted-acct.json",
 			payloadGetter: getRequestPayload,
 			messageGetter: getMessage,
-			expectedCode:  http.StatusBadRequest,
+			expectedCode:  http.StatusServiceUnavailable,
 			accountReq:    true,
 		},
 	}
@@ -278,30 +283,32 @@ func (gr *getResponseFromDirectory) assert(t *testing.T) {
 	//t *testing.T, dir string, payloadGetter func(*testing.T, []byte) []byte, messageGetter func(*testing.T, []byte) []byte, expectedCode int, aliased bool) {
 	t.Helper()
 	var filename string
-	var fileData []byte
+	var filesToAssert []string
 	if gr.file == "" {
+		// Append every file found in `gr.dir` to the `filesToAssert` array and test them all
 		for _, fileInfo := range fetchFiles(t, gr.dir) {
-			filename = gr.dir + "/" + fileInfo.Name()
-			fileData = readFile(t, filename)
-			code, msg := gr.doRequest(t, gr.payloadGetter(t, fileData))
-			fmt.Printf("Processing %s\n", filename)
-			assertResponseCode(t, filename, code, gr.expectedCode, msg)
-
-			expectMsg := gr.messageGetter(t, fileData)
-			if len(expectMsg) > 0 {
-				assert.Equal(t, string(expectMsg), msg, "file %s had bad response body", filename)
-			}
+			filesToAssert = append(filesToAssert, gr.dir+"/"+fileInfo.Name())
 		}
 	} else {
-		filename = gr.dir + "/" + gr.file
-		fileData = readFile(t, filename)
+		// Just test the single `gr.file`, and not the entiriety of files that may be found in `gr.dir`
+		filesToAssert = append(filesToAssert, gr.dir+"/"+gr.file)
+	}
+
+	var fileData []byte
+	// Test the one or more test files appended to `filesToAssert`
+	for _, testFile := range filesToAssert {
+		fileData = readFile(t, testFile)
 		code, msg := gr.doRequest(t, gr.payloadGetter(t, fileData))
-		fmt.Printf("Single file processing %s\n", filename)
+		fmt.Printf("Processing %s\n", testFile)
 		assertResponseCode(t, filename, code, gr.expectedCode, msg)
 
 		expectMsg := gr.messageGetter(t, fileData)
-		if len(expectMsg) > 0 {
-			assert.Equal(t, string(expectMsg), msg, "file %s had bad response body", filename)
+		if gr.description != "" {
+			if len(expectMsg) > 0 {
+				assert.Equal(t, string(expectMsg), msg, "Test failed. %s. Filename: \n", gr.description, filename)
+			} else {
+				assert.Equal(t, string(expectMsg), msg, "file %s had bad response body", filename)
+			}
 		}
 	}
 }

--- a/endpoints/openrtb2/sample-requests/account-required/no-acct.json
+++ b/endpoints/openrtb2/sample-requests/account-required/no-acct.json
@@ -1,0 +1,66 @@
+{
+    "description": "This request comes with no account id",
+    "message": "Invalid request: Prebid-server has been configured to discard requests that don't come with an Account ID. Please reach out to the prebid server host.\n",
+  
+    "requestPayload": {
+      "id": "some-request-id",
+      "site": {
+      	"page": "test.somepage.com"
+      },
+      "user": { },
+      "imp": [
+        {
+        	"id": "my-imp-id",
+        	"banner": {
+        		"format": [
+        			{
+        				"w": 300,
+        				"h": 600
+        			}
+        		]
+        	},
+        	"pmp": {
+        		"deals": [
+        			{
+        				"id": "some-deal-id"
+        			}
+        		]
+        	},
+        	"ext": {
+        		"appnexus": {
+        			"placementId": 10433394
+        		}
+        	}
+        }
+      ],
+      "tmax": 500,
+      "ext": {
+        "prebid": {
+          "aliases": {
+            "districtm": "appnexus"
+          },
+          "bidadjustmentfactors": {
+            "appnexus": 1.01,
+            "districtm": 0.98,
+            "rubicon": 0.99
+          },
+          "cache": {
+            "bids": {}
+          },
+          "targeting": {
+            "includewinners": false,
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "max": 20,
+                  "increment": 0.10
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/endpoints/openrtb2/sample-requests/account-required/no-acct.json
+++ b/endpoints/openrtb2/sample-requests/account-required/no-acct.json
@@ -10,27 +10,27 @@
       "user": { },
       "imp": [
         {
-        	"id": "my-imp-id",
-        	"banner": {
-        		"format": [
-        			{
-        				"w": 300,
-        				"h": 600
-        			}
-        		]
-        	},
-        	"pmp": {
-        		"deals": [
-        			{
-        				"id": "some-deal-id"
-        			}
-        		]
-        	},
-        	"ext": {
-        		"appnexus": {
-        			"placementId": 10433394
-        		}
-        	}
+          "id": "my-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 600
+              }
+            ]
+          },
+          "pmp": {
+            "deals": [
+              {
+                "id": "some-deal-id"
+              }
+            ]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 10433394
+            }
+          }
         }
       ],
       "tmax": 500,

--- a/endpoints/openrtb2/sample-requests/account-required/with-acct.json
+++ b/endpoints/openrtb2/sample-requests/account-required/with-acct.json
@@ -1,0 +1,67 @@
+{
+    "description": "This request comes with no account id",
+    "message": "Invalid request: Prebid-server has been configured to discard requests that don't come with an Account ID. Please reach out to the prebid server host.\n",
+  
+    "requestPayload": {
+      "id": "some-request-id",
+      "site": {
+        "publisher": { "id": "not_bad_acct"},
+      	"page": "test.somepage.com"
+      },
+      "user": { },
+      "imp": [
+        {
+        	"id": "my-imp-id",
+        	"banner": {
+        		"format": [
+        			{
+        				"w": 300,
+        				"h": 600
+        			}
+        		]
+        	},
+        	"pmp": {
+        		"deals": [
+        			{
+        				"id": "some-deal-id"
+        			}
+        		]
+        	},
+        	"ext": {
+        		"appnexus": {
+        			"placementId": 10433394
+        		}
+        	}
+        }
+      ],
+      "tmax": 500,
+      "ext": {
+        "prebid": {
+          "aliases": {
+            "districtm": "appnexus"
+          },
+          "bidadjustmentfactors": {
+            "appnexus": 1.01,
+            "districtm": 0.98,
+            "rubicon": 0.99
+          },
+          "cache": {
+            "bids": {}
+          },
+          "targeting": {
+            "includewinners": false,
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "max": 20,
+                  "increment": 0.10
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/endpoints/openrtb2/sample-requests/account-required/with-acct.json
+++ b/endpoints/openrtb2/sample-requests/account-required/with-acct.json
@@ -11,27 +11,27 @@
       "user": { },
       "imp": [
         {
-        	"id": "my-imp-id",
-        	"banner": {
-        		"format": [
-        			{
-        				"w": 300,
-        				"h": 600
-        			}
-        		]
-        	},
-        	"pmp": {
-        		"deals": [
-        			{
-        				"id": "some-deal-id"
-        			}
-        		]
-        	},
-        	"ext": {
-        		"appnexus": {
-        			"placementId": 10433394
-        		}
-        	}
+          "id": "my-imp-id",
+          "banner": {
+            "format": [
+               {
+                 "w": 300,
+                 "h": 600
+               }
+            ]
+          },
+          "pmp": {
+            "deals": [
+              {
+                "id": "some-deal-id"
+              }
+            ]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 10433394
+            }
+          }
         }
       ],
       "tmax": 500,

--- a/endpoints/openrtb2/sample-requests/blacklisted/blacklisted-acct.json
+++ b/endpoints/openrtb2/sample-requests/blacklisted/blacklisted-acct.json
@@ -1,6 +1,6 @@
 {
     "description": "This is a perfectly valid request except that it comes from a blacklisted Account",
-    "message": "Invalid request: Prebid-server has blacklisted Account ID: bad_acct, pleaase reach out to the prebid server host.\n",
+    "message": "Invalid request: Prebid-server has blacklisted Account ID: bad_acct, please reach out to the prebid server host.\n",
   
     "requestPayload": {
       "id": "some-request-id",

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -251,7 +251,6 @@ func handleError(labels pbsmetrics.Labels, w http.ResponseWriter, errL []error, 
 		erVal := errortypes.DecodeError(er)
 		if erVal == errortypes.BlacklistedAppCode || erVal == errortypes.BlacklistedAcctCode {
 			status = http.StatusServiceUnavailable
-			//labels.RequestStatus = pbsmetrics.RequestStatusBlacklisted
 		} else if erVal == errortypes.AcctRequiredCode {
 			status = http.StatusBadRequest
 			labels.RequestStatus = pbsmetrics.RequestStatusBadInput

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -252,7 +252,7 @@ func handleError(labels pbsmetrics.Labels, w http.ResponseWriter, errL []error, 
 		if erVal == errortypes.BlacklistedAppCode || erVal == errortypes.BlacklistedAcctCode {
 			status = http.StatusServiceUnavailable
 			//labels.RequestStatus = pbsmetrics.RequestStatusBlacklisted
-		} else if erVal == errortypes.AcctRequired {
+		} else if erVal == errortypes.AcctRequiredCode {
 			status = http.StatusBadRequest
 			labels.RequestStatus = pbsmetrics.RequestStatusBadInput
 		}

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -11,6 +11,7 @@ const (
 	FailedToRequestBidsCode
 	BidderTemporarilyDisabledCode
 	BlacklistedAcctCode
+	AcctRequiredCode
 )
 
 // We should use this code for any Error interface that is not in this package
@@ -83,6 +84,22 @@ func (err *BlacklistedAcct) Error() string {
 
 func (err *BlacklistedAcct) Code() int {
 	return BlacklistedAcctCode
+}
+
+// AcctRequired should be used when the environment variable ACCOUNT_REQUIRED has been set to not
+// process requests that don't come with a valid account ID
+//
+// These errors will be written to  http.ResponseWriter before canceling execution
+type AcctRequired struct {
+	Message string
+}
+
+func (err *AcctRequired) Error() string {
+	return err.Message
+}
+
+func (err *AcctRequired) Code() int {
+	return AcctRequiredCode
 }
 
 // BadServerResponse should be used when returning errors which are caused by bad/unexpected behavior on the remote server.


### PR DESCRIPTION
Adds feature to create a config option (boolean) to turn on/off enforcement of publisher/account ID in the resolved request for openrtb2 endpoint.