### PR TITLE
Updated price granularity unmarshal to accept empty values and ranges

### DIFF
--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -148,10 +148,11 @@ func (pg *PriceGranularity) UnmarshalJSON(b []byte) error {
 			}
 			prevMax = gr.Max
 		}
-	} else {
-		return errors.New("Price granularity error: empty granularity definition supplied")
+		*pg = PriceGranularity(pgraw)
+		return nil
 	}
-	*pg = PriceGranularity(pgraw)
+	// Default to medium if no ranges are specified
+	*pg = priceGranularityMed
 	return nil
 }
 

--- a/openrtb_ext/request_test.go
+++ b/openrtb_ext/request_test.go
@@ -175,11 +175,22 @@ var validGranularityTests []granularityTestData = []granularityTestData{
 			},
 		},
 	},
+	{
+		json:   []byte(`{}`),
+		target: priceGranularityMed,
+	},
+	{
+		json:   []byte(`{"precision": 2}`),
+		target: priceGranularityMed,
+	},
+	{
+		json:   []byte(`{"precision": 2, "ranges":[]}`),
+		target: priceGranularityMed,
+	},
 }
 
 func TestGranularityUnmarshalBad(t *testing.T) {
 	tests := [][]byte{
-		[]byte(`{}`),
 		[]byte(`[]`),
 		[]byte(`{"precision": -1, "ranges": [{"max":20, "increment":0.5}]}`),
 		[]byte(`{"ranges":[{"max":20, "increment": -1}]}`),


### PR DESCRIPTION
Original issue: https://github.com/prebid/prebid-server/issues/1215

Updated the unmarshal for price granularity to use the default object if the request object is empty, or contains no ranges.