### PR TITLE
Rubicon liveramp param

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -672,10 +672,7 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 
 		if request.User != nil {
 			userCopy := *request.User
-			userExtRP := rubiconUserExt{
-				RP:          rubiconUserExtRP{Target: rubiconExt.Visitor},
-				LiverampIdl: "",
-			}
+			userExtRP := rubiconUserExt{RP: rubiconUserExtRP{Target: rubiconExt.Visitor}}
 
 			if request.User.Ext != nil {
 				var userExt *openrtb_ext.ExtUser

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -93,11 +93,12 @@ type rubiconExtUserTpID struct {
 }
 
 type rubiconUserExt struct {
-	Consent   string                        `json:"consent,omitempty"`
-	DigiTrust *openrtb_ext.ExtUserDigiTrust `json:"digitrust"`
-	Eids      []openrtb_ext.ExtUserEid      `json:"eids,omitempty"`
-	TpID      []rubiconExtUserTpID          `json:"tpid,omitempty"`
-	RP        rubiconUserExtRP              `json:"rp"`
+	Consent     string                        `json:"consent,omitempty"`
+	DigiTrust   *openrtb_ext.ExtUserDigiTrust `json:"digitrust"`
+	Eids        []openrtb_ext.ExtUserEid      `json:"eids,omitempty"`
+	TpID        []rubiconExtUserTpID          `json:"tpid,omitempty"`
+	RP          rubiconUserExtRP              `json:"rp"`
+	LiverampIdl string                        `json:"liveramp_idl,omitempty"`
 }
 
 type rubiconSiteExtRP struct {
@@ -245,6 +246,12 @@ type rubiconUserExtEidExt struct {
 // defines the contract for bidrequest.user.ext.eids[i].uids[j].ext
 type rubiconUserExtEidUidExt struct {
 	RtiPartner string `json:"rtiPartner,omitempty"`
+}
+
+type mappedRubiconUidsParam struct {
+	tpIds       []rubiconExtUserTpID
+	segments    []string
+	liverampIdl string
 }
 
 //MAS algorithm
@@ -665,7 +672,10 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 
 		if request.User != nil {
 			userCopy := *request.User
-			userExtRP := rubiconUserExt{RP: rubiconUserExtRP{Target: rubiconExt.Visitor}}
+			userExtRP := rubiconUserExt{
+				RP:          rubiconUserExtRP{Target: rubiconExt.Visitor},
+				LiverampIdl: "",
+			}
 
 			if request.User.Ext != nil {
 				var userExt *openrtb_ext.ExtUser
@@ -683,13 +693,18 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 
 				// set user.ext.tpid
 				if len(userExt.Eids) > 0 {
-					if tpIds, segments, errors := getTpIdsAndSegments(userExt.Eids); len(errors) > 0 {
+					mappedRubiconUidsParam, errors := getTpIdsAndSegments(userExt.Eids)
+					if len(errors) > 0 {
 						errs = append(errs, errors...)
 						continue
-					} else if err := updateUserExtWithTpIdsAndSegments(&userExtRP, tpIds, segments); err != nil {
+					}
+
+					if err := updateUserExtWithTpIdsAndSegments(&userExtRP, mappedRubiconUidsParam); err != nil {
 						errs = append(errs, err)
 						continue
 					}
+
+					userExtRP.LiverampIdl = mappedRubiconUidsParam.liverampIdl
 				}
 			}
 
@@ -793,9 +808,11 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 	return requestData, errs
 }
 
-func getTpIdsAndSegments(eids []openrtb_ext.ExtUserEid) ([]rubiconExtUserTpID, []string, []error) {
-	tpIds := make([]rubiconExtUserTpID, 0)
-	segments := make([]string, 0)
+func getTpIdsAndSegments(eids []openrtb_ext.ExtUserEid) (mappedRubiconUidsParam, []error) {
+	rubiconUidsParam := mappedRubiconUidsParam{
+		tpIds:    make([]rubiconExtUserTpID, 0),
+		segments: make([]string, 0),
+	}
 	errs := make([]error, 0)
 
 	for _, eid := range eids {
@@ -815,7 +832,7 @@ func getTpIdsAndSegments(eids []openrtb_ext.ExtUserEid) ([]rubiconExtUserTpID, [
 					}
 
 					if eidUidExt.RtiPartner == "TDID" {
-						tpIds = append(tpIds, rubiconExtUserTpID{Source: "tdid", UID: uid.ID})
+						rubiconUidsParam.tpIds = append(rubiconUidsParam.tpIds, rubiconExtUserTpID{Source: "tdid", UID: uid.ID})
 					}
 				}
 			}
@@ -824,7 +841,7 @@ func getTpIdsAndSegments(eids []openrtb_ext.ExtUserEid) ([]rubiconExtUserTpID, [
 			if len(uids) > 0 {
 				uidId := uids[0].ID
 				if uidId != "" {
-					tpIds = append(tpIds, rubiconExtUserTpID{Source: "liveintent.com", UID: uidId})
+					rubiconUidsParam.tpIds = append(rubiconUidsParam.tpIds, rubiconExtUserTpID{Source: "liveintent.com", UID: uidId})
 				}
 
 				if eid.Ext != nil {
@@ -835,20 +852,28 @@ func getTpIdsAndSegments(eids []openrtb_ext.ExtUserEid) ([]rubiconExtUserTpID, [
 						})
 						continue
 					}
-					segments = eidExt.Segments
+					rubiconUidsParam.segments = eidExt.Segments
+				}
+			}
+		case "liveramp.com":
+			uids := eid.Uids
+			if len(uids) > 0 {
+				uidId := uids[0].ID
+				if uidId != "" && rubiconUidsParam.liverampIdl == "" {
+					rubiconUidsParam.liverampIdl = uidId
 				}
 			}
 		}
 	}
 
-	return tpIds, segments, errs
+	return rubiconUidsParam, errs
 }
 
-func updateUserExtWithTpIdsAndSegments(userExtRP *rubiconUserExt, tpIds []rubiconExtUserTpID, segments []string) error {
-	if len(tpIds) > 0 {
-		userExtRP.TpID = tpIds
+func updateUserExtWithTpIdsAndSegments(userExtRP *rubiconUserExt, rubiconUidsParam mappedRubiconUidsParam) error {
+	if len(rubiconUidsParam.tpIds) > 0 {
+		userExtRP.TpID = rubiconUidsParam.tpIds
 
-		if segments != nil {
+		if rubiconUidsParam.segments != nil {
 			userExtRPTarget := make(map[string]interface{})
 
 			if userExtRP.RP.Target != nil {
@@ -857,7 +882,7 @@ func updateUserExtWithTpIdsAndSegments(userExtRP *rubiconUserExt, tpIds []rubico
 				}
 			}
 
-			userExtRPTarget["LIseg"] = segments
+			userExtRPTarget["LIseg"] = rubiconUidsParam.segments
 
 			if target, err := json.Marshal(&userExtRPTarget); err != nil {
 				return &errortypes.BadInput{Message: err.Error()}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1219,6 +1219,15 @@ func TestOpenRTBRequestWithSpecificExtUserEids(t *testing.T) {
 				"ext": {
 					"segments": ["999","888"]
 				}
+			},
+			{
+				"source": "liveramp.com",
+				"uids": [{
+					"id": "LIVERAMPID"
+				}],
+				"ext": {
+					"segments": ["111","222"]
+				}
 			}
 			]}`),
 		},
@@ -1239,7 +1248,7 @@ func TestOpenRTBRequestWithSpecificExtUserEids(t *testing.T) {
 	}
 
 	assert.NotNil(t, userExt.Eids)
-	assert.Equal(t, 3, len(userExt.Eids), "Eids values are not as expected!")
+	assert.Equal(t, 4, len(userExt.Eids), "Eids values are not as expected!")
 
 	assert.NotNil(t, userExt.TpID)
 	assert.Equal(t, 2, len(userExt.TpID), "TpID values are not as expected!")
@@ -1249,6 +1258,9 @@ func TestOpenRTBRequestWithSpecificExtUserEids(t *testing.T) {
 
 	// liveintent.com
 	assert.Equal(t, "liveintent.com", userExt.TpID[1].Source, "TpID source value is not as expected!")
+
+	// liveramp.com
+	assert.Equal(t, "LIVERAMPID", userExt.LiverampIdl, "Liveramp_idl value is not as expected!")
 
 	userExtRPTarget := make(map[string]interface{})
 	if err := json.Unmarshal(userExt.RP.Target, &userExtRPTarget); err != nil {


### PR DESCRIPTION
should translate the "liveramp.com" id from the "user.ext.eids" array to "user.ext.liveramp_idl" as follows:

```
{
  "user": {
    "ext": {
      "eids": [{
        "source": 'liveramp.com',
        "uids": [{
          "id": "T7JiRRvsRAmh88"
        }]
      }]
    }
  }
}
```

 to XAPI:
```
{
  "user": {
    "ext": {
      "liveramp_idl": "T7JiRRvsRAmh88"
    }
  }
}
```