### PR TITLE
Wrong endpoint for HTTP incremental updates

### DIFF
--- a/stored_requests/events/http/http.go
+++ b/stored_requests/events/http/http.go
@@ -96,7 +96,7 @@ func (e *HTTPEvents) refresh(ticker <-chan time.Time) {
 			thisTimeInUTC := thisTime.UTC()
 			thisEndpoint := e.Endpoint + "?last-modified=" + e.lastUpdate.Format(time.RFC3339)
 			ctx, cancel := e.ctxProducer()
-			resp, err := ctxhttp.Get(ctx, e.client, e.Endpoint)
+			resp, err := ctxhttp.Get(ctx, e.client, thisEndpoint)
 			if respObj, ok := e.parse(thisEndpoint, resp, err); ok {
 				invalidations := events.Invalidation{
 					Requests: extractInvalidations(respObj.StoredRequests),


### PR DESCRIPTION
The incremental endpoint is created as `thisEndpoint` but it was still using the `fetchAll()` endpoint every `refreshRate` interval so the server never pulled in any changes.