### PR TITLE
[Go 1.13] Testing Flags Refactor

### DIFF
--- a/pbs_light.go
+++ b/pbs_light.go
@@ -26,10 +26,11 @@ var Rev string
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
-	flag.Parse() // read glog settings from cmd line
 }
 
 func main() {
+	flag.Parse() // required for glog flags and testing package flags
+
 	v := viper.New()
 	config.SetupViper(v, "pbs")
 	cfg, err := config.New(v)


### PR DESCRIPTION
Go 1.13 includes the following change:

> Testing flags are now registered in the new Init function, which is invoked by the generated main function for the test. As a result, testing flags are now only registered when running a test binary, and packages that call flag.Parse during package initialization may cause tests to fail.

This is partially responsible for introducing an init flow bug when compiling against Go 1.13, causing tests to fail. It doesn't look like `flag.Parse()` needs to be performed during init and everything seems to work fine when its moved to the start of the main method.