### PR TITLE
privacy: Potential JSON injection

### DIFF
--- a/privacy/ccpa/policy.go
+++ b/privacy/ccpa/policy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
@@ -48,9 +47,14 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		return err
 	}
 
-	jsonString, err := json.Marshal(p.Value)
+	var extMap map[string]interface{}
+	err := json.Unmarshal(req.Regs.Ext, &extMap)
 	if err == nil {
-		req.Regs.Ext, err = jsonparser.Set(req.Regs.Ext, jsonString, "us_privacy")
+		extMap["us_privacy"] = p.Value
+		ext, err := json.Marshal(extMap)
+		if err == nil {
+			req.Regs.Ext = ext
+		}
 	}
 	return err
 }

--- a/privacy/ccpa/policy.go
+++ b/privacy/ccpa/policy.go
@@ -40,10 +40,11 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		req.Regs = &openrtb.Regs{}
 	}
 
-	var err error
-
 	if req.Regs.Ext == nil {
-		req.Regs.Ext, err = json.Marshal(openrtb_ext.ExtRegs{USPrivacy: p.Value})
+		ext, err := json.Marshal(openrtb_ext.ExtRegs{USPrivacy: p.Value})
+		if err == nil {
+			req.Regs.Ext = ext
+		}
 		return err
 	}
 

--- a/privacy/ccpa/policy.go
+++ b/privacy/ccpa/policy.go
@@ -40,13 +40,17 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		req.Regs = &openrtb.Regs{}
 	}
 
+	var err error
+
 	if req.Regs.Ext == nil {
-		req.Regs.Ext = json.RawMessage(`{"us_privacy":"` + p.Value + `"}`)
-		return nil
+		req.Regs.Ext, err = json.Marshal(openrtb_ext.ExtRegs{USPrivacy: p.Value})
+		return err
 	}
 
-	var err error
-	req.Regs.Ext, err = jsonparser.Set(req.Regs.Ext, []byte(`"`+p.Value+`"`), "us_privacy")
+	jsonString, err := json.Marshal(p.Value)
+	if err == nil {
+		req.Regs.Ext, err = jsonparser.Set(req.Regs.Ext, jsonString, "us_privacy")
+	}
 	return err
 }
 

--- a/privacy/gdpr/policy.go
+++ b/privacy/gdpr/policy.go
@@ -2,6 +2,7 @@ package gdpr
 
 import (
 	"encoding/json"
+	"github.com/prebid/prebid-server/openrtb_ext"
 
 	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
@@ -24,13 +25,17 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		req.User = &openrtb.User{}
 	}
 
+	var err error
+
 	if req.User.Ext == nil {
-		req.User.Ext = json.RawMessage(`{"consent":"` + p.Consent + `"}`)
-		return nil
+		req.User.Ext, err = json.Marshal(openrtb_ext.ExtUser{Consent: p.Consent})
+		return err
 	}
 
-	var err error
-	req.User.Ext, err = jsonparser.Set(req.User.Ext, []byte(`"`+p.Consent+`"`), "consent")
+	jsonString, err := json.Marshal(p.Consent)
+	if err == nil {
+		req.User.Ext, err = jsonparser.Set(req.User.Ext, jsonString, "consent")
+	}
 	return err
 }
 

--- a/privacy/gdpr/policy.go
+++ b/privacy/gdpr/policy.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/prebid/prebid-server/openrtb_ext"
 
-	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/go-gdpr/vendorconsent"
 )
@@ -33,9 +32,14 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		return err
 	}
 
-	jsonString, err := json.Marshal(p.Consent)
+	var extMap map[string]interface{}
+	err := json.Unmarshal(req.User.Ext, &extMap)
 	if err == nil {
-		req.User.Ext, err = jsonparser.Set(req.User.Ext, jsonString, "consent")
+		extMap["consent"] = p.Consent
+		ext, err := json.Marshal(extMap)
+		if err == nil {
+			req.User.Ext = ext
+		}
 	}
 	return err
 }

--- a/privacy/gdpr/policy.go
+++ b/privacy/gdpr/policy.go
@@ -25,10 +25,11 @@ func (p Policy) Write(req *openrtb.BidRequest) error {
 		req.User = &openrtb.User{}
 	}
 
-	var err error
-
 	if req.User.Ext == nil {
-		req.User.Ext, err = json.Marshal(openrtb_ext.ExtUser{Consent: p.Consent})
+		ext, err := json.Marshal(openrtb_ext.ExtUser{Consent: p.Consent})
+		if err == nil {
+			req.User.Ext = ext
+		}
 		return err
 	}
 

--- a/privacy/gdpr/policy_test.go
+++ b/privacy/gdpr/policy_test.go
@@ -59,6 +59,32 @@ func TestWrite(t *testing.T) {
 				Ext: json.RawMessage(`malformed`)}},
 			expectedError: true,
 		},
+		{
+			description: "Injection Attack With Nil Request User Object",
+			policy:      Policy{Consent: "BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""},
+			request:     &openrtb.BidRequest{},
+			expected: &openrtb.BidRequest{User: &openrtb.User{
+				Ext: json.RawMessage(`{"consent":"BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""}`),
+			}},
+		},
+		{
+			description: "Injection Attack With Nil Request User Ext Object",
+			policy:      Policy{Consent: "BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""},
+			request:     &openrtb.BidRequest{User: &openrtb.User{}},
+			expected: &openrtb.BidRequest{User: &openrtb.User{
+				Ext: json.RawMessage(`{"consent":"BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""}`),
+			}},
+		},
+		{
+			description: "Injection Attack With Existing Request User Ext Object",
+			policy:      Policy{Consent: "BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""},
+			request: &openrtb.BidRequest{User: &openrtb.User{
+				Ext: json.RawMessage(`{"existing":"any"}`),
+			}},
+			expected: &openrtb.BidRequest{User: &openrtb.User{
+				Ext: json.RawMessage(`{"existing":"any","consent":"BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""}`),
+			}},
+		},
 	}
 
 	for _, test := range testCases {

--- a/privacy/gdpr/policy_test.go
+++ b/privacy/gdpr/policy_test.go
@@ -42,7 +42,7 @@ func TestWrite(t *testing.T) {
 			request: &openrtb.BidRequest{User: &openrtb.User{
 				Ext: json.RawMessage(`{"existing":"any"}`)}},
 			expected: &openrtb.BidRequest{User: &openrtb.User{
-				Ext: json.RawMessage(`{"existing":"any","consent":"anyConsent"}`)}},
+				Ext: json.RawMessage(`{"consent":"anyConsent","existing":"any"}`)}},
 		},
 		{
 			description: "Enabled With Existing Request User Ext Object - Overwrites",
@@ -50,7 +50,7 @@ func TestWrite(t *testing.T) {
 			request: &openrtb.BidRequest{User: &openrtb.User{
 				Ext: json.RawMessage(`{"existing":"any","consent":"toBeOverwritten"}`)}},
 			expected: &openrtb.BidRequest{User: &openrtb.User{
-				Ext: json.RawMessage(`{"existing":"any","consent":"anyConsent"}`)}},
+				Ext: json.RawMessage(`{"consent":"anyConsent","existing":"any"}`)}},
 		},
 		{
 			description: "Enabled With Existing Malformed Request User Ext Object",
@@ -82,7 +82,7 @@ func TestWrite(t *testing.T) {
 				Ext: json.RawMessage(`{"existing":"any"}`),
 			}},
 			expected: &openrtb.BidRequest{User: &openrtb.User{
-				Ext: json.RawMessage(`{"existing":"any","consent":"BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\""}`),
+				Ext: json.RawMessage(`{"consent":"BONV8oqONXwgmADACHENAO7pqzAAppY\"},\"oops\":\"malicious\",\"p\":{\"p\":\"","existing":"any"}`),
 			}},
 		},
 	}


### PR DESCRIPTION
`privacy/ccpa/policy.go` and `privacy/gdpr/policy.go` include code that attempts to generate JSON by concatenating strings. If the `us_privacy` or `consent` fields contain the character `"`, this can produce malformed JSON, or JSON with an unintended structure.

This PR fixes the problem by encoding all JSON using the `json` module.

The included tests demonstrate that an attacker could exploit this bug to trick Prebid Server into mutating an OpenRTB bid request to contain arbitrary data, bypassing validation. These tests fail against the existing code.