### PR TITLE
CORS policy for https://prebid.adnxs.com/pbs/v1/cookie_sync

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -304,6 +304,7 @@ func SupportCORS(handler http.Handler) http.Handler {
 		AllowOriginFunc: func(string) bool {
 			return true
 		},
+		AllowedOrigins: []string{"*", "https://prebid.adnxs.com/pbs/v1/cookie_sync"},
 		AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept"}})
 	return c.Handler(handler)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -304,7 +304,7 @@ func SupportCORS(handler http.Handler) http.Handler {
 		AllowOriginFunc: func(string) bool {
 			return true
 		},
-		AllowedOrigins: []string{"*", "https://prebid.adnxs.com/pbs/v1/cookie_sync"},
+		AllowedOrigins: []string{"*"},
 		AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept"}})
 	return c.Handler(handler)
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -72,20 +72,20 @@ func TestExchangeMap(t *testing.T) {
 
 // Prevents #648
 func TestCORSSupport(t *testing.T) {
-	const origin = "https://publisher-domain.com"
+	const anyCrossOriginResource = "*"
 	handler := func(w http.ResponseWriter, r *http.Request) {}
 	cors := SupportCORS(http.HandlerFunc(handler))
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("OPTIONS", "http://some-domain.com/openrtb2/auction", nil)
 	req.Header.Set("Access-Control-Request-Method", "POST")
 	req.Header.Set("Access-Control-Request-Headers", "origin")
-	req.Header.Set("Origin", origin)
+	req.Header.Set("Origin", anyCrossOriginResource)
 
 	if !assert.NoError(t, err) {
 		return
 	}
 	cors.ServeHTTP(rr, req)
-	assert.Equal(t, origin, rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, anyCrossOriginResource, rr.Header().Get("Access-Control-Allow-Origin"))
 }
 
 func TestNoCache(t *testing.T) {


### PR DESCRIPTION
A lot of errors related to publisher integrations have been reported because the apparent lack of the `Access-Control-Allow-Origin` CORS header that is basically a whitelist of the URLs where clients allow to pull content from other source than the origin. In golang's [Go CORS handler](https://github.com/rs/cors) library, not specifying any value inside the `AllowedOrigins` array of the `Options` field, should default to a `"*"` value which, according to the `https://github.com/rs/cors` documentation, should suffice to make the header `Access-Control-Allow-Origin` default to `"*"`. This pull request will explicitly set the `Access-Control-Allow-Origin` to an `"*"` value in order to avoid any `No 'Access-Control-Allow-Origin' header is present on the requested source` errors on the client side.
BEFORE:
```
(dlv) break router/router.go:309
Breakpoint 1 set at 0x17fe5e4 for github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309
(dlv) c
> github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309 (hits goroutine(8):1 total:1) (PC: 0x17fe5e4)
   304:                 AllowOriginFunc: func(string) bool {
   305:                         return true
   306:                 },
   307:                 //AllowedOrigins: []string{"*", "https://prebid.adnxs.com/pbs/v1/cookie_sync"},
   308:                 AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept"}})
=> 309:         return c.Handler(handler)
   310: }
   311:
   312: type defReq struct {
   313:         Ext defExt `json:"ext"`
   314: }
(dlv) p c
*github.com/rs/cors.Cors {
        Log: *log.Logger nil,
        allowedOrigins: []string len: 0, cap: 0, nil,
        allowedWOrigins: []github.com/rs/cors.wildcard len: 0, cap: 0, nil,
        allowOriginFunc: github.com/prebid/prebid-server/router.SupportCORS.func1,
        allowedHeaders: []string len: 5, cap: 8, [
                "Origin",
                "X-Requested-With",
                "Content-Type",
                "Accept",
                "Origin",
        ],
        allowedMethods: []string len: 3, cap: 3, ["GET","POST","HEAD"],
        exposedHeaders: []string len: 0, cap: 0, [],
        maxAge: 0,
        allowedOriginsAll: false,
        allowedHeadersAll: false,
        allowCredentials: true,
        optionPassthrough: false,}
(dlv)
before.txt
```
AFTER
```
Type 'help' for list of commands.
(dlv) break router/router.go:309
Breakpoint 1 set at 0x17fe672 for github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309
(dlv) c
> github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309 (hits goroutine(9):1 total:1) (PC: 0x17fe672)
   304:                 AllowOriginFunc: func(string) bool {
   305:                         return true
   306:                 },
   307:                 AllowedOrigins: []string{"*"},
   308:                 AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept"}})
=> 309:         return c.Handler(handler)
   310: }
   311:
   312: type defReq struct {
   313:         Ext defExt `json:"ext"`
   314: }
(dlv) p c
*github.com/rs/cors.Cors {
        Log: *log.Logger nil,
        allowedOrigins: []string len: 0, cap: 0, nil,
        allowedWOrigins: []github.com/rs/cors.wildcard len: 0, cap: 0, nil,
        allowOriginFunc: github.com/prebid/prebid-server/router.SupportCORS.func1,
        allowedHeaders: []string len: 5, cap: 8, [
                "Origin",
                "X-Requested-With",
                "Content-Type",
                "Accept",
                "Origin",
        ],
        allowedMethods: []string len: 3, cap: 3, ["GET","POST","HEAD"],
        exposedHeaders: []string len: 0, cap: 0, [],
        maxAge: 0,
        allowedOriginsAll: true,
        allowedHeadersAll: false,
        allowCredentials: true,
        optionPassthrough: false,}
(dlv)
after.txt
```

Difference:
```
╰─➤  diff before.txt after.txt
4c4
< > github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309 (hits goroutine(8):1 total:1) (PC: 0x17fe5e4)
---
> > github.com/prebid/prebid-server/router.SupportCORS() ./router.go:309 (hits goroutine(9):1 total:1) (PC: 0x17fe672)
8c8
<    307:                 //AllowedOrigins: []string{"*", "https://prebid.adnxs.com/pbs/v1/cookie_sync"},
---
>    307:                 AllowedOrigins: []string{"*"},
32c32
<         allowedOriginsAll: false,
---
>         allowedOriginsAll: true,
```