### PR TITLE
Add IPv6 Non-Public Network

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -890,13 +890,14 @@ func SetupViper(v *viper.Viper, filename string) {
 	/*  Loopback:   127.0.0.0/8
 	/*
 	/* IPv6
-	/*  Loopback:     ::1/128
-	/*  Unique Local: fc00::/7
-	/*  Link Local:   fe80::/10
-	/*  Multicast:    ff00::/8
+	/*  Loopback:      ::1/128
+	/*  Documentation: 2001:db8::/32
+	/*  Unique Local:  fc00::/7
+	/*  Link Local:    fe80::/10
+	/*  Multicast:     ff00::/8
 	*/
 	v.SetDefault("request_validation.ipv4_private_networks", []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "127.0.0.0/8"})
-	v.SetDefault("request_validation.ipv6_private_networks", []string{"::1/128", "fc00::/7", "fe80::/10", "ff00::/8"})
+	v.SetDefault("request_validation.ipv6_private_networks", []string{"::1/128", "fc00::/7", "fe80::/10", "ff00::/8", "2001:db8::/32"})
 
 	// Set environment variable support:
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))


### PR DESCRIPTION
Update IPv6 private network list to include the documentation range. We're reportedly seeing it in the wild.