### PR TITLE
Restore the AMP privacy exception as an option.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,6 +142,7 @@ type GDPR struct {
 	Timeouts                GDPRTimeouts `mapstructure:"timeouts_ms"`
 	NonStandardPublishers   []string     `mapstructure:"non_standard_publishers,flow"`
 	NonStandardPublisherMap map[string]int
+	AMPException            bool `mapstructure:"amp_exception"`
 }
 
 func (cfg *GDPR) validate(errs configErrors) configErrors {
@@ -768,6 +769,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("gdpr.timeouts_ms.init_vendorlist_fetches", 0)
 	v.SetDefault("gdpr.timeouts_ms.active_vendorlist_fetch", 0)
 	v.SetDefault("gdpr.non_standard_publishers", []string{""})
+	v.SetDefault("gdpr.amp_exception", false)
 	v.SetDefault("ccpa.enforce", false)
 	v.SetDefault("currency_converter.fetch_url", "https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json")
 	v.SetDefault("currency_converter.fetch_interval_seconds", 1800) // fetch currency rates every 30 minutes

--- a/endpoints/auction_test.go
+++ b/endpoints/auction_test.go
@@ -421,6 +421,10 @@ func (m *auctionMockPermissions) PersonalInfoAllowed(ctx context.Context, bidder
 	return m.allowPI, nil
 }
 
+func (m *auctionMockPermissions) AMPException() bool {
+	return false
+}
+
 func TestBidSizeValidate(t *testing.T) {
 	bids := make(pbs.PBSBidSlice, 0)
 	// bid1 will be rejected due to undefined size when adunit has multiple sizes

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -257,3 +257,7 @@ func (g *gdprPerms) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.Bi
 func (g *gdprPerms) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return true, nil
 }
+
+func (g *gdprPerms) AMPException() bool {
+	return false
+}

--- a/endpoints/setuid_test.go
+++ b/endpoints/setuid_test.go
@@ -441,6 +441,10 @@ func (g *mockPermsSetUID) PersonalInfoAllowed(ctx context.Context, bidder openrt
 	return g.allowPI, nil
 }
 
+func (g *mockPermsSetUID) AMPException() bool {
+	return false
+}
+
 func newFakeSyncer(familyName string) usersync.Usersyncer {
 	return fakeSyncer{
 		familyName: familyName,

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -43,6 +43,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 
 	gdpr := extractGDPR(orig, usersyncIfAmbiguous)
 	consent := extractConsent(orig)
+	isAMP := (labels.RType == pbsmetrics.ReqTypeAMP) && gDPR.AMPException()
 
 	privacyEnforcement := privacy.Enforcement{
 		COPPA: orig.Regs != nil && orig.Regs.COPPA == 1,
@@ -65,7 +66,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 			privacyEnforcement.GDPR = false
 		}
 
-		privacyEnforcement.Apply(bidReq)
+		privacyEnforcement.Apply(bidReq, isAMP)
 	}
 
 	return

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -43,7 +43,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 
 	gdpr := extractGDPR(orig, usersyncIfAmbiguous)
 	consent := extractConsent(orig)
-	isAMP := (labels.RType == pbsmetrics.ReqTypeAMP) && gDPR.AMPException()
+	ampGDPRException := (labels.RType == pbsmetrics.ReqTypeAMP) && gDPR.AMPException()
 
 	privacyEnforcement := privacy.Enforcement{
 		COPPA: orig.Regs != nil && orig.Regs.COPPA == 1,
@@ -66,7 +66,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 			privacyEnforcement.GDPR = false
 		}
 
-		privacyEnforcement.Apply(bidReq, isAMP)
+		privacyEnforcement.Apply(bidReq, ampGDPRException)
 	}
 
 	return

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -31,6 +31,10 @@ func (p *permissionsMock) PersonalInfoAllowed(ctx context.Context, bidder openrt
 	return false, nil
 }
 
+func (p *permissionsMock) AMPException() bool {
+	return false
+}
+
 func assertReq(t *testing.T, reqByBidders map[openrtb_ext.BidderName]*openrtb.BidRequest,
 	applyCOPPA bool, consentedVendors map[string]bool) {
 	// assert individual bidder requests

--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -24,6 +24,9 @@ type Permissions interface {
 	//
 	// If the consent string was nonsensical, the returned error will be an ErrorMalformedConsent.
 	PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error)
+
+	// Exposes the AMP execption flag
+	AMPException() bool
 }
 
 const (

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -58,6 +58,10 @@ func (p *permissionsImpl) PersonalInfoAllowed(ctx context.Context, bidder openrt
 	return false, nil
 }
 
+func (p *permissionsImpl) AMPException() bool {
+	return p.cfg.AMPException
+}
+
 func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, consent string) (bool, error) {
 	// If we're not given a consent string, respect the preferences in the app config.
 	if consent == "" {
@@ -144,4 +148,8 @@ func (a AlwaysAllow) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.B
 
 func (a AlwaysAllow) PersonalInfoAllowed(ctx context.Context, bidder openrtb_ext.BidderName, PublisherID string, consent string) (bool, error) {
 	return true, nil
+}
+
+func (a AlwaysAllow) AMPException() bool {
+	return false
 }

--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -41,11 +41,11 @@ const (
 	// ScrubStrategyUserNone does not remove non-location demographic data.
 	ScrubStrategyUserNone ScrubStrategyUser = iota
 
-	// ScrubStrategyUserFull removes the user's buyer id, exchange id year of birth, and gender.
-	ScrubStrategyUserFull
+	// ScrubStrategyUserIDAndDemographic removes the user's buyer id, exchange id year of birth, and gender.
+	ScrubStrategyUserIDAndDemographic
 
-	// ScrubStrategyUserBuyerIDOnly removes the user's buyer id.
-	ScrubStrategyUserBuyerIDOnly
+	// ScrubStrategyUserID removes the user's buyer id.
+	ScrubStrategyUserID
 
 	// ScrubStrategyUserAgeAndGender renoves the user's year of birth, and gender.
 	ScrubStrategyUserAgeAndGender
@@ -53,7 +53,7 @@ const (
 
 // Scrubber removes PII from parts of an OpenRTB request.
 type Scrubber interface {
-	ScrubDevice(device *openrtb.Device, macAndIFA bool, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
+	ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
 	ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo ScrubStrategyGeo) *openrtb.User
 }
 
@@ -64,7 +64,7 @@ func NewScrubber() Scrubber {
 	return scrubber{}
 }
 
-func (scrubber) ScrubDevice(device *openrtb.Device, macAndIFA bool, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
+func (scrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
 	if device == nil {
 		return nil
 	}
@@ -74,11 +74,9 @@ func (scrubber) ScrubDevice(device *openrtb.Device, macAndIFA bool, ipv6 ScrubSt
 	deviceCopy.DIDSHA1 = ""
 	deviceCopy.DPIDMD5 = ""
 	deviceCopy.DPIDSHA1 = ""
-	if macAndIFA {
-		deviceCopy.IFA = ""
-		deviceCopy.MACMD5 = ""
-		deviceCopy.MACSHA1 = ""
-	}
+	deviceCopy.IFA = ""
+	deviceCopy.MACMD5 = ""
+	deviceCopy.MACSHA1 = ""
 	deviceCopy.IP = scrubIPV4(device.IP)
 
 	switch ipv6 {
@@ -106,17 +104,14 @@ func (scrubber) ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo Sc
 	userCopy := *user
 
 	switch strategy {
-	case ScrubStrategyUserFull:
+	case ScrubStrategyUserIDAndDemographic:
 		userCopy.BuyerUID = ""
 		userCopy.ID = ""
 		userCopy.Yob = 0
 		userCopy.Gender = ""
-	case ScrubStrategyUserBuyerIDOnly:
+	case ScrubStrategyUserID:
 		userCopy.BuyerUID = ""
 		userCopy.ID = ""
-	case ScrubStrategyUserAgeAndGender:
-		userCopy.Yob = 0
-		userCopy.Gender = ""
 	}
 
 	switch geo {

--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -34,21 +34,27 @@ const (
 	ScrubStrategyGeoReducedPrecision
 )
 
-// ScrubStrategyDemographic defines the approach to non-location demographic data.
-type ScrubStrategyDemographic int
+// ScrubStrategyUser defines the approach to scrub PII from user data.
+type ScrubStrategyUser int
 
 const (
-	// ScrubStrategyDemographicNone does not remove non-location demographic data.
-	ScrubStrategyDemographicNone ScrubStrategyDemographic = iota
+	// ScrubStrategyUserNone does not remove non-location demographic data.
+	ScrubStrategyUserNone ScrubStrategyUser = iota
 
-	// ScrubStrategyDemographicAgeAndGender removes age and gender data.
-	ScrubStrategyDemographicAgeAndGender
+	// ScrubStrategyUserFull removes the user's buyer id, exchange id year of birth, and gender.
+	ScrubStrategyUserFull
+
+	// ScrubStrategyUserBuyerIDOnly removes the user's buyer id.
+	ScrubStrategyUserBuyerIDOnly
+
+	// ScrubStrategyUserAgeAndGender renoves the user's year of birth, and gender.
+	ScrubStrategyUserAgeAndGender
 )
 
 // Scrubber removes PII from parts of an OpenRTB request.
 type Scrubber interface {
-	ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
-	ScrubUser(user *openrtb.User, demographic ScrubStrategyDemographic, geo ScrubStrategyGeo) *openrtb.User
+	ScrubDevice(device *openrtb.Device, macAndIFA bool, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
+	ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo ScrubStrategyGeo) *openrtb.User
 }
 
 type scrubber struct{}
@@ -58,7 +64,7 @@ func NewScrubber() Scrubber {
 	return scrubber{}
 }
 
-func (scrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
+func (scrubber) ScrubDevice(device *openrtb.Device, macAndIFA bool, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
 	if device == nil {
 		return nil
 	}
@@ -68,9 +74,11 @@ func (scrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo 
 	deviceCopy.DIDSHA1 = ""
 	deviceCopy.DPIDMD5 = ""
 	deviceCopy.DPIDSHA1 = ""
-	deviceCopy.IFA = ""
-	deviceCopy.MACMD5 = ""
-	deviceCopy.MACSHA1 = ""
+	if macAndIFA {
+		deviceCopy.IFA = ""
+		deviceCopy.MACMD5 = ""
+		deviceCopy.MACSHA1 = ""
+	}
 	deviceCopy.IP = scrubIPV4(device.IP)
 
 	switch ipv6 {
@@ -90,17 +98,23 @@ func (scrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo 
 	return &deviceCopy
 }
 
-func (scrubber) ScrubUser(user *openrtb.User, demographic ScrubStrategyDemographic, geo ScrubStrategyGeo) *openrtb.User {
+func (scrubber) ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo ScrubStrategyGeo) *openrtb.User {
 	if user == nil {
 		return nil
 	}
 
 	userCopy := *user
-	userCopy.BuyerUID = ""
-	userCopy.ID = ""
 
-	switch demographic {
-	case ScrubStrategyDemographicAgeAndGender:
+	switch strategy {
+	case ScrubStrategyUserFull:
+		userCopy.BuyerUID = ""
+		userCopy.ID = ""
+		userCopy.Yob = 0
+		userCopy.Gender = ""
+	case ScrubStrategyUserBuyerIDOnly:
+		userCopy.BuyerUID = ""
+		userCopy.ID = ""
+	case ScrubStrategyUserAgeAndGender:
 		userCopy.Yob = 0
 		userCopy.Gender = ""
 	}

--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -38,7 +38,7 @@ const (
 type ScrubStrategyUser int
 
 const (
-	// ScrubStrategyUserNone does not remove non-location demographic data.
+	// ScrubStrategyUserNone does not remove non-location data.
 	ScrubStrategyUserNone ScrubStrategyUser = iota
 
 	// ScrubStrategyUserIDAndDemographic removes the user's buyer id, exchange id year of birth, and gender.

--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -46,9 +46,6 @@ const (
 
 	// ScrubStrategyUserID removes the user's buyer id.
 	ScrubStrategyUserID
-
-	// ScrubStrategyUserAgeAndGender renoves the user's year of birth, and gender.
-	ScrubStrategyUserAgeAndGender
 )
 
 // Scrubber removes PII from parts of an OpenRTB request.

--- a/privacy/scrubber_test.go
+++ b/privacy/scrubber_test.go
@@ -225,13 +225,13 @@ func TestScrubDevice(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		result := NewScrubber().ScrubDevice(device, test.ipv6, test.geo)
+		result := NewScrubber().ScrubDevice(device, true, test.ipv6, test.geo)
 		assert.Equal(t, test.expected, result, test.description)
 	}
 }
 
 func TestScrubDeviceNil(t *testing.T) {
-	result := NewScrubber().ScrubDevice(nil, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
+	result := NewScrubber().ScrubDevice(nil, true, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
 	assert.Nil(t, result)
 }
 
@@ -252,7 +252,7 @@ func TestScrubUser(t *testing.T) {
 
 	testCases := []struct {
 		expected    *openrtb.User
-		demographic ScrubStrategyDemographic
+		user        ScrubStrategyUser
 		geo         ScrubStrategyGeo
 		description string
 	}{
@@ -265,8 +265,8 @@ func TestScrubUser(t *testing.T) {
 				Gender:   "",
 				Geo:      &openrtb.Geo{},
 			},
-			demographic: ScrubStrategyDemographicAgeAndGender,
-			geo:         ScrubStrategyGeoFull,
+			user: ScrubStrategyUserFull,
+			geo:  ScrubStrategyGeoFull,
 		},
 		{
 			description: "Demographic Age And Gender & Geo Reduced",
@@ -283,8 +283,8 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			demographic: ScrubStrategyDemographicAgeAndGender,
-			geo:         ScrubStrategyGeoReducedPrecision,
+			user: ScrubStrategyUserFull,
+			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
 			description: "Demographic Age And Gender & Geo None",
@@ -301,8 +301,8 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			demographic: ScrubStrategyDemographicAgeAndGender,
-			geo:         ScrubStrategyGeoNone,
+			user: ScrubStrategyUserFull,
+			geo:  ScrubStrategyGeoNone,
 		},
 		{
 			description: "Demographic None & Geo Full",
@@ -313,8 +313,8 @@ func TestScrubUser(t *testing.T) {
 				Gender:   "anyGender",
 				Geo:      &openrtb.Geo{},
 			},
-			demographic: ScrubStrategyDemographicNone,
-			geo:         ScrubStrategyGeoFull,
+			user: ScrubStrategyUserBuyerIDOnly,
+			geo:  ScrubStrategyGeoFull,
 		},
 		{
 			description: "Demographic None & Geo Reduced",
@@ -331,8 +331,8 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			demographic: ScrubStrategyDemographicNone,
-			geo:         ScrubStrategyGeoReducedPrecision,
+			user: ScrubStrategyUserBuyerIDOnly,
+			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
 			description: "Demographic None & Geo None",
@@ -349,19 +349,19 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			demographic: ScrubStrategyDemographicNone,
-			geo:         ScrubStrategyGeoNone,
+			user: ScrubStrategyUserBuyerIDOnly,
+			geo:  ScrubStrategyGeoNone,
 		},
 	}
 
 	for _, test := range testCases {
-		result := NewScrubber().ScrubUser(user, test.demographic, test.geo)
+		result := NewScrubber().ScrubUser(user, test.user, test.geo)
 		assert.Equal(t, test.expected, result, test.description)
 	}
 }
 
 func TestScrubUserNil(t *testing.T) {
-	result := NewScrubber().ScrubUser(nil, ScrubStrategyDemographicNone, ScrubStrategyGeoNone)
+	result := NewScrubber().ScrubUser(nil, ScrubStrategyUserNone, ScrubStrategyGeoNone)
 	assert.Nil(t, result)
 }
 

--- a/privacy/scrubber_test.go
+++ b/privacy/scrubber_test.go
@@ -287,7 +287,7 @@ func TestScrubUser(t *testing.T) {
 			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "Demographic Age And Gender & Geo None",
+			description: "Demographic Full & Geo None",
 			expected: &openrtb.User{
 				ID:       "",
 				BuyerUID: "",
@@ -305,7 +305,7 @@ func TestScrubUser(t *testing.T) {
 			geo:  ScrubStrategyGeoNone,
 		},
 		{
-			description: "Demographic None & Geo Full",
+			description: "Demographic Buyer ID & Geo Full",
 			expected: &openrtb.User{
 				ID:       "",
 				BuyerUID: "",
@@ -317,7 +317,7 @@ func TestScrubUser(t *testing.T) {
 			geo:  ScrubStrategyGeoFull,
 		},
 		{
-			description: "Demographic None & Geo Reduced",
+			description: "Demographic Buyer ID & Geo Reduced",
 			expected: &openrtb.User{
 				ID:       "",
 				BuyerUID: "",
@@ -335,7 +335,25 @@ func TestScrubUser(t *testing.T) {
 			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "Demographic None & Geo None",
+			description: "Demographic AgeAndGender & Geo None",
+			expected: &openrtb.User{
+				ID:       "anyID",
+				BuyerUID: "anyBuyerUID",
+				Yob:      0,
+				Gender:   "",
+				Geo: &openrtb.Geo{
+					Lat:   123.456,
+					Lon:   678.89,
+					Metro: "some metro",
+					City:  "some city",
+					ZIP:   "some zip",
+				},
+			},
+			user: ScrubStrategyUserAgeAndGender,
+			geo:  ScrubStrategyGeoNone,
+		},
+		{
+			description: "Demographic BuyerIDOnly & Geo None",
 			expected: &openrtb.User{
 				ID:       "",
 				BuyerUID: "",

--- a/privacy/scrubber_test.go
+++ b/privacy/scrubber_test.go
@@ -225,13 +225,13 @@ func TestScrubDevice(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		result := NewScrubber().ScrubDevice(device, true, test.ipv6, test.geo)
+		result := NewScrubber().ScrubDevice(device, test.ipv6, test.geo)
 		assert.Equal(t, test.expected, result, test.description)
 	}
 }
 
 func TestScrubDeviceNil(t *testing.T) {
-	result := NewScrubber().ScrubDevice(nil, true, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
+	result := NewScrubber().ScrubDevice(nil, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
 	assert.Nil(t, result)
 }
 
@@ -265,7 +265,7 @@ func TestScrubUser(t *testing.T) {
 				Gender:   "",
 				Geo:      &openrtb.Geo{},
 			},
-			user: ScrubStrategyUserFull,
+			user: ScrubStrategyUserIDAndDemographic,
 			geo:  ScrubStrategyGeoFull,
 		},
 		{
@@ -283,7 +283,7 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			user: ScrubStrategyUserFull,
+			user: ScrubStrategyUserIDAndDemographic,
 			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
@@ -301,7 +301,7 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			user: ScrubStrategyUserFull,
+			user: ScrubStrategyUserIDAndDemographic,
 			geo:  ScrubStrategyGeoNone,
 		},
 		{
@@ -313,7 +313,7 @@ func TestScrubUser(t *testing.T) {
 				Gender:   "anyGender",
 				Geo:      &openrtb.Geo{},
 			},
-			user: ScrubStrategyUserBuyerIDOnly,
+			user: ScrubStrategyUserID,
 			geo:  ScrubStrategyGeoFull,
 		},
 		{
@@ -331,16 +331,16 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			user: ScrubStrategyUserBuyerIDOnly,
+			user: ScrubStrategyUserID,
 			geo:  ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "Demographic AgeAndGender & Geo None",
+			description: "Demographic None & Geo None",
 			expected: &openrtb.User{
 				ID:       "anyID",
 				BuyerUID: "anyBuyerUID",
-				Yob:      0,
-				Gender:   "",
+				Yob:      42,
+				Gender:   "anyGender",
 				Geo: &openrtb.Geo{
 					Lat:   123.456,
 					Lon:   678.89,
@@ -349,7 +349,7 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			user: ScrubStrategyUserAgeAndGender,
+			user: ScrubStrategyUserNone,
 			geo:  ScrubStrategyGeoNone,
 		},
 		{
@@ -367,7 +367,7 @@ func TestScrubUser(t *testing.T) {
 					ZIP:   "some zip",
 				},
 			},
-			user: ScrubStrategyUserBuyerIDOnly,
+			user: ScrubStrategyUserID,
 			geo:  ScrubStrategyGeoNone,
 		},
 	}


### PR DESCRIPTION
Also note I have restored the ScrubStrategyUserNone even though it is not used in this code. It can be a source of confusion that some things are "silently" scrubbed and will be useful for the TCF 2 PR. The old (recently merged) code depended on the fact that if the scrubber was invoked at all, there were some things we would always scrub. This creates confusion when trying to extend the privacy scrubber, as you have to check in an unexpected place if there are more things that you may or may not want scrubbed in your new use case.