### PR TITLE
fix for using bid.ext.bidType field to set bid type in PubMatic adapter response

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -21,7 +21,7 @@ import (
 )
 
 const MAX_IMPRESSIONS_PUBMATIC = 30
-const bidTypeExtKey = "bidType"
+const bidTypeExtKey = "BidType"
 
 type PubmaticAdapter struct {
 	http *adapters.HTTPAdapter
@@ -569,8 +569,18 @@ func getBidType(bidExt json.RawMessage) openrtb_ext.BidType {
 		if err == nil {
 			err = json.Unmarshal(extbyte, &bidExtMap)
 			if err == nil && bidExtMap[bidTypeExtKey] != nil {
-				bidTypeStr := bidExtMap[bidTypeExtKey].(string)
-				bidType = openrtb_ext.BidType(bidTypeStr)
+				bidTypeVal := int(bidExtMap[bidTypeExtKey].(float64))
+				switch bidTypeVal {
+				case 0:
+					bidType = openrtb_ext.BidTypeBanner
+				case 1:
+					bidType = openrtb_ext.BidTypeVideo
+				case 2:
+					bidType = openrtb_ext.BidTypeNative
+				default:
+					// default value is banner
+					bidType = openrtb_ext.BidTypeBanner
+				}
 			}
 		}
 	}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/cache/dummycache"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -671,12 +672,12 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	}
 }
 
-func TestGetBidType(t *testing.T) {
+func TestGetBidTypeVideo(t *testing.T) {
 	extJSON := `{"BidType":1}`
 	extrm := json.RawMessage(extJSON)
 	actualBidTypeValue := getBidType(extrm)
-	if actualBidTypeValue != "video" {
-		t.Errorf("Expected Bid Type value was: video, actual value is: %v", actualBidTypeValue)
+	if actualBidTypeValue != openrtb_ext.BidTypeVideo {
+		t.Errorf("Expected Bid Type value was: %v, actual value is: %v", openrtb_ext.BidTypeVideo, actualBidTypeValue)
 	}
 }
 
@@ -687,5 +688,32 @@ func TestGetBidTypeForMissingBidTypeExt(t *testing.T) {
 	// banner is the default bid type when no bidType key is present in the bid.ext
 	if actualBidTypeValue != "banner" {
 		t.Errorf("Expected Bid Type value was: banner, actual value is: %v", actualBidTypeValue)
+	}
+}
+
+func TestGetBidTypeBanner(t *testing.T) {
+	extJSON := `{"BidType":0}`
+	extrm := json.RawMessage(extJSON)
+	actualBidTypeValue := getBidType(extrm)
+	if actualBidTypeValue != openrtb_ext.BidTypeBanner {
+		t.Errorf("Expected Bid Type value was: %v, actual value is: %v", openrtb_ext.BidTypeBanner, actualBidTypeValue)
+	}
+}
+
+func TestGetBidTypeNative(t *testing.T) {
+	extJSON := `{"BidType":2}`
+	extrm := json.RawMessage(extJSON)
+	actualBidTypeValue := getBidType(extrm)
+	if actualBidTypeValue != openrtb_ext.BidTypeNative {
+		t.Errorf("Expected Bid Type value was: %v, actual value is: %v", openrtb_ext.BidTypeNative, actualBidTypeValue)
+	}
+}
+
+func TestGetBidTypeForUnsupportedCode(t *testing.T) {
+	extJSON := `{"BidType":99}`
+	extrm := json.RawMessage(extJSON)
+	actualBidTypeValue := getBidType(extrm)
+	if actualBidTypeValue != openrtb_ext.BidTypeBanner {
+		t.Errorf("Expected Bid Type value was: %v, actual value is: %v", openrtb_ext.BidTypeBanner, actualBidTypeValue)
 	}
 }

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -672,7 +672,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 }
 
 func TestGetBidType(t *testing.T) {
-	extJSON := `{"bidType":"video"}`
+	extJSON := `{"BidType":1}`
 	extrm := json.RawMessage(extJSON)
 	actualBidTypeValue := getBidType(extrm)
 	if actualBidTypeValue != "video" {

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -670,3 +670,22 @@ func TestPubmaticSampleRequest(t *testing.T) {
 		t.Fatalf("Error when parsing request: %v", err)
 	}
 }
+
+func TestGetBidType(t *testing.T) {
+	extJSON := `{"bidType":"video"}`
+	extrm := json.RawMessage(extJSON)
+	actualBidTypeValue := getBidType(extrm)
+	if actualBidTypeValue != "video" {
+		t.Errorf("Expected Bid Type value was: video, actual value is: %v", actualBidTypeValue)
+	}
+}
+
+func TestGetBidTypeForMissingBidTypeExt(t *testing.T) {
+	extJSON := `{}`
+	extrm := json.RawMessage(extJSON)
+	actualBidTypeValue := getBidType(extrm)
+	// banner is the default bid type when no bidType key is present in the bid.ext
+	if actualBidTypeValue != "banner" {
+		t.Errorf("Expected Bid Type value was: banner, actual value is: %v", actualBidTypeValue)
+	}
+}

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -115,7 +115,7 @@
                   "ext": {
                     "dspid": 6,
                     "deal_channel": 1,
-                    "bidType": "video"
+                    "BidType": 1
                   }
                 }]
               }
@@ -146,7 +146,7 @@
               "ext": {
                 "dspid": 6,
                 "deal_channel": 1,
-                "bidType": "video"
+                "BidType": 1
               }
             },
             "type": "video"

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -114,7 +114,8 @@
                   "dealid":"test deal",
                   "ext": {
                     "dspid": 6,
-                    "deal_channel": 1
+                    "deal_channel": 1,
+                    "bidType": "video"
                   }
                 }]
               }
@@ -144,7 +145,8 @@
               "dealid":"test deal",
               "ext": {
                 "dspid": 6,
-                "deal_channel": 1
+                "deal_channel": 1,
+                "bidType": "video"
               }
             },
             "type": "video"


### PR DESCRIPTION
This PR has the fix for issue #862 .
The changes here include using the bid.ext.bidType field to set the bid type in PubMatic adapter response. Default value is "banner".