### PR TITLE
github-actions validation checker for PRs and master branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types:
+      - created
+name: Validate
+jobs:
+  Go:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Validate
+      run: |
+        ./validate.sh --nofmt --cov --race 10
+      env:
+        GO111MODULE: "on"


### PR DESCRIPTION
Add github-actions PR and master validation checker.

This works everywhere the repo was forked or mirrored without any additional configuration, unlike the Travis setup.

Reference: https://github.com/mvdan/github-actions-golang

Example results because it's not running in the main prebid repo:
https://github.com/openx/prebid-server-openx/pull/7

![Screen Shot 2020-09-03 at 10 48 45 AM](https://user-images.githubusercontent.com/5796634/92149634-21d96880-edd3-11ea-9a36-68d37dd904ec.png)
