### PR TITLE
[Sharethrough] Handle requests without User

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -71,7 +71,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	}
 
 	pKey := strImpParams.Pkey
-	userInfo := s.Util.parseUserExt(request.User)
+	userInfo := s.Util.parseUserInfo(request.User)
 
 	var height, width uint64
 	if len(strImpParams.IframeSize) >= 2 {
@@ -92,7 +92,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 			Width:              width,
 			InstantPlayCapable: s.Util.canAutoPlayVideo(request.Device.UA, s.UserAgentParsers),
 			TheTradeDeskUserId: userInfo.TtdUid,
-			SharethroughUserId: request.User.BuyerUID,
+			SharethroughUserId: userInfo.StxUid,
 		}),
 		Body:    nil,
 		Headers: headers,

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -70,7 +70,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 		inputDom string
 		expected *adapters.RequestData
 	}{
-		"Generates the correct AdServer request from Imp": {
+		"Generates the correct AdServer request from Imp (no user provided)": {
 			inputImp: openrtb.Imp{
 				ID:  "abc",
 				Ext: []byte(`{ "bidder": {"pkey": "pkey", "iframe": true, "iframeSize": [10, 20]} }`),
@@ -85,7 +85,6 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 					IP: "127.0.0.1",
 				},
 				Site: &openrtb.Site{Page: "http://a.domain.com/page"},
-				User: &openrtb.User{},
 			},
 			inputDom: "http://a.domain.com",
 			expected: &adapters.RequestData{

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -20,7 +20,7 @@ const minSafariVersion = 10
 
 type UtilityInterface interface {
 	gdprApplies(*openrtb.BidRequest) bool
-	parseUserExt(*openrtb.User) userInfo
+	parseUserInfo(*openrtb.User) userInfo
 
 	getAdMarkup([]byte, openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
 	getPlacementSize([]openrtb.Format) (uint64, uint64)
@@ -44,6 +44,7 @@ type userExt struct {
 type userInfo struct {
 	Consent string
 	TtdUid  string
+	StxUid  string
 }
 
 func (u Util) getAdMarkup(strRawResp []byte, strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
@@ -189,9 +190,15 @@ func (u Util) gdprApplies(request *openrtb.BidRequest) bool {
 	return gdprApplies != 0
 }
 
-func (u Util) parseUserExt(user *openrtb.User) (ui userInfo) {
+func (u Util) parseUserInfo(user *openrtb.User) (ui userInfo) {
+	if user == nil {
+		return
+	}
+
+	ui.StxUid = user.BuyerUID
+
 	var userExt userExt
-	if user != nil && user.Ext != nil {
+	if user.Ext != nil {
 		if err := json.Unmarshal(user.Ext, &userExt); err == nil {
 			ui.Consent = userExt.Consent
 			for i := 0; i < len(userExt.Eids); i++ {


### PR DESCRIPTION
This provides a fix to issues raised after merging #1016 

- Extract user.BuyerId from `parseUserInfo` (renamed from `parseUserExt`)
- Handle case where `request.User` is `nil`
- Change `TestSuccessRequestFromOpenRTB` to have no `request.User` instead of empty object

@hhhjort @guscarreon FYI