### PR TITLE
Empty seatBid.httpcalls when adapter modifies request test flag

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -104,6 +104,7 @@ type bidderAdapter struct {
 }
 
 func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions, reqInfo *adapters.ExtraRequestInfo) (*pbsOrtbSeatBid, []error) {
+	testFlag := request.Test == 1
 	reqData, errs := bidder.Bidder.MakeRequests(request, reqInfo)
 
 	if len(reqData) == 0 {
@@ -139,7 +140,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb.Bi
 	for i := 0; i < len(reqData); i++ {
 		httpInfo := <-responseChannel
 		// If this is a test bid, capture debugging info from the requests.
-		if request.Test == 1 {
+		if testFlag {
 			seatBid.httpCalls = append(seatBid.httpCalls, makeExt(httpInfo))
 		}
 


### PR DESCRIPTION
Issue #1334 exposed the inability of **Prebid Server** to record `*openrtb_ext.ExtHttpCall` information into the `pbsOrtbSeatBid` objects when a particular adapter's `MakeRequests()` implementation overrides the `openrtb.BidRequest` `Test` flag value. This PR attempts to correct this bug by recording the `Test` flag before  the `MakeRequests()` call in order to avoid adding unnecessary parameters.