### PR TITLE
fix: avoid unexpected EOF on gz writer

### DIFF
--- a/analytics/pubstack/eventchannel/eventchannel.go
+++ b/analytics/pubstack/eventchannel/eventchannel.go
@@ -94,9 +94,9 @@ func (c *EventChannel) flush() {
 	}
 
 	// finish writing gzip header
-	err := c.gz.Flush()
+	err := c.gz.Close()
 	if err != nil {
-		glog.Warning("[pubstack] fail to flush gzipped buffer")
+		glog.Warning("[pubstack] fail to close gzipped buffer")
 		return
 	}
 

--- a/analytics/pubstack/eventchannel/eventchannel.go
+++ b/analytics/pubstack/eventchannel/eventchannel.go
@@ -93,6 +93,9 @@ func (c *EventChannel) flush() {
 		return
 	}
 
+	// reset buffers and writers
+	defer c.reset()
+
 	// finish writing gzip header
 	err := c.gz.Close()
 	if err != nil {
@@ -107,9 +110,6 @@ func (c *EventChannel) flush() {
 		glog.Warning("[pubstack] fail to copy the buffer")
 		return
 	}
-
-	// reset buffers and writers
-	c.reset()
 
 	// send events (async)
 	go c.send(payload)

--- a/analytics/pubstack/eventchannel/eventchannel_test.go
+++ b/analytics/pubstack/eventchannel/eventchannel_test.go
@@ -134,3 +134,42 @@ func TestEventChannel_Push(t *testing.T) {
 	assert.Equal(t, string(data), "onetwothreefourfivesixseven")
 
 }
+
+func TestEventChannel_OutputFormat(t *testing.T) {
+
+	toGzip := func(payload string) []byte {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+
+		if _, err := zw.Write([]byte(payload)); err != nil {
+			assert.Fail(t, err.Error())
+		}
+
+		if err := zw.Close(); err != nil {
+			assert.Fail(t, err.Error())
+		}
+		return buf.Bytes()
+	}
+
+	data := make([]byte, 0)
+	send := func(payload []byte) error {
+		data = append(data, payload...)
+		return nil
+	}
+
+	eventChannel := NewEventChannel(send, 15000, 10, 2*time.Minute)
+
+	eventChannel.Push([]byte("one"))
+	eventChannel.flush()
+	eventChannel.Push([]byte("two"))
+	eventChannel.Push([]byte("three"))
+
+	eventChannel.Close()
+
+	time.Sleep(10 * time.Millisecond)
+
+	expected := append(toGzip("one"), toGzip("twothree")...)
+
+	assert.Equal(t, expected, data)
+
+}


### PR DESCRIPTION
We've spotted an issue on our side. This PR fixes it.