### PR TITLE
TripleLift's Inventory Code Parameter is Required

### DIFF
--- a/static/bidder-params/triplelift.json
+++ b/static/bidder-params/triplelift.json
@@ -11,11 +11,5 @@
     },
     "floor" :  {"description" : "the bid floor", "type": "number" }
   },
-  "oneOf": [{
-    "oneOf": [{
-      "required": ["inventoryCode"]
-    }] }],
-  "not": {
-    "required": ["floor"]
-  }
+  "required": ["inventoryCode"]
 }


### PR DESCRIPTION
After being advised by Hans, this PR tries to simplify the file `static/bidder-params/triplelift.json` in order to be leaner by eliminating the unnecessary complexity of the `oneOf` and `not` objects.