### PR TITLE
Add imp.ext.is_rewarded_inventory flag for rewarded video in Rubicon

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -129,6 +129,7 @@ type rubiconVideoParams struct {
 type rubiconVideoExt struct {
 	Skip      int               `json:"skip,omitempty"`
 	SkipDelay int               `json:"skipdelay,omitempty"`
+	VideoType string            `json:"videotype,omitempty"`
 	RP        rubiconVideoExtRP `json:"rp"`
 }
 
@@ -693,8 +694,14 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 				continue
 			}
 
+			// if imp.ext.is_rewarded_inventory = 1, set imp.video.ext.videotype = "rewarded"
+			var videoType = ""
+			if extImpPrebid := bidderExt.Prebid; extImpPrebid != nil && extImpPrebid.IsRewardedInventory == 1 {
+				videoType = "rewarded"
+			}
+
 			videoCopy := *thisImp.Video
-			videoExt := rubiconVideoExt{Skip: rubiconExt.Video.Skip, SkipDelay: rubiconExt.Video.SkipDelay, RP: rubiconVideoExtRP{SizeID: rubiconExt.Video.VideoSizeID}}
+			videoExt := rubiconVideoExt{Skip: rubiconExt.Video.Skip, SkipDelay: rubiconExt.Video.SkipDelay, VideoType: videoType, RP: rubiconVideoExtRP{SizeID: rubiconExt.Video.VideoSizeID}}
 			videoCopy.Ext, err = json.Marshal(&videoExt)
 			thisImp.Video = &videoCopy
 			thisImp.Banner = nil

--- a/openrtb_ext/imp.go
+++ b/openrtb_ext/imp.go
@@ -20,6 +20,9 @@ type ExtImp struct {
 type ExtImpPrebid struct {
 	StoredRequest *ExtStoredRequest `json:"storedrequest"`
 
+	// Rewarded inventory signal, can be 0 or 1
+	IsRewardedInventory int8 `json:"is_rewarded_inventory"`
+
 	// NOTE: This is not part of the official API, we are not expecting clients
 	// migrate from imp[...].ext.${BIDDER} to imp[...].ext.prebid.bidder.${BIDDER}
 	// at this time


### PR DESCRIPTION
This PR adds `rewarded video support` in Rubicon bidder.

**Requirements**
- When PBS receives the imp.ext.is_rewarded_inventory= 1 signal, set transform the signal to XAPI in the imp.video.ext.videotype = "rewarded" field
- Rewarded inventory signal should only be expected to come in the video object (i.e. no banner support)
- Inbound signal from PBS should always expected to be a 1 to signal rewarded video, no other signal will be supported, including true

**Examples**

Prebid request:
```
{
...
  "imp": [
    {
      "id": "imp-id-1",
      "ext": {
        "prebid": {
          "is_rewarded_inventory": 1
        }
      }
    }
  ]
...
}
```

XAPI request:
```
{
...
  "imp": [
    {
      "video": {
        "w": 468,
        "h": 1360,
        "ext": {
          "videotype": "rewarded",
          "rp": {
            "size_id": 201
          }
        }
      },
      "ext": {
        "rp": {
          "zone_id": 99999
        }
      }
    }
  ]
...
}
```