### PR TITLE
Updated condition for setting brand_category_uniqueness flag

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -347,7 +347,7 @@ func (a *AppNexusAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *ada
 	if reqExt.Appnexus == nil {
 		reqExt.Appnexus = &appnexusReqExtAppnexus{}
 	}
-	includeBrandCategory := reqExt.Prebid.Targeting != nil && reqExt.Prebid.Targeting.IncludeBrandCategory != nil
+	includeBrandCategory := reqExt.Prebid.Targeting != nil && reqExt.Prebid.Targeting.IncludeBrandCategory != nil && reqExt.Prebid.Targeting.IncludeBrandCategory.WithCategory
 	if includeBrandCategory {
 		reqExt.Appnexus.BrandCategoryUniqueness = &includeBrandCategory
 		reqExt.Appnexus.IncludeBrandCategory = &includeBrandCategory

--- a/adapters/appnexus/appnexustest/exemplary/optional-params-withcatfalse.json
+++ b/adapters/appnexus/appnexustest/exemplary/optional-params-withcatfalse.json
@@ -37,9 +37,9 @@
       "prebid": {
         "targeting": {
           "includebrandcategory": {
-            "primaryadserver": 1,
+            "primaryadserver": 0,
             "publisher": "",
-            "withcategory": true
+            "withcategory": false
           }
         }
       }
@@ -54,8 +54,6 @@
           "id": "test-request-id",
           "ext": {
             "appnexus": {
-              "include_brand_category": true,
-              "brand_category_uniqueness": true,
               "hb_source": 5
             },
             "prebid": {
@@ -63,9 +61,9 @@
                 "durationrangesec": null,
                 "includebidderkeys": true,
                 "includebrandcategory": {
-                  "primaryadserver": 1,
+                  "primaryadserver": 0,
                   "publisher": "",
-                  "withcategory": true
+                  "withcategory": false
                 },
                 "includewinners": true,
                 "pricegranularity": {


### PR DESCRIPTION
`brand_category_uniqueness` was always being set to enabled, as we created a default `includebrandcategory` in the video endpoint. This update omits the flag if no `includebrandcategory` is set.