### PR TITLE
Implement returnCreative

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -34,6 +34,13 @@ type ContextKey string
 
 const DebugContextKey = ContextKey("debugInfo")
 
+//type bidResponseExtConfig struct {
+//	includeDebugInfo, cacheBids, cacheVAST, returnCreative bool
+//}
+type extCacheInstructions struct {
+	cacheBids, cacheVAST, returnCreative bool
+}
+
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
 type Exchange interface {
 	// HoldAuction executes an OpenRTB v2.5 Auction.
@@ -103,8 +110,8 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 		return nil, err
 	}
 
-	shouldCacheBids, shouldCacheVAST := getExtCacheInfo(requestExt)
-	targData := getExtTargetData(requestExt, shouldCacheBids, shouldCacheVAST)
+	cacheInstructions := getExtCacheInstructions(requestExt)
+	targData := getExtTargetData(requestExt, &cacheInstructions)
 	if targData != nil {
 		_, targData.cacheHost, targData.cachePath = e.cache.GetExtCacheData()
 	}
@@ -155,7 +162,7 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 
 	// If we need to cache bids, then it will take some time to call prebid cache.
 	// We should reduce the amount of time the bidders have, to compensate.
-	auctionCtx, cancel := e.makeAuctionContext(ctx, shouldCacheBids)
+	auctionCtx, cancel := e.makeAuctionContext(ctx, cacheInstructions.cacheBids)
 	defer cancel()
 
 	// Get currency rates conversions for the auction
@@ -234,7 +241,7 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 	}
 
 	// Build the response
-	return e.buildBidResponse(ctx, liveAdapters, adapterBids, bidRequest, adapterExtra, auc, bidResponseExt, errs)
+	return e.buildBidResponse(ctx, liveAdapters, adapterBids, bidRequest, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, errs)
 }
 
 type DealTierInfo struct {
@@ -479,7 +486,7 @@ func errsToBidderErrors(errs []error) []openrtb_ext.ExtBidderError {
 }
 
 // This piece takes all the bids supplied by the adapters and crafts an openRTB response to send back to the requester
-func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, bidRequest *openrtb.BidRequest, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, errList []error) (*openrtb.BidResponse, error) {
+func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, bidRequest *openrtb.BidRequest, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnCreative bool, errList []error) (*openrtb.BidResponse, error) {
 	bidResponse := new(openrtb.BidResponse)
 
 	bidResponse.ID = bidRequest.ID
@@ -494,7 +501,7 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 	for _, a := range liveAdapters {
 		//while processing every single bib, do we need to handle categories here?
 		if adapterBids[a] != nil && len(adapterBids[a].bids) > 0 {
-			sb := e.makeSeatBid(adapterBids[a], a, adapterExtra, auc)
+			sb := e.makeSeatBid(adapterBids[a], a, adapterExtra, auc, returnCreative)
 			seatBids = append(seatBids, *sb)
 			bidResponse.Cur = adapterBids[a].currency
 		}
@@ -751,7 +758,7 @@ func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*pb
 
 // Return an openrtb seatBid for a bidder
 // BuildBidResponse is responsible for ensuring nil bid seatbids are not included
-func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction) *openrtb.SeatBid {
+func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, returnCreative bool) *openrtb.SeatBid {
 	seatBid := new(openrtb.SeatBid)
 	seatBid.Seat = adapter.String()
 	// Prebid cannot support roadblocking
@@ -774,7 +781,7 @@ func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.B
 	}
 
 	var errList []error
-	seatBid.Bid, errList = e.makeBid(adapterBid.bids, adapter, auc)
+	seatBid.Bid, errList = e.makeBid(adapterBid.bids, auc, returnCreative)
 	if len(errList) > 0 {
 		adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, errsToBidderErrors(errList)...)
 	}
@@ -783,7 +790,7 @@ func (e *exchange) makeSeatBid(adapterBid *pbsOrtbSeatBid, adapter openrtb_ext.B
 }
 
 // Create the Bid array inside of SeatBid
-func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName, auc *auction) ([]openrtb.Bid, []error) {
+func (e *exchange) makeBid(Bids []*pbsOrtbBid, auc *auction, returnCreative bool) ([]openrtb.Bid, []error) {
 	bids := make([]openrtb.Bid, 0, len(Bids))
 	errList := make([]error, 0, 1)
 	for _, thisBid := range Bids {
@@ -806,6 +813,9 @@ func (e *exchange) makeBid(Bids []*pbsOrtbBid, adapter openrtb_ext.BidderName, a
 		} else {
 			bids = append(bids, *thisBid.bid)
 			bids[len(bids)-1].Ext = ext
+			if !returnCreative {
+				bids[len(bids)-1].AdM = ""
+			}
 		}
 	}
 	return bids, errList

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -34,9 +34,6 @@ type ContextKey string
 
 const DebugContextKey = ContextKey("debugInfo")
 
-//type bidResponseExtConfig struct {
-//	includeDebugInfo, cacheBids, cacheVAST, returnCreative bool
-//}
 type extCacheInstructions struct {
 	cacheBids, cacheVAST, returnCreative bool
 }

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -367,7 +367,7 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 				},
 				{
 					"Bids returnCreative is true, expect valid AdM",
-					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":true}}}}`),
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true},"vastXml":{"returnCreative":false}}}}`),
 					sampleAd,
 				},
 				{

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -461,7 +461,7 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 	}
 }
 
-func TestGetBidCacheInfoEndToEnd(t *testing.T) { //Test returnCreative here, or similar to this test
+func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	testUUID := "CACHE_UUID_1234"
 	testExternalCacheScheme := "https"
 	testExternalCacheHost := "www.externalprebidcache.net"
@@ -508,7 +508,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) { //Test returnCreative here, or 
 			NURL:           "",
 			BURL:           "",
 			LURL:           "",
-			AdM:            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>",
+			AdM:            "",
 			AdID:           "",
 			ADomain:        nil,
 			Bundle:         "",
@@ -610,7 +610,6 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) { //Test returnCreative here, or 
 				Seat: string(bidderName),
 				Bid: []openrtb.Bid{
 					{
-						AdM: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>",
 						Ext: json.RawMessage(`{ "prebid": { "cache": { "bids": { "cacheId": "` + testUUID + `", "url": "` + testExternalCacheScheme + `://` + testExternalCacheHost + `/` + testExternalCachePath + `?uuid=` + testUUID + `" }, "key": "", "url": "" }`),
 					},
 				},
@@ -634,8 +633,6 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) { //Test returnCreative here, or 
 	assert.NoErrorf(t, err, "[TestGetBidCacheInfo] Error found while trying to json parse the url field from actual build response. Message: %v \n", err)
 
 	assert.Equal(t, expCacheURL, cacheURL, "[TestGetBidCacheInfo] cacheId field in ext should equal \"%s\" \n", expCacheURL)
-
-	// compare cache URL
 }
 
 func TestBidReturnsCreative(t *testing.T) {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -129,7 +129,7 @@ func TestCharacterEscape(t *testing.T) {
 	var errList []error
 
 	/* 	4) Build bid response 									*/
-	bidResp, err := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, errList)
+	bidResp, err := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, true, errList)
 
 	/* 	5) Assert we have no errors and one '&' character as we are supposed to 	*/
 	if err != nil {
@@ -274,7 +274,194 @@ func TestDebugBehaviour(t *testing.T) {
 	}
 }
 
-func TestGetBidCacheInfoEndToEnd(t *testing.T) {
+func TestReturnCreativeEndToEnd(t *testing.T) {
+	sampleAd := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>"
+
+	// Define test cases
+	type aTest struct {
+		desc   string
+		inExt  json.RawMessage
+		outAdM string
+	}
+	testGroups := []struct {
+		groupDesc   string
+		testCases   []aTest
+		expectError bool
+	}{
+		{
+			groupDesc: "Invalid or malformed bidRequest Ext, expect error in these scenarios",
+			testCases: []aTest{
+				{
+					desc:  "Malformed ext in bidRequest",
+					inExt: json.RawMessage(`malformed`),
+				},
+				{
+					desc:  "empty cache field",
+					inExt: json.RawMessage(`{"prebid":{"cache":{}}}`),
+				},
+			},
+			expectError: true,
+		},
+		{
+			groupDesc: "Valid bidRequest Ext but no returnCreative value specified, default to returning creative",
+			testCases: []aTest{
+				{
+					"Nil ext in bidRequest",
+					nil,
+					sampleAd,
+				},
+				{
+					"empty ext",
+					json.RawMessage(``),
+					sampleAd,
+				},
+				{
+					"bids doesn't come with returnCreative value",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{}}}}`),
+					sampleAd,
+				},
+				{
+					"vast doesn't come with returnCreative value",
+					json.RawMessage(`{"prebid":{"cache":{"vastXml":{}}}}`),
+					sampleAd,
+				},
+			},
+		},
+		{
+			groupDesc: "Bids field comes with returnCreative value",
+			testCases: []aTest{
+				{
+					"Bids returnCreative set to true, return ad markup in response",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true}}}}`),
+					sampleAd,
+				},
+				{
+					"Bids returnCreative set to false, don't return ad markup in response",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false}}}}`),
+					"",
+				},
+			},
+		},
+		{
+			groupDesc: "Vast field comes with returnCreative value",
+			testCases: []aTest{
+				{
+					"Vast returnCreative set to true, return ad markup in response",
+					json.RawMessage(`{"prebid":{"cache":{"vastXml":{"returnCreative":true}}}}`),
+					sampleAd,
+				},
+				{
+					"Vast returnCreative set to false, don't return ad markup in response",
+					json.RawMessage(`{"prebid":{"cache":{"vastXml":{"returnCreative":false}}}}`),
+					"",
+				},
+			},
+		},
+		{
+			groupDesc: "Both Bids and Vast come with their own returnCreative value",
+			testCases: []aTest{
+				{
+					"Both false, expect empty AdM",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":false}}}}`),
+					"",
+				},
+				{
+					"Bids returnCreative is true, expect valid AdM",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":true}}}}`),
+					sampleAd,
+				},
+				{
+					"Vast returnCreative is true, expect valid AdM",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":true}}}}`),
+					sampleAd,
+				},
+				{
+					"Both field's returnCreative set to true, expect valid AdM",
+					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true},"vastXml":{"returnCreative":true}}}}`),
+					sampleAd,
+				},
+			},
+		},
+	}
+
+	// Init an exchange to run an auction from
+	noBidServer := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(204) }
+	server := httptest.NewServer(http.HandlerFunc(noBidServer))
+	defer server.Close()
+
+	categoriesFetcher, error := newCategoryFetcher("./test/category-mapping")
+	if error != nil {
+		t.Errorf("Failed to create a category Fetcher: %v", error)
+	}
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{
+			Bids: []*adapters.TypedBid{
+				{
+					Bid: &openrtb.Bid{AdM: sampleAd},
+				},
+			},
+		},
+	}
+
+	e := new(exchange)
+	e.adapterMap = map[openrtb_ext.BidderName]adaptedBidder{
+		openrtb_ext.BidderAppnexus: adaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.DummyMetricsEngine{}, openrtb_ext.BidderAppnexus),
+	}
+	e.cache = &wellBehavedCache{}
+	e.me = &metricsConf.DummyMetricsEngine{}
+	e.gDPR = gdpr.AlwaysAllow{}
+	e.currencyConverter = currencies.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	// Define mock incoming bid requeset
+	mockBidRequest := &openrtb.BidRequest{
+		ID: "some-request-id",
+		Imp: []openrtb.Imp{{
+			ID:     "some-impression-id",
+			Banner: &openrtb.Banner{Format: []openrtb.Format{{W: 300, H: 250}, {W: 300, H: 600}}},
+			Ext:    json.RawMessage(`{"appnexus": {"placementId": 1}}`),
+		}},
+		Site: &openrtb.Site{Page: "prebid.org", Ext: json.RawMessage(`{"amp":0}`)},
+	}
+
+	// Run tests
+	for _, testGroup := range testGroups {
+		for _, test := range testGroup.testCases {
+			mockBidRequest.Ext = test.inExt
+
+			// Run test
+			outBidResponse, err := e.HoldAuction(context.Background(), mockBidRequest, &emptyUsersync{}, pbsmetrics.Labels{}, &config.Account{}, &categoriesFetcher, nil)
+
+			// Assert return error, if any
+			if testGroup.expectError {
+				assert.Errorf(t, err, "HoldAuction expected to throw error for: %s - %s. \n", testGroup.groupDesc, test.desc)
+				continue
+			} else {
+				assert.NoErrorf(t, err, "%s: %s. HoldAuction error: %v \n", testGroup.groupDesc, test.desc, err)
+			}
+
+			// Assert returned bid
+			if !assert.NotNil(t, outBidResponse, "%s: %s. outBidResponse is nil \n", testGroup.groupDesc, test.desc) {
+				return
+			}
+			if !assert.NotEmpty(t, outBidResponse.SeatBid, "%s: %s. outBidResponse.SeatBid is empty \n", testGroup.groupDesc, test.desc) {
+				return
+			}
+			if !assert.NotEmpty(t, outBidResponse.SeatBid[0].Bid, "%s: %s. outBidResponse.SeatBid[0].Bid is empty \n", testGroup.groupDesc, test.desc) {
+				return
+			}
+			assert.Equal(t, test.outAdM, outBidResponse.SeatBid[0].Bid[0].AdM, "Ad markup string doesn't match in: %s - %s \n", testGroup.groupDesc, test.desc)
+		}
+	}
+}
+
+func TestGetBidCacheInfoEndToEnd(t *testing.T) { //Test returnCreative here, or similar to this test
 	testUUID := "CACHE_UUID_1234"
 	testExternalCacheScheme := "https"
 	testExternalCacheHost := "www.externalprebidcache.net"
@@ -321,7 +508,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 			NURL:           "",
 			BURL:           "",
 			LURL:           "",
-			AdM:            "",
+			AdM:            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>",
 			AdID:           "",
 			ADomain:        nil,
 			Bundle:         "",
@@ -412,7 +599,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	var errList []error
 
 	/* 	4) Build bid response 									*/
-	bid_resp, err := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, errList)
+	bid_resp, err := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, true, errList)
 
 	/* 	5) Assert we have no errors and the bid response we expected*/
 	assert.NoError(t, err, "[TestGetBidCacheInfo] buildBidResponse() threw an error")
@@ -423,6 +610,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 				Seat: string(bidderName),
 				Bid: []openrtb.Bid{
 					{
+						AdM: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>",
 						Ext: json.RawMessage(`{ "prebid": { "cache": { "bids": { "cacheId": "` + testUUID + `", "url": "` + testExternalCacheScheme + `://` + testExternalCacheHost + `/` + testExternalCachePath + `?uuid=` + testUUID + `" }, "key": "", "url": "" }`),
 					},
 				},
@@ -438,7 +626,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 
 	assert.Equal(t, expCacheUUID, cacheUUID, "[TestGetBidCacheInfo] cacheId field in ext should equal \"%s\" \n", expCacheUUID)
 
-	// compare cache UUID
+	// compare cache URL
 	expCacheURL, err := jsonparser.GetString(expectedBidResponse.SeatBid[0].Bid[0].Ext, "prebid", "cache", "bids", "url")
 	assert.NoErrorf(t, err, "[TestGetBidCacheInfo] Error found while trying to json parse the url field from expected build response. Message: %v \n", err)
 
@@ -446,6 +634,71 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	assert.NoErrorf(t, err, "[TestGetBidCacheInfo] Error found while trying to json parse the url field from actual build response. Message: %v \n", err)
 
 	assert.Equal(t, expCacheURL, cacheURL, "[TestGetBidCacheInfo] cacheId field in ext should equal \"%s\" \n", expCacheURL)
+
+	// compare cache URL
+}
+
+func TestBidReturnsCreative(t *testing.T) {
+	sampleAd := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>"
+	sampleOpenrtbBid := &openrtb.Bid{ID: "some-bid-id", AdM: sampleAd}
+
+	// Define test cases
+	testCases := []struct {
+		description            string
+		inReturnCreative       bool
+		expectedCreativeMarkup string
+	}{
+		{
+			"returnCreative set to true, expect a full creative markup string in returned bid",
+			true,
+			sampleAd,
+		},
+		{
+			"returnCreative set to false, expect empty creative markup string in returned bid",
+			false,
+			"",
+		},
+	}
+
+	// Test set up
+	sampleBids := []*pbsOrtbBid{
+		{
+			bid:        sampleOpenrtbBid,
+			bidType:    openrtb_ext.BidTypeBanner,
+			bidTargets: map[string]string{},
+		},
+	}
+	sampleAuction := &auction{cacheIds: map[*openrtb.Bid]string{sampleOpenrtbBid: "CACHE_UUID_1234"}}
+
+	noBidHandler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(204) }
+	server := httptest.NewServer(http.HandlerFunc(noBidHandler))
+	defer server.Close()
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{},
+	}
+	e := new(exchange)
+	e.adapterMap = map[openrtb_ext.BidderName]adaptedBidder{
+		openrtb_ext.BidderAppnexus: adaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.DummyMetricsEngine{}, openrtb_ext.BidderAppnexus),
+	}
+	e.cache = &wellBehavedCache{}
+	e.me = &metricsConf.DummyMetricsEngine{}
+	e.gDPR = gdpr.AlwaysAllow{}
+	e.currencyConverter = currencies.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	//Run tests
+	for _, test := range testCases {
+		resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, test.inReturnCreative)
+
+		assert.Equal(t, 0, len(resultingErrs), "%s. Test should not return errors \n", test.description)
+		assert.Equal(t, test.expectedCreativeMarkup, resultingBids[0].AdM, "%s. Ad markup string doesn't match expected \n", test.description)
+	}
 }
 
 func TestGetBidCacheInfo(t *testing.T) {
@@ -707,7 +960,7 @@ func TestBidResponseCurrency(t *testing.T) {
 
 	// Run tests
 	for i := range testCases {
-		actualBidResp, err := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, nil, errList)
+		actualBidResp, err := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, nil, true, errList)
 		assert.NoError(t, err, fmt.Sprintf("[TEST_FAILED] e.buildBidResponse resturns error in test: %s Error message: %s \n", testCases[i].description, err))
 		assert.Equalf(t, testCases[i].expectedBidResponse, actualBidResp, fmt.Sprintf("[TEST_FAILED] Objects must be equal for test: %s \n Expected: >>%s<< \n Actual: >>%s<< ", testCases[i].description, testCases[i].expectedBidResponse.Ext, actualBidResp.Ext))
 	}

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -446,15 +446,37 @@ func extractBidRequestExt(bidRequest *openrtb.BidRequest) (*openrtb_ext.ExtReque
 	return requestExt, nil
 }
 
-func getExtCacheInfo(requestExt *openrtb_ext.ExtRequest) (shouldCacheBids bool, shouldCacheVAST bool) {
+func getExtCacheInstructions(requestExt *openrtb_ext.ExtRequest) extCacheInstructions {
+	//returnCreative defaults to true
+	cacheInstructions := extCacheInstructions{returnCreative: true}
+	foundBidsRC := false
+	foundVastRC := false
+
 	if requestExt != nil && requestExt.Prebid.Cache != nil {
-		shouldCacheBids = requestExt.Prebid.Cache.Bids != nil
-		shouldCacheVAST = requestExt.Prebid.Cache.VastXML != nil
+		if requestExt.Prebid.Cache.Bids != nil {
+			cacheInstructions.cacheBids = true
+			if requestExt.Prebid.Cache.Bids.ReturnCreative != nil {
+				cacheInstructions.returnCreative = *requestExt.Prebid.Cache.Bids.ReturnCreative
+				foundBidsRC = true
+			}
+		}
+		if requestExt.Prebid.Cache.VastXML != nil {
+			cacheInstructions.cacheVAST = true
+			if requestExt.Prebid.Cache.VastXML.ReturnCreative != nil {
+				cacheInstructions.returnCreative = *requestExt.Prebid.Cache.VastXML.ReturnCreative
+				foundVastRC = true
+			}
+		}
 	}
-	return
+
+	if foundBidsRC && foundVastRC {
+		cacheInstructions.returnCreative = *requestExt.Prebid.Cache.Bids.ReturnCreative || *requestExt.Prebid.Cache.VastXML.ReturnCreative
+	}
+
+	return cacheInstructions
 }
 
-func getExtTargetData(requestExt *openrtb_ext.ExtRequest, shouldCacheBids bool, shouldCacheVAST bool) *targetData {
+func getExtTargetData(requestExt *openrtb_ext.ExtRequest, cacheInstructions *extCacheInstructions) *targetData {
 	var targData *targetData
 
 	if requestExt != nil && requestExt.Prebid.Targeting != nil {
@@ -462,8 +484,8 @@ func getExtTargetData(requestExt *openrtb_ext.ExtRequest, shouldCacheBids bool, 
 			priceGranularity:  requestExt.Prebid.Targeting.PriceGranularity,
 			includeWinners:    requestExt.Prebid.Targeting.IncludeWinners,
 			includeBidderKeys: requestExt.Prebid.Targeting.IncludeBidderKeys,
-			includeCacheBids:  shouldCacheBids,
-			includeCacheVast:  shouldCacheVAST,
+			includeCacheBids:  cacheInstructions.cacheBids,
+			includeCacheVast:  cacheInstructions.cacheVAST,
 			includeFormat:     requestExt.Prebid.Targeting.IncludeFormat,
 		}
 	}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -302,7 +302,11 @@ func TestCleanOpenRTBRequestsSChain(t *testing.T) {
 	}
 }
 
-func TestExtractBidRequesteExt(t *testing.T) {
+func TestExtractBidRequestExt(t *testing.T) {
+	var boolFalse, boolTrue *bool = new(bool), new(bool)
+	*boolFalse = false
+	*boolTrue = true
+
 	testCases := []struct {
 		desc          string
 		inBidRequest  *openrtb.BidRequest
@@ -310,10 +314,34 @@ func TestExtractBidRequesteExt(t *testing.T) {
 		outError      error
 	}{
 		{
-			desc:          "Valid",
-			inBidRequest:  &openrtb.BidRequest{Ext: json.RawMessage(`{"prebid":{"debug":true}}`)},
-			outRequestExt: &openrtb_ext.ExtRequest{Prebid: openrtb_ext.ExtRequestPrebid{Debug: true}},
-			outError:      nil,
+			desc:         "Valid vastxml.returnCreative set to false",
+			inBidRequest: &openrtb.BidRequest{Ext: json.RawMessage(`{"prebid":{"debug":true,"cache":{"vastxml":{"returnCreative":false}}}}`)},
+			outRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Debug: true,
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{
+							ReturnCreative: boolFalse,
+						},
+					},
+				},
+			},
+			outError: nil,
+		},
+		{
+			desc:         "Valid vastxml.returnCreative set to true",
+			inBidRequest: &openrtb.BidRequest{Ext: json.RawMessage(`{"prebid":{"debug":true,"cache":{"vastxml":{"returnCreative":true}}}}`)},
+			outRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Debug: true,
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{
+							ReturnCreative: boolTrue,
+						},
+					},
+				},
+			},
+			outError: nil,
 		},
 		{
 			desc:          "bidRequest nil, we expect an error",
@@ -337,32 +365,44 @@ func TestExtractBidRequesteExt(t *testing.T) {
 	for _, test := range testCases {
 		actualRequestExt, actualErr := extractBidRequestExt(test.inBidRequest)
 
+		// Given that assert.Equal asserts pointer variable equality based on the equality of the referenced values (as opposed to
+		// the memory addresses) the call below asserts whether or not *test.outRequestExt.Prebid.Cache.VastXML.ReturnCreative boolean
+		// value is equal to that of *actualRequestExt.Prebid.Cache.VastXML.ReturnCreative
 		assert.Equal(t, test.outRequestExt, actualRequestExt, "%s. Unexpected RequestExt value. \n", test.desc)
 		assert.Equal(t, test.outError, actualErr, "%s. Unexpected error value. \n", test.desc)
 	}
 }
 
-func TestGetExtCacheInfo(t *testing.T) {
+func TestGetExtCacheInstructions(t *testing.T) {
+	var boolFalse, boolTrue *bool = new(bool), new(bool)
+	*boolFalse = false
+	*boolTrue = true
+
 	testCases := []struct {
-		desc         string
-		inRequestExt *openrtb_ext.ExtRequest
-		outCacheBids bool
-		outCacheVAST bool
+		desc                 string
+		inRequestExt         *openrtb_ext.ExtRequest
+		outCacheInstructions extCacheInstructions
 	}{
 		{
-			desc:         "Nil inRequestExt, both cache flags false",
+			desc:         "Nil inRequestExt, all cache flags false except for returnCreative that defaults to true",
 			inRequestExt: nil,
-			outCacheBids: false,
-			outCacheVAST: false,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      false,
+				returnCreative: true,
+			},
 		},
 		{
-			desc:         "Non-nil inRequestExt, nil Cache info, both cache flags false",
+			desc:         "Non-nil inRequestExt, nil Cache field, all cache flags false except for returnCreative that defaults to true",
 			inRequestExt: &openrtb_ext.ExtRequest{Prebid: openrtb_ext.ExtRequestPrebid{Cache: nil}},
-			outCacheBids: false,
-			outCacheVAST: false,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      false,
+				returnCreative: true,
+			},
 		},
 		{
-			desc: "Non-nil inRequestExt, non-nil Cache info, both ExtRequestPrebidCacheBids and ExtRequestPrebidCacheVAST nil",
+			desc: "Non-nil Cache field, both ExtRequestPrebidCacheBids and ExtRequestPrebidCacheVAST nil returnCreative that defaults to true",
 			inRequestExt: &openrtb_ext.ExtRequest{
 				Prebid: openrtb_ext.ExtRequestPrebid{
 					Cache: &openrtb_ext.ExtRequestPrebidCache{
@@ -371,11 +411,14 @@ func TestGetExtCacheInfo(t *testing.T) {
 					},
 				},
 			},
-			outCacheBids: false,
-			outCacheVAST: false,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      false,
+				returnCreative: true,
+			},
 		},
 		{
-			desc: "Non-nil inRequestExt, non-nil Cache info, both ExtRequestPrebidCacheBids nil, shouldCacheVast true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST with unspecified ReturnCreative field, cacheVAST = true and returnCreative defaults to true",
 			inRequestExt: &openrtb_ext.ExtRequest{
 				Prebid: openrtb_ext.ExtRequestPrebid{
 					Cache: &openrtb_ext.ExtRequestPrebidCache{
@@ -384,11 +427,46 @@ func TestGetExtCacheInfo(t *testing.T) {
 					},
 				},
 			},
-			outCacheBids: false,
-			outCacheVAST: true,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      true,
+				returnCreative: true, // default value
+			},
 		},
 		{
-			desc: "Non-nil inRequestExt, non-nil Cache info, both ExtRequestPrebidCacheVAST nil, shouldCacheBids true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to false, cacheVAST = true and returnCreative = false",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    nil,
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolFalse},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      true,
+				returnCreative: false,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to true, cacheVAST = true and returnCreative = true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    nil,
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolTrue},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      false,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids with unspecified ReturnCreative field, cacheBids = true and returnCreative defaults to true",
 			inRequestExt: &openrtb_ext.ExtRequest{
 				Prebid: openrtb_ext.ExtRequestPrebid{
 					Cache: &openrtb_ext.ExtRequestPrebidCache{
@@ -397,11 +475,46 @@ func TestGetExtCacheInfo(t *testing.T) {
 					},
 				},
 			},
-			outCacheBids: true,
-			outCacheVAST: false,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      false,
+				returnCreative: true, // default value
+			},
 		},
 		{
-			desc: "Non-nil inRequestExt, non-nil Cache info values, both shouldCacheBids and shouldCacheVAST return true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to false, cacheBids = true and returnCreative  = false",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
+						VastXML: nil,
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      false,
+				returnCreative: false,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to true, cacheBids = true and returnCreative  = true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
+						VastXML: nil,
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      false,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST, neither specify a ReturnCreative field value, all extCacheInstructions fields set to true",
 			inRequestExt: &openrtb_ext.ExtRequest{
 				Prebid: openrtb_ext.ExtRequestPrebid{
 					Cache: &openrtb_ext.ExtRequestPrebidCache{
@@ -410,23 +523,123 @@ func TestGetExtCacheInfo(t *testing.T) {
 					},
 				},
 			},
-			outCacheBids: true,
-			outCacheVAST: true,
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets ReturnCreative to true, all extCacheInstructions fields set to true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolTrue},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets ReturnCreative to false, returnCreative = false",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolFalse},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: false,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets ReturnCreative to true, all extCacheInstructions fields set to true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets ReturnCreative to false, returnCreative = false",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: false,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolTrue},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
+		},
+		{
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			inRequestExt: &openrtb_ext.ExtRequest{
+				Prebid: openrtb_ext.ExtRequestPrebid{
+					Cache: &openrtb_ext.ExtRequestPrebidCache{
+						Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
+						VastXML: &openrtb_ext.ExtRequestPrebidCacheVAST{ReturnCreative: boolFalse},
+					},
+				},
+			},
+			outCacheInstructions: extCacheInstructions{
+				cacheBids:      true,
+				cacheVAST:      true,
+				returnCreative: true,
+			},
 		},
 	}
-	for _, test := range testCases {
-		shouldCacheBids, shouldCacheVAST := getExtCacheInfo(test.inRequestExt)
 
-		assert.Equal(t, test.outCacheBids, shouldCacheBids, "%s. Unexpected shouldCacheBids value. \n", test.desc)
-		assert.Equal(t, test.outCacheVAST, shouldCacheVAST, "%s. Unexpected shouldCacheVAST value. \n", test.desc)
+	for _, test := range testCases {
+		cacheInstructions := getExtCacheInstructions(test.inRequestExt)
+
+		assert.Equal(t, test.outCacheInstructions.cacheBids, cacheInstructions.cacheBids, "%s. Unexpected shouldCacheBids value. \n", test.desc)
+		assert.Equal(t, test.outCacheInstructions.cacheVAST, cacheInstructions.cacheVAST, "%s. Unexpected shouldCacheVAST value. \n", test.desc)
+		assert.Equal(t, test.outCacheInstructions.returnCreative, cacheInstructions.returnCreative, "%s. Unexpected returnCreative value. \n", test.desc)
 	}
 }
 
 func TestGetExtTargetData(t *testing.T) {
 	type inTest struct {
-		requestExt      *openrtb_ext.ExtRequest
-		shouldCacheBids bool
-		shouldCacheVAST bool
+		requestExt        *openrtb_ext.ExtRequest
+		cacheInstructions *extCacheInstructions
 	}
 	type outTest struct {
 		targetData    *targetData
@@ -440,9 +653,11 @@ func TestGetExtTargetData(t *testing.T) {
 		{
 			"nil requestExt, nil outTargetData",
 			inTest{
-				requestExt:      nil,
-				shouldCacheBids: true,
-				shouldCacheVAST: true,
+				requestExt: nil,
+				cacheInstructions: &extCacheInstructions{
+					cacheBids: true,
+					cacheVAST: true,
+				},
 			},
 			outTest{targetData: nil, nilTargetData: true},
 		},
@@ -454,8 +669,10 @@ func TestGetExtTargetData(t *testing.T) {
 						Targeting: nil,
 					},
 				},
-				shouldCacheBids: true,
-				shouldCacheVAST: true,
+				cacheInstructions: &extCacheInstructions{
+					cacheBids: true,
+					cacheVAST: true,
+				},
 			},
 			outTest{targetData: nil, nilTargetData: true},
 		},
@@ -474,8 +691,10 @@ func TestGetExtTargetData(t *testing.T) {
 						},
 					},
 				},
-				shouldCacheBids: true,
-				shouldCacheVAST: true,
+				cacheInstructions: &extCacheInstructions{
+					cacheBids: true,
+					cacheVAST: true,
+				},
 			},
 			outTest{
 				targetData: &targetData{
@@ -493,7 +712,7 @@ func TestGetExtTargetData(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		actualTargetData := getExtTargetData(test.in.requestExt, test.in.shouldCacheBids, test.in.shouldCacheVAST)
+		actualTargetData := getExtTargetData(test.in.requestExt, test.in.cacheInstructions)
 
 		if test.out.nilTargetData {
 			assert.Nil(t, actualTargetData, "%s. Targeting data should be nil. \n", test.desc)

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -75,10 +75,14 @@ func (ert *ExtRequestPrebidCache) UnmarshalJSON(b []byte) error {
 }
 
 // ExtRequestPrebidCacheBids defines the contract for bidrequest.ext.prebid.cache.bids
-type ExtRequestPrebidCacheBids struct{}
+type ExtRequestPrebidCacheBids struct {
+	ReturnCreative *bool `json:"returnCreative"`
+}
 
 // ExtRequestPrebidCacheVAST defines the contract for bidrequest.ext.prebid.cache.vastxml
-type ExtRequestPrebidCacheVAST struct{}
+type ExtRequestPrebidCacheVAST struct {
+	ReturnCreative *bool `json:"returnCreative"`
+}
 
 // ExtRequestTargeting defines the contract for bidrequest.ext.prebid.targeting
 type ExtRequestTargeting struct {


### PR DESCRIPTION
This PR implements the ability to return empty ad markup strings in bidResponses when `ext.prebid.cache.vast.returnCreative` or `ext.prebid.cache.bids.returnCreative` is set to false in the incoming bid request. Please let me know your thoughts.

In summary:
**Bid request**
Note the new `returnCreative` field in the bid request extension: 
```
  {
    "id":"an-id",
    "imp":[
      {...}
    ],
    "site":{...},
    "user": {...},
    "ext": {
      "prebid":{
        "cache":{
          "bids":{
            "returnCreative":false //<-- new
          }
        }
      }
    }
  },
```

**Bid Response**
Given the `returnCreative` field in the bid request extension value set to false, an empty `AdM` value is returned in the bid response:
```
{
  "status" : 200,
  "body": {
    "id":"an-id",
    "seatBid":[
      {
        "bid": [
          {
            "id": "video1AdmVideo",
            "impid": "video1",
            "price": 20,
            "adm": "",  //<-- empty when returnCreative is false
            "adid": "1088",
            "w": 300,
            "h": 250,
            "ext": {
              "prebid": {
                "type": "video"
              }
            }
          }
        ],
        "seat": "a-biddername"
      }
    ]
  }
}
```