### PR TITLE
 BidResponseのCurrencyをBidRequestに合わせる

### DIFF
--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -210,6 +210,7 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb.BidRequest, ex
 				Bid:     &bid,
 				BidType: bitType,
 			})
+			bidResponse.Currency = adg.getCurrency(internalRequest)
 			return bidResponse, nil
 		}
 	}


### PR DESCRIPTION
```
In adapters/adgeneration/adgenerationtest/exemplary/single-banner.json:
> +                        "viewable_imp": [
+                            "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
+                        ],
+                        "viewable_measured": [
+                            "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
+                        ]
+                    },
+                    "ttl": 10,
+                    "w": 300
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+          "currency": "JPY",
Does this currency really expected ?
Because go tests not checking for this value (you can change it to smth else and test still PASS).
USD is the actual currency that was returned.
```

私自身の設定ミスなので修正しました

test_json.go 125行目
```
	for i := 0; i < len(spec.BidResponses); i++ {
		diffStrings(t, "check Currency", bidResponses[i].Currency, spec.BidResponses[i].C)
		diffBidLists(t, filename, bidResponses[i].Bids, spec.BidResponses[i].Bids)
	}
}
```

で、修正前がUSD、修正後がJPY担っていることも確認済み