### PR TITLE
Lazy FileFetcher (#1402)

### DIFF
--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -939,6 +939,10 @@ func (cf *mockAmpStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs
 	return cf.data, nil, nil
 }
 
+func (cf mockAmpStoredReqFetcher) FetchAllRequests(ctx context.Context) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	return cf.data, nil, nil
+}
+
 type mockAmpExchange struct {
 	lastRequest *openrtb.BidRequest
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1716,6 +1716,10 @@ func (cf mockStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs []s
 	return testStoredRequestData, testStoredImpData, nil
 }
 
+func (cf mockStoredReqFetcher) FetchAllRequests(ctx context.Context) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	return testStoredRequestData, testStoredImpData, nil
+}
+
 type mockExchange struct {
 	lastRequest *openrtb.BidRequest
 }

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -1270,6 +1270,10 @@ func (cf mockVideoStoredReqFetcher) FetchRequests(ctx context.Context, requestID
 	return testVideoStoredRequestData, testVideoStoredImpData, nil
 }
 
+func (cf mockVideoStoredReqFetcher) FetchAllRequests(ctx context.Context) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	return testVideoStoredRequestData, testVideoStoredImpData, nil
+}
+
 type mockExchangeVideo struct {
 	lastRequest *openrtb.BidRequest
 	cache       *mockCacheClient

--- a/stored_requests/backends/empty_fetcher/fetcher.go
+++ b/stored_requests/backends/empty_fetcher/fetcher.go
@@ -3,6 +3,7 @@ package empty_fetcher
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/prebid/prebid-server/stored_requests"
 )
 
@@ -27,6 +28,14 @@ func (fetcher EmptyFetcher) FetchRequests(ctx context.Context, requestIDs []stri
 	return
 }
 
+func (fetcher EmptyFetcher) FetchAllRequests(ctx context.Context) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	return
+}
+
 func (fetcher EmptyFetcher) FetchCategories(ctx context.Context, primaryAdServer, publisherId, iabCategory string) (string, error) {
 	return "", nil
+}
+
+func (fetcher EmptyFetcher) FetchAllCategories(ctx context.Context) (categories map[string]json.RawMessage, errs []error) {
+	return
 }

--- a/stored_requests/events/files/files.go
+++ b/stored_requests/events/files/files.go
@@ -1,0 +1,46 @@
+package files
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/stored_requests"
+	"github.com/prebid/prebid-server/stored_requests/backends/file_fetcher"
+	"github.com/prebid/prebid-server/stored_requests/events"
+)
+
+type fileEventProducer struct {
+	invalidations chan events.Invalidation
+	saves         chan events.Save
+}
+
+func (f *fileEventProducer) Saves() <-chan events.Save {
+	return f.saves
+}
+func (f *fileEventProducer) Invalidations() <-chan events.Invalidation {
+	return nil
+}
+
+// NewFilesLoader returns an EventProducer preloaded with all the stored reqs+imps
+func NewFilesLoader(cfg config.FileFetcherConfig) events.EventProducer {
+	fp := &fileEventProducer{
+		saves: make(chan events.Save, 1),
+	}
+	if fetcher, err := file_fetcher.NewFileFetcher(cfg.Path); err == nil {
+		reqData, impData, errs := fetcher.(stored_requests.Fetcher).FetchAllRequests(context.Background())
+		if len(reqData) > 0 || len(impData) > 0 {
+			fp.saves <- events.Save{
+				Requests: reqData,
+				Imps:     impData,
+			}
+		}
+		for _, err := range errs {
+			glog.Warning(err.Error())
+		}
+	} else {
+		glog.Warningf("Failed to prefetch files from %s: %v", cfg.Path, err)
+		close(fp.saves)
+	}
+	return fp
+}

--- a/stored_requests/events/files/files_test.go
+++ b/stored_requests/events/files/files_test.go
@@ -1,0 +1,21 @@
+package files
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFilesLoader(t *testing.T) {
+	ev := NewFilesLoader(config.FileFetcherConfig{
+		Path: "../../backends/file_fetcher/test",
+	})
+	theSave := <-ev.Saves()
+
+	assert.Equal(t, 2, len(theSave.Requests))
+	assert.JSONEq(t, `{"test":"foo"}`, string(theSave.Requests["1"]))
+
+	assert.Equal(t, len(theSave.Imps), 1)
+	assert.JSONEq(t, `{"imp":true}`, string(theSave.Imps["some-imp"]))
+}


### PR DESCRIPTION
Replaces the eager file fetcher for stored requests and categories with a lazy one.
This allows the cache layer to work and control refresh intervals for stored requests, but not for categories yet.

This configuration now works to cache files with the given settings. Before the change, it would cache data that is already in memory.
```yaml
stored_requests:
  filesystem: true
  directorypath: "./stored_requests/data/by_id"
  in_memory_cache:
    type: lru
    ttl_seconds: 10
    request_cache_size_bytes: 1000
    imp_cache_size_bytes: 5000
```
