### PR TITLE
Fix Go 1.14 Error Message Changes

### DIFF
--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -2,17 +2,18 @@ package sharethrough
 
 import (
 	"fmt"
-	"github.com/mxmCherry/openrtb"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/openrtb_ext"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/errortypes"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockUtil struct {
@@ -538,15 +539,15 @@ func TestFailParseUri(t *testing.T) {
 	}{
 		"Fails decoding if unable to parse URI": {
 			input:         "test:/#$%?#",
-			expectedError: `parse test:/#$%?#: invalid URL escape "%?#"`,
+			expectedError: `parse (\")?test:/#\$%\?#(\")?: invalid URL escape \"%\?#\"`,
 		},
 		"Fails decoding if height not provided": {
 			input:         "http://abc.com?width=10",
-			expectedError: `strconv.ParseUint: parsing "": invalid syntax`,
+			expectedError: `strconv.ParseUint: parsing \"\": invalid syntax`,
 		},
 		"Fails decoding if width not provided": {
 			input:         "http://abc.com?height=10",
-			expectedError: `strconv.ParseUint: parsing "": invalid syntax`,
+			expectedError: `strconv.ParseUint: parsing \"\": invalid syntax`,
 		},
 	}
 
@@ -559,6 +560,6 @@ func TestFailParseUri(t *testing.T) {
 
 		assert.Nil(output)
 		assert.NotNil(actualError)
-		assert.Equal(test.expectedError, actualError.Error())
+		assert.Regexp(test.expectedError, actualError.Error())
 	}
 }

--- a/adapters/tappx/tappxtest/supplemental/banner-impression-badhost.json
+++ b/adapters/tappx/tappxtest/supplemental/banner-impression-badhost.json
@@ -31,8 +31,8 @@
 
   "expectedMakeRequestsErrors": [
     {
-      "value": "Malformed URL: parse https://example.ho%st.tappx.com: invalid URL escape \"%st\"",
-      "comparison": "literal"
+      "value": "Malformed URL: parse (\\\")?https://example\\.ho%st\\.tappx.com(\\\")?: invalid URL escape \\\"%st\\\"",
+      "comparison": "regex"
     }
   ]
  


### PR DESCRIPTION
Go 1.14 introduces a change to the formatting of error message. This broke two tests which rely on the platform error message. Per the release notes, the change is:

https://golang.org/doc/go1.14
> net/url
> When parsing of a URL fails (for example by Parse or ParseRequestURI), the resulting Error message will now quote the unparsable URL. This provides clearer structure and consistency with other parsing errors.

I changed the affect tests to regex comparisons for compatibility with at least 1.14, 1.13, and 1.12.