### PR TITLE
[Sharethrough] Support bidfloor

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -130,7 +130,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adap
 	bidResponse := adapters.NewBidderResponse()
 
 	bidResponse.Currency = "USD"
-	typedBid := &adapters.TypedBid{BidType: openrtb_ext.BidTypeNative}
+	typedBid := &adapters.TypedBid{BidType: openrtb_ext.BidTypeBanner}
 
 	if len(strResp.Creatives) == 0 {
 		errs = append(errs, &errortypes.BadInput{Message: "No creative provided"})

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -71,6 +71,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
+	headers.Add("Accept-Encoding", "gzip")
 	headers.Add("Origin", domain)
 	headers.Add("Referer", request.Site.Page)
 	headers.Add("X-Forwarded-For", request.Device.IP)

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -49,6 +49,7 @@ type ButlerRequestBody struct {
 	BlockedAdvDomains []string `json:"badv,omitempty"`
 	MaxTimeout        int64    `json:"tmax"`
 	Deadline          string   `json:"deadline"`
+	BidFloor          float64  `json:"bidfloor,omitempty"`
 }
 
 type StrUriHelper struct {
@@ -96,7 +97,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 		height, width = 1, 1
 	}
 
-	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request)
+	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request, imp)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +170,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adap
 	return bidResponse, errs
 }
 
-func (h StrBodyHelper) buildBody(request *openrtb.BidRequest) (body []byte, err error) {
+func (h StrBodyHelper) buildBody(request *openrtb.BidRequest, imp openrtb.Imp) (body []byte, err error) {
 	timeout := request.TMax
 	if timeout == 0 {
 		timeout = defaultTmax
@@ -179,6 +180,7 @@ func (h StrBodyHelper) buildBody(request *openrtb.BidRequest) (body []byte, err 
 		BlockedAdvDomains: request.BAdv,
 		MaxTimeout:        timeout,
 		Deadline:          h.Clock.now().Add(time.Duration(timeout) * time.Millisecond).Format(time.RFC3339Nano),
+		BidFloor:          imp.BidFloor,
 	})
 
 	return

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -90,8 +90,10 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	var height, width uint64
 	if len(strImpParams.IframeSize) >= 2 {
 		height, width = uint64(strImpParams.IframeSize[0]), uint64(strImpParams.IframeSize[1])
-	} else {
+	} else if imp.Banner != nil {
 		height, width = s.Util.getPlacementSize(imp.Banner.Format)
+	} else {
+		height, width = 1, 1
 	}
 
 	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request)

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -88,15 +88,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 
 	pKey := strImpParams.Pkey
 	userInfo := s.Util.parseUserInfo(request.User)
-
-	var height, width uint64
-	if len(strImpParams.IframeSize) >= 2 {
-		height, width = uint64(strImpParams.IframeSize[0]), uint64(strImpParams.IframeSize[1])
-	} else if imp.Banner != nil {
-		height, width = s.Util.getPlacementSize(imp.Banner.Format)
-	} else {
-		height, width = 1, 1
-	}
+	height, width := s.Util.getPlacementSize(imp, strImpParams)
 
 	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request, imp)
 	if err != nil {

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -31,7 +31,7 @@ func (m MockUtil) gdprApplies(request *openrtb.BidRequest) bool {
 	return m.mockGdprApplies()
 }
 
-func (m MockUtil) getPlacementSize(formats []openrtb.Format) (height uint64, width uint64) {
+func (m MockUtil) getPlacementSize(imp openrtb.Imp, strImpParams openrtb_ext.ExtImpSharethrough) (height uint64, width uint64) {
 	return m.mockGetPlacementSize()
 }
 

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -106,6 +106,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},
+					"Accept-Encoding": []string{"gzip"},
 					"Origin":          []string{"http://a.domain.com"},
 					"Referer":         []string{"http://a.domain.com/page"},
 					"User-Agent":      []string{"Android Chome/60"},
@@ -139,6 +140,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},
+					"Accept-Encoding": []string{"gzip"},
 					"Origin":          []string{"http://a.domain.com"},
 					"Referer":         []string{"http://a.domain.com/page"},
 					"User-Agent":      []string{"Android Chome/60"},

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -286,7 +286,7 @@ func TestSuccessResponseToOpenRTB(t *testing.T) {
 			inputStrResp: []byte(`{ "adserverRequestId": "arid", "bidId": "bid", "creatives": [{"cpm": 10, "creative": {"campaign_key": "cmpKey", "creative_key": "creaKey", "deal_id": "dealId"}}] }`),
 			expectedSuccess: &adapters.BidderResponse{
 				Bids: []*adapters.TypedBid{{
-					BidType: openrtb_ext.BidTypeNative,
+					BidType: openrtb_ext.BidTypeBanner,
 					Bid: &openrtb.Bid{
 						AdID:   "arid",
 						ID:     "bid",

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -10,7 +10,7 @@ import (
 )
 
 const supplyId = "FGMrCMMc"
-const strVersion = 5
+const strVersion = 6
 
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{

--- a/adapters/sharethrough/utils_test.go
+++ b/adapters/sharethrough/utils_test.go
@@ -71,6 +71,49 @@ func TestGetAdMarkup(t *testing.T) {
 
 func TestGetPlacementSize(t *testing.T) {
 	tests := map[string]struct {
+		imp            openrtb.Imp
+		strImpParams   openrtb_ext.ExtImpSharethrough
+		expectedHeight uint64
+		expectedWidth  uint64
+	}{
+		"Returns size from STR params if provided": {
+			imp:            openrtb.Imp{},
+			strImpParams:   openrtb_ext.ExtImpSharethrough{IframeSize: []int{100, 200}},
+			expectedHeight: 100,
+			expectedWidth:  200,
+		},
+		"Skips size from STR params if malformed": {
+			imp:            openrtb.Imp{},
+			strImpParams:   openrtb_ext.ExtImpSharethrough{IframeSize: []int{100}},
+			expectedHeight: 1,
+			expectedWidth:  1,
+		},
+		"Returns size from banner format if provided": {
+			imp:            openrtb.Imp{Banner: &openrtb.Banner{Format: []openrtb.Format{{H: 100, W: 200}}}},
+			strImpParams:   openrtb_ext.ExtImpSharethrough{},
+			expectedHeight: 100,
+			expectedWidth:  200,
+		},
+		"Defaults to 1x1": {
+			imp:            openrtb.Imp{},
+			strImpParams:   openrtb_ext.ExtImpSharethrough{},
+			expectedHeight: 1,
+			expectedWidth:  1,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Logf("Test case: %s\n", testName)
+		assert := assert.New(t)
+
+		outputHeight, outputWidth := Util{}.getPlacementSize(test.imp, test.strImpParams)
+		assert.Equal(test.expectedHeight, outputHeight)
+		assert.Equal(test.expectedWidth, outputWidth)
+	}
+}
+
+func TestGetBestFormat(t *testing.T) {
+	tests := map[string]struct {
 		input          []openrtb.Format
 		expectedHeight uint64
 		expectedWidth  uint64
@@ -96,7 +139,7 @@ func TestGetPlacementSize(t *testing.T) {
 		t.Logf("Test case: %s\n", testName)
 		assert := assert.New(t)
 
-		outputHeight, outputWidth := Util{}.getPlacementSize(test.input)
+		outputHeight, outputWidth := Util{}.getBestFormat(test.input)
 		assert.Equal(test.expectedHeight, outputHeight)
 		assert.Equal(test.expectedWidth, outputWidth)
 	}


### PR DESCRIPTION
List of changes:
- Provide `bidfloor` to ad server
- Fix Native demand (null pointer exception) when no iframe size provided
- Change bid type to `banner`
- Accept `gzip` encoding