### PR TITLE
Panics happen when left with zero length []Imp

### DIFF
--- a/adapters/info.go
+++ b/adapters/info.go
@@ -60,7 +60,7 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb.BidRequest, reqInfo *Ext
 
 	// If all imps in bid request come with unsupported media types, exit
 	if numToFilter == len(request.Imp) {
-		return nil, append(errs, BadInput("Bid request didn't contain media types supported by bidder"))
+		return nil, append(errs, BadInput("Bid request didn't contain media types supported by the bidder"))
 	}
 
 	if numToFilter != 0 {

--- a/adapters/info_test.go
+++ b/adapters/info_test.go
@@ -85,7 +85,7 @@ func TestImpFiltering(t *testing.T) {
 				Site: &openrtb.Site{},
 			},
 			expectedErrors: []error{
-				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by bidder"},
+				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by the bidder"},
 			},
 			expectedImpLen: 0,
 		},
@@ -97,7 +97,7 @@ func TestImpFiltering(t *testing.T) {
 			},
 			expectedErrors: []error{
 				&errortypes.BadInput{Message: "request.imp[0] uses video, but this bidder doesn't support it"},
-				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by bidder"},
+				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by the bidder"},
 			},
 			expectedImpLen: 0,
 		},
@@ -115,7 +115,7 @@ func TestImpFiltering(t *testing.T) {
 				&errortypes.BadInput{Message: "request.imp[0] uses video, but this bidder doesn't support it"},
 				&errortypes.BadInput{Message: "request.imp[1] uses native, but this bidder doesn't support it"},
 				&errortypes.BadInput{Message: "request.imp[2] uses audio, but this bidder doesn't support it"},
-				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by bidder"},
+				&errortypes.BadInput{Message: "Bid request didn't contain media types supported by the bidder"},
 			},
 			expectedImpLen: 0,
 		},
@@ -174,7 +174,7 @@ func TestImpFiltering(t *testing.T) {
 		}
 
 		// Extra MakeRequests() call check: our mockBidder returns an adapter request for every imp
-		assert.Equal(t, test.expectedImpLen, len(actualAdapterRequests), "Test failed. Incorrect lenght of filtered imps: %s", test.description)
+		assert.Len(t, actualAdapterRequests, test.expectedImpLen, "Test failed. Incorrect lenght of filtered imps: %s", test.description)
 	}
 }
 


### PR DESCRIPTION
Sometimes an `openrtb.BidRequest`'s `[]Imp` slice gets completely emptied after filtering out imps with wrong media types in `adapters/info.go` as defined in the bidder's `static/bidder-info/*.yaml` file. This pull request modifies the `InfoAwareBidder`'s filtering process to not send requests with an empty `Imp` slice to any adapter to avoid panics in case the bidder's adapter de-references an slice element.

**Test request:**
```
{
	"id": "some-request-id",
	"site": {
		"page": "prebid.org"
	},
	"imp": [{
		"id": "some-impression-id",
		"video": {
			"mimes": ["video/mp4"],
			"w": 640,
			"h": 480
		},
		"ext": {
			"33across": {
				"siteId": "fake-site-id",
				"productId": "inview"
			}
		}
	}],
	"tmax": 100000
}
```

**Test request output before this PR's changes:**
Client
```
╰─➤  curl --data '{"id":"some-request-id","site":{"page":"prebid.org"},"imp":[{"id":"some-impression-id","video":{"mimes":["video/mp4"],"w":640,"h":480},"ext":{"33across":{"siteId":"fake-site-id","productId":"inview"}}}],"tmax":100000}' http://localhost:8000/openrtb2/auction
{"id":"some-request-id","ext":{"responsetimemillis":{"":0},"tmaxrequest":100000}}
```

Server
```
╰─➤  ./prebid-server
E0826 21:23:42.755239   29799 exchange.go:429] OpenRTB auction recovered panic from Bidder 33across: runtime error: index out of range [0] with length 0. Account id: unknown, All Bidders: 33across, Stack trace is: goroutine 172 [running]:
runtime/debug.Stack(0xc0005e3118, 0xc00048e5b8, 0x8)
        /usr/local/opt/go/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/prebid/prebid-server/exchange.(*exchange).recoverSafely.func1.1(0xc00061d5c0, 0xc00048e590, 0x8, 0xc0005a0380, 0xc00062ff00, 0xc00040c3c0)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/exchange.go:431 +0x319
panic(0x18adae0, 0xc0003268e0)
        /usr/local/opt/go/libexec/src/runtime/panic.go:969 +0x166
github.com/prebid/prebid-server/adapters/33across.preprocess(0xc00007d548, 0x10e2733, 0xc00098a0d0)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/adapters/33across/33across.go:72 +0x446
github.com/prebid/prebid-server/adapters/33across.(*TtxAdapter).makeRequest(0xc00062a560, 0xc0008c6280, 0xc00007d840, 0x104de6e, 0x101644a, 0xc0002f9570)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/adapters/33across/33across.go:48 +0x77
github.com/prebid/prebid-server/adapters/33across.(*TtxAdapter).MakeRequests(0xc00062a560, 0xc0008c6280, 0xc0009f7300, 0x1, 0xc0009f7330, 0x1, 0x1, 0x1, 0xc0009f7330)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/adapters/33across/33across.go:32 +0x3f
github.com/prebid/prebid-server/adapters.(*InfoAwareBidder).MakeRequests(0xc00032ade0, 0xc0008c6280, 0xc0009f7300, 0xc00007d9a8, 0x1692386, 0xc000913790, 0x1a6ebe0, 0xc0006a2000, 0xc0007b2000)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/adapters/info.go:64 +0x12d
github.com/prebid/prebid-server/exchange.(*bidderAdapter).requestBid(0xc0006aaa50, 0x1a71a60, 0xc00040c240, 0xc0008c6280, 0xc00048e590, 0x8, 0x3ff0000000000000, 0x1a68860, 0xc00019c0e0, 0xc0009f7300, ...)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/bidder.go:118 +0x65
github.com/prebid/prebid-server/exchange.(*validatedBidder).requestBid(0xc00062bc60, 0x1a71a60, 0xc00040c240, 0xc0008c6280, 0xc00048e590, 0x8, 0x3ff0000000000000, 0x1a68860, 0xc00019c0e0, 0xc0009f7300, ...)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/bidder_validate_bids.go:32 +0xbf
github.com/prebid/prebid-server/exchange.(*exchange).getAllBids.func1(0xc00048e590, 0x8, 0xc00048e590, 0x8, 0xc0008c6280, 0xc0005a0380, 0x1a68860, 0xc00019c0e0)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/exchange.go:364 +0x29c
github.com/prebid/prebid-server/exchange.(*exchange).recoverSafely.func1(0xc00048e590, 0x8, 0xc00048e590, 0x8, 0xc0008c6280, 0xc0005a0380, 0x1a68860, 0xc00019c0e0)
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/exchange.go:439 +0xf6
created by github.com/prebid/prebid-server/exchange.(*exchange).getAllBids
        /Users/gcarreongutierrez/go/src/github.com/prebid/prebid-server/exchange/exchange.go:393 +0x20d
```


**After this changes**
Client
```
╰─➤  curl --data '{"id":"some-request-id","site":{"page":"prebid.org"},"imp":[{"id":"some-impression-id","video":{"mimes":["video/mp4"],"w":640,"h":480},"ext":{"33across":{"siteId":"fake-site-id","productId":"inview"}}}],"tmax":100000}' http://localhost:8000/openrtb2/auction
{"id":"some-request-id","ext":{"errors":{"33across":[{"code":2,"message":"request.imp[0] uses video, but this bidder doesn't support it"},{"code":2,"message":"Bid request didn't contain media types supported by bidder"}]},"responsetimemillis":{"33across":0},"tmaxrequest":100000}}
```


Server
```
╰─➤  ./prebid-server
```