### PR TITLE
AdOcean adapter - Support for sizes defined in prebid configuration.

### DIFF
--- a/adapters/adocean/adocean.go
+++ b/adapters/adocean/adocean.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -19,7 +20,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-const adapterVersion = "1.0.0"
+const adapterVersion = "1.1.0"
 const maxUriLength = 8000
 const measurementCode = `
 	<script>
@@ -49,6 +50,12 @@ type ResponseAdUnit struct {
 	WinURL   string `json:"winUrl"`
 	StatsURL string `json:"statsUrl"`
 	Error    string `json:"error"`
+}
+
+type requestData struct {
+	Url        string
+	Headers    *http.Header
+	SlaveSizes map[string]string
 }
 
 func NewAdOceanBidder(client *http.Client, endpointTemplateString string) *AdOceanAdapter {
@@ -89,44 +96,58 @@ func (a *AdOceanAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 		}
 	}
 
-	var httpRequests []*adapters.RequestData
 	var errors []error
-
+	requestsData := make([]*requestData, 0, len(request.Imp))
 	for _, auction := range request.Imp {
-		newHttpRequest, err := a.makeRequest(httpRequests, &auction, request, consentString)
+		err := a.addNewBid(&requestsData, &auction, request, consentString)
 		if err != nil {
 			errors = append(errors, err)
-		} else if newHttpRequest != nil {
-			httpRequests = append(httpRequests, newHttpRequest)
 		}
+	}
+
+	httpRequests := make([]*adapters.RequestData, 0, len(requestsData))
+	for _, requestData := range requestsData {
+		httpRequests = append(httpRequests, &adapters.RequestData{
+			Method:  "GET",
+			Uri:     requestData.Url,
+			Headers: *requestData.Headers,
+		})
 	}
 
 	return httpRequests, errors
 }
 
-func (a *AdOceanAdapter) makeRequest(existingRequests []*adapters.RequestData, imp *openrtb.Imp, request *openrtb.BidRequest, consentString string) (*adapters.RequestData, error) {
+func (a *AdOceanAdapter) addNewBid(
+	requestsData *[]*requestData,
+	imp *openrtb.Imp,
+	request *openrtb.BidRequest,
+	consentString string,
+) error {
 	var bidderExt adapters.ExtImpBidder
 	if err := json.Unmarshal(imp.Ext, &bidderExt); err != nil {
-		return nil, &errortypes.BadInput{
+		return &errortypes.BadInput{
 			Message: "Error parsing bidderExt object",
 		}
 	}
 
 	var adOceanExt openrtb_ext.ExtImpAdOcean
 	if err := json.Unmarshal(bidderExt.Bidder, &adOceanExt); err != nil {
-		return nil, &errortypes.BadInput{
+		return &errortypes.BadInput{
 			Message: "Error parsing adOceanExt parameters",
 		}
 	}
 
-	addedToExistingRequest := addToExistingRequest(existingRequests, &adOceanExt, imp.ID)
+	addedToExistingRequest := addToExistingRequest(*requestsData, &adOceanExt, imp, (request.Test == 1))
 	if addedToExistingRequest {
-		return nil, nil
+		return nil
 	}
 
-	url, err := a.makeURL(&adOceanExt, imp.ID, request, consentString)
+	slaveSizes := map[string]string{}
+	slaveSizes[adOceanExt.SlaveID] = getImpSizes(imp)
+
+	url, err := a.makeURL(&adOceanExt, imp, request, slaveSizes, consentString)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	headers := http.Header{}
@@ -147,43 +168,52 @@ func (a *AdOceanAdapter) makeRequest(existingRequests []*adapters.RequestData, i
 		headers.Add("Referer", request.Site.Page)
 	}
 
-	return &adapters.RequestData{
-		Method:  "GET",
-		Uri:     url,
-		Headers: headers,
-	}, nil
+	*requestsData = append(*requestsData, &requestData{
+		Url:        url,
+		Headers:    &headers,
+		SlaveSizes: slaveSizes,
+	})
+
+	return nil
 }
 
-func addToExistingRequest(existingRequests []*adapters.RequestData, newParams *openrtb_ext.ExtImpAdOcean, auctionID string) bool {
-requestsLoop:
-	for _, request := range existingRequests {
-		endpointURL, _ := url.Parse(request.Uri)
-		queryParams := endpointURL.Query()
+func addToExistingRequest(requestsData []*requestData, newParams *openrtb_ext.ExtImpAdOcean, imp *openrtb.Imp, testImp bool) bool {
+	auctionID := imp.ID
+
+	for _, requestData := range requestsData {
+		endpointUrl, _ := url.Parse(requestData.Url)
+		queryParams := endpointUrl.Query()
 		masterID := queryParams["id"][0]
 
 		if masterID == newParams.MasterID {
-			aids := queryParams["aid"]
-			for _, aid := range aids {
-				slaveID := strings.SplitN(aid, ":", 2)[0]
-				if slaveID == newParams.SlaveID {
-					continue requestsLoop
-				}
+			if _, has := requestData.SlaveSizes[newParams.SlaveID]; has {
+				continue
 			}
 
 			queryParams.Add("aid", newParams.SlaveID+":"+auctionID)
-			endpointURL.RawQuery = queryParams.Encode()
-			newUri := endpointURL.String()
+			requestData.SlaveSizes[newParams.SlaveID] = getImpSizes(imp)
+			setSlaveSizesParam(&queryParams, requestData.SlaveSizes, testImp)
+			endpointUrl.RawQuery = queryParams.Encode()
+			newUri := endpointUrl.String()
 			if len(newUri) < maxUriLength {
-				request.Uri = newUri
+				requestData.Url = newUri
 				return true
 			}
+
+			delete(requestData.SlaveSizes, newParams.SlaveID)
 		}
 	}
 
 	return false
 }
 
-func (a *AdOceanAdapter) makeURL(params *openrtb_ext.ExtImpAdOcean, auctionID string, request *openrtb.BidRequest, consentString string) (string, error) {
+func (a *AdOceanAdapter) makeURL(
+	params *openrtb_ext.ExtImpAdOcean,
+	imp *openrtb.Imp,
+	request *openrtb.BidRequest,
+	slaveSizes map[string]string,
+	consentString string,
+) (string, error) {
 	endpointParams := macros.EndpointTemplateParams{Host: params.EmitterDomain}
 	host, err := macros.ResolveMacros(a.endpointTemplate, endpointParams)
 	if err != nil {
@@ -205,6 +235,7 @@ func (a *AdOceanAdapter) makeURL(params *openrtb_ext.ExtImpAdOcean, auctionID st
 	}
 	endpointURL.Path = "/_" + strconv.Itoa(randomizedPart) + "/ad.json"
 
+	auctionID := imp.ID
 	queryParams := url.Values{}
 	queryParams.Add("pbsrv_v", adapterVersion)
 	queryParams.Add("id", params.MasterID)
@@ -218,9 +249,58 @@ func (a *AdOceanAdapter) makeURL(params *openrtb_ext.ExtImpAdOcean, auctionID st
 	if request.User != nil && request.User.BuyerUID != "" {
 		queryParams.Add("hcuserid", request.User.BuyerUID)
 	}
+
+	setSlaveSizesParam(&queryParams, slaveSizes, (request.Test == 1))
 	endpointURL.RawQuery = queryParams.Encode()
 
 	return endpointURL.String(), nil
+}
+
+func getImpSizes(imp *openrtb.Imp) string {
+	if imp.Banner == nil {
+		return ""
+	}
+
+	if len(imp.Banner.Format) > 0 {
+		sizes := make([]string, len(imp.Banner.Format))
+		for i, format := range imp.Banner.Format {
+			sizes[i] = strconv.FormatUint(format.W, 10) + "x" + strconv.FormatUint(format.H, 10)
+		}
+
+		return strings.Join(sizes, "_")
+	}
+
+	if imp.Banner.W != nil && imp.Banner.H != nil {
+		return strconv.FormatUint(*imp.Banner.W, 10) + "x" + strconv.FormatUint(*imp.Banner.H, 10)
+	}
+
+	return ""
+}
+
+func setSlaveSizesParam(queryParams *url.Values, slaveSizes map[string]string, orderByKey bool) {
+	sizeValues := make([]string, 0, len(slaveSizes))
+	slaveIDs := make([]string, 0, len(slaveSizes))
+	for k := range slaveSizes {
+		slaveIDs = append(slaveIDs, k)
+	}
+
+	if orderByKey {
+		sort.Strings(slaveIDs)
+	}
+
+	for _, slaveID := range slaveIDs {
+		sizes := slaveSizes[slaveID]
+		if sizes == "" {
+			continue
+		}
+
+		rawSlaveID := strings.Replace(slaveID, "adocean", "", 1)
+		sizeValues = append(sizeValues, rawSlaveID+"~"+sizes)
+	}
+
+	if len(sizeValues) > 0 {
+		queryParams.Set("aosspsizes", strings.Join(sizeValues, "-"))
+	}
 }
 
 func (a *AdOceanAdapter) MakeBids(

--- a/adapters/adocean/adoceantest/exemplary/multi-banner-impression.json
+++ b/adapters/adocean/adoceantest/exemplary/multi-banner-impression.json
@@ -18,6 +18,9 @@
         "format": [{
           "w": 300,
           "h": 250
+        }, {
+          "w": 320,
+          "h": 600
         }]
       }
     }, {
@@ -68,7 +71,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Asecod-twelve&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Asecod-twelve&aosspsizes=myaowafpdwlrks~300x250-myaozpniqismex~300x250_320x600&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
     },
     "mockResponse": {
       "status": 200,

--- a/adapters/adocean/adoceantest/exemplary/single-banner-impression.json
+++ b/adapters/adocean/adoceantest/exemplary/single-banner-impression.json
@@ -59,7 +59,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+        "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aosspsizes=myaozpniqismex~300x250&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
       },
       "mockResponse": {
         "status": 200,

--- a/adapters/adocean/adoceantest/supplemental/bad-response.json
+++ b/adapters/adocean/adoceantest/supplemental/bad-response.json
@@ -49,7 +49,7 @@
   "httpCalls": [
     {
         "expectedRequest": {
-          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aosspsizes=myaozpniqismex~300x250&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
         },
       "mockResponse": {
         "status": 200,

--- a/adapters/adocean/adoceantest/supplemental/encode-error.json
+++ b/adapters/adocean/adoceantest/supplemental/encode-error.json
@@ -49,7 +49,7 @@
   "httpCalls": [
     {
         "expectedRequest": {
-          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aosspsizes=myaozpniqismex~300x250&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
         },
       "mockResponse": {
         "status": 200,

--- a/adapters/adocean/adoceantest/supplemental/network-error.json
+++ b/adapters/adocean/adoceantest/supplemental/network-error.json
@@ -49,7 +49,7 @@
   "httpCalls": [
     {
         "expectedRequest": {
-          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+          "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aosspsizes=myaozpniqismex~300x250&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
         },
       "mockResponse": {
         "status": 500,

--- a/adapters/adocean/adoceantest/supplemental/no-sizes.json
+++ b/adapters/adocean/adoceantest/supplemental/no-sizes.json
@@ -13,12 +13,6 @@
           "masterId": "tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7",
           "slaveId": "adoceanmyaozpniqismex"
         }
-      },
-      "banner": {
-        "format": [{
-          "w": 300,
-          "h": 250
-        }]
       }
     }, {
       "id": "ao-test-two",
@@ -30,10 +24,7 @@
         }
       },
       "banner": {
-        "format": [{
-          "w": 300,
-          "h": 250
-        }]
+        "format": []
       }
     }, {
       "id": "ao-test-three",
@@ -45,10 +36,8 @@
         }
       },
       "banner": {
-        "format": [{
-          "w": 300,
-          "h": 250
-        }]
+        "w": 300,
+        "h": 250
       }
     }],
     "test": 1,
@@ -83,13 +72,22 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Aao-test-two&aosspsizes=myaowafpdwlrks~300x250-myaozpniqismex~300x250&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
+      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Aao-test-two&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
     },
     "mockResponse": {
       "status": 200,
       "body": [{
           "id": "adoceanmyaozpniqismex",
-          "error": "true"
+          "price": "1",
+          "winurl": "https://win-url.com",
+          "statsUrl": "https://stats-url.com",
+          "code": " <!-- code 1 --> ",
+          "currency": "EUR",
+          "minFloorPrice": "0.01",
+          "width": "300",
+          "height": "250",
+          "crid": "0af345b42983cc4bc0",
+          "ttl": "300"
         },
         {
           "id": "adoceanmyaowafpdwlrks",
@@ -130,6 +128,17 @@
   "expectedBidResponses": [{
     "currency": "EUR",
     "bids": [{
+      "bid": {
+        "id": "adoceanmyaozpniqismex",
+        "impid": "ao-test",
+        "price": 1,
+        "adm": " <script> +function() { var wu = \"https://win-url.com\"; var su = \"https://stats-url.com\".replace(/\\[TIMESTAMP\\]/, Date.now()); if (wu && !(navigator.sendBeacon && navigator.sendBeacon(wu))) { (new Image(1,1)).src = wu } if (su && !(navigator.sendBeacon && navigator.sendBeacon(su))) { (new Image(1,1)).src = su } }(); </script>  <!-- code 1 --> ",
+        "crid": "0af345b42983cc4bc0",
+        "w": 300,
+        "h": 250
+      },
+      "type": "banner"
+    }, {
       "bid": {
         "id": "adoceanmyaowafpdwlrks",
         "impid": "ao-test-two",

--- a/adapters/adocean/adoceantest/supplemental/requests-merge.json
+++ b/adapters/adocean/adoceantest/supplemental/requests-merge.json
@@ -83,7 +83,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Aao-test-two&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaozpniqismex%3Aao-test&aid=adoceanmyaowafpdwlrks%3Aao-test-two&aosspsizes=myaowafpdwlrks~300x250-myaozpniqismex~300x250&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
     },
     "mockResponse": {
       "status": 200,
@@ -117,7 +117,7 @@
     }
   }, {
     "expectedRequest": {
-      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaowafpdwlrks%3Aao-test-three&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.0.0"
+      "uri": "https://myao.adocean.pl/_10000000/ad.json?aid=adoceanmyaowafpdwlrks%3Aao-test-three&aosspsizes=myaowafpdwlrks~300x250&gdpr=1&gdpr_consent=COwK6gaOwK6gaFmAAAENAPCAAAAAAAAAAAAAAAAAAAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw&id=tmYF.DMl7ZBq.Nqt2Bq4FutQTJfTpxCOmtNPZoQUDcL.G7&nc=1&nosecure=1&pbsrv_v=1.1.0"
     },
     "mockResponse": {
       "status": 200,


### PR DESCRIPTION
Support for sizes defined in Prebid.js configuration. Previously only sizes defined on SSP side were taken into account, the ones from Prebid was ignored.