### PR TITLE
[currency converter] allow to deduce reverse rate

### DIFF
--- a/currencies/rates.go
+++ b/currencies/rates.go
@@ -62,9 +62,12 @@ func (r *Rates) GetRate(from string, to string) (float64, error) {
 	}
 	if r.Conversions != nil {
 		if conversion, present := r.Conversions[fromUnit.String()][toUnit.String()]; present {
+			// In case we have an entry FROM -> TO
 			return conversion, err
+		} else if conversion, present := r.Conversions[toUnit.String()][fromUnit.String()]; present {
+			// In case we have an entry TO -> FROM
+			return 1 / conversion, err
 		}
-
 		return 0, fmt.Errorf("Currency conversion rate not found: '%s' => '%s'", fromUnit.String(), toUnit.String())
 	}
 	return 0, errors.New("rates are nil")

--- a/currencies/rates_test.go
+++ b/currencies/rates_test.go
@@ -163,6 +163,60 @@ func TestGetRate(t *testing.T) {
 	}
 }
 
+func TestGetRate_ReverseConversion(t *testing.T) {
+
+	// Setup:
+	rates := currencies.NewRates(time.Now(), map[string]map[string]float64{
+		"USD": {
+			"GBP": 0.77208,
+		},
+		"EUR": {
+			"USD": 0.88723,
+		},
+	})
+
+	testCases := []struct {
+		from         string
+		to           string
+		expectedRate float64
+		description  string
+	}{
+		{
+			from:         "USD",
+			to:           "GBP",
+			expectedRate: 0.77208,
+			description:  "case 1 - Rate is present directly and will be returned as is",
+		},
+		{
+			from:         "EUR",
+			to:           "USD",
+			expectedRate: 0.88723,
+			description:  "case 2 - Rate is present directly and will be returned as is (2)",
+		},
+		{
+			from:         "GBP",
+			to:           "USD",
+			expectedRate: 1 / 0.77208,
+			description:  "case 3 - Rate is not present but the reverse one is, will return the computed rate from the reverse entry",
+		},
+		{
+			from:         "USD",
+			to:           "EUR",
+			expectedRate: 1 / 0.88723,
+			description:  "case 4 - Rate is not present but the reverse one is, will return the computed rate from the reverse entry (2)",
+		},
+	}
+
+	for _, tc := range testCases {
+		// Execute:
+		rate, err := rates.GetRate(tc.from, tc.to)
+
+		// Verify:
+		assert.Nil(t, err, "err should be nil: "+tc.description)
+		assert.Equal(t, tc.expectedRate, rate, "rate doesn't match the expected one: "+tc.description)
+	}
+}
+
 func TestGetRate_EmptyRates(t *testing.T) {
 
 	// Setup:


### PR DESCRIPTION
This CL allows the currency rate currency to deduce a currency rate even
if not directly defined in the table but the reverse rate is present.

E.q.

USD => EUR is 1.0897
EUR => USD is not set

Old behavior when asking rate from EUR to USD will not be found,
New behavior is using the known reverse rate to deduce the rate.

Rate for 2 USD will be 2 * (1 / 1.0897)