### PR TITLE
update static bidder params for rubicon video to follow the json marshaling names

### DIFF
--- a/static/bidder-params/rubicon.json
+++ b/static/bidder-params/rubicon.json
@@ -37,27 +37,27 @@
       "type": "object",
       "description": "An object defining additional Rubicon video parameters",
       "properties": {
-        "Language": {
+        "language": {
           "type": "string",
           "description": "Language of the ad - should match content video"
         },
-        "PlayerHeight": {
+        "playerHeight": {
           "type": "integer",
           "description": "Height in pixels of the video player"
         },
-        "PlayerWidth": {
+        "playerWidth": {
           "type": "integer",
           "description": "Width in pixels of the video player"
         },
-        "VideoSizeID": {
+        "size_id": {
           "type": "integer",
           "description": "Rubicon size_id, used to describe type of video ad (preroll, postroll, etc)"
         },
-        "Skip": {
+        "skip": {
           "type": "integer",
           "description": "Can this ad be skipped ( 0 = no, 1 = yes)"
         },
-        "SkipDelay": {
+        "skipdelay": {
           "type": "integer",
           "description": "number of seconds until the ad can be skipped"
         }


### PR DESCRIPTION
Want the field names in /bidder/params to follow the exactly what the code expects when deserializing the JSON request. Its misleading the the /bidder/params say that they key is called VideoSizeID when it really needs to be passed as size_id in the request