### PR TITLE
Add Support For imp.ext.prebid For DealTiers

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -235,34 +235,19 @@ func (e *exchange) HoldAuction(ctx context.Context, bidRequest *openrtb.BidReque
 	return e.buildBidResponse(ctx, liveAdapters, adapterBids, bidRequest, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, errs)
 }
 
-type DealTierInfo struct {
-	Prefix      string `json:"prefix"`
-	MinDealTier int    `json:"minDealTier"`
-}
-
-type DealTier struct {
-	Info *DealTierInfo `json:"dealTier,omitempty"`
-}
-
-type BidderDealTier struct {
-	DealInfo map[string]*DealTier
-}
-
 // applyDealSupport updates targeting keys with deal prefixes if minimum deal tier exceeded
 func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction, bidCategory map[string]string) []error {
 	errs := []error{}
 	impDealMap := getDealTiers(bidRequest)
 
 	for impID, topBidsPerImp := range auc.winningBidsByBidder {
-		impDeal := impDealMap[impID].DealInfo
+		impDeal := impDealMap[impID]
 		for bidder, topBidPerBidder := range topBidsPerImp {
-			bidderString := bidder.String()
-
 			if topBidPerBidder.dealPriority > 0 {
-				if validateAndNormalizeDealTier(impDeal[bidderString]) {
-					updateHbPbCatDur(topBidPerBidder, impDeal[bidderString].Info, bidCategory)
+				if validateDealTier(impDeal[bidder]) {
+					updateHbPbCatDur(topBidPerBidder, impDeal[bidder], bidCategory)
 				} else {
-					errs = append(errs, fmt.Errorf("dealTier configuration invalid for bidder '%s', imp ID '%s'", bidderString, impID))
+					errs = append(errs, fmt.Errorf("dealTier configuration invalid for bidder '%s', imp ID '%s'", string(bidder), impID))
 				}
 			}
 		}
@@ -272,34 +257,27 @@ func applyDealSupport(bidRequest *openrtb.BidRequest, auc *auction, bidCategory 
 }
 
 // getDealTiers creates map of impression to bidder deal tier configuration
-func getDealTiers(bidRequest *openrtb.BidRequest) map[string]*BidderDealTier {
-	impDealMap := make(map[string]*BidderDealTier)
+func getDealTiers(bidRequest *openrtb.BidRequest) map[string]openrtb_ext.DealTierBidderMap {
+	impDealMap := make(map[string]openrtb_ext.DealTierBidderMap)
 
 	for _, imp := range bidRequest.Imp {
-		var bidderDealTier BidderDealTier
-		err := json.Unmarshal(imp.Ext, &bidderDealTier.DealInfo)
+		dealTierBidderMap, err := openrtb_ext.ReadDealTiersFromImp(imp)
 		if err != nil {
 			continue
 		}
-
-		impDealMap[imp.ID] = &bidderDealTier
+		impDealMap[imp.ID] = dealTierBidderMap
 	}
 
 	return impDealMap
 }
 
-func validateAndNormalizeDealTier(impDeal *DealTier) bool {
-	if impDeal == nil || impDeal.Info == nil {
-		return false
-	}
-	// Remove whitespace from prefix before checking if it can be used
-	impDeal.Info.Prefix = strings.ReplaceAll(impDeal.Info.Prefix, " ", "")
-	return len(impDeal.Info.Prefix) > 0 && impDeal.Info.MinDealTier > 0
+func validateDealTier(dealTier openrtb_ext.DealTier) bool {
+	return len(dealTier.Prefix) > 0 && dealTier.MinDealTier > 0
 }
 
-func updateHbPbCatDur(bid *pbsOrtbBid, dealTierInfo *DealTierInfo, bidCategory map[string]string) {
-	if bid.dealPriority >= dealTierInfo.MinDealTier {
-		prefixTier := fmt.Sprintf("%s%d_", dealTierInfo.Prefix, bid.dealPriority)
+func updateHbPbCatDur(bid *pbsOrtbBid, dealTier openrtb_ext.DealTier, bidCategory map[string]string) {
+	if bid.dealPriority >= dealTier.MinDealTier {
+		prefixTier := fmt.Sprintf("%s%d_", dealTier.Prefix, bid.dealPriority)
 
 		if oldCatDur, ok := bidCategory[bid.bid.ID]; ok {
 			oldCatDurSplit := strings.SplitAfterN(oldCatDur, "_", 2)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2166,119 +2166,91 @@ func TestApplyDealSupport(t *testing.T) {
 
 func TestGetDealTiers(t *testing.T) {
 	testCases := []struct {
-		impExt       json.RawMessage
-		bidderResult map[string]bool // true indicates bidder had valid config, false indicates invalid
+		description string
+		request     openrtb.BidRequest
+		expected    map[string]openrtb_ext.DealTierBidderMap
 	}{
 		{
-			impExt: json.RawMessage(`{"validbase": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
-			bidderResult: map[string]bool{
-				"validbase": true,
+			description: "None",
+			request: openrtb.BidRequest{
+				Imp: []openrtb.Imp{},
 			},
+			expected: map[string]openrtb_ext.DealTierBidderMap{},
 		},
 		{
-			impExt: json.RawMessage(`{"validmultiple1": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}, "validmultiple2": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
-			bidderResult: map[string]bool{
-				"validmultiple1": true,
-				"validmultiple2": true,
-			},
-		},
-		{
-			impExt: json.RawMessage(`{"nodealtier": {"placementId": 10433394}}`),
-			bidderResult: map[string]bool{
-				"nodealtier": false,
-			},
-		},
-		{
-			impExt: json.RawMessage(`{"validbase": {"placementId": 10433394}, "onedealTier2": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
-			bidderResult: map[string]bool{
-				"onedealTier2": true,
-				"validbase":    false,
-			},
-		},
-	}
-
-	filledDealTier := DealTier{
-		Info: &DealTierInfo{
-			Prefix:      "tier",
-			MinDealTier: 5,
-		},
-	}
-	emptyDealTier := DealTier{}
-
-	for _, test := range testCases {
-		bidRequest := &openrtb.BidRequest{
-			ID: "some-request-id",
-			Imp: []openrtb.Imp{
-				{
-					ID:  "imp_id1",
-					Ext: test.impExt,
+			description: "One",
+			request: openrtb.BidRequest{
+				Imp: []openrtb.Imp{
+					{ID: "imp1", Ext: json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "tier"}}}`)},
 				},
 			},
-		}
+			expected: map[string]openrtb_ext.DealTierBidderMap{
+				"imp1": {openrtb_ext.BidderAppnexus: {Prefix: "tier", MinDealTier: 5}},
+			},
+		},
+		{
+			description: "Many",
+			request: openrtb.BidRequest{
+				Imp: []openrtb.Imp{
+					{ID: "imp1", Ext: json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "tier1"}}}`)},
+					{ID: "imp2", Ext: json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 8, "prefix": "tier2"}}}`)},
+				},
+			},
+			expected: map[string]openrtb_ext.DealTierBidderMap{
+				"imp1": {openrtb_ext.BidderAppnexus: {Prefix: "tier1", MinDealTier: 5}},
+				"imp2": {openrtb_ext.BidderAppnexus: {Prefix: "tier2", MinDealTier: 8}},
+			},
+		},
+		{
+			description: "Many - Skips Malformed",
+			request: openrtb.BidRequest{
+				Imp: []openrtb.Imp{
+					{ID: "imp1", Ext: json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "tier1"}}}`)},
+					{ID: "imp2", Ext: json.RawMessage(`{"appnexus": {"dealTier": "wrong type"}}`)},
+				},
+			},
+			expected: map[string]openrtb_ext.DealTierBidderMap{
+				"imp1": {openrtb_ext.BidderAppnexus: {Prefix: "tier1", MinDealTier: 5}},
+			},
+		},
+	}
 
-		impDealMap := getDealTiers(bidRequest)
-
-		for bidder, valid := range test.bidderResult {
-			if valid {
-				assert.Equal(t, &filledDealTier, impDealMap["imp_id1"].DealInfo[bidder], "DealTier should be filled with config data")
-			} else {
-				assert.Equal(t, &emptyDealTier, impDealMap["imp_id1"].DealInfo[bidder], "DealTier should be empty")
-			}
-		}
+	for _, test := range testCases {
+		result := getDealTiers(&test.request)
+		assert.Equal(t, test.expected, result, test.description)
 	}
 }
 
-func TestValidateAndNormalizeDealTier(t *testing.T) {
+func TestValidateDealTier(t *testing.T) {
 	testCases := []struct {
 		description    string
-		params         json.RawMessage
+		dealTier       openrtb_ext.DealTier
 		expectedResult bool
 	}{
 		{
-			description:    "BidderDealTier should be valid",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "tier"}, "placementId": 10433394}}`),
+			description:    "Valid",
+			dealTier:       openrtb_ext.DealTier{Prefix: "prefix", MinDealTier: 5},
 			expectedResult: true,
 		},
 		{
-			description:    "BidderDealTier should be invalid due to empty prefix",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": ""}, "placementId": 10433394}}`),
+			description:    "Invalid - Empty",
+			dealTier:       openrtb_ext.DealTier{},
 			expectedResult: false,
 		},
 		{
-			description:    "BidderDealTier should be invalid due to empty dealTier",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {}, "placementId": 10433394}}`),
+			description:    "Invalid - Empty Prefix",
+			dealTier:       openrtb_ext.DealTier{MinDealTier: 5},
 			expectedResult: false,
 		},
 		{
-			description:    "BidderDealTier should be invalid due to missing minDealTier",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {"prefix": "tier"}, "placementId": 10433394}}`),
+			description:    "Invalid - Empty Deal Tier",
+			dealTier:       openrtb_ext.DealTier{Prefix: "prefix"},
 			expectedResult: false,
-		},
-		{
-			description:    "BidderDealTier should be invalid due to missing dealTier",
-			params:         json.RawMessage(`{"appnexus": {"placementId": 10433394}}`),
-			expectedResult: false,
-		},
-		{
-			description:    "BidderDealTier should be invalid due to prefix containing all whitespace",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "    "}, "placementId": 10433394}}`),
-			expectedResult: false,
-		},
-		{
-			description:    "BidderDealTier should be valid after removing whitespace",
-			params:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "    prefixwith  sp aces "}, "placementId": 10433394}}`),
-			expectedResult: true,
 		},
 	}
 
 	for _, test := range testCases {
-		var bidderDealTier BidderDealTier
-		err := json.Unmarshal(test.params, &bidderDealTier.DealInfo)
-		if err != nil {
-			assert.Fail(t, "Unable to unmarshal JSON data for testing BidderDealTier")
-		}
-
-		assert.Equal(t, test.expectedResult, validateAndNormalizeDealTier(bidderDealTier.DealInfo["appnexus"]), test.description)
+		assert.Equal(t, test.expectedResult, validateDealTier(test.dealTier), test.description)
 	}
 }
 
@@ -2286,7 +2258,7 @@ func TestUpdateHbPbCatDur(t *testing.T) {
 	testCases := []struct {
 		description        string
 		targ               map[string]string
-		dealTier           *DealTierInfo
+		dealTier           openrtb_ext.DealTier
 		dealPriority       int
 		expectedHbPbCatDur string
 	}{
@@ -2296,7 +2268,7 @@ func TestUpdateHbPbCatDur(t *testing.T) {
 				"hb_pb":         "12.00",
 				"hb_pb_cat_dur": "12.00_movies_30s",
 			},
-			dealTier: &DealTierInfo{
+			dealTier: openrtb_ext.DealTier{
 				Prefix:      "tier",
 				MinDealTier: 5,
 			},
@@ -2309,7 +2281,7 @@ func TestUpdateHbPbCatDur(t *testing.T) {
 				"hb_pb":         "12.00",
 				"hb_pb_cat_dur": "12.00_auto_30s",
 			},
-			dealTier: &DealTierInfo{
+			dealTier: openrtb_ext.DealTier{
 				Prefix:      "tier",
 				MinDealTier: 10,
 			},
@@ -2322,7 +2294,7 @@ func TestUpdateHbPbCatDur(t *testing.T) {
 				"hb_pb":         "12.00",
 				"hb_pb_cat_dur": "12.00_medicine_30s",
 			},
-			dealTier: &DealTierInfo{
+			dealTier: openrtb_ext.DealTier{
 				Prefix:      "tier",
 				MinDealTier: 1,
 			},

--- a/openrtb_ext/deal_tier.go
+++ b/openrtb_ext/deal_tier.go
@@ -2,7 +2,6 @@ package openrtb_ext
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/mxmCherry/openrtb"
 )
@@ -37,7 +36,7 @@ func ReadDealTiersFromImp(imp openrtb.Imp) (DealTierBidderMap, error) {
 	}
 	for bidder, param := range impExt {
 		if param.DealTier != nil {
-			dealTiers[BidderName(bidder)] = normalizeDealTier(param.DealTier)
+			dealTiers[BidderName(bidder)] = *param.DealTier
 		}
 	}
 
@@ -54,15 +53,9 @@ func ReadDealTiersFromImp(imp openrtb.Imp) (DealTierBidderMap, error) {
 	}
 	for bidder, param := range impPrebidExt.Prebid.Bidders {
 		if param.DealTier != nil {
-			dealTiers[BidderName(bidder)] = normalizeDealTier(param.DealTier)
+			dealTiers[BidderName(bidder)] = *param.DealTier
 		}
 	}
 
 	return dealTiers, nil
-}
-
-func normalizeDealTier(dealTier *DealTier) DealTier {
-	x := *dealTier
-	x.Prefix = strings.ReplaceAll(x.Prefix, " ", "")
-	return x
 }

--- a/openrtb_ext/deal_tier.go
+++ b/openrtb_ext/deal_tier.go
@@ -1,0 +1,68 @@
+package openrtb_ext
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/mxmCherry/openrtb"
+)
+
+// DealTier defines the configuration of a deal tier.
+type DealTier struct {
+	// Prefix specifies the beginning of the hb_pb_cat_dur targeting key value. Must be non-empty.
+	Prefix string `json:"prefix"`
+
+	// MinDealTier specifies the minimum deal priority value (inclusive) that must be met for the targeting
+	// key value to be modified. Must be greater than 0.
+	MinDealTier int `json:"minDealTier"`
+}
+
+// DealTierBidderMap defines a correlation between bidders and deal tiers.
+type DealTierBidderMap map[BidderName]DealTier
+
+// ReadDealTiersFromImp returns a map of bidder deal tiers read from the impression of an original request (not split / cleaned).
+func ReadDealTiersFromImp(imp openrtb.Imp) (DealTierBidderMap, error) {
+	dealTiers := make(DealTierBidderMap)
+
+	if len(imp.Ext) == 0 {
+		return dealTiers, nil
+	}
+
+	// imp.ext.{bidder}
+	var impExt map[string]struct {
+		DealTier *DealTier `json:"dealTier"`
+	}
+	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
+		return nil, err
+	}
+	for bidder, param := range impExt {
+		if param.DealTier != nil {
+			dealTiers[BidderName(bidder)] = normalizeDealTier(param.DealTier)
+		}
+	}
+
+	// imp.ext.prebid.{bidder}
+	var impPrebidExt struct {
+		Prebid struct {
+			Bidders map[string]struct {
+				DealTier *DealTier `json:"dealTier"`
+			} `json:"bidder"`
+		} `json:"prebid"`
+	}
+	if err := json.Unmarshal(imp.Ext, &impPrebidExt); err != nil {
+		return nil, err
+	}
+	for bidder, param := range impPrebidExt.Prebid.Bidders {
+		if param.DealTier != nil {
+			dealTiers[BidderName(bidder)] = normalizeDealTier(param.DealTier)
+		}
+	}
+
+	return dealTiers, nil
+}
+
+func normalizeDealTier(dealTier *DealTier) DealTier {
+	x := *dealTier
+	x.Prefix = strings.ReplaceAll(x.Prefix, " ", "")
+	return x
+}

--- a/openrtb_ext/deal_tier_test.go
+++ b/openrtb_ext/deal_tier_test.go
@@ -46,11 +46,6 @@ func TestReadDealTiersFromImp(t *testing.T) {
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext - normalize prefix",
-			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": " any Prefix "}}}`),
-			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
-		},
-		{
 			description:   "imp.ext - error",
 			impExt:        json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
 			expectedError: "json: cannot unmarshal string into Go struct field .dealTier of type openrtb_ext.DealTier",
@@ -69,11 +64,6 @@ func TestReadDealTiersFromImp(t *testing.T) {
 			description:    "imp.ext.prebid - no deal tier",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{},
-		},
-		{
-			description:    "imp.ext.prebid - normalize prefix",
-			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": " anyPr  efix "}}}}}`),
-			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
 		},
 		{
 			description:   "imp.ext.prebid - error",

--- a/openrtb_ext/deal_tier_test.go
+++ b/openrtb_ext/deal_tier_test.go
@@ -1,0 +1,108 @@
+package openrtb_ext
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mxmCherry/openrtb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadDealTiersFromImp(t *testing.T) {
+	testCases := []struct {
+		description    string
+		impExt         json.RawMessage
+		expectedResult DealTierBidderMap
+		expectedError  string
+	}{
+		{
+			description:    "Nil",
+			impExt:         nil,
+			expectedResult: DealTierBidderMap{},
+		},
+		{
+			description:    "None",
+			impExt:         json.RawMessage(``),
+			expectedResult: DealTierBidderMap{},
+		},
+		{
+			description:    "Empty Object",
+			impExt:         json.RawMessage(`{}`),
+			expectedResult: DealTierBidderMap{},
+		},
+		{
+			description:    "imp.ext - with other params",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:    "imp.ext - multiple",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "appnexusPrefix"}, "placementId": 12345}, "rubicon": {"dealTier": {"minDealTier": 8, "prefix": "rubiconPrefix"}, "placementId": 12345}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "appnexusPrefix", MinDealTier: 5}, BidderRubicon: {Prefix: "rubiconPrefix", MinDealTier: 8}},
+		},
+		{
+			description:    "imp.ext - no deal tier",
+			impExt:         json.RawMessage(`{"appnexus": {"placementId": 12345}}`),
+			expectedResult: DealTierBidderMap{},
+		},
+		{
+			description:    "imp.ext - normalize prefix",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": " any Prefix "}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:   "imp.ext - error",
+			impExt:        json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
+			expectedError: "json: cannot unmarshal string into Go struct field .dealTier of type openrtb_ext.DealTier",
+		},
+		{
+			description:    "imp.ext.prebid",
+			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:    "imp.ext.prebid- multiple",
+			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "appnexusPrefix"}, "placementId": 12345}, "rubicon": {"dealTier": {"minDealTier": 8, "prefix": "rubiconPrefix"}, "placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "appnexusPrefix", MinDealTier: 5}, BidderRubicon: {Prefix: "rubiconPrefix", MinDealTier: 8}},
+		},
+		{
+			description:    "imp.ext.prebid - no deal tier",
+			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{},
+		},
+		{
+			description:    "imp.ext.prebid - normalize prefix",
+			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": " anyPr  efix "}}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:   "imp.ext.prebid - error",
+			impExt:        json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": "wrong type", "placementId": 12345}}}}`),
+			expectedError: "json: cannot unmarshal string into Go struct field .prebid.bidder.dealTier of type openrtb_ext.DealTier",
+		},
+		{
+			description:    "imp.ext.prebid wins over imp.ext",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "impExt"}, "placementId": 12345}, "prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 8, "prefix": "impExtPrebid"}, "placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "impExtPrebid", MinDealTier: 8}},
+		},
+		{
+			description:    "imp.ext.prebid coexists with imp.ext",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "impExt"}, "placementId": 12345}, "prebid": {"bidder": {"rubicon": {"dealTier": {"minDealTier": 8, "prefix": "impExtPrebid"}, "placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "impExt", MinDealTier: 5}, BidderRubicon: {Prefix: "impExtPrebid", MinDealTier: 8}},
+		},
+	}
+
+	for _, test := range testCases {
+		imp := openrtb.Imp{Ext: test.impExt}
+
+		result, err := ReadDealTiersFromImp(imp)
+
+		assert.Equal(t, test.expectedResult, result, test.description+":result")
+
+		if len(test.expectedError) == 0 {
+			assert.NoError(t, err, test.description+":error")
+		} else {
+			assert.EqualError(t, err, test.expectedError, test.description+":error")
+		}
+	}
+}

--- a/openrtb_ext/imp.go
+++ b/openrtb_ext/imp.go
@@ -4,29 +4,15 @@ import (
 	"encoding/json"
 )
 
-// ExtImp defines the contract for bidrequest.imp[i].ext
-type ExtImp struct {
-	Prebid     *ExtImpPrebid     `json:"prebid"`
-	Appnexus   *ExtImpAppnexus   `json:"appnexus"`
-	Consumable *ExtImpConsumable `json:"consumable"`
-	Rubicon    *ExtImpRubicon    `json:"rubicon"`
-	Adform     *ExtImpAdform     `json:"adform"`
-	Rhythmone  *ExtImpRhythmone  `json:"rhythmone"`
-	Unruly     *ExtImpUnruly     `json:"unruly"`
-	EmxDigital *ExtImpEmxDigital `json:"emx_digital"`
-}
-
 // ExtImpPrebid defines the contract for bidrequest.imp[i].ext.prebid
 type ExtImpPrebid struct {
+	// StoredRequest specifies which stored impression to use, if any.
 	StoredRequest *ExtStoredRequest `json:"storedrequest"`
 
-	// Rewarded inventory signal, can be 0 or 1
+	// IsRewardedInventory is a signal intended for video impressions. Must be 0 or 1.
 	IsRewardedInventory int8 `json:"is_rewarded_inventory"`
 
-	// NOTE: This is not part of the official API, we are not expecting clients
-	// migrate from imp[...].ext.${BIDDER} to imp[...].ext.prebid.bidder.${BIDDER}
-	// at this time
-	// https://github.com/prebid/prebid-server/pull/846#issuecomment-476352224
+	// Bidder is the preferred approach for providing paramters to be interepreted by the bidder's adapter.
 	Bidder map[string]json.RawMessage `json:"bidder"`
 }
 


### PR DESCRIPTION
The code which implements DealTiers (largely for long form video auctions) doesn't check the newly preferred `imp.ext.prebid.bidder.{bidder}` section. This fixes that.