### PR TITLE
Clarify stored configuration warnings by indicating dataType

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,9 @@ func (c configErrors) Error() string {
 func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
-	errs = cfg.StoredRequests.validate("stored_requests", requestDataType, errs)
+	errs = cfg.StoredRequests.validate("stored_requests", RequestDataType, errs)
+	cfg.CategoryMapping.DataType = CategoryDataType // CategoryMapping has no other validation
+	cfg.StoredVideo.DataType = VideoDataType        // StoredVideo has no other validation
 	errs = cfg.Metrics.validate(errs)
 	if cfg.MaxRequestSize < 0 {
 		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))

--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,7 @@ func (c configErrors) Error() string {
 func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
-	errs = cfg.StoredRequests.validate(errs)
+	errs = cfg.StoredRequests.validate("stored_requests", requestDataType, errs)
 	errs = cfg.Metrics.validate(errs)
 	if cfg.MaxRequestSize < 0 {
 		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -14,10 +14,10 @@ import (
 type DataType string
 
 const (
-	requestDataType  DataType = "Request"
-	impDataType      DataType = "Imp"
-	categoryDataType DataType = "Category"
-	videoDataType    DataType = "Video"
+	RequestDataType    DataType = "Request"
+	CategoryDataType   DataType = "Category"
+	VideoDataType      DataType = "Video"
+	AmpRequestDataType DataType = "Amp Request"
 )
 
 // StoredRequests configures the backend used to store requests on the server.

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,8 +10,20 @@ import (
 	"github.com/golang/glog"
 )
 
+// DataType constants
+type DataType string
+
+const (
+	requestDataType  DataType = "Request"
+	impDataType      DataType = "Imp"
+	categoryDataType DataType = "Category"
+	videoDataType    DataType = "Video"
+)
+
 // StoredRequests configures the backend used to store requests on the server.
 type StoredRequests struct {
+	// DataType is a tag pushed from upstream indicating the type of object fetched here
+	DataType DataType
 	// Files should be true if Stored Requests should be loaded from the filesystem.
 	Files bool `mapstructure:"filesystem"`
 	//If data should be loaded from file system, path should be specified in configuration
@@ -39,6 +50,8 @@ type StoredRequests struct {
 
 // StoredRequestsSlim struct defines options for stored requests from a single endpoint
 type StoredRequestsSlim struct {
+	// DataType is a tag pushed from upstream indicating the type of object fetched here
+	DataType DataType
 	// Files should be used if Stored Requests should be loaded from the filesystem.
 	// Fetchers are in stored_requests/backends/file_system/fetcher.go
 	Files FileFetcherConfig `mapstructure:"filesystem"`
@@ -118,25 +131,26 @@ type HTTPFetcherConfig struct {
 	AmpEndpoint string `mapstructure:"amp_endpoint"`
 }
 
-func (cfg *StoredRequests) validate(errs configErrors) configErrors {
+func (cfg *StoredRequests) validate(section string, dataType DataType, errs configErrors) configErrors {
+	cfg.DataType = dataType
 	if cfg.InMemoryCache.Type == "none" {
 		if cfg.CacheEventsAPI {
-			errs = append(errs, errors.New("stored_requests.cache_events_api must be false if stored_requests.in_memory_cache=none"))
+			errs = append(errs, fmt.Errorf("%s: cache_events_api must be false if in_memory_cache=none", section))
 		}
 
 		if cfg.HTTPEvents.RefreshRate != 0 {
-			errs = append(errs, errors.New("stored_requests.http_events.refresh_rate_seconds must be 0 if stored_requests.in_memory_cache=none"))
+			errs = append(errs, fmt.Errorf("%s: http_events.refresh_rate_seconds must be 0 if in_memory_cache=none", section))
 		}
 
 		if cfg.Postgres.PollUpdates.Query != "" {
-			errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.query must be empty if stored_requests.in_memory_cache=none"))
+			errs = append(errs, fmt.Errorf("%s: postgres.poll_for_updates.query must be empty if in_memory_cache=none", section))
 		}
 		if cfg.Postgres.CacheInitialization.Query != "" {
-			errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.query must be empty if stored_requests.in_memory_cache=none"))
+			errs = append(errs, fmt.Errorf("%s: postgres.initialize_caches.query must be empty if in_memory_cache=none", section))
 		}
 	}
-	errs = cfg.InMemoryCache.validate(errs)
-	errs = cfg.Postgres.validate(errs)
+	errs = cfg.InMemoryCache.validate(section, errs)
+	errs = cfg.Postgres.validate(section, errs)
 	return errs
 }
 
@@ -158,12 +172,12 @@ type PostgresConfig struct {
 	PollUpdates         PostgresUpdatePolling    `mapstructure:"poll_for_updates"`
 }
 
-func (cfg *PostgresConfig) validate(errs configErrors) configErrors {
+func (cfg *PostgresConfig) validate(section string, errs configErrors) configErrors {
 	if cfg.ConnectionInfo.Database == "" {
 		return errs
 	}
 
-	return cfg.PollUpdates.validate(errs)
+	return cfg.PollUpdates.validate(section, errs)
 }
 
 // PostgresConnection has options which put types to the Postgres Connection string. See:
@@ -298,29 +312,29 @@ type PostgresCacheInitializerSlim struct {
 	Query string `mapstructure:"query"`
 }
 
-func (cfg *PostgresCacheInitializerSlim) validate(errs configErrors) configErrors {
+func (cfg *PostgresCacheInitializerSlim) validate(section string, errs configErrors) configErrors {
 	if cfg.Query == "" {
 		return errs
 	}
 	if cfg.Timeout <= 0 {
-		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.timeout_ms must be positive"))
+		errs = append(errs, fmt.Errorf("%s: postgres.initialize_caches.timeout_ms must be positive", section))
 	}
 	if strings.Contains(cfg.Query, "$") {
-		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.query should not contain any wildcards (e.g. $1)"))
+		errs = append(errs, fmt.Errorf("%s: postgres.initialize_caches.query should not contain any wildcards (e.g. $1)", section))
 	}
 	return errs
 }
 
-func (cfg *PostgresCacheInitializer) validate(errs configErrors) configErrors {
+func (cfg *PostgresCacheInitializer) validate(section string, errs configErrors) configErrors {
 	if cfg.Query == "" && cfg.AmpQuery == "" {
 		return errs
 	}
 
 	slim := &PostgresCacheInitializerSlim{Timeout: cfg.Timeout, Query: cfg.Query}
-	errs = slim.validate(errs)
+	errs = slim.validate(section, errs)
 
 	if strings.Contains(cfg.AmpQuery, "$") {
-		errs = append(errs, errors.New("stored_requests.postgres.initialize_caches.amp_query should not contain any wildcards (e.g. $1)"))
+		errs = append(errs, fmt.Errorf("%s: postgres.initialize_caches.amp_query should not contain any wildcards (e.g. $1)", section))
 	}
 
 	return errs
@@ -370,34 +384,34 @@ type PostgresUpdatePolling struct {
 	AmpQuery string `mapstructure:"amp_query"`
 }
 
-func (cfg *PostgresUpdatePollingSlim) validate(errs configErrors) configErrors {
+func (cfg *PostgresUpdatePollingSlim) validate(section string, errs configErrors) configErrors {
 	if cfg.Query == "" {
 		return errs
 	}
 
 	if cfg.RefreshRate <= 0 {
-		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.refresh_rate_seconds must be > 0"))
+		errs = append(errs, fmt.Errorf("%s: postgres.poll_for_updates.refresh_rate_seconds must be > 0", section))
 	}
 
 	if cfg.Timeout <= 0 {
-		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.timeout_ms must be > 0"))
+		errs = append(errs, fmt.Errorf("%s: postgres.poll_for_updates.timeout_ms must be > 0", section))
 	}
 
 	if !strings.Contains(cfg.Query, "$1") || strings.Contains(cfg.Query, "$2") {
-		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.query must contain exactly one wildcard"))
+		errs = append(errs, fmt.Errorf("%s: postgres.poll_for_updates.query must contain exactly one wildcard", section))
 	}
 	return errs
 }
 
-func (cfg *PostgresUpdatePolling) validate(errs configErrors) configErrors {
+func (cfg *PostgresUpdatePolling) validate(section string, errs configErrors) configErrors {
 	if cfg.Query == "" && cfg.AmpQuery == "" {
 		return errs
 	}
 	slim := &PostgresUpdatePollingSlim{RefreshRate: cfg.RefreshRate, Timeout: cfg.Timeout, Query: cfg.Query}
-	errs = slim.validate(errs)
+	errs = slim.validate(section, errs)
 
 	if !strings.Contains(cfg.AmpQuery, "$1") || strings.Contains(cfg.AmpQuery, "$2") {
-		errs = append(errs, errors.New("stored_requests.postgres.poll_for_updates.amp_query must contain exactly one wildcard"))
+		errs = append(errs, fmt.Errorf("%s: postgres.poll_for_updates.amp_query must contain exactly one wildcard", section))
 	}
 	return errs
 }
@@ -473,29 +487,29 @@ type InMemoryCache struct {
 	ImpCacheSize int `mapstructure:"imp_cache_size_bytes"`
 }
 
-func (cfg *InMemoryCache) validate(errs configErrors) configErrors {
+func (cfg *InMemoryCache) validate(section string, errs configErrors) configErrors {
 	switch cfg.Type {
 	case "none":
 		// No errors for no config options
 	case "unbounded":
 		if cfg.TTL != 0 {
-			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache must be 0 for unbounded caches. Got %d", cfg.TTL))
+			errs = append(errs, fmt.Errorf("%s: in_memory_cache must be 0 for unbounded caches. Got %d", section, cfg.TTL))
 		}
 		if cfg.RequestCacheSize != 0 {
-			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.request_cache_size_bytes must be 0 for unbounded caches. Got %d", cfg.RequestCacheSize))
+			errs = append(errs, fmt.Errorf("%s: in_memory_cache.request_cache_size_bytes must be 0 for unbounded caches. Got %d", section, cfg.RequestCacheSize))
 		}
 		if cfg.ImpCacheSize != 0 {
-			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.imp_cache_size_bytes must be 0 for unbounded caches. Got %d", cfg.ImpCacheSize))
+			errs = append(errs, fmt.Errorf("%s: in_memory_cache.imp_cache_size_bytes must be 0 for unbounded caches. Got %d", section, cfg.ImpCacheSize))
 		}
 	case "lru":
 		if cfg.RequestCacheSize <= 0 {
-			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.request_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got %d", cfg.RequestCacheSize))
+			errs = append(errs, fmt.Errorf("%s: in_memory_cache.request_cache_size_bytes must be >= 0 when in_memory_cache.type=lru. Got %d", section, cfg.RequestCacheSize))
 		}
 		if cfg.ImpCacheSize <= 0 {
-			errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.imp_cache_size_bytes must be >= 0 when stored_requests.in_memory_cache.type=lru. Got %d", cfg.ImpCacheSize))
+			errs = append(errs, fmt.Errorf("%s: in_memory_cache.imp_cache_size_bytes must be >= 0 when in_memory_cache.type=lru. Got %d", section, cfg.ImpCacheSize))
 		}
 	default:
-		errs = append(errs, fmt.Errorf("stored_requests.in_memory_cache.type %s is invalid", cfg.Type))
+		errs = append(errs, fmt.Errorf("%s: in_memory_cache.type %s is invalid", section, cfg.Type))
 	}
 	return errs
 }

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -17,7 +17,7 @@ const (
 	RequestDataType    DataType = "Request"
 	CategoryDataType   DataType = "Category"
 	VideoDataType      DataType = "Video"
-	AmpRequestDataType DataType = "Amp Request"
+	AMPRequestDataType DataType = "Amp Request"
 )
 
 // StoredRequests configures the backend used to store requests on the server.

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -78,40 +78,40 @@ func TestPostgressConnString(t *testing.T) {
 func TestInMemoryCacheValidation(t *testing.T) {
 	assertNoErrs(t, (&InMemoryCache{
 		Type: "unbounded",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertNoErrs(t, (&InMemoryCache{
 		Type: "none",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertNoErrs(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type: "unrecognized",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:         "unbounded",
 		ImpCacheSize: 1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "unbounded",
 		RequestCacheSize: 1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type: "unbounded",
 		TTL:  500,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 0,
 		ImpCacheSize:     1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     0,
-	}).validate(nil))
+	}).validate("Test", nil))
 }
 
 func assertErrsExist(t *testing.T, err configErrors) {

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -163,7 +163,7 @@ func resolvedStoredRequestsConfig(cfg *config.Configuration) (auc, amp config.St
 
 	// Amp endpoint uses all the slim data but some fields get replacyed by Amp* version of similar fields
 	amp = auc
-	amp.DataType = config.AmpRequestDataType
+	amp.DataType = config.AMPRequestDataType
 	amp.Postgres.FetcherQueries.QueryTemplate = sr.Postgres.FetcherQueries.AmpQueryTemplate
 	amp.Postgres.CacheInitialization.Query = sr.Postgres.CacheInitialization.AmpQuery
 	amp.Postgres.PollUpdates.Query = sr.Postgres.PollUpdates.AmpQuery


### PR DESCRIPTION
Add a hidden DataType field to StoredRequest, StoredRequestSlim structs, populated with the datatype ("Request", "Category",  etc). Modify warnings to include this field so we know which section they refer to. A misleading warning about ext.prebid.storedrequest being ignored in the wrong section was also fixed.

Startup log messages before the change:

> Loading Stored Requests from filesystem at path ./stored_requests/data/by_id
No Stored Request cache configured. The Fetcher backend will be used for all Stored Requests.
Loading Stored Requests from filesystem at path ./stored_requests/data/by_id
No Stored Request cache configured. The Fetcher backend will be used for all Stored Requests.
Loading Stored Requests from filesystem at path ./static/category-mapping 
No Stored Request support configured. request.imp[i].ext.prebid.storedrequest will be ignored. If you need this, check your app config
No Stored Request cache configured. The Fetcher backend will be used for all Stored Requests.

After the change:

> Loading Stored Request data from filesystem at path ./stored_requests/data/by_id
No Stored Request cache configured. The Request Fetcher backend will be used for all data requests
Loading Stored Amp Request data from filesystem at path ./stored_requests/data/by_id
No Stored Amp Request cache configured. The Amp Request Fetcher backend will be used for all data requests
Loading Stored Category data from filesystem at path ./static/category-mapping
No Stored Video support configured. If you need this, check your app config
No Stored Video cache configured. The Video Fetcher backend will be used for all data requests

