### PR TITLE
Set storedRequestTimeoutMillis as cutomizable config variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -863,6 +863,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("stored_requests.postgres.poll_for_updates.amp_query", "")
 	v.SetDefault("stored_requests.http.endpoint", "")
 	v.SetDefault("stored_requests.http.amp_endpoint", "")
+	v.SetDefault("stored_requests.http.fetcher_timeout", 50)
 	v.SetDefault("stored_requests.in_memory_cache.type", "none")
 	v.SetDefault("stored_requests.in_memory_cache.ttl_seconds", 0)
 	v.SetDefault("stored_requests.in_memory_cache.request_cache_size_bytes", 0)

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -96,8 +96,9 @@ type FileFetcherConfig struct {
 
 // HTTPFetcherConfig configures a stored_requests/backends/http_fetcher/fetcher.go
 type HTTPFetcherConfig struct {
-	Endpoint    string `mapstructure:"endpoint"`
-	AmpEndpoint string `mapstructure:"amp_endpoint"`
+	Endpoint       string `mapstructure:"endpoint"`
+	AmpEndpoint    string `mapstructure:"amp_endpoint"`
+	FetcherTimeout uint16 `mapstructure:"fetcher_timeout"`
 }
 
 // Migrate combined stored_requests+amp configuration to separate simple config sections

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -314,7 +314,7 @@ func (deps *endpointDeps) loadRequestJSONForAmp(httpRequest *http.Request) (req 
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(storedRequestTimeoutMillis)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration((*deps.cfg).StoredRequests.HTTP.FetcherTimeout)*time.Millisecond)
 	defer cancel()
 
 	storedRequests, _, errs := deps.storedReqFetcher.FetchRequests(ctx, []string{ampID}, nil)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -39,8 +39,6 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
-const storedRequestTimeoutMillis = 50
-
 var (
 	dntKey      string = http.CanonicalHeaderKey("DNT")
 	dntDisabled int8   = 0
@@ -226,7 +224,7 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request) (req *openrtb.
 		}
 	}
 
-	timeout := parseTimeout(requestJson, time.Duration(storedRequestTimeoutMillis)*time.Millisecond)
+	timeout := parseTimeout(requestJson, time.Duration((*deps.cfg).StoredRequests.HTTP.FetcherTimeout)*time.Millisecond)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -419,7 +419,7 @@ func createImpressionTemplate(imp openrtb.Imp, video *openrtb.Video) openrtb.Imp
 }
 
 func (deps *endpointDeps) loadStoredImp(storedImpId string) (openrtb.Imp, []error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(storedRequestTimeoutMillis)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration((*deps.cfg).StoredRequests.HTTP.FetcherTimeout)*time.Millisecond)
 	defer cancel()
 
 	impr := openrtb.Imp{}


### PR DESCRIPTION
Set storedRequestTimeoutMillis as global config variable, allowing http fetchers timeout customization through stored_requests.http.fetcher_timeout config.
https://github.com/prebid/prebid-server/issues/1527