### PR TITLE
replacing info@prebid.org maintainer email addrs

### DIFF
--- a/static/bidder-info/appnexus.yaml
+++ b/static/bidder-info/appnexus.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "info@prebid.org"
+  email: "prebid-server@xandr.com"
 capabilities:
   app:
     mediaTypes:

--- a/static/bidder-info/audienceNetwork.yaml
+++ b/static/bidder-info/audienceNetwork.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "info@prebid.org"
+  email: "none"
 capabilities:
   site:
     mediaTypes:

--- a/static/bidder-info/ix.yaml
+++ b/static/bidder-info/ix.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "info@prebid.org"
+  email: "pdu-supply-prebid@indexexchange.com"
 capabilities:
   site:
     mediaTypes:

--- a/static/bidder-info/pulsepoint.yaml
+++ b/static/bidder-info/pulsepoint.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "info@prebid.org"
+  email: "ExchangeTeam@pulsepoint.com"
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
info@prebid.org received email for one of these adapters. Fixing the addresses.