### PR TITLE
[Sharethrough] Adapter fixes

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -71,7 +71,6 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
-	headers.Add("Accept-Encoding", "gzip")
 	headers.Add("Origin", domain)
 	headers.Add("Referer", request.Site.Page)
 	headers.Add("X-Forwarded-For", request.Device.IP)

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -90,7 +90,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	userInfo := s.Util.parseUserInfo(request.User)
 	height, width := s.Util.getPlacementSize(imp, strImpParams)
 
-	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request, imp)
+	jsonBody, err := (StrBodyHelper{Clock: s.Util.getClock()}).buildBody(request, strImpParams)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adap
 	return bidResponse, errs
 }
 
-func (h StrBodyHelper) buildBody(request *openrtb.BidRequest, imp openrtb.Imp) (body []byte, err error) {
+func (h StrBodyHelper) buildBody(request *openrtb.BidRequest, strImpParams openrtb_ext.ExtImpSharethrough) (body []byte, err error) {
 	timeout := request.TMax
 	if timeout == 0 {
 		timeout = defaultTmax
@@ -173,7 +173,7 @@ func (h StrBodyHelper) buildBody(request *openrtb.BidRequest, imp openrtb.Imp) (
 		BlockedAdvDomains: request.BAdv,
 		MaxTimeout:        timeout,
 		Deadline:          h.Clock.now().Add(time.Duration(timeout) * time.Millisecond).Format(time.RFC3339Nano),
-		BidFloor:          imp.BidFloor,
+		BidFloor:          strImpParams.BidFloor,
 	})
 
 	return

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -105,7 +105,6 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},
-					"Accept-Encoding": []string{"gzip"},
 					"Origin":          []string{"http://a.domain.com"},
 					"Referer":         []string{"http://a.domain.com/page"},
 					"User-Agent":      []string{"Android Chome/60"},
@@ -139,7 +138,6 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},
-					"Accept-Encoding": []string{"gzip"},
 					"Origin":          []string{"http://a.domain.com"},
 					"Referer":         []string{"http://a.domain.com/page"},
 					"User-Agent":      []string{"Android Chome/60"},

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -82,11 +82,10 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 		"Generates the correct AdServer request from Imp (no user provided)": {
 			inputImp: openrtb.Imp{
 				ID:  "abc",
-				Ext: []byte(`{ "bidder": {"pkey": "pkey", "iframe": true, "iframeSize": [10, 20]} }`),
+				Ext: []byte(`{ "bidder": {"pkey": "pkey", "iframe": true, "iframeSize": [10, 20], "bidfloor": 1.0} }`),
 				Banner: &openrtb.Banner{
 					Format: []openrtb.Format{{H: 30, W: 40}},
 				},
-				BidFloor: 1.0,
 			},
 			inputReq: &openrtb.BidRequest{
 				App: &openrtb.App{Ext: []byte(`{}`)},
@@ -379,13 +378,13 @@ func TestFailResponseToOpenRTB(t *testing.T) {
 func TestBuildBody(t *testing.T) {
 	tests := map[string]struct {
 		inputRequest  *openrtb.BidRequest
-		inputImp      openrtb.Imp
+		inputImp      openrtb_ext.ExtImpSharethrough
 		expectedJson  []byte
 		expectedError error
 	}{
 		"Empty input: skips badomains, tmax default to 10 sec and sets deadline accordingly": {
 			inputRequest:  &openrtb.BidRequest{},
-			inputImp:      openrtb.Imp{},
+			inputImp:      openrtb_ext.ExtImpSharethrough{},
 			expectedJson:  []byte(`{"tmax":10000, "deadline":"2019-09-12T11:29:10.000123456Z"}`),
 			expectedError: nil,
 		},
@@ -393,7 +392,7 @@ func TestBuildBody(t *testing.T) {
 			inputRequest: &openrtb.BidRequest{
 				BAdv: []string{"dom1.com", "dom2.com"},
 			},
-			inputImp:      openrtb.Imp{},
+			inputImp:      openrtb_ext.ExtImpSharethrough{},
 			expectedJson:  []byte(`{"badv": ["dom1.com", "dom2.com"], "tmax":10000, "deadline":"2019-09-12T11:29:10.000123456Z"}`),
 			expectedError: nil,
 		},
@@ -401,13 +400,13 @@ func TestBuildBody(t *testing.T) {
 			inputRequest: &openrtb.BidRequest{
 				TMax: 500,
 			},
-			inputImp:      openrtb.Imp{},
+			inputImp:      openrtb_ext.ExtImpSharethrough{},
 			expectedJson:  []byte(`{"tmax": 500, "deadline":"2019-09-12T11:29:00.500123456Z"}`),
 			expectedError: nil,
 		},
 		"Sets bidfloor according to the Imp object": {
 			inputRequest: &openrtb.BidRequest{},
-			inputImp: openrtb.Imp{
+			inputImp: openrtb_ext.ExtImpSharethrough{
 				BidFloor: 1.23,
 			},
 			expectedJson:  []byte(`{"tmax":10000, "deadline":"2019-09-12T11:29:10.000123456Z", "bidfloor":1.23}`),

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -10,7 +10,7 @@ import (
 )
 
 const supplyId = "FGMrCMMc"
-const strVersion = 6
+const strVersion = 7
 
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{

--- a/openrtb_ext/imp_sharethrough.go
+++ b/openrtb_ext/imp_sharethrough.go
@@ -1,9 +1,10 @@
 package openrtb_ext
 
 type ExtImpSharethrough struct {
-	Pkey       string `json:"pkey"`
-	Iframe     bool   `json:"iframe"`
-	IframeSize []int  `json:"iframeSize"`
+	Pkey       string  `json:"pkey"`
+	Iframe     bool    `json:"iframe"`
+	IframeSize []int   `json:"iframeSize"`
+	BidFloor   float64 `json:"bidfloor"`
 }
 
 // ExtImpSharethrough defines the contract for bidrequest.imp[i].ext.sharethrough

--- a/static/bidder-params/sharethrough.json
+++ b/static/bidder-params/sharethrough.json
@@ -22,6 +22,10 @@
       },
       "description": "iframe dimensions",
       "default": [0, 0]
+    },
+    "bidfloor": {
+      "type": "number",
+      "description": "The floor price, or minimum amount, a publisher will accept for an impression, given in CPM in USD"
     }
   },
   "required": ["pkey"]


### PR DESCRIPTION
Couple of fixes:
- get `bidfloor` from custom impression params
- remove `gzip` header