### PR TITLE
Add Go 1.14 Build Target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - '1.12'
   - '1.13'
+  - '1.14'
 
 go_import_path: github.com/prebid/prebid-server
 


### PR DESCRIPTION
Step 1: Fix Go 1.14 compilation and test cases. (Completed By https://github.com/prebid/prebid-server/pull/1271)

Step 2: Add Go 1.14 build target. <- This PR :)

Step 3: Remove Go 1.12 build target. Update Docker image to use 1.14.2. Update docs.