### PR TITLE
[Go 1.13] Testing Expected Errors Refactor

### DIFF
--- a/adapters/adkernelAdn/adkerneladntest/supplemental/banner-impression-nosizes.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/banner-impression-nosizes.json
@@ -27,7 +27,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Expected at least one banner.format entry or explicit w/h"
+    {
+      "value": "Expected at least one banner.format entry or explicit w/h",
+      "comparison": "literal"
+    }
   ]
- 
+  
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/http-err-status.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/http-err-status.json
@@ -49,5 +49,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Unexpected http status code: 404"]
+  "expectedMakeBidsErrors": [ 
+    {
+      "value": "Unexpected http status code: 404",
+      "comparison": "literal" 
+    }
+  ]
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/native-impression.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/native-impression.json
@@ -28,7 +28,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Invalid imp with id=adunit-1. Expected imp.banner or imp.video"
+    {
+      "value": "Invalid imp with id=adunit-1. Expected imp.banner or imp.video",
+      "comparison": "literal"
+    }
   ]
- 
+  
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/no-imps.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/no-imps.json
@@ -9,5 +9,10 @@
       }
     }
   },
-  "expectedMakeRequestsErrors": ["No impression in the bid request"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "No impression in the bid request",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/two-impressions-two-seatbids.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/two-impressions-two-seatbids.json
@@ -97,5 +97,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Invalid SeatBids count: 2"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Invalid SeatBids count: 2",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-1.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-1.json
@@ -17,6 +17,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "json: cannot unmarshal string into Go struct field ExtImpAdkernelAdn.pubId of type int"
+    {
+      "value": "json: cannot unmarshal string into Go struct field ExtImpAdkernelAdn.pubId of type int",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-2.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-2.json
@@ -17,6 +17,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Invalid pubId value. Ignoring imp id=malconfigured-adunit"
+    {
+      "value": "Invalid pubId value. Ignoring imp id=malconfigured-adunit",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-3.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/wrong-imp-ext-3.json
@@ -15,6 +15,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Invalid pubId value. Ignoring imp id=malconfigured-adunit"
+    {
+      "value": "Invalid pubId value. Ignoring imp id=malconfigured-adunit",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adpone/adponetest/supplemental/bad_response.json
+++ b/adapters/adpone/adponetest/supplemental/bad_response.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adpone/adponetest/supplemental/status_400.json
+++ b/adapters/adpone/adponetest/supplemental/status_400.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adpone/adponetest/supplemental/status_418.json
+++ b/adapters/adpone/adponetest/supplemental/status_418.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adtelligent/adtelligenttest/supplemental/audio.json
+++ b/adapters/adtelligent/adtelligenttest/supplemental/audio.json
@@ -17,6 +17,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ignoring imp id=unsupported-audio-imp, Adtelligent supports only Video and Banner"
+    {
+      "value": "ignoring imp id=unsupported-audio-imp, Adtelligent supports only Video and Banner",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adtelligent/adtelligenttest/supplemental/native.json
+++ b/adapters/adtelligent/adtelligenttest/supplemental/native.json
@@ -17,6 +17,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ignoring imp id=unsupported-native-imp, Adtelligent supports only Video and Banner"
+    {
+      "value": "ignoring imp id=unsupported-native-imp, Adtelligent supports only Video and Banner",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adtelligent/adtelligenttest/supplemental/wrong-impression-ext.json
+++ b/adapters/adtelligent/adtelligenttest/supplemental/wrong-impression-ext.json
@@ -18,6 +18,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ignoring imp id=unsupported-native-imp, error while decoding impExt, err: json: cannot unmarshal string into Go struct field ExtImpAdtelligent.aid of type int"
+    {
+      "value": "ignoring imp id=unsupported-native-imp, error while decoding impExt, err: json: cannot unmarshal string into Go struct field ExtImpAdtelligent.aid of type int",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/adtelligent/adtelligenttest/supplemental/wrong-impression-mapping.json
+++ b/adapters/adtelligent/adtelligenttest/supplemental/wrong-impression-mapping.json
@@ -69,6 +69,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "ignoring bid id=test-bid-id, request doesn't contain any impression with id=SOME-WRONG-IMP-ID"
+    {
+      "value": "ignoring bid id=test-bid-id, request doesn't contain any impression with id=SOME-WRONG-IMP-ID",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-banner.json
+++ b/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-banner.json
@@ -28,7 +28,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
-    "no valid impressions were found"
+    {
+      "value": "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
+      "comparison": "literal"
+    },
+    {
+      "value": "no valid impressions were found",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-video.json
+++ b/adapters/beachfront/beachfronttest/supplemental/unmarshal-error-video.json
@@ -28,7 +28,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
-    "no valid impressions were found"
+    {
+      "value": "json: cannot unmarshal object into Go struct field ExtImpBeachfront.appId of type string",
+      "comparison": "literal"
+    },
+    {
+      "value": "no valid impressions were found",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/brightroll/brightrolltest/supplemental/invalid-extension.json
+++ b/adapters/brightroll/brightrolltest/supplemental/invalid-extension.json
@@ -23,6 +23,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-       "ext.bidder.publisher not provided"
+    {
+      "value": "ext.bidder.publisher not provided",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/brightroll/brightrolltest/supplemental/invalid-imp.json
+++ b/adapters/brightroll/brightrolltest/supplemental/invalid-imp.json
@@ -8,6 +8,9 @@
     }
   },
   "expectedMakeRequestsErrors": [
-    "No impression in the bid request"
+    {
+      "value": "No impression in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/brightroll/brightrolltest/supplemental/missing-extension.json
+++ b/adapters/brightroll/brightrolltest/supplemental/missing-extension.json
@@ -14,6 +14,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-  "ext.bidder not provided"
-]
+    {
+      "value": "ext.bidder not provided",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/brightroll/brightrolltest/supplemental/missing-param.json
+++ b/adapters/brightroll/brightrolltest/supplemental/missing-param.json
@@ -26,6 +26,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "publisher is empty"
+    {
+      "value": "publisher is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/bad-imp-banner-missing-sizes.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/bad-imp-banner-missing-sizes.json
@@ -18,6 +18,14 @@
       "page": "http://www.publisher.com/awesome/site?with=some&parameters=here"
     }
   },
-  "expectedMakeRequestsErrors": ["Need at least one size to build request",
-"Error in preprocess of Imp, err: [Need at least one size to build request]"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Need at least one size to build request",
+      "comparison": "literal"
+    },
+    {
+      "value": "Error in preprocess of Imp, err: [Need at least one size to build request]",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/bad-imp-ext-tagid-value.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/bad-imp-ext-tagid-value.json
@@ -20,5 +20,14 @@
       "page": "http://www.publisher.com/awesome/site?with=some&parameters=here"
     }
   },
-  "expectedMakeRequestsErrors": ["ignoring imp id=test-imp-id, invalid tagid must be a String of numbers","Error in preprocess of Imp, err: [ignoring imp id=test-imp-id, invalid tagid must be a String of numbers]"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "ignoring imp id=test-imp-id, invalid tagid must be a String of numbers",
+      "comparison": "literal"
+    },
+    {
+      "value": "Error in preprocess of Imp, err: [ignoring imp id=test-imp-id, invalid tagid must be a String of numbers]",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/invalid-request-no-banner.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/invalid-request-no-banner.json
@@ -13,5 +13,14 @@
       ]
     },
 
-    "expectedMakeRequestsErrors": ["Request needs to include a Banner object","Error in preprocess of Imp, err: [Request needs to include a Banner object]"]
+    "expectedMakeRequestsErrors": [
+      {
+        "value": "Request needs to include a Banner object",
+        "comparison": "literal"
+      },
+      {
+        "value": "Error in preprocess of Imp, err: [Request needs to include a Banner object]",
+        "comparison": "literal"
+      }
+    ]
   }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/invalid-response-unmarshall-error.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/invalid-response-unmarshall-error.json
@@ -54,5 +54,10 @@
           }
     }],
 
-    "expectedMakeBidsErrors": ["Unable to unpackage bid response. Error: json: cannot unmarshal string into Go struct field Bid.w of type uint64"]
+    "expectedMakeBidsErrors": [
+        {
+            "value": "Unable to unpackage bid response\\. Error: json: cannot unmarshal string into Go struct field (Bid\\.seatbid\\.bid\\.w|Bid\\.w) of type uint64",
+            "comparison": "regex"
+        }
+    ]
 }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/no-imps-in-request.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/no-imps-in-request.json
@@ -9,5 +9,10 @@
         }
       },
 
-      "expectedMakeRequestsErrors": ["No Imps in Bid Request"]
+      "expectedMakeRequestsErrors": [
+        {
+          "value": "No Imps in Bid Request",
+          "comparison": "literal"
+        }
+      ]
 }

--- a/adapters/emx_digital/emx_digitaltest/supplemental/server-error-code.json
+++ b/adapters/emx_digital/emx_digitaltest/supplemental/server-error-code.json
@@ -43,5 +43,10 @@
       }
     ],
 
-    "expectedMakeBidsErrors": ["Invalid Status Returned: 500. Run with request.debug = 1 for more info"]
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Invalid Status Returned: 500. Run with request.debug = 1 for more info",
+        "comparison": "literal"
+      }
+    ]
   }

--- a/adapters/engagebdr/engagebdrtest/supplemental/audio.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/audio.json
@@ -16,7 +16,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Ignoring imp id=test-imp-id, invalid MediaType. EngageBDR only supports Banner, Video and Native."
+    {
+      "value": "Ignoring imp id=test-imp-id, invalid MediaType. EngageBDR only supports Banner, Video and Native.",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/engagebdr/engagebdrtest/supplemental/multi-1-invalid-imp.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/multi-1-invalid-imp.json
@@ -26,7 +26,10 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "Ignoring imp id=test-imp-id-2, error while decoding impExt, err: unexpected end of JSON input."
+    {
+      "value": "Ignoring imp id=test-imp-id-2, error while decoding impExt, err: unexpected end of JSON input.",
+      "comparison": "literal"
+    }
   ],
   "httpCalls": [
     {

--- a/adapters/engagebdr/engagebdrtest/supplemental/no-imp-ext-bidder.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/no-imp-ext-bidder.json
@@ -15,7 +15,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Ignoring imp id=test-imp-id, error while decoding impExt, err: unexpected end of JSON input."
+    {
+      "value": "Ignoring imp id=test-imp-id, error while decoding impExt, err: unexpected end of JSON input.",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/engagebdr/engagebdrtest/supplemental/no-imp-ext.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/no-imp-ext.json
@@ -13,7 +13,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Ignoring imp id=test-imp-id, error while decoding extImpBidder, err: unexpected end of JSON input."
+    {
+      "value": "Ignoring imp id=test-imp-id, error while decoding extImpBidder, err: unexpected end of JSON input.",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/engagebdr/engagebdrtest/supplemental/no-imp-sspid.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/no-imp-sspid.json
@@ -17,7 +17,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Ignoring imp id=test-imp-id, no sspid present."
+    {
+      "value": "Ignoring imp id=test-imp-id, no sspid present.",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/engagebdr/engagebdrtest/supplemental/no-imp.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/no-imp.json
@@ -6,7 +6,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Invalid BidRequest. No valid imp."
+    {
+      "value": "Invalid BidRequest. No valid imp.",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/engagebdr/engagebdrtest/supplemental/response-500.json
+++ b/adapters/engagebdr/engagebdrtest/supplemental/response-500.json
@@ -43,7 +43,10 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 500. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }
 

--- a/adapters/eplanning/eplanningtest/supplemental/bad-imp-ext.json
+++ b/adapters/eplanning/eplanningtest/supplemental/bad-imp-ext.json
@@ -17,5 +17,10 @@
       }
     ]
   },
-  "expectedMakeRequestsErrors": ["Ignoring imp id=test-imp-id, error while decoding impExt, err: json: cannot unmarshal number into Go struct field ExtImpEPlanning.ci of type string"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Ignoring imp id=test-imp-id, error while decoding impExt, err: json: cannot unmarshal number into Go struct field ExtImpEPlanning.ci of type string",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/eplanning/eplanningtest/supplemental/banner-no-clientid.json
+++ b/adapters/eplanning/eplanningtest/supplemental/banner-no-clientid.json
@@ -16,5 +16,10 @@
         }
       ]
     },
-    "expectedMakeRequestsErrors": ["Ignoring imp id=test-imp-id, no ClientID present"]
+    "expectedMakeRequestsErrors": [
+      {
+        "value": "Ignoring imp id=test-imp-id, no ClientID present",
+        "comparison": "literal"
+      }
+    ]
 }

--- a/adapters/eplanning/eplanningtest/supplemental/invalid-response-unmarshall-error.json
+++ b/adapters/eplanning/eplanningtest/supplemental/invalid-response-unmarshall-error.json
@@ -45,6 +45,11 @@
       }
     ],
 
-    "expectedMakeBidsErrors": ["Error unmarshaling HB response: json: cannot unmarshal string into Go struct field hbResponseAd.w of type uint64"]
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Error unmarshaling HB response: json: cannot unmarshal string into Go struct field (hbResponseAd\\.sp\\.a\\.w|hbResponseAd\\.w) of type uint64",
+        "comparison": "regex"
+      }
+    ]
   }
   

--- a/adapters/eplanning/eplanningtest/supplemental/server-bad-request.json
+++ b/adapters/eplanning/eplanningtest/supplemental/server-bad-request.json
@@ -48,6 +48,11 @@
       }
     ],
   
-    "expectedMakeBidsErrors": ["Unexpected status code: 400. Run with request.debug = 1 for more info"]
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+        "comparison": "literal"
+      }
+    ]
   }
   

--- a/adapters/eplanning/eplanningtest/supplemental/server-error-code.json
+++ b/adapters/eplanning/eplanningtest/supplemental/server-error-code.json
@@ -48,6 +48,11 @@
       }
     ],
   
-    "expectedMakeBidsErrors": ["Unexpected status code: 500. Run with request.debug = 1 for more info"]
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+        "comparison": "literal"
+      }
+    ]
   }
   

--- a/adapters/gamma/gammatest/supplemental/bad-request-no-imps.json
+++ b/adapters/gamma/gammatest/supplemental/bad-request-no-imps.json
@@ -3,5 +3,10 @@
     "id": "test-request-id",
     "imp": []
   },
-  "expectedMakeRequestsErrors": ["No impressions in the bid request"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "No impressions in the bid request",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/gamma/gammatest/supplemental/bad-request.json
+++ b/adapters/gamma/gammatest/supplemental/bad-request.json
@@ -48,6 +48,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/bad-response-no-body.json
+++ b/adapters/gamma/gammatest/supplemental/bad-response-no-body.json
@@ -38,6 +38,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "bad server response: &{%!d(string=unexpected end of JSON input) 0}. "
+    {
+      "value": "bad server response: &{%!d(string=unexpected end of JSON input) 0}. ",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/ignore-imp.json
+++ b/adapters/gamma/gammatest/supplemental/ignore-imp.json
@@ -146,5 +146,10 @@
       "type": "video"
     }
   ],
-  "expectedMakeRequestsErrors": ["Gamma only supports banner and video media types. Ignoring imp id=unsupported-audio-imp"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Gamma only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/gamma/gammatest/supplemental/invalid-extension.json
+++ b/adapters/gamma/gammatest/supplemental/invalid-extension.json
@@ -23,6 +23,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-       "ext.bidder.publisher not provided"
+    {
+      "value": "ext.bidder.publisher not provided",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/invalid-imp.json
+++ b/adapters/gamma/gammatest/supplemental/invalid-imp.json
@@ -8,6 +8,9 @@
     }
   },
   "expectedMakeRequestsErrors": [
-    "No impressions in the bid request"
+    {
+      "value": "No impressions in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/missing-extension.json
+++ b/adapters/gamma/gammatest/supplemental/missing-extension.json
@@ -20,6 +20,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-  "ext.bidder not provided"
-]
+    {
+      "value": "ext.bidder not provided",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/gamma/gammatest/supplemental/missing-param.json
+++ b/adapters/gamma/gammatest/supplemental/missing-param.json
@@ -28,6 +28,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "PartnerID is empty"
+    {
+      "value": "PartnerID is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/missing-web.json
+++ b/adapters/gamma/gammatest/supplemental/missing-web.json
@@ -27,6 +27,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "WebID is empty"
+    {
+      "value": "WebID is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/missing-zone.json
+++ b/adapters/gamma/gammatest/supplemental/missing-zone.json
@@ -28,6 +28,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "ZoneID is empty"
+    {
+      "value": "ZoneID is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/status-forbidden.json
+++ b/adapters/gamma/gammatest/supplemental/status-forbidden.json
@@ -48,6 +48,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 403. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 403. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamma/gammatest/supplemental/unsupported-audio.json
+++ b/adapters/gamma/gammatest/supplemental/unsupported-audio.json
@@ -19,7 +19,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Gamma only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
-    "No valid impression in the bid request"
+    {
+      "value": "Gamma only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impression in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/audio.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/audio.json
@@ -17,7 +17,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
-    "No valid impression in the bid request"
+    {
+      "value": "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-audio-imp",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impression in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-request-no-imps.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-request-no-imps.json
@@ -3,5 +3,10 @@
     "id": "test-request-id",
     "imp": []
   },
-  "expectedMakeRequestsErrors": ["No impressions in the bid request"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "No impressions in the bid request",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-request.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-request.json
@@ -25,7 +25,13 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "Gamoshi only supports banner and video media types. Ignoring imp id=test-imp-id",
-    "No valid impression in the bid request"
+    {
+      "value": "Gamoshi only supports banner and video media types. Ignoring imp id=test-imp-id",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impression in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/bad-response-no-body.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/bad-response-no-body.json
@@ -49,6 +49,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "bad server response: unexpected end of JSON input. "
+    {
+      "value": "bad server response: unexpected end of JSON input. ",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-extension.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-extension.json
@@ -23,6 +23,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-       "ext.bidder.supplyPartnerId not provided"
+    {
+      "value": "ext.bidder.supplyPartnerId not provided",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-imp-no-supplyPartnerId.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-imp-no-supplyPartnerId.json
@@ -15,6 +15,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "supplyPartnerId is empty"
+    {
+      "value": "supplyPartnerId is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/invalid-imp.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/invalid-imp.json
@@ -8,6 +8,9 @@
     }
   },
   "expectedMakeRequestsErrors": [
-    "No impressions in the bid request"
+    {
+      "value": "No impressions in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/missing-extension.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/missing-extension.json
@@ -14,6 +14,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-  "ext.bidder not provided"
-]
+    {
+      "value": "ext.bidder not provided",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/missing-param.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/missing-param.json
@@ -26,6 +26,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-    "supplyPartnerId is empty"
+    {
+      "value": "supplyPartnerId is empty",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/native.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/native.json
@@ -17,7 +17,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-native-imp",
-    "No valid impression in the bid request"
+    {
+      "value": "Gamoshi only supports banner and video media types. Ignoring imp id=unsupported-native-imp",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impression in the bid request",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/status-bad-request.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/status-bad-request.json
@@ -50,6 +50,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. "
+    {
+      "value": "Unexpected status code: 400. ",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/gamoshi/gamoshitest/supplemental/unexpected-status-code.json
+++ b/adapters/gamoshi/gamoshitest/supplemental/unexpected-status-code.json
@@ -50,6 +50,9 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "unexpected status code: 500. Run with request.debug = 1 for more info"
+    {
+      "value": "unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/grid/gridtest/supplemental/bad_response.json
+++ b/adapters/grid/gridtest/supplemental/bad_response.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/grid/gridtest/supplemental/status_400.json
+++ b/adapters/grid/gridtest/supplemental/status_400.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/grid/gridtest/supplemental/status_418.json
+++ b/adapters/grid/gridtest/supplemental/status_418.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/bad_response.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/bad_response.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/multi-seatbid.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/multi-seatbid.json
@@ -55,6 +55,9 @@
     }],
 
     "expectedMakeBidsErrors": [
-        "Unexpected SeatBid! Must be only one but have: 2"
+        {
+            "value":  "Unexpected SeatBid! Must be only one but have: 2",
+            "comparison": "literal"
+        }
     ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/native.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/native.json
@@ -56,6 +56,9 @@
     }],
 
     "expectedMakeBidsErrors": [
-        "Unknown impression type for ID: \"test-imp-id\""
+        {
+            "value":  "Unknown impression type for ID: \"test-imp-id\"",
+            "comparison": "literal"
+        }
     ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/status_400.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/status_400.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/status_418.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/status_418.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/improvedigital/improvedigitaltest/supplemental/wrong_impid.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/wrong_impid.json
@@ -72,6 +72,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Failed to find impression for ID: \"unknown_impid\""
+    {
+      "value": "Failed to find impression for ID: \"unknown_impid\"",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/bad_response.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/bad_response.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Error unmarshaling LockerDome bid response - json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "Error unmarshaling LockerDome bid response - json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/empty_adUnitId_param.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/empty_adUnitId_param.json
@@ -22,7 +22,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ext.bidder.adUnitId is empty.",
-    "No valid or supported impressions in the bid request."
+    {
+      "value": "ext.bidder.adUnitId is empty.",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid or supported impressions in the bid request.",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/empty_imps.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/empty_imps.json
@@ -5,6 +5,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "No valid impressions in the bid request."
+    {
+      "value": "No valid impressions in the bid request.",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/no_adUnitId_param.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/no_adUnitId_param.json
@@ -18,7 +18,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ext.bidder.adUnitId was not provided.",
-    "No valid or supported impressions in the bid request."
+    {
+      "value": "ext.bidder.adUnitId was not provided.",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid or supported impressions in the bid request.",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/no_ext.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/no_ext.json
@@ -17,7 +17,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "ext was not provided.",
-    "No valid or supported impressions in the bid request."
+    {
+      "value": "ext was not provided.",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid or supported impressions in the bid request.",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/status_400.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/status_400.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/status_418.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/status_418.json
@@ -55,6 +55,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/lockerdome/lockerdometest/supplemental/unsupported_imp_type.json
+++ b/adapters/lockerdome/lockerdometest/supplemental/unsupported_imp_type.json
@@ -22,7 +22,13 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "LockerDome does not currently support non-banner types.",
-    "No valid or supported impressions in the bid request."
+    {
+      "value": "LockerDome does not currently support non-banner types.",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid or supported impressions in the bid request.",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/mgid/mgidtest/supplemental/noaccountid.json
+++ b/adapters/mgid/mgidtest/supplemental/noaccountid.json
@@ -24,6 +24,9 @@
     }
   },
   "expectedMakeRequestsErrors" : [
-    "accountId is not set"
+    {
+      "value": "accountId is not set",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/mgid/mgidtest/supplemental/status_not200.json
+++ b/adapters/mgid/mgidtest/supplemental/status_not200.json
@@ -64,7 +64,10 @@
     }
   ],
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 404. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 404. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ],
   "expectedBidResponses": []
 }

--- a/adapters/pubmatic/pubmatictest/supplemental/audio.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/audio.json
@@ -21,6 +21,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Invalid MediaType. PubMatic only supports Banner and Video. Ignoring ImpID=unsupported-audio-imp"
+    {
+      "value": "Invalid MediaType. PubMatic only supports Banner and Video. Ignoring ImpID=unsupported-audio-imp",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
@@ -96,11 +96,29 @@
     },
   
     "expectedMakeRequestsErrors": [
-        "Invalid adSlot AdTag_Div1@",
-        "Invalid size provided in adSlot AdTag_Div1@300",
-        "Invalid width provided in adSlot AdTag_Div1@valx250",
-        "Invalid height provided in adSlot AdTag_Div1@300xval",
-        "Invalid height provided in adSlot AdTag_Div1@300x",
-        "Invalid width provided in adSlot AdTag_Div1@x250"
+        {
+            "value": "Invalid adSlot AdTag_Div1@",
+            "comparison": "literal"
+        },
+        {
+            "value": "Invalid size provided in adSlot AdTag_Div1@300",
+            "comparison": "literal"
+        },
+        {
+            "value": "Invalid width provided in adSlot AdTag_Div1@valx250",
+            "comparison": "literal"
+        },
+        {
+            "value": "Invalid height provided in adSlot AdTag_Div1@300xval",
+            "comparison": "literal"
+        },
+        {
+            "value": "Invalid height provided in adSlot AdTag_Div1@300x",
+            "comparison": "literal"
+        },
+        {
+            "value": "Invalid width provided in adSlot AdTag_Div1@x250",
+            "comparison": "literal"
+        }
       ]
   }

--- a/adapters/rhythmone/rhythmonetest/supplemental/missing-extension.json
+++ b/adapters/rhythmone/rhythmonetest/supplemental/missing-extension.json
@@ -24,6 +24,9 @@
     ]
   },
   "expectedMakeRequestsErrors": [
-  	"ext data not provided in imp id=test-missing-ext-id. Abort all Request"
-]
+	{
+	  "value": "ext data not provided in imp id=test-missing-ext-id. Abort all Request",
+	  "comparison": "literal"
+	}
+  ]
 }

--- a/adapters/rtbhouse/rtbhousetest/supplemental/bad_response.json
+++ b/adapters/rtbhouse/rtbhousetest/supplemental/bad_response.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/rtbhouse/rtbhousetest/supplemental/status_400.json
+++ b/adapters/rtbhouse/rtbhousetest/supplemental/status_400.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/rtbhouse/rtbhousetest/supplemental/status_418.json
+++ b/adapters/rtbhouse/rtbhousetest/supplemental/status_418.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
+++ b/adapters/rubicon/rubicontest/supplemental/no-format-elements.json
@@ -20,5 +20,10 @@
     ]
   },
 
-  "expectedMakeRequestsErrors": ["rubicon imps must have at least one imp.format element"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "rubicon imps must have at least one imp.format element",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/somoaudience/somoaudiencetest/supplemental/bad-request-response.json
+++ b/adapters/somoaudience/somoaudiencetest/supplemental/bad-request-response.json
@@ -63,7 +63,10 @@
   ],
 
   "expectedMakeBidsErrors": [
-      "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 
 }

--- a/adapters/somoaudience/somoaudiencetest/supplemental/im-a-teapot-response.json
+++ b/adapters/somoaudience/somoaudiencetest/supplemental/im-a-teapot-response.json
@@ -63,7 +63,10 @@
   ],
 
   "expectedMakeBidsErrors": [
-      "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 
 }

--- a/adapters/somoaudience/somoaudiencetest/supplemental/missing-bidder.json
+++ b/adapters/somoaudience/somoaudiencetest/supplemental/missing-bidder.json
@@ -24,8 +24,11 @@
   },
 
   "expectedMakeRequestsErrors": [
-  "ignoring imp id=empty-extbid-test, error while decoding impExt, err: unexpected end of JSON input"
+    {
+      "value": "ignoring imp id=empty-extbid-test, error while decoding impExt, err: unexpected end of JSON input",
+      "comparison": "literal"
+    }
   ]
 
-
+  
 }

--- a/adapters/somoaudience/somoaudiencetest/supplemental/missing-ext.json
+++ b/adapters/somoaudience/somoaudiencetest/supplemental/missing-ext.json
@@ -21,8 +21,11 @@
   },
 
   "expectedMakeRequestsErrors": [
-      "ignoring imp id=empty-extbid-test, extImpBidder is empty"
+    {
+      "value": "ignoring imp id=empty-extbid-test, extImpBidder is empty",
+      "comparison": "literal"
+    } 
   ]
 
-
+  
 }

--- a/adapters/tappx/tappxtest/supplemental/banner-impression-noendpoint.json
+++ b/adapters/tappx/tappxtest/supplemental/banner-impression-noendpoint.json
@@ -29,7 +29,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Tappx endpoint undefined"
+    {
+      "value": "Tappx endpoint undefined",
+      "comparison": "literal"
+    }
   ]
- 
+  
 }

--- a/adapters/tappx/tappxtest/supplemental/banner-impression-nohost.json
+++ b/adapters/tappx/tappxtest/supplemental/banner-impression-nohost.json
@@ -29,7 +29,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Tappx host undefined"
+    {
+      "value": "Tappx host undefined",
+      "comparison": "literal"
+    }
   ]
  
 }

--- a/adapters/tappx/tappxtest/supplemental/banner-impression-nokey.json
+++ b/adapters/tappx/tappxtest/supplemental/banner-impression-nokey.json
@@ -29,7 +29,10 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Tappx key undefined"
+    {
+      "value": "Tappx key undefined",
+      "comparison": "literal"
+    }
   ]
  
 }

--- a/adapters/tappx/tappxtest/supplemental/http-err-status.json
+++ b/adapters/tappx/tappxtest/supplemental/http-err-status.json
@@ -65,5 +65,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Unexpected status code: 400. Run with request.debug = 1 for more info"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/tappx/tappxtest/supplemental/http-err-status2.json
+++ b/adapters/tappx/tappxtest/supplemental/http-err-status2.json
@@ -65,5 +65,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Unexpected status code: 500. Run with request.debug = 1 for more info"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/tappx/tappxtest/supplemental/no-imps.json
+++ b/adapters/tappx/tappxtest/supplemental/no-imps.json
@@ -11,5 +11,10 @@
       }
     }
   },
-  "expectedMakeRequestsErrors": ["No impression in the bid request"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "No impression in the bid request",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/tappx/tappxtest/supplemental/wrong-imp-ext-1.json
+++ b/adapters/tappx/tappxtest/supplemental/wrong-imp-ext-1.json
@@ -20,6 +20,9 @@
   },
 
   "expectedMakeRequestsErrors": [
-    "Error parsing tappxExt parameters"
+    {
+      "value": "Error parsing tappxExt parameters",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/triplelift/triplelifttest/supplemental/badext.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badext.json
@@ -1,5 +1,14 @@
 {
-  "expectedMakeRequestsErrors" : ["json: cannot unmarshal string into Go value of type adapters.ExtImpBidder","No valid impressions for triplelift"],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "json: cannot unmarshal string into Go value of type adapters.ExtImpBidder",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impressions for triplelift",
+      "comparison": "literal"
+    }
+  ],
   "mockBidRequest": {
     "id": "test-request-id",
     "imp": [

--- a/adapters/triplelift/triplelifttest/supplemental/badextbidder.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badextbidder.json
@@ -1,5 +1,14 @@
 {
-  "expectedMakeRequestsErrors" : ["json: cannot unmarshal string into Go value of type openrtb_ext.ExtImpTriplelift","No valid impressions for triplelift"],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb_ext.ExtImpTriplelift",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impressions for triplelift",
+      "comparison": "literal"
+    }
+  ],
   "mockBidRequest": {
     "id": "test-request-id",
     "imp": [

--- a/adapters/triplelift/triplelifttest/supplemental/badlyformed.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badlyformed.json
@@ -1,5 +1,14 @@
 {
-  "expectedMakeRequestsErrors" : ["neither Banner nor Video object specified","No valid impressions for triplelift"],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "neither Banner nor Video object specified",
+      "comparison": "literal"
+    },
+    {
+      "value": "No valid impressions for triplelift",
+      "comparison": "literal"
+    }
+  ],
   "mockBidRequest": {
     "id": "test-request-id",
     "imp": [

--- a/adapters/triplelift/triplelifttest/supplemental/badresponseext.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badresponseext.json
@@ -95,5 +95,10 @@
       ]
     }
   ],
-  "expectedMakeBidsErrors": ["json: cannot unmarshal string into Go value of type triplelift.TripleliftRespExt"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "json: cannot unmarshal string into Go value of type triplelift.TripleliftRespExt",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/triplelift/triplelifttest/supplemental/badstatuscode.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badstatuscode.json
@@ -94,5 +94,10 @@
   ],
   "expectedBidResponses": [
   ],
-  "expectedMakeBidsErrors": ["Unexpected status code: 400. Run with request.debug = 1 for more info"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/triplelift/triplelifttest/supplemental/notgoodstatuscode.json
+++ b/adapters/triplelift/triplelifttest/supplemental/notgoodstatuscode.json
@@ -94,5 +94,10 @@
   ],
   "expectedBidResponses": [
   ],
-  "expectedMakeBidsErrors": ["Unexpected status code: 302. Run with request.debug = 1 for more info"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 302. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/required-nobidder-info.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/required-nobidder-info.json
@@ -11,5 +11,10 @@
     ]
   },
 
-  "expectedMakeRequestsErrors": ["imp #0: ext.bidder not provided"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp #0: ext.bidder not provided",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/required-noimp.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/required-noimp.json
@@ -5,5 +5,10 @@
     ]
   },
 
-  "expectedMakeRequestsErrors": ["No impression in the bid request"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "No impression in the bid request",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/required-params-dcn.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/required-params-dcn.json
@@ -16,5 +16,10 @@
     "site": {}
   },
 
-  "expectedMakeRequestsErrors": ["imp #0: missing param dcn"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp #0: missing param dcn",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/required-params-pos.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/required-params-pos.json
@@ -17,5 +17,10 @@
     "site": {}
   },
 
-  "expectedMakeRequestsErrors": ["imp #0: missing param pos"]
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp #0: missing param pos",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/server-error.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/server-error.json
@@ -64,5 +64,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Unexpected status code: 500."]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500.",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/verizonmedia/verizonmediatest/supplemental/server-response-wrong-impid.json
+++ b/adapters/verizonmedia/verizonmediatest/supplemental/server-response-wrong-impid.json
@@ -94,5 +94,10 @@
     }
   ],
 
-  "expectedMakeBidsErrors": ["Unknown ad unit code 'wrong'"]
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unknown ad unit code 'wrong'",
+      "comparison": "literal"
+    }
+  ]
 }

--- a/adapters/visx/visxtest/supplemental/bad_response.json
+++ b/adapters/visx/visxtest/supplemental/bad_response.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "json: cannot unmarshal string into Go value of type openrtb.BidResponse"
+    {
+      "value": "json: cannot unmarshal string into Go value of type openrtb.BidResponse",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/visx/visxtest/supplemental/status_400.json
+++ b/adapters/visx/visxtest/supplemental/status_400.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 400. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }

--- a/adapters/visx/visxtest/supplemental/status_418.json
+++ b/adapters/visx/visxtest/supplemental/status_418.json
@@ -53,6 +53,9 @@
   ],
 
   "expectedMakeBidsErrors": [
-    "Unexpected status code: 418. Run with request.debug = 1 for more info"
+    {
+      "value": "Unexpected status code: 418. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
   ]
 }


### PR DESCRIPTION
Go 1.13 includes a change to the `encoding/json.UnmarshalTypeError` where the `Field` now includes the full object path. This affects the deserialization error message and breaks two adapter tests which rely on error string comparison.

See:
https://github.com/golang/go/commit/29bc4f12581d836a96139c924f16a4987324edd1

To avoid requiring Go 1.13 as a minimum version due to this change, those tests should accept either expected error message. To accomplish this, I propose to enhance the expected error string comparison to support regex, which gives us enough flexibility to express both variants. This PR changes the error strings to a complex type for which a comparison mode is specified. This also gives us a foundation to build upon for potential other comparison modes.

I experimented with changing all string comparisons to regex, but it became complicated and non-obvious as regex special characters like . and [ would need to be escaped.

.. or, the affected adapters `eplanning` and `emx_digital` might be altered to produce uniform (but likely less detailed) error messages for json deserialization issues.

Thoughts?