### PR TITLE
Consolidate StoredRequest configs, add validation for all data types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,9 @@ func (c configErrors) Error() string {
 func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
-	errs = cfg.StoredRequests.validate(errs)
+	errs = cfg.StoredRequests.validate("stored_requests", RequestDataType, errs)
+	cfg.CategoryMapping.DataType = CategoryDataType // CategoryMapping has no other validation
+	cfg.StoredVideo.DataType = VideoDataType        // StoredVideo has no other validation
 	errs = cfg.Metrics.validate(errs)
 	if cfg.MaxRequestSize < 0 {
 		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))

--- a/config/config.go
+++ b/config/config.go
@@ -29,17 +29,17 @@ type Configuration struct {
 	EnableGzip  bool       `mapstructure:"enable_gzip"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
-	StatusResponse  string          `mapstructure:"status_response"`
-	AuctionTimeouts AuctionTimeouts `mapstructure:"auction_timeouts_ms"`
-	CacheURL        Cache           `mapstructure:"cache"`
-	ExtCacheURL     ExternalCache   `mapstructure:"external_cache"`
-	RecaptchaSecret string          `mapstructure:"recaptcha_secret"`
-	HostCookie      HostCookie      `mapstructure:"host_cookie"`
-	Metrics         Metrics         `mapstructure:"metrics"`
-	DataCache       DataCache       `mapstructure:"datacache"`
-	StoredRequests  StoredRequests  `mapstructure:"stored_requests"`
-	StoredAmp       StoredRequests  `mapstructure:"stored_amp_req"`
-	CategoryMapping StoredRequests  `mapstructure:"category_mapping"`
+	StatusResponse    string          `mapstructure:"status_response"`
+	AuctionTimeouts   AuctionTimeouts `mapstructure:"auction_timeouts_ms"`
+	CacheURL          Cache           `mapstructure:"cache"`
+	ExtCacheURL       ExternalCache   `mapstructure:"external_cache"`
+	RecaptchaSecret   string          `mapstructure:"recaptcha_secret"`
+	HostCookie        HostCookie      `mapstructure:"host_cookie"`
+	Metrics           Metrics         `mapstructure:"metrics"`
+	DataCache         DataCache       `mapstructure:"datacache"`
+	StoredRequests    StoredRequests  `mapstructure:"stored_requests"`
+	StoredRequestsAMP StoredRequests  `mapstructure:"stored_amp_req"`
+	CategoryMapping   StoredRequests  `mapstructure:"category_mapping"`
 	// Note that StoredVideo refers to stored video requests, and has nothing to do with caching video creatives.
 	StoredVideo StoredRequests `mapstructure:"stored_video_req"`
 
@@ -105,7 +105,7 @@ func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
 	errs = cfg.StoredRequests.validate("stored_req", errs)
-	errs = cfg.StoredAmp.validate("stored_amp_req", errs)
+	errs = cfg.StoredRequestsAMP.validate("stored_amp_req", errs)
 	errs = cfg.CategoryMapping.validate("categories", errs)
 	errs = cfg.StoredVideo.validate("stored_video_req", errs)
 	errs = cfg.Metrics.validate(errs)

--- a/config/config.go
+++ b/config/config.go
@@ -29,18 +29,19 @@ type Configuration struct {
 	EnableGzip  bool       `mapstructure:"enable_gzip"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
-	StatusResponse  string             `mapstructure:"status_response"`
-	AuctionTimeouts AuctionTimeouts    `mapstructure:"auction_timeouts_ms"`
-	CacheURL        Cache              `mapstructure:"cache"`
-	ExtCacheURL     ExternalCache      `mapstructure:"external_cache"`
-	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
-	HostCookie      HostCookie         `mapstructure:"host_cookie"`
-	Metrics         Metrics            `mapstructure:"metrics"`
-	DataCache       DataCache          `mapstructure:"datacache"`
-	StoredRequests  StoredRequests     `mapstructure:"stored_requests"`
-	CategoryMapping StoredRequestsSlim `mapstructure:"category_mapping"`
+	StatusResponse  string          `mapstructure:"status_response"`
+	AuctionTimeouts AuctionTimeouts `mapstructure:"auction_timeouts_ms"`
+	CacheURL        Cache           `mapstructure:"cache"`
+	ExtCacheURL     ExternalCache   `mapstructure:"external_cache"`
+	RecaptchaSecret string          `mapstructure:"recaptcha_secret"`
+	HostCookie      HostCookie      `mapstructure:"host_cookie"`
+	Metrics         Metrics         `mapstructure:"metrics"`
+	DataCache       DataCache       `mapstructure:"datacache"`
+	StoredRequests  StoredRequests  `mapstructure:"stored_requests"`
+	StoredAmp       StoredRequests  `mapstructure:"stored_amp_req"`
+	CategoryMapping StoredRequests  `mapstructure:"category_mapping"`
 	// Note that StoredVideo refers to stored video requests, and has nothing to do with caching video creatives.
-	StoredVideo StoredRequestsSlim `mapstructure:"stored_video_req"`
+	StoredVideo StoredRequests `mapstructure:"stored_video_req"`
 
 	// Adapters should have a key for every openrtb_ext.BidderName, converted to lower-case.
 	// Se also: https://github.com/spf13/viper/issues/371#issuecomment-335388559
@@ -103,9 +104,10 @@ func (c configErrors) Error() string {
 func (cfg *Configuration) validate() configErrors {
 	var errs configErrors
 	errs = cfg.AuctionTimeouts.validate(errs)
-	errs = cfg.StoredRequests.validate("stored_requests", RequestDataType, errs)
-	cfg.CategoryMapping.DataType = CategoryDataType // CategoryMapping has no other validation
-	cfg.StoredVideo.DataType = VideoDataType        // StoredVideo has no other validation
+	errs = cfg.StoredRequests.validate("stored_req", errs)
+	errs = cfg.StoredAmp.validate("stored_amp_req", errs)
+	errs = cfg.CategoryMapping.validate("categories", errs)
+	errs = cfg.StoredVideo.validate("stored_video_req", errs)
 	errs = cfg.Metrics.validate(errs)
 	if cfg.MaxRequestSize < 0 {
 		errs = append(errs, fmt.Errorf("cfg.max_request_size must be >= 0. Got %d", cfg.MaxRequestSize))
@@ -601,6 +603,9 @@ func New(v *viper.Viper) (*Configuration, error) {
 		c.BlacklistedAcctMap[c.BlacklistedAccts[i]] = true
 	}
 
+	// Migrate combo stored request config to separate stored_reqs and amp stored_reqs configs.
+	resolvedStoredRequestsConfig(&c)
+
 	glog.Info("Logging the resolved configuration:")
 	logGeneral(reflect.ValueOf(c), "  \t")
 	if errs := c.validate(); len(errs) > 0 {
@@ -718,6 +723,7 @@ func SetupViper(v *viper.Viper, filename string) {
 		v.AddConfigPath(".")
 		v.AddConfigPath("/etc/config")
 	}
+
 	// Fixes #475: Some defaults will be set just so they are accessible via environment variables
 	// (basically so viper knows they exist)
 	v.SetDefault("external_url", "http://localhost:8000")
@@ -775,7 +781,8 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("category_mapping.filesystem.enabled", true)
 	v.SetDefault("category_mapping.filesystem.directorypath", "./static/category-mapping")
 	v.SetDefault("category_mapping.http.endpoint", "")
-	v.SetDefault("stored_requests.filesystem", false)
+	v.SetDefault("stored_requests.filesystem.enabled", false)
+	v.SetDefault("stored_requests.filesystem.directorypath", "./stored_requests/data/by_id")
 	v.SetDefault("stored_requests.directorypath", "./stored_requests/data/by_id")
 	v.SetDefault("stored_requests.postgres.connection.dbname", "")
 	v.SetDefault("stored_requests.postgres.connection.host", "")
@@ -991,6 +998,22 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetEnvPrefix("PBS")
 	v.AutomaticEnv()
 	v.ReadInConfig()
+
+	// Migrate config settings to maintain compatibility with old configs
+	migrateConfig(v)
+}
+
+func migrateConfig(v *viper.Viper) {
+	// if stored_requests.filesystem is not a map in conf file as expected from defaults,
+	// means we have old-style settings; migrate them to new filesystem map to avoid breaking viper
+	if _, ok := v.Get("stored_requests.filesystem").(map[string]interface{}); !ok {
+		glog.Warning("stored_requests.filesystem should be changed to stored_requests.filesystem.enabled")
+		glog.Warning("stored_requests.directorypath should be changed to stored_requests.filesystem.directorypath")
+		m := v.GetStringMap("stored_requests.filesystem")
+		m["enabled"] = v.GetBool("stored_requests.filesystem")
+		m["directorypath"] = v.GetString("stored_requests.directorypath")
+		v.Set("stored_requests.filesystem", m)
+	}
 }
 
 func setBidderDefaults(v *viper.Viper, bidder string) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -120,6 +121,8 @@ func TestDefaults(t *testing.T) {
 	cmpBools(t, "account_adapter_details", cfg.Metrics.Disabled.AccountAdapterDetails, false)
 	cmpBools(t, "adapter_connections_metrics", cfg.Metrics.Disabled.AdapterConnectionMetrics, true)
 	cmpStrings(t, "certificates_file", cfg.PemCertsFile, "")
+	cmpBools(t, "stored_requests.filesystem.enabled", false, cfg.StoredRequests.Files.Enabled)
+	cmpStrings(t, "stored_requests.filesystem.directorypath", "./stored_requests/data/by_id", cfg.StoredRequests.Files.Path)
 }
 
 var fullConfig = []byte(`
@@ -269,6 +272,12 @@ adapters:
     usersync_url: http//test-bh.ybp.yahoo.com/sync/appnexuspbs?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&url=%s
   adkerneladn:
      usersync_url: http:\\tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r=
+`)
+
+var oldStoredRequestsConfig = []byte(`
+stored_requests:
+  filesystem: true
+  directorypath: "/somepath"
 `)
 
 func cmpStrings(t *testing.T, key string, a string, b string) {
@@ -423,15 +432,51 @@ func TestUnmarshalAdapterExtraInfo(t *testing.T) {
 func TestValidConfig(t *testing.T) {
 	cfg := Configuration{
 		StoredRequests: StoredRequests{
-			Files: true,
+			Files: FileFetcherConfig{Enabled: true},
 			InMemoryCache: InMemoryCache{
 				Type: "none",
 			},
 		},
+		StoredVideo: StoredRequests{
+			Files: FileFetcherConfig{Enabled: true},
+			InMemoryCache: InMemoryCache{
+				Type: "none",
+			},
+		},
+		CategoryMapping: StoredRequests{
+			Files: FileFetcherConfig{Enabled: true},
+		},
 	}
 
+	resolvedStoredRequestsConfig(&cfg)
 	err := cfg.validate()
 	assert.Nil(t, err, "OpenRTB filesystem config should work. %v", err)
+}
+
+func TestMigrateConfig(t *testing.T) {
+	v := viper.New()
+	SetupViper(v, "")
+	v.SetConfigType("yaml")
+	v.ReadConfig(bytes.NewBuffer(oldStoredRequestsConfig))
+	migrateConfig(v)
+	cfg, err := New(v)
+	assert.NoError(t, err, "Setting up config should work but it doesn't")
+	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
+	cmpStrings(t, "stored_requests.filesystem.path", "/somepath", cfg.StoredRequests.Files.Path)
+}
+
+func TestMigrateConfigFromEnv(t *testing.T) {
+	if oldval, ok := os.LookupEnv("PBS_STORED_REQUESTS_FILESYSTEM"); ok {
+		defer os.Setenv("PBS_STORED_REQUESTS_FILESYSTEM", oldval)
+	} else {
+		defer os.Unsetenv("PBS_STORED_REQUESTS_FILESYSTEM")
+	}
+	os.Setenv("PBS_STORED_REQUESTS_FILESYSTEM", "true")
+	v := viper.New()
+	SetupViper(v, "")
+	cfg, err := New(v)
+	assert.NoError(t, err, "Setting up config should work but it doesn't")
+	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
 }
 
 func TestInvalidAdapterEndpointConfig(t *testing.T) {

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -17,7 +17,7 @@ const (
 	RequestDataType    DataType = "Request"
 	CategoryDataType   DataType = "Category"
 	VideoDataType      DataType = "Video"
-	AMPRequestDataType DataType = "Amp Request"
+	AMPRequestDataType DataType = "AMP Request"
 )
 
 func (sr *StoredRequests) DataType() DataType {
@@ -91,12 +91,12 @@ type HTTPFetcherConfig struct {
 // Migrate combined stored_requests+amp configuration to separate simple config sections
 func resolvedStoredRequestsConfig(cfg *Configuration) {
 	sr := &cfg.StoredRequests
-	amp := &cfg.StoredAmp
+	amp := &cfg.StoredRequestsAMP
 
 	sr.CacheEvents.Endpoint = "/storedrequests/openrtb2" // why is this here and not SetDefault ?
 
 	// Amp uses the same config but some fields get replaced by Amp* version of similar fields
-	cfg.StoredAmp = cfg.StoredRequests
+	cfg.StoredRequestsAMP = cfg.StoredRequests
 	amp.Postgres.FetcherQueries.QueryTemplate = sr.Postgres.FetcherQueries.AmpQueryTemplate
 	amp.Postgres.CacheInitialization.Query = sr.Postgres.CacheInitialization.AmpQuery
 	amp.Postgres.PollUpdates.Query = sr.Postgres.PollUpdates.AmpQuery
@@ -106,7 +106,7 @@ func resolvedStoredRequestsConfig(cfg *Configuration) {
 
 	// Set data types for each section
 	cfg.StoredRequests.dataType = RequestDataType
-	cfg.StoredAmp.dataType = AMPRequestDataType
+	cfg.StoredRequestsAMP.dataType = AMPRequestDataType
 	cfg.StoredVideo.dataType = VideoDataType
 	cfg.CategoryMapping.dataType = CategoryDataType
 	return

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -20,11 +20,15 @@ const (
 	AMPRequestDataType DataType = "Amp Request"
 )
 
+func (sr *StoredRequests) DataType() DataType {
+	return sr.dataType
+}
+
 // StoredRequests struct defines options for stored requests for each data type
 // including some amp stored_requests options
 type StoredRequests struct {
-	// DataType is a tag pushed from upstream indicating the type of object fetched here
-	DataType DataType
+	// dataType is a tag pushed from upstream indicating the type of object fetched here
+	dataType DataType
 	// Files should be used if Stored Requests should be loaded from the filesystem.
 	// Fetchers are in stored_requests/backends/file_system/fetcher.go
 	Files FileFetcherConfig `mapstructure:"filesystem"`
@@ -101,10 +105,10 @@ func resolvedStoredRequestsConfig(cfg *Configuration) {
 	amp.HTTPEvents.Endpoint = sr.HTTPEvents.AmpEndpoint
 
 	// Set data types for each section
-	cfg.StoredRequests.DataType = RequestDataType
-	cfg.StoredAmp.DataType = AMPRequestDataType
-	cfg.StoredVideo.DataType = VideoDataType
-	cfg.CategoryMapping.DataType = CategoryDataType
+	cfg.StoredRequests.dataType = RequestDataType
+	cfg.StoredAmp.dataType = AMPRequestDataType
+	cfg.StoredVideo.dataType = VideoDataType
+	cfg.CategoryMapping.dataType = CategoryDataType
 	return
 }
 
@@ -112,7 +116,7 @@ func (cfg *StoredRequests) validate(section string, errs configErrors) configErr
 	errs = cfg.Postgres.validate(section, errs)
 
 	// Categories do not use cache so none of the following checks apply
-	if cfg.DataType == CategoryDataType {
+	if cfg.dataType == CategoryDataType {
 		return errs
 	}
 

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -78,40 +78,40 @@ func TestPostgressConnString(t *testing.T) {
 func TestInMemoryCacheValidation(t *testing.T) {
 	assertNoErrs(t, (&InMemoryCache{
 		Type: "unbounded",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertNoErrs(t, (&InMemoryCache{
 		Type: "none",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertNoErrs(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type: "unrecognized",
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:         "unbounded",
 		ImpCacheSize: 1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "unbounded",
 		RequestCacheSize: 1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type: "unbounded",
 		TTL:  500,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 0,
 		ImpCacheSize:     1000,
-	}).validate(nil))
+	}).validate("Test", nil))
 	assertErrsExist(t, (&InMemoryCache{
 		Type:             "lru",
 		RequestCacheSize: 1000,
 		ImpCacheSize:     0,
-	}).validate(nil))
+	}).validate("Test", nil))
 }
 
 func assertErrsExist(t *testing.T, err configErrors) {

--- a/config/stored_requests_test.go
+++ b/config/stored_requests_test.go
@@ -203,7 +203,7 @@ func TestResolveConfig(t *testing.T) {
 
 	resolvedStoredRequestsConfig(cfg)
 	auc := &cfg.StoredRequests
-	amp := &cfg.StoredAmp
+	amp := &cfg.StoredRequestsAMP
 
 	// Auction should have the non-amp values in it
 	assertStringsEqual(t, auc.CacheEvents.Endpoint, "/storedrequests/openrtb2")

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -47,19 +47,20 @@ func CreateStoredRequests(cfg *config.StoredRequestsSlim, metricsEngine pbsmetri
 		conn := cfg.Postgres.ConnectionInfo.ConnString()
 
 		if dbc.conn == "" {
-			glog.Infof("Connecting to Postgres for Stored Requests. DB=%s, host=%s, port=%d, user=%s",
+			glog.Infof("Connecting to Postgres for Stored %s. DB=%s, host=%s, port=%d, user=%s",
+				cfg.DataType,
 				cfg.Postgres.ConnectionInfo.Database,
 				cfg.Postgres.ConnectionInfo.Host,
 				cfg.Postgres.ConnectionInfo.Port,
 				cfg.Postgres.ConnectionInfo.Username)
-			db := newPostgresDB(cfg.Postgres.ConnectionInfo)
+			db := newPostgresDB(cfg.DataType, cfg.Postgres.ConnectionInfo)
 			dbc.conn = conn
 			dbc.db = db
 		}
 
 		// Error out if config is trying to use multiple database connections for different stored requests (not supported yet)
 		if conn != dbc.conn {
-			glog.Fatal("Multiple database connection settings found in Stored Requests config, only a single database connection is currently supported.")
+			glog.Fatal("Multiple database connection settings found in config, only a single database connection is currently supported.")
 		}
 	}
 
@@ -142,6 +143,7 @@ func resolvedStoredRequestsConfig(cfg *config.Configuration) (auc, amp config.St
 	sr := &cfg.StoredRequests
 
 	// Auction endpoint uses non-Amp fields so can just copy the slin data
+	auc.DataType = sr.DataType
 	auc.Files.Enabled = sr.Files
 	auc.Files.Path = sr.Path
 	auc.Postgres.ConnectionInfo = sr.Postgres.ConnectionInfo
@@ -160,21 +162,13 @@ func resolvedStoredRequestsConfig(cfg *config.Configuration) (auc, amp config.St
 	auc.HTTPEvents.Endpoint = sr.HTTPEvents.Endpoint
 
 	// Amp endpoint uses all the slim data but some fields get replacyed by Amp* version of similar fields
-	amp.Files.Enabled = sr.Files
-	amp.Files.Path = sr.Path
-	amp.Postgres.ConnectionInfo = sr.Postgres.ConnectionInfo
+	amp = auc
+	amp.DataType = config.AMPRequestDataType
 	amp.Postgres.FetcherQueries.QueryTemplate = sr.Postgres.FetcherQueries.AmpQueryTemplate
-	amp.Postgres.CacheInitialization.Timeout = sr.Postgres.CacheInitialization.Timeout
 	amp.Postgres.CacheInitialization.Query = sr.Postgres.CacheInitialization.AmpQuery
-	amp.Postgres.PollUpdates.RefreshRate = sr.Postgres.PollUpdates.RefreshRate
-	amp.Postgres.PollUpdates.Timeout = sr.Postgres.PollUpdates.Timeout
 	amp.Postgres.PollUpdates.Query = sr.Postgres.PollUpdates.AmpQuery
 	amp.HTTP.Endpoint = sr.HTTP.AmpEndpoint
-	amp.InMemoryCache = sr.InMemoryCache
-	amp.CacheEvents.Enabled = sr.CacheEventsAPI
 	amp.CacheEvents.Endpoint = "/storedrequests/amp"
-	amp.HTTPEvents.RefreshRate = sr.HTTPEvents.RefreshRate
-	amp.HTTPEvents.Timeout = sr.HTTPEvents.Timeout
 	amp.HTTPEvents.Endpoint = sr.HTTPEvents.AmpEndpoint
 
 	return
@@ -200,25 +194,25 @@ func newFetcher(cfg *config.StoredRequestsSlim, client *http.Client, db *sql.DB)
 	idList := make(stored_requests.MultiFetcher, 0, 3)
 
 	if cfg.Files.Enabled {
-		fFetcher := newFilesystem(cfg.Files.Path)
+		fFetcher := newFilesystem(cfg.DataType, cfg.Files.Path)
 		idList = append(idList, fFetcher)
 	}
 	if cfg.Postgres.FetcherQueries.QueryTemplate != "" {
-		glog.Infof("Loading Stored Requests via Postgres.\nQuery: %s", cfg.Postgres.FetcherQueries.QueryTemplate)
+		glog.Infof("Loading Stored %s data via Postgres.\nQuery: %s", cfg.DataType, cfg.Postgres.FetcherQueries.QueryTemplate)
 		idList = append(idList, db_fetcher.NewFetcher(db, cfg.Postgres.FetcherQueries.MakeQuery))
 	}
 	if cfg.HTTP.Endpoint != "" {
-		glog.Infof("Loading Stored Requests via HTTP. endpoint=%s", cfg.HTTP.Endpoint)
+		glog.Infof("Loading Stored %s data via HTTP. endpoint=%s", cfg.DataType, cfg.HTTP.Endpoint)
 		idList = append(idList, http_fetcher.NewFetcher(client, cfg.HTTP.Endpoint))
 	}
 
-	fetcher = consolidate(idList)
+	fetcher = consolidate(cfg.DataType, idList)
 	return
 }
 
 func newCache(cfg *config.StoredRequestsSlim) stored_requests.Cache {
 	if cfg.InMemoryCache.Type == "none" {
-		glog.Info("No Stored Request cache configured. The Fetcher backend will be used for all Stored Requests.")
+		glog.Infof("No Stored %s cache configured. The %s Fetcher backend will be used for all data requests", cfg.DataType, cfg.DataType)
 		return &nil_cache.NilCache{}
 	}
 
@@ -269,32 +263,37 @@ func newHttpEvents(client *http.Client, timeout time.Duration, refreshRate time.
 	return httpEvents.NewHTTPEvents(client, endpoint, ctxProducer, refreshRate)
 }
 
-func newFilesystem(configPath string) stored_requests.AllFetcher {
-	glog.Infof("Loading Stored Requests from filesystem at path %s", configPath)
+func newFilesystem(dataType config.DataType, configPath string) stored_requests.AllFetcher {
+	glog.Infof("Loading Stored %s data from filesystem at path %s", dataType, configPath)
 	fetcher, err := file_fetcher.NewFileFetcher(configPath)
 	if err != nil {
-		glog.Fatalf("Failed to create a FileFetcher: %v", err)
+		glog.Fatalf("Failed to create a %s FileFetcher: %v", dataType, err)
 	}
 	return fetcher
 }
 
-func newPostgresDB(cfg config.PostgresConnection) *sql.DB {
+func newPostgresDB(dataType config.DataType, cfg config.PostgresConnection) *sql.DB {
 	db, err := sql.Open("postgres", cfg.ConnString())
 	if err != nil {
-		glog.Fatalf("Failed to open postgres connection: %v", err)
+		glog.Fatalf("Failed to open %s postgres connection: %v", dataType, err)
 	}
 
 	if err := db.Ping(); err != nil {
-		glog.Fatalf("Failed to ping postgres: %v", err)
+		glog.Fatalf("Failed to ping %s postgres: %v", dataType, err)
 	}
 
 	return db
 }
 
 // consolidate returns a single Fetcher from an array of fetchers of any size.
-func consolidate(fetchers []stored_requests.AllFetcher) stored_requests.AllFetcher {
+func consolidate(dataType config.DataType, fetchers []stored_requests.AllFetcher) stored_requests.AllFetcher {
 	if len(fetchers) == 0 {
-		glog.Warning("No Stored Request support configured. request.imp[i].ext.prebid.storedrequest will be ignored. If you need this, check your app config")
+		switch dataType {
+		case config.RequestDataType:
+			glog.Warning("No Stored Request support configured. request.imp[i].ext.prebid.storedrequest will be ignored. If you need this, check your app config")
+		default:
+			glog.Warningf("No Stored %s support configured. If you need this, check your app config", dataType)
+		}
 		return empty_fetcher.EmptyFetcher{}
 	} else if len(fetchers) == 1 {
 		return fetchers[0]

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -115,7 +115,7 @@ func NewStoredRequests(cfg *config.Configuration, metricsEngine pbsmetrics.Metri
 	var dbc dbConnection
 
 	fetcher1, shutdown1 := CreateStoredRequests(&cfg.StoredRequests, metricsEngine, client, router, &dbc)
-	fetcher2, shutdown2 := CreateStoredRequests(&cfg.StoredAmp, metricsEngine, client, router, &dbc)
+	fetcher2, shutdown2 := CreateStoredRequests(&cfg.StoredRequestsAMP, metricsEngine, client, router, &dbc)
 	fetcher3, shutdown3 := CreateStoredRequests(&cfg.CategoryMapping, metricsEngine, client, router, &dbc)
 	fetcher4, shutdown4 := CreateStoredRequests(&cfg.StoredVideo, metricsEngine, client, router, &dbc)
 

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -48,12 +48,12 @@ func CreateStoredRequests(cfg *config.StoredRequests, metricsEngine pbsmetrics.M
 
 		if dbc.conn == "" {
 			glog.Infof("Connecting to Postgres for Stored %s. DB=%s, host=%s, port=%d, user=%s",
-				cfg.DataType,
+				cfg.DataType(),
 				cfg.Postgres.ConnectionInfo.Database,
 				cfg.Postgres.ConnectionInfo.Host,
 				cfg.Postgres.ConnectionInfo.Port,
 				cfg.Postgres.ConnectionInfo.Username)
-			db := newPostgresDB(cfg.DataType, cfg.Postgres.ConnectionInfo)
+			db := newPostgresDB(cfg.DataType(), cfg.Postgres.ConnectionInfo)
 			dbc.conn = conn
 			dbc.db = db
 		}
@@ -156,25 +156,25 @@ func newFetcher(cfg *config.StoredRequests, client *http.Client, db *sql.DB) (fe
 	idList := make(stored_requests.MultiFetcher, 0, 3)
 
 	if cfg.Files.Enabled {
-		fFetcher := newFilesystem(cfg.DataType, cfg.Files.Path)
+		fFetcher := newFilesystem(cfg.DataType(), cfg.Files.Path)
 		idList = append(idList, fFetcher)
 	}
 	if cfg.Postgres.FetcherQueries.QueryTemplate != "" {
-		glog.Infof("Loading Stored %s data via Postgres.\nQuery: %s", cfg.DataType, cfg.Postgres.FetcherQueries.QueryTemplate)
+		glog.Infof("Loading Stored %s data via Postgres.\nQuery: %s", cfg.DataType(), cfg.Postgres.FetcherQueries.QueryTemplate)
 		idList = append(idList, db_fetcher.NewFetcher(db, cfg.Postgres.FetcherQueries.MakeQuery))
 	}
 	if cfg.HTTP.Endpoint != "" {
-		glog.Infof("Loading Stored %s data via HTTP. endpoint=%s", cfg.DataType, cfg.HTTP.Endpoint)
+		glog.Infof("Loading Stored %s data via HTTP. endpoint=%s", cfg.DataType(), cfg.HTTP.Endpoint)
 		idList = append(idList, http_fetcher.NewFetcher(client, cfg.HTTP.Endpoint))
 	}
 
-	fetcher = consolidate(cfg.DataType, idList)
+	fetcher = consolidate(cfg.DataType(), idList)
 	return
 }
 
 func newCache(cfg *config.StoredRequests) stored_requests.Cache {
 	if cfg.InMemoryCache.Type == "none" {
-		glog.Infof("No Stored %s cache configured. The %s Fetcher backend will be used for all data requests", cfg.DataType, cfg.DataType)
+		glog.Infof("No Stored %s cache configured. The %s Fetcher backend will be used for all data requests", cfg.DataType(), cfg.DataType())
 		return &nil_cache.NilCache{}
 	}
 


### PR DESCRIPTION
- Includes #1446 
- Drop the "Slim" versions of stored request configuration
- Unify stored_requests, categories, stored_video_req configuration
- Add stored_amp, still built from stored_requests but moved to config. Should eventually be its own section.
- Added validation for categories and stored_video_req (previously missing).
- Net fewer lines of code than before

Testing validation for stored_video_req with this bad config
```yaml
stored_video_req:
  in_memory_cache:
    type: none
  cache_events:
    enabled: true
    endpoint: "/foo"
  postgres:
    connection:
      dbname: "blah"
    fetcher:
      query: "blah"
    poll_for_updates:
      query: "blah"
      timeout_ms: 0
```

Before the change, prebid-server starts and can crash:
```
I0821 18:22:59.943387   50156 config.go:50] Connecting to Postgres for Stored Video. DB=blah, host=, port=0, user=
F0821 18:22:59.947503   50156 config.go:282] Failed to ping Video postgres: dial tcp 127.0.0.1:5432: connect: connection refused
goroutine 1 [running]:
github.com/golang/glog.stacks(0xc00048d600, 0xc000138280, 0x81, 0xa0)
```

After the change:
```
F0821 18:19:50.035239   50048 main.go:37] Configuration could not be loaded or did not pass validation: validation errors are:

  stored_video_req: postgres.poll_for_updates.refresh_rate_seconds must be > 0
  stored_video_req: postgres.poll_for_updates.timeout_ms must be > 0
  stored_video_req: postgres.poll_for_updates.query must contain exactly one wildcard
  stored_video_req: cache_events must be disabled if in_memory_cache=none
  stored_video_req: postgres.poll_for_updates.query must be empty if in_memory_cache=none
```
