### PR TITLE
consumable: Correct GDPR vendor ID to 591.

### DIFF
--- a/adapters/consumable/usersync.go
+++ b/adapters/consumable/usersync.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prebid/prebid-server/usersync"
 )
 
-var VENDOR_ID uint16 = 65535 // TODO: Insert consumable value when one is assigned
+var VENDOR_ID uint16 = 591
 
 func NewConsumableSyncer(temp *template.Template) usersync.Usersyncer {
 

--- a/adapters/consumable/usersync_test.go
+++ b/adapters/consumable/usersync_test.go
@@ -30,6 +30,6 @@ func TestConsumableSyncer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "//e.serverbid.com/udb/9969/match?gdpr=A&euconsent=B&us_privacy=C&redir=http%3A%2F%2Flocalhost%3A8000%2Fsetuid%3Fbidder%3Dconsumable%26gdpr%3DA%26gdpr_consent%3DB%26uid%3D", u.URL)
 	assert.Equal(t, "redirect", u.Type)
-	assert.Equal(t, uint16(65535), syncer.GDPRVendorID())
+	assert.Equal(t, uint16(591), syncer.GDPRVendorID())
 	assert.Equal(t, false, u.SupportCORS)
 }


### PR DESCRIPTION
Corrects Consumable’s GDPR vendor ID from 65535 to 591.

Fixes #1299.

CC @naffis.