### PR TITLE
Consumable: Correct bid type, should always be "banner".

### DIFF
--- a/adapters/consumable/consumable.go
+++ b/adapters/consumable/consumable.go
@@ -269,7 +269,7 @@ func (a *ConsumableAdapter) MakeBids(
 
 			bidderResponse.Bids = append(bidderResponse.Bids, &adapters.TypedBid{
 				Bid:     &bid,
-				BidType: getMediaTypeForImp(getImp(bid.ImpID, internalRequest.Imp)),
+				BidType: openrtb_ext.BidTypeBanner,
 			})
 		}
 	}
@@ -301,16 +301,6 @@ func extractExtensions(impression openrtb.Imp) (*adapters.ExtImpBidder, *openrtb
 	}
 
 	return &bidderExt, &consumableExt, nil
-}
-
-func getMediaTypeForImp(imp *openrtb.Imp) openrtb_ext.BidType {
-	// TODO: Whatever logic we need here possibly as follows - may always be Video when we bid
-	if imp.Banner != nil {
-		return openrtb_ext.BidTypeBanner
-	} else if imp.Video != nil {
-		return openrtb_ext.BidTypeVideo
-	}
-	return openrtb_ext.BidTypeVideo
 }
 
 func testConsumableBidder(testClock instant, endpoint string) *ConsumableAdapter {

--- a/adapters/consumable/consumable.go
+++ b/adapters/consumable/consumable.go
@@ -268,7 +268,10 @@ func (a *ConsumableAdapter) MakeBids(
 			//bid.referrer = utils.getTopWindowUrl();
 
 			bidderResponse.Bids = append(bidderResponse.Bids, &adapters.TypedBid{
-				Bid:     &bid,
+				Bid: &bid,
+				// Consumable units are always HTML, never VAST.
+				// From Prebid's point of view, this means that Consumable units
+				// are always "banners".
 				BidType: openrtb_ext.BidTypeBanner,
 			})
 		}


### PR DESCRIPTION
I am raising this PR on behalf of Consumable, CC @naffis.

This PR (hopefully) fixes issue #862 for Consumable, where the Consumable adapter would respond incorrectly when bidding on multi-format slots.

My understanding is that `BidTypeVideo` is for VAST units.

Consumable units are always HTML, never VAST. Sometimes the HTML unit itself embeds video, but my understanding is that from Prebid's point of view the `BidType` for that unit is still `BidTypeBanner`.

Therefore my understanding is that Consumable units are always `BidTypeBanner`.

Please let me know if my understanding is incorrect. I found the documentation for this quite difficult to understand.