### PR TITLE
Fixed TCF2 Geo Only Enforcement

### DIFF
--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -107,12 +107,10 @@ func cleanOpenRTBRequests(ctx context.Context,
 			coreBidder := resolveBidder(bidder.String(), aliases)
 
 			var publisherID = labels.PubID
-			ok, geo, id, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, publisherID, consent)
-			privacyEnforcement.GDPR = !ok && err == nil
+			_, geo, id, err := gDPR.PersonalInfoAllowed(ctx, coreBidder, publisherID, consent)
 			privacyEnforcement.GDPRGeo = !geo && err == nil
 			privacyEnforcement.GDPRID = !id && err == nil
 		} else {
-			privacyEnforcement.GDPR = false
 			privacyEnforcement.GDPRGeo = false
 			privacyEnforcement.GDPRID = false
 		}

--- a/privacy/enforcement.go
+++ b/privacy/enforcement.go
@@ -8,7 +8,6 @@ import (
 type Enforcement struct {
 	CCPA    bool
 	COPPA   bool
-	GDPR    bool
 	GDPRGeo bool
 	GDPRID  bool
 	LMT     bool
@@ -16,7 +15,7 @@ type Enforcement struct {
 
 // Any returns true if at least one privacy policy requires enforcement.
 func (e Enforcement) Any() bool {
-	return e.CCPA || e.COPPA || e.GDPR || e.GDPRGeo || e.GDPRID || e.LMT
+	return e.CCPA || e.COPPA || e.GDPRGeo || e.GDPRID || e.LMT
 }
 
 // Apply cleans personally identifiable information from an OpenRTB bid request.
@@ -26,9 +25,25 @@ func (e Enforcement) Apply(bidRequest *openrtb.BidRequest, ampGDPRException bool
 
 func (e Enforcement) apply(bidRequest *openrtb.BidRequest, ampGDPRException bool, scrubber Scrubber) {
 	if bidRequest != nil && e.Any() {
-		bidRequest.Device = scrubber.ScrubDevice(bidRequest.Device, e.getIPv6ScrubStrategy(), e.getGeoScrubStrategy())
+		bidRequest.Device = scrubber.ScrubDevice(bidRequest.Device, e.getDeviceIDScrubStrategy(), e.getIPv4ScrubStrategy(), e.getIPv6ScrubStrategy(), e.getGeoScrubStrategy())
 		bidRequest.User = scrubber.ScrubUser(bidRequest.User, e.getUserScrubStrategy(ampGDPRException), e.getGeoScrubStrategy())
 	}
+}
+
+func (e Enforcement) getDeviceIDScrubStrategy() ScrubStrategyDeviceID {
+	if e.COPPA || e.GDPRID || e.CCPA || e.LMT {
+		return ScrubStrategyDeviceIDAll
+	}
+
+	return ScrubStrategyDeviceIDNone
+}
+
+func (e Enforcement) getIPv4ScrubStrategy() ScrubStrategyIPV4 {
+	if e.COPPA || e.GDPRGeo || e.CCPA || e.LMT {
+		return ScrubStrategyIPV4Lowest8
+	}
+
+	return ScrubStrategyIPV4None
 }
 
 func (e Enforcement) getIPv6ScrubStrategy() ScrubStrategyIPV6 {
@@ -36,7 +51,7 @@ func (e Enforcement) getIPv6ScrubStrategy() ScrubStrategyIPV6 {
 		return ScrubStrategyIPV6Lowest32
 	}
 
-	if e.GDPR || e.CCPA || e.LMT {
+	if e.GDPRGeo || e.CCPA || e.LMT {
 		return ScrubStrategyIPV6Lowest16
 	}
 
@@ -60,12 +75,11 @@ func (e Enforcement) getUserScrubStrategy(ampGDPRException bool) ScrubStrategyUs
 		return ScrubStrategyUserIDAndDemographic
 	}
 
-	if e.GDPR && ampGDPRException {
-		return ScrubStrategyUserNone
+	if e.CCPA || e.LMT {
+		return ScrubStrategyUserID
 	}
 
-	// If no user scrubbing is needed, then return none, else scrub ID (COPPA checked above)
-	if e.CCPA || e.GDPRID || e.LMT {
+	if e.GDPRID && !ampGDPRException {
 		return ScrubStrategyUserID
 	}
 

--- a/privacy/enforcement_test.go
+++ b/privacy/enforcement_test.go
@@ -19,7 +19,6 @@ func TestAny(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    false,
 				GDPRGeo: false,
 				GDPRID:  false,
 				LMT:     false,
@@ -31,7 +30,6 @@ func TestAny(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    true,
 				COPPA:   true,
-				GDPR:    true,
 				GDPRGeo: true,
 				GDPRID:  true,
 				LMT:     true,
@@ -43,7 +41,6 @@ func TestAny(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   true,
-				GDPR:    false,
 				GDPRGeo: false,
 				GDPRID:  false,
 				LMT:     true,
@@ -63,6 +60,8 @@ func TestApply(t *testing.T) {
 		description        string
 		enforcement        Enforcement
 		ampGDPRException   bool
+		expectedDeviceID   ScrubStrategyDeviceID
+		expectedDeviceIPv4 ScrubStrategyIPV4
 		expectedDeviceIPv6 ScrubStrategyIPV6
 		expectedDeviceGeo  ScrubStrategyGeo
 		expectedUser       ScrubStrategyUser
@@ -73,12 +72,12 @@ func TestApply(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    true,
 				COPPA:   true,
-				GDPR:    true,
 				GDPRGeo: true,
 				GDPRID:  true,
 				LMT:     true,
 			},
-			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest32,
 			expectedDeviceGeo:  ScrubStrategyGeoFull,
 			expectedUser:       ScrubStrategyUserIDAndDemographic,
@@ -89,12 +88,12 @@ func TestApply(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    true,
 				COPPA:   false,
-				GDPR:    false,
 				GDPRGeo: false,
 				GDPRID:  false,
 				LMT:     false,
 			},
-			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
 			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
 			expectedUser:       ScrubStrategyUserID,
@@ -105,124 +104,97 @@ func TestApply(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   true,
-				GDPR:    false,
 				GDPRGeo: false,
 				GDPRID:  false,
 				LMT:     false,
 			},
-			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest32,
 			expectedDeviceGeo:  ScrubStrategyGeoFull,
 			expectedUser:       ScrubStrategyUserIDAndDemographic,
 			expectedUserGeo:    ScrubStrategyGeoFull,
 		},
 		{
-			description: "GDPR Only",
+			description: "GDPR Only - Full",
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    true,
 				GDPRGeo: true,
 				GDPRID:  true,
 				LMT:     false,
 			},
 			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
 			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
 			expectedUser:       ScrubStrategyUserID,
 			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "GDPR Only, ampGDPRException",
+			description: "GDPR Only - Full - AMP Exception",
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    true,
 				GDPRGeo: true,
 				GDPRID:  true,
 				LMT:     false,
 			},
 			ampGDPRException:   true,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
 			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
 			expectedUser:       ScrubStrategyUserNone,
 			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "CCPA Only, ampGDPRException",
-			enforcement: Enforcement{
-				CCPA:    true,
-				COPPA:   false,
-				GDPR:    false,
-				GDPRGeo: false,
-				GDPRID:  false,
-				LMT:     false,
-			},
-			ampGDPRException:   true,
-			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
-			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
-			expectedUser:       ScrubStrategyUserID,
-			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
-		},
-		{
-			description: "COPPA and GDPR, ampGDPRException",
-			enforcement: Enforcement{
-				CCPA:    false,
-				COPPA:   true,
-				GDPR:    true,
-				GDPRGeo: true,
-				GDPRID:  true,
-				LMT:     false,
-			},
-			ampGDPRException:   true,
-			expectedDeviceIPv6: ScrubStrategyIPV6Lowest32,
-			expectedDeviceGeo:  ScrubStrategyGeoFull,
-			expectedUser:       ScrubStrategyUserIDAndDemographic,
-			expectedUserGeo:    ScrubStrategyGeoFull,
-		},
-		{
-			description: "GDPR Only, no Geo",
+			description: "GDPR Only - ID Only",
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    true,
 				GDPRGeo: false,
 				GDPRID:  true,
 				LMT:     false,
 			},
 			ampGDPRException:   false,
-			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4None,
+			expectedDeviceIPv6: ScrubStrategyIPV6None,
 			expectedDeviceGeo:  ScrubStrategyGeoNone,
 			expectedUser:       ScrubStrategyUserID,
 			expectedUserGeo:    ScrubStrategyGeoNone,
 		},
 		{
-			description: "GDPR Only, Geo only",
+			description: "GDPR Only - ID Only - AMP Exception",
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    false,
-				GDPRGeo: true,
-				GDPRID:  false,
+				GDPRGeo: false,
+				GDPRID:  true,
 				LMT:     false,
 			},
-			ampGDPRException:   false,
+			ampGDPRException:   true,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4None,
 			expectedDeviceIPv6: ScrubStrategyIPV6None,
-			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
+			expectedDeviceGeo:  ScrubStrategyGeoNone,
 			expectedUser:       ScrubStrategyUserNone,
-			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
+			expectedUserGeo:    ScrubStrategyGeoNone,
 		},
 		{
-			description: "GDPR Only, ID exception",
+			description: "GDPR Only - Geo Only",
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    true,
 				GDPRGeo: true,
 				GDPRID:  false,
 				LMT:     false,
 			},
 			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDNone,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
 			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
 			expectedUser:       ScrubStrategyUserNone,
@@ -233,32 +205,50 @@ func TestApply(t *testing.T) {
 			enforcement: Enforcement{
 				CCPA:    false,
 				COPPA:   false,
-				GDPR:    false,
 				GDPRGeo: false,
 				GDPRID:  false,
 				LMT:     true,
 			},
-			ampGDPRException:   false,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
 			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
 			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
 			expectedUser:       ScrubStrategyUserID,
 			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
 		},
 		{
-			description: "LMT Only, ampGDPRException",
+			description: "Interactions: COPPA Only + AMP Exception",
 			enforcement: Enforcement{
 				CCPA:    false,
-				COPPA:   false,
-				GDPR:    false,
+				COPPA:   true,
 				GDPRGeo: false,
 				GDPRID:  false,
-				LMT:     true,
+				LMT:     false,
 			},
 			ampGDPRException:   true,
-			expectedDeviceIPv6: ScrubStrategyIPV6Lowest16,
-			expectedDeviceGeo:  ScrubStrategyGeoReducedPrecision,
-			expectedUser:       ScrubStrategyUserID,
-			expectedUserGeo:    ScrubStrategyGeoReducedPrecision,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
+			expectedDeviceIPv6: ScrubStrategyIPV6Lowest32,
+			expectedDeviceGeo:  ScrubStrategyGeoFull,
+			expectedUser:       ScrubStrategyUserIDAndDemographic,
+			expectedUserGeo:    ScrubStrategyGeoFull,
+		},
+		{
+			description: "Interactions: COPPA + GDPR Full + AMP Exception",
+			enforcement: Enforcement{
+				CCPA:    false,
+				COPPA:   true,
+				GDPRGeo: true,
+				GDPRID:  true,
+				LMT:     false,
+			},
+			ampGDPRException:   true,
+			expectedDeviceID:   ScrubStrategyDeviceIDAll,
+			expectedDeviceIPv4: ScrubStrategyIPV4Lowest8,
+			expectedDeviceIPv6: ScrubStrategyIPV6Lowest32,
+			expectedDeviceGeo:  ScrubStrategyGeoFull,
+			expectedUser:       ScrubStrategyUserIDAndDemographic,
+			expectedUserGeo:    ScrubStrategyGeoFull,
 		},
 	}
 
@@ -271,7 +261,7 @@ func TestApply(t *testing.T) {
 		replacedUser := &openrtb.User{}
 
 		m := &mockScrubber{}
-		m.On("ScrubDevice", req.Device, test.expectedDeviceIPv6, test.expectedDeviceGeo).Return(replacedDevice).Once()
+		m.On("ScrubDevice", req.Device, test.expectedDeviceID, test.expectedDeviceIPv4, test.expectedDeviceIPv6, test.expectedDeviceGeo).Return(replacedDevice).Once()
 		m.On("ScrubUser", req.User, test.expectedUser, test.expectedUserGeo).Return(replacedUser).Once()
 
 		test.enforcement.apply(req, test.ampGDPRException, m)
@@ -290,7 +280,6 @@ func TestApplyNoneApplicable(t *testing.T) {
 	enforcement := Enforcement{
 		CCPA:    false,
 		COPPA:   false,
-		GDPR:    false,
 		GDPRGeo: false,
 		GDPRID:  false,
 		LMT:     false,
@@ -315,8 +304,8 @@ type mockScrubber struct {
 	mock.Mock
 }
 
-func (m *mockScrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
-	args := m.Called(device, ipv6, geo)
+func (m *mockScrubber) ScrubDevice(device *openrtb.Device, id ScrubStrategyDeviceID, ipv4 ScrubStrategyIPV4, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
+	args := m.Called(device, id, ipv4, ipv6, geo)
 	return args.Get(0).(*openrtb.Device)
 }
 

--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -7,6 +7,17 @@ import (
 	"github.com/mxmCherry/openrtb"
 )
 
+// ScrubStrategyIPV4 defines the approach to scrub PII from an IPV4 address.
+type ScrubStrategyIPV4 int
+
+const (
+	// ScrubStrategyIPV4None does not remove any part of an IPV4 address.
+	ScrubStrategyIPV4None ScrubStrategyIPV4 = iota
+
+	// ScrubStrategyIPV4Lowest8 zeroes out the last 8 bits of an IPV4 address.
+	ScrubStrategyIPV4Lowest8
+)
+
 // ScrubStrategyIPV6 defines the approach to scrub PII from an IPV6 address.
 type ScrubStrategyIPV6 int
 
@@ -49,9 +60,20 @@ const (
 	ScrubStrategyUserID
 )
 
+// ScrubStrategyDeviceID defines the approach to remove hardware id and device id data.
+type ScrubStrategyDeviceID int
+
+const (
+	// ScrubStrategyDeviceIDNone does not remove hardware id and device id data.
+	ScrubStrategyDeviceIDNone ScrubStrategyDeviceID = iota
+
+	// ScrubStrategyDeviceIDAll removes all hardware and device id data (ifa, mac hashes device id hashes)
+	ScrubStrategyDeviceIDAll
+)
+
 // Scrubber removes PII from parts of an OpenRTB request.
 type Scrubber interface {
-	ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
+	ScrubDevice(device *openrtb.Device, id ScrubStrategyDeviceID, ipv4 ScrubStrategyIPV4, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device
 	ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo ScrubStrategyGeo) *openrtb.User
 }
 
@@ -62,20 +84,28 @@ func NewScrubber() Scrubber {
 	return scrubber{}
 }
 
-func (scrubber) ScrubDevice(device *openrtb.Device, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
+func (scrubber) ScrubDevice(device *openrtb.Device, id ScrubStrategyDeviceID, ipv4 ScrubStrategyIPV4, ipv6 ScrubStrategyIPV6, geo ScrubStrategyGeo) *openrtb.Device {
 	if device == nil {
 		return nil
 	}
 
 	deviceCopy := *device
-	deviceCopy.DIDMD5 = ""
-	deviceCopy.DIDSHA1 = ""
-	deviceCopy.DPIDMD5 = ""
-	deviceCopy.DPIDSHA1 = ""
-	deviceCopy.IFA = ""
-	deviceCopy.MACMD5 = ""
-	deviceCopy.MACSHA1 = ""
-	deviceCopy.IP = scrubIPV4(device.IP)
+
+	switch id {
+	case ScrubStrategyDeviceIDAll:
+		deviceCopy.DIDMD5 = ""
+		deviceCopy.DIDSHA1 = ""
+		deviceCopy.DPIDMD5 = ""
+		deviceCopy.DPIDSHA1 = ""
+		deviceCopy.IFA = ""
+		deviceCopy.MACMD5 = ""
+		deviceCopy.MACSHA1 = ""
+	}
+
+	switch ipv4 {
+	case ScrubStrategyIPV4Lowest8:
+		deviceCopy.IP = scrubIPV4Lowest8(device.IP)
+	}
 
 	switch ipv6 {
 	case ScrubStrategyIPV6Lowest16:
@@ -124,7 +154,7 @@ func (scrubber) ScrubUser(user *openrtb.User, strategy ScrubStrategyUser, geo Sc
 	return &userCopy
 }
 
-func scrubIPV4(ip string) string {
+func scrubIPV4Lowest8(ip string) string {
 	i := strings.LastIndex(ip, ".")
 	if i == -1 {
 		return ""

--- a/privacy/scrubber_test.go
+++ b/privacy/scrubber_test.go
@@ -31,11 +31,21 @@ func TestScrubDevice(t *testing.T) {
 	testCases := []struct {
 		description string
 		expected    *openrtb.Device
+		id          ScrubStrategyDeviceID
+		ipv4        ScrubStrategyIPV4
 		ipv6        ScrubStrategyIPV6
 		geo         ScrubStrategyGeo
 	}{
 		{
-			description: "IPv6 Lowest 32 & Geo Full",
+			description: "All Strageties - None",
+			expected:    device,
+			id:          ScrubStrategyDeviceIDNone,
+			ipv4:        ScrubStrategyIPV4None,
+			ipv6:        ScrubStrategyIPV6None,
+			geo:         ScrubStrategyGeoNone,
+		},
+		{
+			description: "All Strageties - Strictest",
 			expected: &openrtb.Device{
 				DIDMD5:   "",
 				DIDSHA1:  "",
@@ -48,11 +58,13 @@ func TestScrubDevice(t *testing.T) {
 				IPv6:     "2001:0db8:0000:0000:0000:ff00:0:0",
 				Geo:      &openrtb.Geo{},
 			},
+			id:   ScrubStrategyDeviceIDAll,
+			ipv4: ScrubStrategyIPV4Lowest8,
 			ipv6: ScrubStrategyIPV6Lowest32,
 			geo:  ScrubStrategyGeoFull,
 		},
 		{
-			description: "IPv6 Lowest 16 & Geo Full",
+			description: "Isolated - ID - All",
 			expected: &openrtb.Device{
 				DIDMD5:   "",
 				DIDSHA1:  "",
@@ -61,178 +73,126 @@ func TestScrubDevice(t *testing.T) {
 				MACSHA1:  "",
 				MACMD5:   "",
 				IFA:      "",
+				IP:       "1.2.3.4",
+				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
+				Geo:      device.Geo,
+			},
+			id:   ScrubStrategyDeviceIDAll,
+			ipv4: ScrubStrategyIPV4None,
+			ipv6: ScrubStrategyIPV6None,
+			geo:  ScrubStrategyGeoNone,
+		},
+		{
+			description: "Isolated - IPv4 - Lowest 8",
+			expected: &openrtb.Device{
+				DIDMD5:   "anyDIDMD5",
+				DIDSHA1:  "anyDIDSHA1",
+				DPIDMD5:  "anyDPIDMD5",
+				DPIDSHA1: "anyDPIDSHA1",
+				MACSHA1:  "anyMACSHA1",
+				MACMD5:   "anyMACMD5",
+				IFA:      "anyIFA",
 				IP:       "1.2.3.0",
+				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
+				Geo:      device.Geo,
+			},
+			id:   ScrubStrategyDeviceIDNone,
+			ipv4: ScrubStrategyIPV4Lowest8,
+			ipv6: ScrubStrategyIPV6None,
+			geo:  ScrubStrategyGeoNone,
+		},
+		{
+			description: "Isolated - IPv6 - Lowest 16",
+			expected: &openrtb.Device{
+				DIDMD5:   "anyDIDMD5",
+				DIDSHA1:  "anyDIDSHA1",
+				DPIDMD5:  "anyDPIDMD5",
+				DPIDSHA1: "anyDPIDSHA1",
+				MACSHA1:  "anyMACSHA1",
+				MACMD5:   "anyMACMD5",
+				IFA:      "anyIFA",
+				IP:       "1.2.3.4",
 				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:0",
+				Geo:      device.Geo,
+			},
+			id:   ScrubStrategyDeviceIDNone,
+			ipv4: ScrubStrategyIPV4None,
+			ipv6: ScrubStrategyIPV6Lowest16,
+			geo:  ScrubStrategyGeoNone,
+		},
+		{
+			description: "Isolated - IPv6 - Lowest 32",
+			expected: &openrtb.Device{
+				DIDMD5:   "anyDIDMD5",
+				DIDSHA1:  "anyDIDSHA1",
+				DPIDMD5:  "anyDPIDMD5",
+				DPIDSHA1: "anyDPIDSHA1",
+				MACSHA1:  "anyMACSHA1",
+				MACMD5:   "anyMACMD5",
+				IFA:      "anyIFA",
+				IP:       "1.2.3.4",
+				IPv6:     "2001:0db8:0000:0000:0000:ff00:0:0",
+				Geo:      device.Geo,
+			},
+			id:   ScrubStrategyDeviceIDNone,
+			ipv4: ScrubStrategyIPV4None,
+			ipv6: ScrubStrategyIPV6Lowest32,
+			geo:  ScrubStrategyGeoNone,
+		},
+		{
+			description: "Isolated - Geo - Reduced Precision",
+			expected: &openrtb.Device{
+				DIDMD5:   "anyDIDMD5",
+				DIDSHA1:  "anyDIDSHA1",
+				DPIDMD5:  "anyDPIDMD5",
+				DPIDSHA1: "anyDPIDSHA1",
+				MACSHA1:  "anyMACSHA1",
+				MACMD5:   "anyMACMD5",
+				IFA:      "anyIFA",
+				IP:       "1.2.3.4",
+				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
+				Geo: &openrtb.Geo{
+					Lat:   123.46,
+					Lon:   678.89,
+					Metro: "some metro",
+					City:  "some city",
+					ZIP:   "some zip",
+				},
+			},
+			id:   ScrubStrategyDeviceIDNone,
+			ipv4: ScrubStrategyIPV4None,
+			ipv6: ScrubStrategyIPV6None,
+			geo:  ScrubStrategyGeoReducedPrecision,
+		},
+		{
+			description: "Isolated - Geo - Full",
+			expected: &openrtb.Device{
+				DIDMD5:   "anyDIDMD5",
+				DIDSHA1:  "anyDIDSHA1",
+				DPIDMD5:  "anyDPIDMD5",
+				DPIDSHA1: "anyDPIDSHA1",
+				MACSHA1:  "anyMACSHA1",
+				MACMD5:   "anyMACMD5",
+				IFA:      "anyIFA",
+				IP:       "1.2.3.4",
+				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
 				Geo:      &openrtb.Geo{},
 			},
-			ipv6: ScrubStrategyIPV6Lowest16,
-			geo:  ScrubStrategyGeoFull,
-		},
-		{
-			description: "IPv6 None & Geo Full",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
-				Geo:      &openrtb.Geo{},
-			},
+			id:   ScrubStrategyDeviceIDNone,
+			ipv4: ScrubStrategyIPV4None,
 			ipv6: ScrubStrategyIPV6None,
 			geo:  ScrubStrategyGeoFull,
-		},
-		{
-			description: "IPv6 Lowest 32 & Geo Reduced",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0:0",
-				Geo: &openrtb.Geo{
-					Lat:   123.46,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6Lowest32,
-			geo:  ScrubStrategyGeoReducedPrecision,
-		},
-		{
-			description: "IPv6 Lowest 16 & Geo Reduced",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:0",
-				Geo: &openrtb.Geo{
-					Lat:   123.46,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6Lowest16,
-			geo:  ScrubStrategyGeoReducedPrecision,
-		},
-		{
-			description: "IPv6 None & Geo Reduced",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
-				Geo: &openrtb.Geo{
-					Lat:   123.46,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6None,
-			geo:  ScrubStrategyGeoReducedPrecision,
-		},
-		{
-			description: "IPv6 Lowest 32 & Geo None",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0:0",
-				Geo: &openrtb.Geo{
-					Lat:   123.456,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6Lowest32,
-			geo:  ScrubStrategyGeoNone,
-		},
-		{
-			description: "IPv6 Lowest 16 & Geo None",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:0",
-				Geo: &openrtb.Geo{
-					Lat:   123.456,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6Lowest16,
-			geo:  ScrubStrategyGeoNone,
-		},
-		{
-			description: "IPv6 None & Geo None",
-			expected: &openrtb.Device{
-				DIDMD5:   "",
-				DIDSHA1:  "",
-				DPIDMD5:  "",
-				DPIDSHA1: "",
-				MACSHA1:  "",
-				MACMD5:   "",
-				IFA:      "",
-				IP:       "1.2.3.0",
-				IPv6:     "2001:0db8:0000:0000:0000:ff00:0042:8329",
-				Geo: &openrtb.Geo{
-					Lat:   123.456,
-					Lon:   678.89,
-					Metro: "some metro",
-					City:  "some city",
-					ZIP:   "some zip",
-				},
-			},
-			ipv6: ScrubStrategyIPV6None,
-			geo:  ScrubStrategyGeoNone,
 		},
 	}
 
 	for _, test := range testCases {
-		result := NewScrubber().ScrubDevice(device, test.ipv6, test.geo)
+		result := NewScrubber().ScrubDevice(device, test.id, test.ipv4, test.ipv6, test.geo)
 		assert.Equal(t, test.expected, result, test.description)
 	}
 }
 
 func TestScrubDeviceNil(t *testing.T) {
-	result := NewScrubber().ScrubDevice(nil, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
+	result := NewScrubber().ScrubDevice(nil, ScrubStrategyDeviceIDNone, ScrubStrategyIPV4None, ScrubStrategyIPV6None, ScrubStrategyGeoNone)
 	assert.Nil(t, result)
 }
 
@@ -458,7 +418,7 @@ func TestScrubIPV4(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		result := scrubIPV4(test.IP)
+		result := scrubIPV4Lowest8(test.IP)
 		assert.Equal(t, test.cleanedIP, result, test.description)
 	}
 }


### PR DESCRIPTION
We currently remove the device ID information (ifa, mac hash, device hash) for GDPR when a TCF2 consent string only triggers Geo enforcement but allows IDs to be passed.