### PR TITLE
Triplelift: Add SRA Support

### DIFF
--- a/adapters/triplelift/triplelift_test.go
+++ b/adapters/triplelift/triplelift_test.go
@@ -6,5 +6,5 @@ import (
 )
 
 func TestJsonSamples(t *testing.T) {
-	adapterstest.RunJSONBidderTest(t, "triplelifttest", NewTripleliftBidder(nil, "http://tlx.3lift.net/s2s/auction?supplier_id=20"))
+	adapterstest.RunJSONBidderTest(t, "triplelifttest", NewTripleliftBidder(nil, "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20"))
 }

--- a/adapters/triplelift/triplelifttest/exemplary/optional-params.json
+++ b/adapters/triplelift/triplelifttest/exemplary/optional-params.json
@@ -28,7 +28,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/triplelift/triplelifttest/exemplary/simple-banner.json
+++ b/adapters/triplelift/triplelifttest/exemplary/simple-banner.json
@@ -27,7 +27,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/triplelift/triplelifttest/exemplary/simple-video.json
+++ b/adapters/triplelift/triplelifttest/exemplary/simple-video.json
@@ -122,7 +122,7 @@
             "adomain": [
               "foo.com"
             ],
-            "iurl": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+            "iurl": "http://tlx.3lift.net/s2s/auction?sra=1supplier_id=20",
             "cid": "958",
             "crid": "29681110",
             "w": 300,

--- a/adapters/triplelift/triplelifttest/exemplary/simple-video.json
+++ b/adapters/triplelift/triplelifttest/exemplary/simple-video.json
@@ -33,7 +33,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [
@@ -85,7 +85,7 @@
                   "adomain": [
                     "foo.com"
                   ],
-                  "iurl": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+                  "iurl": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
                   "cid": "958",
                   "crid": "29681110",
                   "h": 250,

--- a/adapters/triplelift/triplelifttest/exemplary/simple-video.json
+++ b/adapters/triplelift/triplelifttest/exemplary/simple-video.json
@@ -122,7 +122,7 @@
             "adomain": [
               "foo.com"
             ],
-            "iurl": "http://tlx.3lift.net/s2s/auction?sra=1supplier_id=20",
+            "iurl": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
             "cid": "958",
             "crid": "29681110",
             "w": 300,

--- a/adapters/triplelift/triplelifttest/supplemental/badresponseext.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badresponseext.json
@@ -27,7 +27,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/triplelift/triplelifttest/supplemental/badstatuscode.json
+++ b/adapters/triplelift/triplelifttest/supplemental/badstatuscode.json
@@ -27,7 +27,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/triplelift/triplelifttest/supplemental/notgoodstatuscode.json
+++ b/adapters/triplelift/triplelifttest/supplemental/notgoodstatuscode.json
@@ -27,7 +27,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tlx.3lift.net/s2s/auction?supplier_id=20",
+        "uri": "http://tlx.3lift.net/s2s/auction?sra=1&supplier_id=20",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/triplelift_native/triplelift_native_test.go
+++ b/adapters/triplelift_native/triplelift_native_test.go
@@ -19,5 +19,5 @@ func TestBadConfig(t *testing.T) {
 }
 
 func TestJsonSamples(t *testing.T) {
-	adapterstest.RunJSONBidderTest(t, "triplelift_nativetest", NewTripleliftNativeBidder(nil, "http://tlx.3lift.net/s2sn/auction?supplier_id=20", "{\"publisher_whitelist\":[\"foo\",\"bar\",\"baz\"]}"))
+	adapterstest.RunJSONBidderTest(t, "triplelift_nativetest", NewTripleliftNativeBidder(nil, "http://tlx.3lift.net/s2sn/auction?sra=1&supplier_id=20", "{\"publisher_whitelist\":[\"foo\",\"bar\",\"baz\"]}"))
 }

--- a/adapters/triplelift_native/triplelift_native_test.go
+++ b/adapters/triplelift_native/triplelift_native_test.go
@@ -19,5 +19,5 @@ func TestBadConfig(t *testing.T) {
 }
 
 func TestJsonSamples(t *testing.T) {
-	adapterstest.RunJSONBidderTest(t, "triplelift_nativetest", NewTripleliftNativeBidder(nil, "http://tlx.3lift.net/s2sn/auction?sra=1&supplier_id=20", "{\"publisher_whitelist\":[\"foo\",\"bar\",\"baz\"]}"))
+	adapterstest.RunJSONBidderTest(t, "triplelift_nativetest", NewTripleliftNativeBidder(nil, "http://tlx.3lift.net/s2sn/auction?supplier_id=20", "{\"publisher_whitelist\":[\"foo\",\"bar\",\"baz\"]}"))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -805,7 +805,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.telaria.endpoint", "https://ads.tremorhub.com/ad/rtb/prebid")
 	v.SetDefault("adapters.triplelift_native.disabled", true)
 	v.SetDefault("adapters.triplelift_native.extra_info", "{\"publisher_whitelist\":[]}")
-	v.SetDefault("adapters.triplelift.endpoint", "https://tlx.3lift.com/s2s/auction?supplier_id=20")
+	v.SetDefault("adapters.triplelift.endpoint", "https://tlx.3lift.com/s2s/auction?sra=1&supplier_id=20")
 	v.SetDefault("adapters.ucfunnel.endpoint", "http://apac-hk-adx.aralego.com/prebid")
 	v.SetDefault("adapters.unruly.endpoint", "http://targeting.unrulymedia.com/openrtb/2.2")
 	v.SetDefault("adapters.valueimpression.endpoint", "https://rtb.valueimpression.com/endpoint")


### PR DESCRIPTION
- Adds SRA support by appending `sra=1` param to Triplelift endpoint in config.go for /s2s endpoint
- Edits all references to include `sra=1`