### PR TITLE
If Device.UA is not present in request body, init it with user-agent from header

### DIFF
--- a/endpoints/openrtb2/sample-requests/video/video_valid_sample_with_device_user_agent.json
+++ b/endpoints/openrtb2/sample-requests/video/video_valid_sample_with_device_user_agent.json
@@ -1,0 +1,80 @@
+
+{
+  "accountid": "555888777",
+  "podconfig": {
+    "durationrangesec": [
+      30
+    ],
+    "requireexactduration": true,
+    "pods": [
+      {
+        "podid": 1,
+        "adpoddurationsec": 180,
+        "configid": "fba10607-0c12-43d1-ad07-b8a513bc75d6"
+      },
+      {
+        "podid": 2,
+        "adpoddurationsec": 150,
+        "configid": "8b452b41-2681-4a20-9086-6f16ffad7773"
+      }
+    ]
+  },
+  "site": {
+    "page": "prebid.com"
+  },
+  "user": {
+    "buyeruids": {
+      "appnexus": "unique_id_an",
+      "rubicon": "unique_id_rubi"
+    },
+    "gdpr": {
+      "consentrequired": false,
+      "consentstring": "something"
+    },
+    "yob": 1991,
+    "gender": "F",
+    "keywords": "Hotels, Travelling"
+  },
+  "device": {
+    "ua": "TestHeaderSample",
+    "ip": "123.145.167.10",
+    "devicetype": 1,
+    "dnt": 33,
+    "ifa": "AA000DFE74168477C70D291f574D344790E0BB11",
+    "lmt": 44,
+    "os": "mac os",
+    "w": 640,
+    "h": 480,
+    "didsha1": "didsha1",
+    "didmd5": "didmd5",
+    "dpidsha1": "dpidsha1",
+    "dpidmd5": "dpidmd5",
+    "macsha1": "macsha1",
+    "macmd5": "macmd5"
+  },
+  "includebrandcategory":{
+    "primaryadserver": 1,
+    "publisher": ""
+  },
+  "video": {
+    "w": 640,
+    "h": 480,
+    "mimes": [
+      "video/mp4"
+    ],
+    "protocols": [
+      2,3,5,6
+    ]
+  },
+  "content": {
+    "episode": 6,
+    "title": "episodeName",
+    "series": "TvName",
+    "season": "season3",
+    "len": 900,
+    "livestream": 0
+  },
+  "cacheconfig": {
+    "ttl": 42
+  }
+}

--- a/endpoints/openrtb2/sample-requests/video/video_valid_sample_without_device_user_agent.json
+++ b/endpoints/openrtb2/sample-requests/video/video_valid_sample_without_device_user_agent.json
@@ -1,0 +1,63 @@
+
+{
+  "accountid": "555888777",
+  "podconfig": {
+    "durationrangesec": [
+      30
+    ],
+    "requireexactduration": true,
+    "pods": [
+      {
+        "podid": 1,
+        "adpoddurationsec": 180,
+        "configid": "fba10607-0c12-43d1-ad07-b8a513bc75d6"
+      },
+      {
+        "podid": 2,
+        "adpoddurationsec": 150,
+        "configid": "8b452b41-2681-4a20-9086-6f16ffad7773"
+      }
+    ]
+  },
+  "site": {
+    "page": "prebid.com"
+  },
+  "user": {
+    "buyeruids": {
+      "appnexus": "unique_id_an",
+      "rubicon": "unique_id_rubi"
+    },
+    "gdpr": {
+      "consentrequired": false,
+      "consentstring": "something"
+    },
+    "yob": 1991,
+    "gender": "F",
+    "keywords": "Hotels, Travelling"
+  },
+  "includebrandcategory":{
+    "primaryadserver": 1,
+    "publisher": ""
+  },
+  "video": {
+    "w": 640,
+    "h": 480,
+    "mimes": [
+      "video/mp4"
+    ],
+    "protocols": [
+      2,3,5,6
+    ]
+  },
+  "content": {
+    "episode": 6,
+    "title": "episodeName",
+    "series": "TvName",
+    "season": "season3",
+    "len": 900,
+    "livestream": 0
+  },
+  "cacheconfig": {
+    "ttl": 42
+  }
+}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -566,10 +566,7 @@ func (deps *endpointDeps) parseVideoRequest(request []byte, headers http.Header)
 
 	//if Device.UA is not present in request body, init it with user-agent from request header if it's present
 	if req.Device.UA == "" {
-		userAgent := headers.Get("User-Agent")
-		if userAgent != "" {
-			req.Device.UA = userAgent
-		}
+		req.Device.UA = headers.Get("User-Agent")
 	}
 
 	errL, podErrors := deps.validateVideoRequest(req)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -140,6 +140,14 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	//create full open rtb req from full video request
 	mergeData(videoBidReq, bidReq)
 
+	//if Device.UA is not present in request body, init it with user-agent from request header if it's present
+	if videoBidReq.Device.UA == "" {
+		userAgent := r.Header.Get("User-Agent")
+		if userAgent != "" {
+			videoBidReq.Device.UA = userAgent
+		}
+	}
+
 	initialPodNumber := len(videoBidReq.PodConfig.Pods)
 	if len(podErrors) > 0 {
 		//remove incorrect pods


### PR DESCRIPTION
Cannot come up with unit tests for this change. Do we want it? 