### PR TITLE
remove min from price granularity example

### DIFF
--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -141,12 +141,12 @@ MediaType PriceGranularity (PBS-Java only) - when a single OpenRTB request conta
                     "targeting": {
                         "mediatypepricegranularity": {
                             "banner": { "ranges": [
-                                {"min": 0, "max": 20, "increment": 0.5}
+                                {"max": 20, "increment": 0.5}
                             ]},
                             "video": { "ranges": [
-                                {"min": 0, "max": 10, "increment": 1},
-                                {"min": 10, "max": 20, "increment": 2},
-                                {"min": 20, "max": 50, "increment": 5}
+                                {"max": 10, "increment": 1},
+                                {"max": 20, "increment": 2},
+                                {"max": 50, "increment": 5}
                             ]}
                         }
                     }


### PR DESCRIPTION
code already ignores min, bringing docs in line