### PR TITLE
Adding support for deal prefixes

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -87,6 +87,7 @@ type appnexusBidExtAppnexus struct {
 	BrandId       int                    `json:"brand_id"`
 	BrandCategory int                    `json:"brand_category_id"`
 	CreativeInfo  appnexusBidExtCreative `json:"creative_info"`
+	DealPriority  int                    `json:"deal_priority"`
 }
 
 type appnexusBidExt struct {
@@ -543,9 +544,10 @@ func (a *AppNexusAdapter) MakeBids(internalRequest *openrtb.BidRequest, external
 					}
 
 					bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
-						Bid:      &bid,
-						BidType:  bidType,
-						BidVideo: impVideo,
+						Bid:          &bid,
+						BidType:      bidType,
+						BidVideo:     impVideo,
+						DealPriority: bidExt.Appnexus.DealPriority,
 					})
 				} else {
 					errs = append(errs, err)

--- a/adapters/appnexus/appnexusplatformtest/exemplary/simple-auction.json
+++ b/adapters/appnexus/appnexusplatformtest/exemplary/simple-auction.json
@@ -80,7 +80,8 @@
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
-					  "ranking_price": 0.000000
+					  "ranking_price": 0.000000,
+					  "deal_priority": 5
 					}
 				  }
 				}]
@@ -118,7 +119,8 @@
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,
-				  "ranking_price": 0.000000
+				  "ranking_price": 0.000000,
+				  "deal_priority": 5
 				}
 			  }
 			},

--- a/adapters/appnexus/appnexusplatformtest/video/simple-video.json
+++ b/adapters/appnexus/appnexusplatformtest/video/simple-video.json
@@ -80,7 +80,8 @@
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
-					  "ranking_price": 0.000000
+					  "ranking_price": 0.000000,
+					  "deal_priority": 5
 					}
 				  }
 				}]
@@ -118,7 +119,8 @@
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,
-				  "ranking_price": 0.000000
+				  "ranking_price": 0.000000,
+				  "deal_priority": 5
 				}
 			  }
 			},

--- a/adapters/appnexus/appnexustest/amp/simple-banner.json
+++ b/adapters/appnexus/appnexustest/amp/simple-banner.json
@@ -91,7 +91,8 @@
                     "auction_id": 8189378542222915032,
                     "bid_ad_type": 0,
                     "bidder_id": 2,
-                    "ranking_price": 0.000000
+                    "ranking_price": 0.000000,
+                    "deal_priority": 5
                   }
                 }
               }]
@@ -129,7 +130,8 @@
                 "auction_id": 8189378542222915032,
                 "bid_ad_type": 0,
                 "bidder_id": 2,
-                "ranking_price": 0.000000
+                "ranking_price": 0.000000,
+                "deal_priority": 5
               }
             }
           },

--- a/adapters/appnexus/appnexustest/amp/simple-video.json
+++ b/adapters/appnexus/appnexustest/amp/simple-video.json
@@ -82,7 +82,8 @@
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
-					  "ranking_price": 0.000000
+					  "ranking_price": 0.000000,
+					  "deal_priority": 5
 					}
 				  }
 				}]
@@ -120,7 +121,8 @@
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,
-				  "ranking_price": 0.000000
+				  "ranking_price": 0.000000,
+				  "deal_priority": 5
 				}
 			  }
 			},

--- a/adapters/appnexus/appnexustest/exemplary/native-1.1.json
+++ b/adapters/appnexus/appnexustest/exemplary/native-1.1.json
@@ -96,7 +96,8 @@
                       "brand_category_id": 350,
                       "auction_id": 5607483846416358664,
                       "bidder_id": 2,
-                      "bid_ad_type": 3
+                      "bid_ad_type": 3,
+                      "deal_priority": 5
                     }
                   }
                 }
@@ -136,7 +137,8 @@
                 "brand_category_id": 350,
                 "auction_id": 5607483846416358664,
                 "bidder_id": 2,
-                "bid_ad_type": 3
+                "bid_ad_type": 3,
+                "deal_priority": 5
               }
             }
           },

--- a/adapters/appnexus/appnexustest/exemplary/simple-banner.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-banner.json
@@ -89,7 +89,8 @@
                     "auction_id": 8189378542222915032,
                     "bid_ad_type": 0,
                     "bidder_id": 2,
-                    "ranking_price": 0.000000
+                    "ranking_price": 0.000000,
+                    "deal_priority": 5
                   }
                 }
               }]
@@ -127,7 +128,8 @@
                 "auction_id": 8189378542222915032,
                 "bid_ad_type": 0,
                 "bidder_id": 2,
-                "ranking_price": 0.000000
+                "ranking_price": 0.000000,
+                "deal_priority": 5
               }
             }
           },

--- a/adapters/appnexus/appnexustest/exemplary/simple-video.json
+++ b/adapters/appnexus/appnexustest/exemplary/simple-video.json
@@ -80,7 +80,8 @@
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
-					  "ranking_price": 0.000000
+					  "ranking_price": 0.000000,
+					  "deal_priority": 5
 					}
 				  }
 				}]
@@ -118,7 +119,8 @@
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,
-				  "ranking_price": 0.000000
+				  "ranking_price": 0.000000,
+				  "deal_priority": 5
 				}
 			  }
 			},

--- a/adapters/appnexus/appnexustest/exemplary/video-invalid-category.json
+++ b/adapters/appnexus/appnexustest/exemplary/video-invalid-category.json
@@ -79,7 +79,8 @@
 					  "auction_id": 8189378542222915032,
 					  "bid_ad_type": 1,
 					  "bidder_id": 2,
-					  "ranking_price": 0.000000
+					  "ranking_price": 0.000000,
+					  "deal_priority": 5
 					}
 				  }
 				}]
@@ -116,7 +117,8 @@
 				  "auction_id": 8189378542222915032,
 				  "bid_ad_type": 1,
 				  "bidder_id": 2,
-				  "ranking_price": 0.000000
+				  "ranking_price": 0.000000,
+				  "deal_priority": 5
 				}
 			  }
 			},

--- a/adapters/appnexus/appnexustest/supplemental/displaymanager-test.json
+++ b/adapters/appnexus/appnexustest/supplemental/displaymanager-test.json
@@ -106,7 +106,8 @@
                       "auction_id": 8189378542222915032,
                       "bid_ad_type": 0,
                       "bidder_id": 2,
-                      "ranking_price": 0.000000
+                      "ranking_price": 0.000000,
+                      "deal_priority": 5
                     }
                   }
                 }]
@@ -144,7 +145,8 @@
                   "auction_id": 8189378542222915032,
                   "bid_ad_type": 0,
                   "bidder_id": 2,
-                  "ranking_price": 0.000000
+                  "ranking_price": 0.000000,
+                  "deal_priority": 5
                 }
               }
             },

--- a/adapters/appnexus/appnexustest/supplemental/multi-bid.json
+++ b/adapters/appnexus/appnexustest/supplemental/multi-bid.json
@@ -89,7 +89,8 @@
                     "auction_id": 8189378542222915032,
                     "bid_ad_type": 0,
                     "bidder_id": 2,
-                    "ranking_price": 0.000000
+                    "ranking_price": 0.000000,
+                    "deal_priority": 4
                   }
                 }
               },
@@ -112,7 +113,8 @@
                     "auction_id": 8189378542222915032,
                     "bid_ad_type": 0,
                     "bidder_id": 2,
-                    "ranking_price": 0.000000
+                    "ranking_price": 0.000000,
+                    "deal_priority": 5
                   }
                 }
               }]
@@ -150,7 +152,8 @@
                 "auction_id": 8189378542222915032,
                 "bid_ad_type": 0,
                 "bidder_id": 2,
-                "ranking_price": 0.000000
+                "ranking_price": 0.000000,
+                "deal_priority": 4
               }
             }
           },
@@ -177,7 +180,8 @@
                 "auction_id": 8189378542222915032,
                 "bid_ad_type": 0,
                 "bidder_id": 2,
-                "ranking_price": 0.000000
+                "ranking_price": 0.000000,
+                "deal_priority": 5
               }
             }
           },

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -96,9 +96,10 @@ func NewBidderResponse() *BidderResponse {
 // TypedBid.BidType will become "response.seatbid[i].bid.ext.prebid.type" in the final OpenRTB response.
 // TypedBid.BidVideo will become "response.seatbid[i].bid.ext.prebid.video" in the final OpenRTB response.
 type TypedBid struct {
-	Bid      *openrtb.Bid
-	BidType  openrtb_ext.BidType
-	BidVideo *openrtb_ext.ExtBidPrebidVideo
+	Bid          *openrtb.Bid
+	BidType      openrtb_ext.BidType
+	BidVideo     *openrtb_ext.ExtBidPrebidVideo
+	DealPriority int
 }
 
 // RequestData and ResponseData exist so that prebid-server core code can implement its "debug" functionality

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -95,6 +95,7 @@ func NewBidderResponse() *BidderResponse {
 // TypedBid.Bid.Ext will become "response.seatbid[i].bid.ext.bidder" in the final OpenRTB response.
 // TypedBid.BidType will become "response.seatbid[i].bid.ext.prebid.type" in the final OpenRTB response.
 // TypedBid.BidVideo will become "response.seatbid[i].bid.ext.prebid.video" in the final OpenRTB response.
+// TypedBid.DealPriority will become "response.seatbid[i].bid.dealPriority" in the final OpenRTB response.
 type TypedBid struct {
 	Bid          *openrtb.Bid
 	BidType      openrtb_ext.BidType

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -550,8 +550,9 @@ func createBidExtension(videoRequest *openrtb_ext.BidRequestVideo) ([]byte, erro
 	}
 
 	prebid := openrtb_ext.ExtRequestPrebid{
-		Cache:     &cache,
-		Targeting: &targeting,
+		Cache:        &cache,
+		Targeting:    &targeting,
+		SupportDeals: videoRequest.SupportDeals,
 	}
 	extReq := openrtb_ext.ExtRequest{Prebid: prebid}
 

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -50,6 +50,7 @@ type adaptedBidder interface {
 // pbsOrtbBid.bidType will become "response.seatbid[i].bid.ext.prebid.type" in the final OpenRTB response.
 // pbsOrtbBid.bidTargets does not need to be filled out by the Bidder. It will be set later by the exchange.
 // pbsOrtbBid.bidVideo is optional but should be filled out by the Bidder if bidType is video.
+// pbsOrtbBid.dealPriority will become "response.seatbid[i].bid.dealPriority" in the final OpenRTB response.
 type pbsOrtbBid struct {
 	bid          *openrtb.Bid
 	bidType      openrtb_ext.BidType

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -51,10 +51,11 @@ type adaptedBidder interface {
 // pbsOrtbBid.bidTargets does not need to be filled out by the Bidder. It will be set later by the exchange.
 // pbsOrtbBid.bidVideo is optional but should be filled out by the Bidder if bidType is video.
 type pbsOrtbBid struct {
-	bid        *openrtb.Bid
-	bidType    openrtb_ext.BidType
-	bidTargets map[string]string
-	bidVideo   *openrtb_ext.ExtBidPrebidVideo
+	bid          *openrtb.Bid
+	bidType      openrtb_ext.BidType
+	bidTargets   map[string]string
+	bidVideo     *openrtb_ext.ExtBidPrebidVideo
+	dealPriority int
 }
 
 // pbsOrtbSeatBid is a SeatBid returned by an adaptedBidder.
@@ -182,9 +183,10 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment * conversionRate
 						}
 						seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
-							bid:      bidResponse.Bids[i].Bid,
-							bidType:  bidResponse.Bids[i].BidType,
-							bidVideo: bidResponse.Bids[i].BidVideo,
+							bid:          bidResponse.Bids[i].Bid,
+							bidType:      bidResponse.Bids[i].BidType,
+							bidVideo:     bidResponse.Bids[i].BidVideo,
+							dealPriority: bidResponse.Bids[i].DealPriority,
 						})
 					}
 				} else {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -39,13 +39,15 @@ func TestSingleBidder(t *testing.T) {
 				Bid: &openrtb.Bid{
 					Price: firstInitialPrice,
 				},
-				BidType: openrtb_ext.BidTypeBanner,
+				BidType:      openrtb_ext.BidTypeBanner,
+				DealPriority: 4,
 			},
 			{
 				Bid: &openrtb.Bid{
 					Price: secondInitialPrice,
 				},
-				BidType: openrtb_ext.BidTypeVideo,
+				BidType:      openrtb_ext.BidTypeVideo,
+				DealPriority: 5,
 			},
 		},
 	}
@@ -87,6 +89,9 @@ func TestSingleBidder(t *testing.T) {
 		}
 		if typedBid.BidType != seatBid.bids[index].bidType {
 			t.Errorf("Bid %d did not have the right type. Expected %s, got %s", index, typedBid.BidType, seatBid.bids[index].bidType)
+		}
+		if typedBid.DealPriority != seatBid.bids[index].dealPriority {
+			t.Errorf("Bid %d did not have the right deal priority. Expected %s, got %s", index, typedBid.BidType, seatBid.bids[index].bidType)
 		}
 	}
 	if mockBidderResponse.Bids[0].Bid.Price != bidAdjustment*firstInitialPrice {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/prebid/prebid-server/stored_requests"
@@ -167,10 +168,90 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 			}
 			targData.setTargeting(auc, bidRequest.App != nil, bidCategory)
 		}
+
+		if requestExt.Prebid.SupportDeals {
+			applyDealSupport(bidRequest, auc)
+		}
 	}
 
 	// Build the response
 	return e.buildBidResponse(ctx, liveAdapters, adapterBids, bidRequest, resolvedRequest, adapterExtra, auc, errs)
+}
+
+// TODO needs better naming
+type DealTierInfo struct {
+	Prefix      string `json:"prefix"`
+	MinDealTier int    `json:"minDealTier"`
+}
+
+type DealTier struct {
+	Info *DealTierInfo `json:"dealTier,omitempty"`
+}
+
+type BidderDealTier struct {
+	DealInfo map[string]*DealTier
+}
+
+// Updates targeting keys with deal prefixes if minimum deal tier exceeded
+func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction) {
+	impDealMap := getDealTiers(bidRequest)
+
+	for impId, topBidsPerImp := range auc.winningBidsByBidder {
+		impDeal := impDealMap[impId].DealInfo
+		for bidderName, topBidPerBidder := range topBidsPerImp {
+			if validateDealTier(impDeal[bidderName.String()]) {
+				updateCatDur(topBidPerBidder, impDeal[bidderName.String()].Info)
+			}
+		}
+	}
+}
+
+func getDealTiers(bidRequest *openrtb.BidRequest) map[string]*BidderDealTier {
+	impDealMap := make(map[string]*BidderDealTier)
+
+	for _, imp := range bidRequest.Imp {
+		var bidderDealTier BidderDealTier
+		err := json.Unmarshal(imp.Ext, &bidderDealTier.DealInfo)
+		if err != nil {
+			continue
+		}
+		impDealMap[imp.ID] = &bidderDealTier
+	}
+
+	return impDealMap
+}
+
+func validateDealTier(impDeal *DealTier) bool {
+	return impDeal.Info != nil && len(impDeal.Info.Prefix) > 0
+}
+
+func updateCatDur(topBidPerBidder *pbsOrtbBid, dealTierInfo *DealTierInfo) {
+	var anExt AppNexusExt
+	err := json.Unmarshal(topBidPerBidder.bid.Ext, &anExt)
+	if err != nil {
+		return
+	}
+
+	if anExt.Info.Priority >= dealTierInfo.MinDealTier {
+		newPb := fmt.Sprintf("%s%d", dealTierInfo.Prefix, anExt.Info.Priority)
+
+		if oldCatDur, ok := topBidPerBidder.bidTargets["hb_pb_cat_dur"]; ok {
+			oldCatDurSplit := strings.SplitAfterN(oldCatDur, "_", 2)
+			oldCatDurSplit[0] = newPb + "_"
+
+			newCatDur := strings.Join(oldCatDurSplit, "")
+			topBidPerBidder.bidTargets["hb_pb_cat_dur"] = newCatDur
+		}
+	}
+}
+
+type DealPriority struct {
+	Priority int `json:"deal_priority"`
+	Extra    json.RawMessage
+}
+
+type AppNexusExt struct {
+	Info DealPriority `json:"appnexus"`
 }
 
 func (e *exchange) makeAuctionContext(ctx context.Context, needsCache bool) (auctionCtx context.Context, cancel context.CancelFunc) {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -205,10 +205,12 @@ func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction) []error {
 		for bidderName, topBidPerBidder := range topBidsPerImp {
 			bidderString := bidderName.String()
 
-			if validateDealTier(impDeal[bidderString]) {
-				updateCatDur(topBidPerBidder, impDeal[bidderString].Info)
-			} else {
-				errs = append(errs, fmt.Errorf("dealTier configuration invalid for bidder '%s', imp ID '%s'", bidderString, impID))
+			if topBidPerBidder.dealPriority > 0 {
+				if validateDealTier(impDeal[bidderString]) {
+					updateCatDur(topBidPerBidder, impDeal[bidderString].Info)
+				} else {
+					errs = append(errs, fmt.Errorf("dealTier configuration invalid for bidder '%s', imp ID '%s'", bidderString, impID))
+				}
 			}
 		}
 	}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -192,7 +192,7 @@ type BidderDealTier struct {
 	DealInfo map[string]*DealTier
 }
 
-// Updates targeting keys with deal prefixes if minimum deal tier exceeded
+// applyDealSupport updates targeting keys with deal prefixes if minimum deal tier exceeded
 func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction) []error {
 	errs := []error{}
 	impDealMap := getDealTiers(bidRequest)
@@ -203,7 +203,7 @@ func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction) []error {
 			bidderString := bidder.String()
 
 			if topBidPerBidder.dealPriority > 0 {
-				if validateDealTier(impDeal[bidderString]) {
+				if validateAndNormalizeDealTier(impDeal[bidderString]) {
 					updateHbPbCatDur(topBidPerBidder, impDeal[bidderString].Info)
 				} else {
 					errs = append(errs, fmt.Errorf("dealTier configuration invalid for bidder '%s', imp ID '%s'", bidderString, impID))
@@ -232,8 +232,8 @@ func getDealTiers(bidRequest *openrtb.BidRequest) map[string]*BidderDealTier {
 	return impDealMap
 }
 
-func validateDealTier(impDeal *DealTier) bool {
-	if impDeal.Info == nil {
+func validateAndNormalizeDealTier(impDeal *DealTier) bool {
+	if impDeal == nil || impDeal.Info == nil {
 		return false
 	}
 	// Remove whitespace from prefix before checking if it can be used

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1471,7 +1471,7 @@ func TestGetDealTiers(t *testing.T) {
 	}
 }
 
-func TestValidateDealTier(t *testing.T) {
+func TestValidateAndNormalizeDealTier(t *testing.T) {
 	testCases := []struct {
 		description    string
 		params         json.RawMessage
@@ -1521,7 +1521,7 @@ func TestValidateDealTier(t *testing.T) {
 			assert.Fail(t, "Unable to unmarshal JSON data for testing BidderDealTier")
 		}
 
-		assert.Equal(t, test.expectedResult, validateDealTier(bidderDealTier.DealInfo["appnexus"]), test.description)
+		assert.Equal(t, test.expectedResult, validateAndNormalizeDealTier(bidderDealTier.DealInfo["appnexus"]), test.description)
 	}
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -914,10 +914,10 @@ func TestCategoryMapping(t *testing.T) {
 	bid3 := openrtb.Bid{ID: "bid_id3", ImpID: "imp_id3", Price: 30.0000, Cat: cats3, W: 1, H: 1}
 	bid4 := openrtb.Bid{ID: "bid_id4", ImpID: "imp_id4", Price: 40.0000, Cat: cats4, W: 1, H: 1}
 
-	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}}
-	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30, PrimaryCategory: "AdapterOverride"}}
-	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
+	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}, 0}
+	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30, PrimaryCategory: "AdapterOverride"}, 0}
+	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
 
 	innerBids := []*pbsOrtbBid{
 		&bid1_1,
@@ -969,10 +969,10 @@ func TestCategoryMappingNoIncludeBrandCategory(t *testing.T) {
 	bid3 := openrtb.Bid{ID: "bid_id3", ImpID: "imp_id3", Price: 30.0000, Cat: cats3, W: 1, H: 1}
 	bid4 := openrtb.Bid{ID: "bid_id4", ImpID: "imp_id4", Price: 40.0000, Cat: cats4, W: 1, H: 1}
 
-	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}}
-	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30, PrimaryCategory: "AdapterOverride"}}
-	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 50}}
+	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}, 0}
+	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30, PrimaryCategory: "AdapterOverride"}, 0}
+	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 50}, 0}
 
 	innerBids := []*pbsOrtbBid{
 		&bid1_1,
@@ -1023,9 +1023,9 @@ func TestCategoryMappingTranslateCategoriesNil(t *testing.T) {
 	bid2 := openrtb.Bid{ID: "bid_id2", ImpID: "imp_id2", Price: 20.0000, Cat: cats2, W: 1, H: 1}
 	bid3 := openrtb.Bid{ID: "bid_id3", ImpID: "imp_id3", Price: 30.0000, Cat: cats3, W: 1, H: 1}
 
-	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}}
-	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
+	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}, 0}
+	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
 
 	innerBids := []*pbsOrtbBid{
 		&bid1_1,
@@ -1105,9 +1105,9 @@ func TestCategoryMappingTranslateCategoriesFalse(t *testing.T) {
 	bid2 := openrtb.Bid{ID: "bid_id2", ImpID: "imp_id2", Price: 20.0000, Cat: cats2, W: 1, H: 1}
 	bid3 := openrtb.Bid{ID: "bid_id3", ImpID: "imp_id3", Price: 30.0000, Cat: cats3, W: 1, H: 1}
 
-	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}}
-	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
+	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 40}, 0}
+	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
 
 	innerBids := []*pbsOrtbBid{
 		&bid1_1,
@@ -1156,10 +1156,10 @@ func TestCategoryDedupe(t *testing.T) {
 	bid3 := openrtb.Bid{ID: "bid_id3", ImpID: "imp_id3", Price: 10.0000, Cat: cats1, W: 1, H: 1}
 	bid4 := openrtb.Bid{ID: "bid_id4", ImpID: "imp_id4", Price: 20.0000, Cat: cats4, W: 1, H: 1}
 
-	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 50}}
-	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
-	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}}
+	bid1_1 := pbsOrtbBid{&bid1, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_2 := pbsOrtbBid{&bid2, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 50}, 0}
+	bid1_3 := pbsOrtbBid{&bid3, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
+	bid1_4 := pbsOrtbBid{&bid4, "video", nil, &openrtb_ext.ExtBidPrebidVideo{Duration: 30}, 0}
 
 	selectedBids := make(map[string]int)
 	expectedCategories := map[string]string{
@@ -1379,19 +1379,11 @@ func TestApplyDealSupport(t *testing.T) {
 		"hb_pb_cat_dur": "12.00_auto_30s",
 	}
 
-	bid1_1 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":5}}`),
-	}, "video", targ1, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_2 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":6}}`),
-	}, "video", targ2, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_3 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":7}}`),
-	}, "video", targ3, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_4 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":8}}`),
-	}, "video", targ4, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_5 := pbsOrtbBid{&openrtb.Bid{}, "video", targ5, &openrtb_ext.ExtBidPrebidVideo{}}
+	bid1_1 := pbsOrtbBid{&openrtb.Bid{}, "video", targ1, &openrtb_ext.ExtBidPrebidVideo{}, 5}
+	bid1_2 := pbsOrtbBid{&openrtb.Bid{}, "video", targ2, &openrtb_ext.ExtBidPrebidVideo{}, 6}
+	bid1_3 := pbsOrtbBid{&openrtb.Bid{}, "video", targ3, &openrtb_ext.ExtBidPrebidVideo{}, 7}
+	bid1_4 := pbsOrtbBid{&openrtb.Bid{}, "video", targ4, &openrtb_ext.ExtBidPrebidVideo{}, 8}
+	bid1_5 := pbsOrtbBid{&openrtb.Bid{}, "video", targ5, &openrtb_ext.ExtBidPrebidVideo{}, 0}
 
 	auc := &auction{
 		winningBidsByBidder: map[string]map[openrtb_ext.BidderName]*pbsOrtbBid{
@@ -1440,7 +1432,7 @@ func TestGetDealTiers(t *testing.T) {
 			},
 			{
 				ID:  "imp_id4",
-				Ext: json.RawMessage(`{"onedealTier1": {"placementId": 10433394}, "onedealTier2": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
+				Ext: json.RawMessage(`{"validbase": {"placementId": 10433394}, "onedealTier2": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
 			},
 		},
 	}
@@ -1459,8 +1451,11 @@ func TestGetDealTiers(t *testing.T) {
 	assert.Equal(t, &filledDealTier, impDealMap["imp_id2"].DealInfo["validmultiple1"], "DealTier should be filled with config data")
 	assert.Equal(t, &filledDealTier, impDealMap["imp_id2"].DealInfo["validmultiple2"], "DealTier should be filled with config data")
 	assert.Equal(t, &emptyDealTier, impDealMap["imp_id3"].DealInfo["nodealtier"], "DealTier should be empty")
-	assert.Equal(t, &emptyDealTier, impDealMap["imp_id4"].DealInfo["onedealTier1"], "DealTier should be empty")
+	assert.Equal(t, &emptyDealTier, impDealMap["imp_id4"].DealInfo["validbase"], "DealTier should be empty")
 	assert.Equal(t, &filledDealTier, impDealMap["imp_id4"].DealInfo["onedealTier2"], "DealTier should be filled with config data")
+
+	_, ok := impDealMap["imp_id4"].DealInfo["validmultiple1"]
+	assert.Equal(t, false, ok, "DealTier should not be initialized")
 }
 
 func TestValidateDealTier(t *testing.T) {
@@ -1485,9 +1480,16 @@ func TestValidateDealTier(t *testing.T) {
 		assert.Fail(t, "Unable to unmarshal JSON data for testing BidderDealTier")
 	}
 
-	rawParams4 := json.RawMessage(`{"appnexus": {"placementId": 10433394}}`)
+	rawParams4 := json.RawMessage(`{"appnexus": {"dealTier": {"prefix": "tier"}, "placementId": 10433394}}`)
 	var bidderDealTier4 BidderDealTier
 	err = json.Unmarshal(rawParams4, &bidderDealTier4.DealInfo)
+	if err != nil {
+		assert.Fail(t, "Unable to unmarshal JSON data for testing BidderDealTier")
+	}
+
+	rawParams5 := json.RawMessage(`{"appnexus": {"placementId": 10433394}}`)
+	var bidderDealTier5 BidderDealTier
+	err = json.Unmarshal(rawParams5, &bidderDealTier5.DealInfo)
 	if err != nil {
 		assert.Fail(t, "Unable to unmarshal JSON data for testing BidderDealTier")
 	}
@@ -1495,7 +1497,8 @@ func TestValidateDealTier(t *testing.T) {
 	assert.Equal(t, true, validateDealTier(bidderDealTier1.DealInfo["appnexus"]), "BidderDealTier should be valid")
 	assert.Equal(t, false, validateDealTier(bidderDealTier2.DealInfo["appnexus"]), "BidderDealTier should be invalid due to empty prefix")
 	assert.Equal(t, false, validateDealTier(bidderDealTier3.DealInfo["appnexus"]), "BidderDealTier should be invalid due to empty dealTier")
-	assert.Equal(t, false, validateDealTier(bidderDealTier4.DealInfo["appnexus"]), "BidderDealTier should be invalid due to missing dealTier")
+	assert.Equal(t, false, validateDealTier(bidderDealTier4.DealInfo["appnexus"]), "BidderDealTier should be invalid due to missing minDealTier")
+	assert.Equal(t, false, validateDealTier(bidderDealTier5.DealInfo["appnexus"]), "BidderDealTier should be invalid due to missing dealTier")
 }
 
 func TestUpdateCatDur(t *testing.T) {
@@ -1516,18 +1519,10 @@ func TestUpdateCatDur(t *testing.T) {
 		"hb_pb_cat_dur": "12.00_30s",
 	}
 
-	bid1_1 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":5}}`),
-	}, "video", targ1, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_2 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":6}}`),
-	}, "video", targ2, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_3 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":7}}`),
-	}, "video", targ3, &openrtb_ext.ExtBidPrebidVideo{}}
-	bid1_4 := pbsOrtbBid{&openrtb.Bid{
-		Ext: json.RawMessage(`{"appnexus":{"deal_priority":8}}`),
-	}, "video", targ4, &openrtb_ext.ExtBidPrebidVideo{}}
+	bid1_1 := pbsOrtbBid{&openrtb.Bid{}, "video", targ1, &openrtb_ext.ExtBidPrebidVideo{}, 5}
+	bid1_2 := pbsOrtbBid{&openrtb.Bid{}, "video", targ2, &openrtb_ext.ExtBidPrebidVideo{}, 6}
+	bid1_3 := pbsOrtbBid{&openrtb.Bid{}, "video", targ3, &openrtb_ext.ExtBidPrebidVideo{}, 7}
+	bid1_4 := pbsOrtbBid{&openrtb.Bid{}, "video", targ4, &openrtb_ext.ExtBidPrebidVideo{}, 8}
 
 	deal1 := &DealTierInfo{
 		Prefix:      "tier",

--- a/openrtb_ext/bid_request_video.go
+++ b/openrtb_ext/bid_request_video.go
@@ -136,6 +136,15 @@ type BidRequestVideo struct {
 	// Description:
 	//   Contains the OpenRTB Regs object to be passed to OpenRTB request
 	Regs *openrtb.Regs `json:"regs,omitempty"`
+
+	// TODO double check naming with client side
+	// Attribute:
+	//   SupportDeals
+	// Type:
+	//   bool; optional
+	// Description:
+	//   Indicates that the response should update keys to include prefix and tier
+	SupportDeals bool `json:"supportdeals,omitempty"`
 }
 
 type PodConfig struct {

--- a/openrtb_ext/bid_request_video.go
+++ b/openrtb_ext/bid_request_video.go
@@ -137,13 +137,12 @@ type BidRequestVideo struct {
 	//   Contains the OpenRTB Regs object to be passed to OpenRTB request
 	Regs *openrtb.Regs `json:"regs,omitempty"`
 
-	// TODO double check naming with client side
 	// Attribute:
-	//   SupportDeals
+	//   supportdeals
 	// Type:
 	//   bool; optional
 	// Description:
-	//   Indicates that the response should update keys to include prefix and tier
+	//   Indicates that the response should update key to include prefix and tier
 	SupportDeals bool `json:"supportdeals,omitempty"`
 }
 

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -17,6 +17,7 @@ type ExtRequestPrebid struct {
 	Cache                *ExtRequestPrebidCache `json:"cache,omitempty"`
 	StoredRequest        *ExtStoredRequest      `json:"storedrequest,omitempty"`
 	Targeting            *ExtRequestTargeting   `json:"targeting,omitempty"`
+	SupportDeals         bool                   `json:"supportdeals,omitempty"`
 }
 
 // ExtRequestPrebidCache defines the contract for bidrequest.ext.prebid.cache


### PR DESCRIPTION
Opening PR to get an early start on review comments. We have a couple questions remaining on our end. One major change that may need to be added is implementing the `pmp` object for targeting deals in the impressions. I will update this PR with any action items regarding this.