### PR TITLE
Cache refactor

### DIFF
--- a/stored_requests/caches/memory/cache.go
+++ b/stored_requests/caches/memory/cache.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/coocood/freecache"
 	"github.com/golang/glog"
-	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/stored_requests"
 )
 
@@ -17,68 +16,51 @@ import (
 // 2. The cache is too large. This will cause the least recently used items to be evicted.
 //
 // For no TTL, use ttlSeconds <= 0
-func NewCache(cfg *config.InMemoryCache) stored_requests.Cache {
-	return &cache{
-		requestDataCache: newCacheForWithLimits(cfg.RequestCacheSize, cfg.TTL, "Request"),
-		impDataCache:     newCacheForWithLimits(cfg.ImpCacheSize, cfg.TTL, "Imp"),
-	}
-}
-
-func newCacheForWithLimits(size int, ttl int, dataType string) mapLike {
+func NewCache(size int, ttl int, dataType string) stored_requests.CacheJSON {
 	if ttl > 0 && size <= 0 {
-		glog.Fatal("No in-memory caches defined with a finite TTL but unbounded size. Config validation should have caught this. Failing fast because something is buggy.")
+		glog.Fatalf("No in-memory %s caches defined with a finite TTL but unbounded size. Config validation should have caught this. Failing fast because something is buggy.", dataType)
 	}
 	if size > 0 {
 		glog.Infof("Using a Stored %s in-memory cache. Max size: %d bytes. TTL: %d seconds.", dataType, size, ttl)
-		return &pbsLRUCache{
-			Cache:      freecache.NewCache(size),
-			ttlSeconds: ttl,
+		return &cache{
+			dataType: dataType,
+			cache: &pbsLRUCache{
+				Cache:      freecache.NewCache(size),
+				ttlSeconds: ttl,
+			},
 		}
 	} else {
 		glog.Infof("Using an unbounded Stored %s in-memory cache.", dataType)
-		return &pbsSyncMap{&sync.Map{}}
+		return &cache{
+			dataType: dataType,
+			cache:    &pbsSyncMap{&sync.Map{}},
+		}
 	}
 }
 
 type cache struct {
-	requestDataCache mapLike
-	impDataCache     mapLike
+	dataType string
+	cache    mapLike
 }
 
-func (c *cache) Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
-	requestData = doGet(c.requestDataCache, requestIDs)
-	impData = doGet(c.impDataCache, impIDs)
-	return
-}
-
-func doGet(cache mapLike, ids []string) (data map[string]json.RawMessage) {
+func (c *cache) Get(ctx context.Context, ids []string) (data map[string]json.RawMessage) {
 	data = make(map[string]json.RawMessage, len(ids))
 	for _, id := range ids {
-		if val, ok := cache.Get(id); ok {
+		if val, ok := c.cache.Get(id); ok {
 			data[id] = val
 		}
 	}
 	return
 }
 
-func (c *cache) Save(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage) {
-	c.doSave(c.requestDataCache, storedRequests)
-	c.doSave(c.impDataCache, storedImps)
-}
-
-func (c *cache) doSave(cache mapLike, values map[string]json.RawMessage) {
-	for id, data := range values {
-		cache.Set(id, data)
+func (c *cache) Save(ctx context.Context, data map[string]json.RawMessage) {
+	for id, data := range data {
+		c.cache.Set(id, data)
 	}
 }
 
-func (c *cache) Invalidate(ctx context.Context, requestIDs []string, impIDs []string) {
-	doInvalidate(c.requestDataCache, requestIDs)
-	doInvalidate(c.impDataCache, impIDs)
-}
-
-func doInvalidate(cache mapLike, ids []string) {
+func (c *cache) Invalidate(ctx context.Context, ids []string) {
 	for _, id := range ids {
-		cache.Delete(id)
+		c.cache.Delete(id)
 	}
 }

--- a/stored_requests/caches/nil_cache/nil_cache.go
+++ b/stored_requests/caches/nil_cache/nil_cache.go
@@ -8,13 +8,14 @@ import (
 // NilCache is a no-op cache which does nothing useful.
 type NilCache struct{}
 
-func (c *NilCache) Get(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage) {
-	return nil, nil
+func (c *NilCache) Get(ctx context.Context, ids []string) map[string]json.RawMessage {
+	return make(map[string]json.RawMessage)
 }
-func (c *NilCache) Save(ctx context.Context, storedRequests map[string]json.RawMessage, storedImps map[string]json.RawMessage) {
+
+func (c *NilCache) Save(ctx context.Context, data map[string]json.RawMessage) {
 	return
 }
 
-func (c *NilCache) Invalidate(ctx context.Context, requestIDs []string, impIDs []string) {
+func (c *NilCache) Invalidate(ctx context.Context, ids []string) {
 	return
 }

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -178,10 +178,13 @@ func newFetcher(cfg *config.StoredRequests, client *http.Client, db *sql.DB) (fe
 func newCache(cfg *config.StoredRequests) stored_requests.Cache {
 	if cfg.InMemoryCache.Type == "none" {
 		glog.Infof("No Stored %s cache configured. The %s Fetcher backend will be used for all data requests", cfg.DataType(), cfg.DataType())
-		return &nil_cache.NilCache{}
+		return stored_requests.Cache{&nil_cache.NilCache{}, &nil_cache.NilCache{}}
 	}
 
-	return memory.NewCache(&cfg.InMemoryCache)
+	return stored_requests.Cache{
+		Requests: memory.NewCache(cfg.InMemoryCache.RequestCacheSize, cfg.InMemoryCache.TTL, "Requests"),
+		Imps:     memory.NewCache(cfg.InMemoryCache.ImpCacheSize, cfg.InMemoryCache.TTL, "Imps"),
+	}
 }
 
 func newEventProducers(cfg *config.StoredRequests, client *http.Client, db *sql.DB, router *httprouter.Router) (eventProducers []events.EventProducer) {

--- a/stored_requests/config/config_test.go
+++ b/stored_requests/config/config_test.go
@@ -102,8 +102,8 @@ func TestNewHTTPEvents(t *testing.T) {
 
 func TestNewEmptyCache(t *testing.T) {
 	cache := newCache(&config.StoredRequests{InMemoryCache: config.InMemoryCache{Type: "none"}})
-	cache.Save(context.Background(), map[string]json.RawMessage{"foo": json.RawMessage("true")}, nil)
-	reqs, _ := cache.Get(context.Background(), []string{"foo"}, nil)
+	cache.Requests.Save(context.Background(), map[string]json.RawMessage{"foo": json.RawMessage("true")})
+	reqs := cache.Requests.Get(context.Background(), []string{"foo"})
 	if len(reqs) != 0 {
 		t.Errorf("The newCache method should return an empty cache if the config asks for it.")
 	}
@@ -117,8 +117,8 @@ func TestNewInMemoryCache(t *testing.T) {
 			ImpCacheSize:     100,
 		},
 	})
-	cache.Save(context.Background(), map[string]json.RawMessage{"foo": json.RawMessage("true")}, nil)
-	reqs, _ := cache.Get(context.Background(), []string{"foo"}, nil)
+	cache.Requests.Save(context.Background(), map[string]json.RawMessage{"foo": json.RawMessage("true")})
+	reqs := cache.Requests.Get(context.Background(), []string{"foo"})
 	if len(reqs) != 1 {
 		t.Errorf("The newCache method should return an in-memory cache if the config asks for it.")
 	}

--- a/stored_requests/events/api/api_test.go
+++ b/stored_requests/events/api/api_test.go
@@ -9,22 +9,21 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/prebid/prebid-server/stored_requests/caches/memory"
 	"github.com/prebid/prebid-server/stored_requests/events"
 )
 
 func TestGoodRequests(t *testing.T) {
-	cache := memory.NewCache(&config.InMemoryCache{
-		RequestCacheSize: 256 * 1024,
-		ImpCacheSize:     256 * 1024,
-		TTL:              -1,
-	})
-
+	cache := stored_requests.Cache{
+		Requests: memory.NewCache(256*1024, -1, "Requests"),
+		Imps:     memory.NewCache(256*1024, -1, "Imps"),
+	}
 	id := "1"
 	config := fmt.Sprintf(`{"id": "%s"}`, id)
 	initialValue := map[string]json.RawMessage{id: json.RawMessage(config)}
-	cache.Save(context.Background(), initialValue, initialValue)
+	cache.Requests.Save(context.Background(), initialValue)
+	cache.Imps.Save(context.Background(), initialValue)
 
 	apiEvents, endpoint := NewEventsAPI()
 
@@ -51,7 +50,8 @@ func TestGoodRequests(t *testing.T) {
 	}
 
 	<-updateOccurred
-	reqData, impData := cache.Get(context.Background(), []string{id}, []string{id})
+	reqData := cache.Requests.Get(context.Background(), []string{id})
+	impData := cache.Imps.Get(context.Background(), []string{id})
 	assertHasValue(t, reqData, id, config)
 	assertHasValue(t, impData, id, config)
 
@@ -66,18 +66,17 @@ func TestGoodRequests(t *testing.T) {
 	}
 
 	<-invalidateOccurred
-	reqData, impData = cache.Get(context.Background(), []string{id}, []string{id})
+	reqData = cache.Requests.Get(context.Background(), []string{id})
+	impData = cache.Imps.Get(context.Background(), []string{id})
 	assertMapLength(t, 0, reqData)
 	assertMapLength(t, 0, impData)
 }
 
 func TestBadRequests(t *testing.T) {
-	cache := memory.NewCache(&config.InMemoryCache{
-		RequestCacheSize: 256 * 1024,
-		ImpCacheSize:     256 * 1024,
-		TTL:              -1,
-	})
-
+	cache := stored_requests.Cache{
+		Requests: memory.NewCache(256*1024, -1, "Requests"),
+		Imps:     memory.NewCache(256*1024, -1, "Imps"),
+	}
 	apiEvents, endpoint := NewEventsAPI()
 	listener := events.SimpleEventListener()
 	go listener.Listen(cache, apiEvents)

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -61,12 +61,14 @@ func (e *EventListener) Listen(cache stored_requests.Cache, events EventProducer
 	for {
 		select {
 		case save := <-events.Saves():
-			cache.Save(context.Background(), save.Requests, save.Imps)
+			cache.Requests.Save(context.Background(), save.Requests)
+			cache.Imps.Save(context.Background(), save.Imps)
 			if e.onSave != nil {
 				e.onSave()
 			}
 		case invalidation := <-events.Invalidations():
-			cache.Invalidate(context.Background(), invalidation.Requests, invalidation.Imps)
+			cache.Requests.Invalidate(context.Background(), invalidation.Requests)
+			cache.Imps.Invalidate(context.Background(), invalidation.Imps)
 			if e.onInvalidate != nil {
 				e.onInvalidate()
 			}

--- a/stored_requests/fetcher.go
+++ b/stored_requests/fetcher.go
@@ -37,9 +37,9 @@ type CategoryFetcher interface {
 
 // AllFetcher is an interface that encapsulates both the original Fetcher and the CategoryFetcher
 type AllFetcher interface {
-	FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error)
-	FetchAccount(ctx context.Context, accountID string) (json.RawMessage, []error)
-	FetchCategories(ctx context.Context, primaryAdServer, publisherId, iabCategory string) (string, error)
+	Fetcher
+	AccountFetcher
+	CategoryFetcher
 }
 
 // NotFoundError is an error type to flag that an ID was not found by the Fetcher.
@@ -62,7 +62,11 @@ func (e NotFoundError) Error() string {
 // Cache is an intermediate layer which can be used to create more complex Fetchers by composition.
 // Implementations must be safe for concurrent access by multiple goroutines.
 // To add a Cache layer in front of a Fetcher, see WithCache()
-type Cache interface {
+type Cache struct {
+	Requests CacheJSON
+	Imps     CacheJSON
+}
+type CacheJSON interface {
 	// Get works much like Fetcher.FetchRequests, with a few exceptions:
 	//
 	// 1. Any (actionable) errors should be logged by the implementation, rather than returned.
@@ -73,37 +77,33 @@ type Cache interface {
 	//
 	// Nil slices and empty strings are treated as "no ops". That is, a nil requestID will always produce a nil
 	// "stored request data" in the response.
-	Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
+	Get(ctx context.Context, ids []string) (data map[string]json.RawMessage)
 
 	// Invalidate will ensure that all values associated with the given IDs
 	// are no longer returned by the cache until new values are saved via Update
-	Invalidate(ctx context.Context, requestIDs []string, impIDs []string)
+	Invalidate(ctx context.Context, ids []string)
 
 	// Save will add or overwrite the data in the cache at the given keys
-	Save(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage)
+	Save(ctx context.Context, data map[string]json.RawMessage)
 }
 
 // ComposedCache creates an interface to treat a slice of caches as a single cache
-type ComposedCache []Cache
+type ComposedCache []CacheJSON
 
 // Get will attempt to Get from the caches in the order in which they are in the slice,
 // stopping as soon as a value is found (or when all caches have been exhausted)
-func (c ComposedCache) Get(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
-	requestData = make(map[string]json.RawMessage, len(requestIDs))
-	impData = make(map[string]json.RawMessage, len(impIDs))
+func (c ComposedCache) Get(ctx context.Context, ids []string) (data map[string]json.RawMessage) {
+	data = make(map[string]json.RawMessage, len(ids))
 
-	remainingReqIDs := requestIDs
-	remainingImpIDs := impIDs
+	remainingIDs := ids
 
 	for _, cache := range c {
-		cachedReqData, cachedImpData := cache.Get(ctx, remainingReqIDs, remainingImpIDs)
+		cachedData := cache.Get(ctx, remainingIDs)
+		data, remainingIDs = updateFromCache(data, remainingIDs, cachedData)
 
-		requestData, remainingReqIDs = updateFromCache(requestData, remainingReqIDs, cachedReqData)
-		impData, remainingImpIDs = updateFromCache(impData, remainingImpIDs, cachedImpData)
-
-		// return if all ids filled
-		if len(remainingReqIDs) == 0 && len(remainingImpIDs) == 0 {
-			return
+		// finish early if all ids filled
+		if len(remainingIDs) == 0 {
+			break
 		}
 	}
 
@@ -129,16 +129,16 @@ func updateFromCache(data map[string]json.RawMessage, ids []string, newData map[
 }
 
 // Invalidate will propagate invalidations to all underlying caches
-func (c ComposedCache) Invalidate(ctx context.Context, requestIDs []string, impIDs []string) {
+func (c ComposedCache) Invalidate(ctx context.Context, ids []string) {
 	for _, cache := range c {
-		cache.Invalidate(ctx, requestIDs, impIDs)
+		cache.Invalidate(ctx, ids)
 	}
 }
 
 // Save will propagate saves to all underlying caches
-func (c ComposedCache) Save(ctx context.Context, requestData map[string]json.RawMessage, impData map[string]json.RawMessage) {
+func (c ComposedCache) Save(ctx context.Context, data map[string]json.RawMessage) {
 	for _, cache := range c {
-		cache.Save(ctx, requestData, impData)
+		cache.Save(ctx, data)
 	}
 }
 
@@ -148,7 +148,7 @@ type fetcherWithCache struct {
 	metricsEngine pbsmetrics.MetricsEngine
 }
 
-// WithCache returns a Fetcher which uses the given Cache before delegating to the original.
+// WithCache returns a Fetcher which uses the given Caches before delegating to the original.
 // This can be called multiple times to compose Cache layers onto the backing Fetcher, though
 // it is usually more desirable to first compose caches with Compose, ensuring propagation of updates
 // and invalidations through all cache layers.
@@ -161,7 +161,9 @@ func WithCache(fetcher AllFetcher, cache Cache, metricsEngine pbsmetrics.Metrics
 }
 
 func (f *fetcherWithCache) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
-	requestData, impData = f.cache.Get(ctx, requestIDs, impIDs)
+
+	requestData = f.cache.Requests.Get(ctx, requestIDs)
+	impData = f.cache.Imps.Get(ctx, impIDs)
 
 	// Fixes #311
 	leftoverImps := findLeftovers(impIDs, impData)
@@ -178,7 +180,8 @@ func (f *fetcherWithCache) FetchRequests(ctx context.Context, requestIDs []strin
 		fetcherReqData, fetcherImpData, fetcherErrs := f.fetcher.FetchRequests(ctx, leftoverReqs, leftoverImps)
 		errs = fetcherErrs
 
-		f.cache.Save(ctx, fetcherReqData, fetcherImpData)
+		f.cache.Requests.Save(ctx, fetcherReqData)
+		f.cache.Imps.Save(ctx, fetcherImpData)
 
 		requestData = mergeData(requestData, fetcherReqData)
 		impData = mergeData(impData, fetcherImpData)


### PR DESCRIPTION
This PR makes the caches generic and reusable. 
There should be no functionality changes visible from a fetcherWithCache user.

Reason: Cache has Fetcher-like functionality to handle both requests and
imps together, and is only usable for these objects. Internally, it still uses two 
caches configured and searched separately. 

The PR moves out the request-specific part into fetcherWithCache only,
which handles separate caches for each object type.

Keeping the req/imp code repetition in fetcher and out of cache allows for
simpler code while preserving existing fetcher functionality.

Changes in this set:

- Cache is now a simple generic id->RawMessage store called CacheJSON
- fetcherWithCache handles the separate req and imp caches
- ComposedCache handles single caches - but it does not appear to be used
- Removed cache overlap tests since they do not apply now
- Slightly less code
