### PR TITLE
enforce video.size_id for video imps in rubicon adapter

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/prebid/prebid-server/pbs"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/golang/glog"
+	"github.com/prebid/prebid-server/pbs"
 
 	"golang.org/x/net/context/ctxhttp"
 
@@ -683,6 +684,13 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 
 		isVideo := isVideo(thisImp)
 		if isVideo {
+			if rubiconExt.Video.VideoSizeID == 0 {
+				errs = append(errs, &errortypes.BadInput{
+					Message: fmt.Sprintf("imp[...].ext.bidder.rubicon.video.size_id must be defined for video impression #%d", i),
+				})
+				continue
+			}
+
 			videoCopy := *thisImp.Video
 			videoExt := rubiconVideoExt{Skip: rubiconExt.Video.Skip, SkipDelay: rubiconExt.Video.SkipDelay, RP: rubiconVideoExtRP{SizeID: rubiconExt.Video.VideoSizeID}}
 			videoCopy.Ext, err = json.Marshal(&videoExt)

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -686,7 +686,7 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 		if isVideo {
 			if rubiconExt.Video.VideoSizeID == 0 {
 				errs = append(errs, &errortypes.BadInput{
-					Message: fmt.Sprintf("imp[...].ext.bidder.rubicon.video.size_id must be defined for video impression #%d", i),
+					Message: fmt.Sprintf("imp[%d].ext.bidder.rubicon.video.size_id must be defined for video impression", i),
 				})
 				continue
 			}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1423,10 +1423,6 @@ func TestOpenRTBCopyBidIdFromResponseIfZero(t *testing.T) {
 	}
 }
 
-//func TestOpenRTBRequestWithVideoMissingSizeID() {
-//
-//}
-
 func TestJsonSamples(t *testing.T) {
 	adapterstest.RunJSONBidderTest(t, "rubicontest", NewRubiconBidder(http.DefaultClient, "uri", "xuser", "xpass", "pbs-test-tracker"))
 }

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1288,8 +1288,9 @@ func TestOpenRTBRequestWithVideoImpEvenIfImpHasBannerButAllRequiredVideoFields(t
 				"zoneId": 8394,
 				"siteId": 283282,
 				"accountId": 7891,
-				"inventory": {"key1" : "val1"},
-				"visitor": {"key2" : "val2"}
+				"inventory": {"key1": "val1"},
+				"visitor": {"key2": "val2"},
+				"video": {"size_id": 1}
 			}}`),
 		}},
 	}
@@ -1421,6 +1422,10 @@ func TestOpenRTBCopyBidIdFromResponseIfZero(t *testing.T) {
 		t.Errorf("Bad bid ID. Expected %s, got %s", "1234567890", theBid.ID)
 	}
 }
+
+//func TestOpenRTBRequestWithVideoMissingSizeID() {
+//
+//}
 
 func TestJsonSamples(t *testing.T) {
 	adapterstest.RunJSONBidderTest(t, "rubicontest", NewRubiconBidder(http.DefaultClient, "uri", "xuser", "xpass", "pbs-test-tracker"))

--- a/adapters/rubicon/rubicontest/supplemental/required-video-size-id.json
+++ b/adapters/rubicon/rubicontest/supplemental/required-video-size-id.json
@@ -24,7 +24,7 @@
     },
     "expectedMakeRequestsErrors": [
         {
-            "value": "imp[...].ext.bidder.rubicon.video.size_id must be defined for video impression #0",
+            "value": "imp[0].ext.bidder.rubicon.video.size_id must be defined for video impression",
             "comparison": "literal"
         }
     ]

--- a/adapters/rubicon/rubicontest/supplemental/required-video-size-id.json
+++ b/adapters/rubicon/rubicontest/supplemental/required-video-size-id.json
@@ -1,0 +1,31 @@
+{
+    "mockBidRequest": {
+        "id": "test-req-id",
+        "imp": [
+            {
+                "id": "test-imp-1",
+                "video": {
+                    "w": 640,
+                    "h": 480,
+                    "linearity": 1
+                },
+                "ext": {
+                    "bidder": {
+                        "accountId": 1001,
+                        "siteId":113932,
+                        "zoneId":535510
+                    }
+                }
+            }
+        ],
+        "site": {
+            "page": "prebid.org"
+        }
+    },
+    "expectedMakeRequestsErrors": [
+        {
+            "value": "imp[...].ext.bidder.rubicon.video.size_id must be defined for video impression #0",
+            "comparison": "literal"
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/prebid/go-gdpr v0.6.0
 	github.com/prometheus/client_golang v0.0.0-20180623155954-77e8f2ddcfed
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prebid/go-gdpr v0.6.0 h1:/GKrygGkUbsgd96HIkjAu7/6CHtRedvcojRtfAd4Igc=
+github.com/prebid/go-gdpr v0.6.0/go.mod h1:FPY0uxSrl9/Mz237LnPo3ge4aCG0wQ9FWf2b4WhwNn0=
 github.com/prometheus/client_golang v0.0.0-20180623155954-77e8f2ddcfed h1:0dloFFFNNDG7c+8qtkYw2FdADrWy9s5cI8wHp6tK3Mg=
 github.com/prometheus/client_golang v0.0.0-20180623155954-77e8f2ddcfed/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=


### PR DESCRIPTION
cc: @bretg 

Based on conversations with Michael Moschovas over at Rubicon, it seems like video.size_id needs to be defined in every video request sent to rubicon