### PR TITLE
TripleLift Native endpoint's Inventory Code Parameter is Required 

### DIFF
--- a/static/bidder-params/triplelift_native.json
+++ b/static/bidder-params/triplelift_native.json
@@ -11,11 +11,5 @@
     },
     "floor" :  {"description" : "the bid floor, in usd", "type": "number" }
   },
-  "oneOf": [{
-    "oneOf": [{
-      "required": ["inventoryCode"]
-    }] }],
-  "not": {
-    "required": ["floor"]
-  }
+  "required": ["inventoryCode"]
 }


### PR DESCRIPTION
This is part 2 of PR #1137 `TripleLift's Inventory Code Parameter is Required`. This PR tries to simplify the file static/bidder-params/triplelift_native.json in order to be leaner by eliminating the unnecessary complexity of the oneOf objects and have the UI show `Inventory Code` not under the "Optional parameters list.