### PR TITLE
Add http api for fetching accounts

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -652,8 +652,7 @@ func TestValidateAccountsConfigRestrictions(t *testing.T) {
 	cfg.Accounts.Postgres.ConnectionInfo.Database = "accounts"
 
 	errs := cfg.validate()
-	assert.Len(t, errs, 2)
-	assert.Contains(t, errs, errors.New("accounts.http: retrieving accounts via http not available, use accounts.files"))
+	assert.Len(t, errs, 1)
 	assert.Contains(t, errs, errors.New("accounts.postgres: retrieving accounts via postgres not available, use accounts.files"))
 }
 

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -137,9 +137,6 @@ func resolvedStoredRequestsConfig(cfg *Configuration) {
 }
 
 func (cfg *StoredRequests) validate(errs configErrors) configErrors {
-	if cfg.DataType() == AccountDataType && cfg.HTTP.Endpoint != "" {
-		errs = append(errs, fmt.Errorf("%s.http: retrieving accounts via http not available, use accounts.files", cfg.Section()))
-	}
 	if cfg.DataType() == AccountDataType && cfg.Postgres.ConnectionInfo.Database != "" {
 		errs = append(errs, fmt.Errorf("%s.postgres: retrieving accounts via postgres not available, use accounts.files", cfg.Section()))
 	} else {

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/prebid/prebid-server/stored_requests"
@@ -19,9 +20,13 @@ import (
 //
 // This file expects the endpoint to satisfy the following API:
 //
+// Stored requests
 // GET {endpoint}?request-ids=["req1","req2"]&imp-ids=["imp1","imp2","imp3"]
 //
-// This endpoint should return a payload like:
+// Accounts
+// GET {endpoint}?account-ids=["acc1","acc2"]
+//
+// The above endpoints should return a payload like:
 //
 // {
 //   "requests": {
@@ -34,12 +39,20 @@ import (
 //     "imp3": null // If imp3 is not found
 //   }
 // }
+// or
+// {
+//   "accounts": {
+//     "acc1": { ... config data for acc1 ... },
+//     "acc2": { ... config data for acc2 ... },
+//   },
+// }
 //
 //
 func NewFetcher(client *http.Client, endpoint string) *HttpFetcher {
 	// Do some work up-front to figure out if the (configurable) endpoint has a query string or not.
 	// When we build requests, we'll either want to add `?request-ids=...&imp-ids=...` _or_
-	// `&request-ids=...&imp-ids=...`, depending.
+	// `&request-ids=...&imp-ids=...`.
+
 	urlPrefix := endpoint
 	if strings.Contains(endpoint, "?") {
 		urlPrefix = urlPrefix + "&"
@@ -47,7 +60,11 @@ func NewFetcher(client *http.Client, endpoint string) *HttpFetcher {
 		urlPrefix = urlPrefix + "?"
 	}
 
-	glog.Info("Making http_fetcher which calls GET " + urlPrefix + "request-ids=%REQUEST_ID_LIST%&imp-ids=%IMP_ID_LIST%")
+	if url, err := url.Parse(endpoint); err != nil {
+		glog.Warningf(`Invalid endpoint "%s": %v`, endpoint, err)
+	} else {
+		glog.Infof("Making http_fetcher for endpoint %v", url)
+	}
 
 	return &HttpFetcher{
 		client:   client,
@@ -81,8 +98,68 @@ func (fetcher *HttpFetcher) FetchRequests(ctx context.Context, requestIDs []stri
 	return
 }
 
-func (fetcher *HttpFetcher) FetchAccount(ctx context.Context, accountID string) (json.RawMessage, []error) {
-	return nil, []error{stored_requests.NotFoundError{accountID, "Account"}}
+// FetchAccounts retrieves account configurations
+//
+// Request format is similar to the one for requests:
+// GET {endpoint}?account-ids=["account1","account2",...]
+//
+// The endpoint is expected to respond with a JSON map with accountID -> json.RawMessage
+// {
+//   "account1": { ... account json ... }
+// }
+// The JSON contents of account config is returned as-is (NOT validated)
+func (fetcher *HttpFetcher) FetchAccounts(ctx context.Context, accountIDs []string) (accountData map[string]json.RawMessage, errs []error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", fetcher.Endpoint+"account-ids=[\""+strings.Join(accountIDs, "\",\"")+"\"]", nil)
+	if err != nil {
+		return nil, []error{
+			fmt.Errorf(`Error fetching accounts "%v" via http: %v`, accountIDs, err),
+		}
+	}
+	httpResp, err := ctxhttp.Do(ctx, fetcher.client, httpReq)
+	if err != nil {
+		return nil, []error{
+			fmt.Errorf(`Error fetching accounts %v via http: %v`, accountIDs, err),
+		}
+	}
+	defer httpResp.Body.Close()
+	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, []error{
+			fmt.Errorf(`Error fetching accounts %v via http: could not read response`, accountIDs),
+		}
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, []error{
+			fmt.Errorf(`Error fetching accounts %v via http: unexpected response status %d`, accountIDs, httpResp.StatusCode),
+		}
+	}
+	var responseData accountsResponseContract
+	if err = json.Unmarshal(respBytes, &responseData); err != nil {
+		return nil, []error{
+			fmt.Errorf(`Error fetching accounts %v via http: malformed response`, accountIDs),
+		}
+	}
+	errs = convertNullsToErrs(responseData.Accounts, "Account", errs)
+	return responseData.Accounts, errs
+}
+
+// FetchAccount fetchers a single accountID and returns its corresponding json
+func (fetcher *HttpFetcher) FetchAccount(ctx context.Context, accountID string) (accountJSON json.RawMessage, errs []error) {
+	accountData, errs := fetcher.FetchAccounts(ctx, []string{accountID})
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	accountJSON, ok := accountData[accountID]
+	if !ok {
+		return nil, []error{stored_requests.NotFoundError{
+			ID:       accountID,
+			DataType: "Account",
+		}}
+	}
+	return accountJSON, []error{}
 }
 
 func (fetcher *HttpFetcher) FetchCategories(ctx context.Context, primaryAdServer, publisherId, iabCategory string) (string, error) {
@@ -189,4 +266,8 @@ func convertNullsToErrs(m map[string]json.RawMessage, dataType string, errs []er
 type responseContract struct {
 	Requests map[string]json.RawMessage `json:"requests"`
 	Imps     map[string]json.RawMessage `json:"imps"`
+}
+
+type accountsResponseContract struct {
+	Accounts map[string]json.RawMessage `json:"accounts"`
 }

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -54,7 +54,7 @@ func NewFetcher(client *http.Client, endpoint string) *HttpFetcher {
 	// `&request-ids=...&imp-ids=...`.
 
 	if url, err := url.Parse(endpoint); err != nil {
-		glog.Errorf(`Invalid endpoint "%s": %v`, endpoint, err)
+		glog.Fatalf(`Invalid endpoint "%s": %v`, endpoint, err)
 	} else {
 		glog.Infof("Making http_fetcher for endpoint %v", url)
 	}
@@ -142,7 +142,7 @@ func (fetcher *HttpFetcher) FetchAccounts(ctx context.Context, accountIDs []stri
 			fmt.Errorf(`Error fetching accounts %v via http: failed to parse response: %v`, accountIDs, err),
 		}
 	}
-	errs := convertNullsToErrs(responseData.Accounts, "Account", nil)
+	errs := convertNullsToErrs(responseData.Accounts, "Account", []error{})
 	return responseData.Accounts, errs
 }
 

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -54,7 +54,7 @@ func NewFetcher(client *http.Client, endpoint string) *HttpFetcher {
 	// `&request-ids=...&imp-ids=...`.
 
 	if url, err := url.Parse(endpoint); err != nil {
-		glog.Warningf(`Invalid endpoint "%s": %v`, endpoint, err)
+		glog.Errorf(`Invalid endpoint "%s": %v`, endpoint, err)
 	} else {
 		glog.Infof("Making http_fetcher for endpoint %v", url)
 	}

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -53,11 +53,10 @@ func NewFetcher(client *http.Client, endpoint string) *HttpFetcher {
 	// When we build requests, we'll either want to add `?request-ids=...&imp-ids=...` _or_
 	// `&request-ids=...&imp-ids=...`.
 
-	if url, err := url.Parse(endpoint); err != nil {
+	if _, err := url.Parse(endpoint); err != nil {
 		glog.Fatalf(`Invalid endpoint "%s": %v`, endpoint, err)
-	} else {
-		glog.Infof("Making http_fetcher for endpoint %v", url)
 	}
+	glog.Infof("Making http_fetcher for endpoint %v", endpoint)
 
 	urlPrefix := endpoint
 	if strings.Contains(endpoint, "?") {

--- a/stored_requests/backends/http_fetcher/fetcher_test.go
+++ b/stored_requests/backends/http_fetcher/fetcher_test.go
@@ -18,9 +18,9 @@ func TestSingleReq(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, nil)
+	assert.Empty(t, errs, "Unexpected errors fetching known requests")
 	assertMapKeys(t, reqData, "req-1")
-	assert.Empty(t, impData)
-	assert.Empty(t, errs)
+	assert.Empty(t, impData, "Unexpected imps returned fetching just requests")
 }
 
 func TestSeveralReqs(t *testing.T) {
@@ -28,9 +28,9 @@ func TestSeveralReqs(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, nil)
+	assert.Empty(t, errs, "Unexpected errors fetching known requests")
 	assertMapKeys(t, reqData, "req-1", "req-2")
-	assert.Empty(t, impData)
-	assert.Empty(t, errs)
+	assert.Empty(t, impData, "Unexpected imps returned fetching just requests")
 }
 
 func TestSingleImp(t *testing.T) {
@@ -38,9 +38,9 @@ func TestSingleImp(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1"})
-	assert.Empty(t, reqData)
+	assert.Empty(t, errs, "Unexpected errors fetching known imps")
+	assert.Empty(t, reqData, "Unexpected requests returned fetching just imps")
 	assertMapKeys(t, impData, "imp-1")
-	assert.Empty(t, errs)
 }
 
 func TestSeveralImps(t *testing.T) {
@@ -48,9 +48,9 @@ func TestSeveralImps(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1", "imp-2"})
-	assert.Empty(t, reqData)
+	assert.Empty(t, errs, "Unexpected errors fetching known imps")
+	assert.Empty(t, reqData, "Unexpected requests returned fetching just imps")
 	assertMapKeys(t, impData, "imp-1", "imp-2")
-	assert.Empty(t, errs)
 }
 
 func TestReqsAndImps(t *testing.T) {
@@ -58,9 +58,9 @@ func TestReqsAndImps(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, []string{"imp-1"})
+	assert.Empty(t, errs, "Unexpected errors fetching known reqs and imps")
 	assertMapKeys(t, reqData, "req-1")
 	assertMapKeys(t, impData, "imp-1")
-	assert.Empty(t, errs)
 }
 
 func TestMissingValues(t *testing.T) {
@@ -68,9 +68,9 @@ func TestMissingValues(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, []string{"imp-1"})
-	assert.Empty(t, reqData)
-	assert.Empty(t, impData)
-	assert.Len(t, errs, 3)
+	assert.Empty(t, reqData, "Fetching unknown reqs should return no reqs")
+	assert.Empty(t, impData, "Fetching unknown imps should return no imps")
+	assert.Len(t, errs, 3, "Fetching 3 unknown reqs+imps should return 3 errors")
 }
 
 func TestFetchAccounts(t *testing.T) {
@@ -78,7 +78,7 @@ func TestFetchAccounts(t *testing.T) {
 	defer close()
 
 	accData, errs := fetcher.FetchAccounts(context.Background(), []string{"acc-1", "acc-2"})
-	assert.Empty(t, errs)
+	assert.Empty(t, errs, "Unexpected error fetching known accounts")
 	assertMapKeys(t, accData, "acc-1", "acc-2")
 }
 
@@ -87,8 +87,8 @@ func TestFetchAccountsNoData(t *testing.T) {
 	defer close()
 
 	accData, errs := fetcher.FetchAccounts(context.Background(), []string{"req-1"})
-	assert.Len(t, errs, 1)
-	assert.Nil(t, accData)
+	assert.Len(t, errs, 1, "Fetching unknown account should have returned an error")
+	assert.Nil(t, accData, "Fetching unknown account should return nil account map")
 }
 
 func TestFetchAccountsBadJSON(t *testing.T) {
@@ -96,8 +96,8 @@ func TestFetchAccountsBadJSON(t *testing.T) {
 	defer close()
 
 	accData, errs := fetcher.FetchAccounts(context.Background(), []string{"req-1"})
-	assert.Len(t, errs, 1)
-	assert.Nil(t, accData)
+	assert.Len(t, errs, 1, "Fetching account with broken json should have returned an error")
+	assert.Nil(t, accData, "Fetching account with broken json should return nil account map")
 }
 
 func TestFetchAccount(t *testing.T) {
@@ -106,7 +106,7 @@ func TestFetchAccount(t *testing.T) {
 
 	account, errs := fetcher.FetchAccount(context.Background(), "acc-1")
 	assert.Empty(t, errs, "Unexpected error fetching existing account")
-	assert.JSONEq(t, `"acc-1"`, string(account), "Unexpected account data returned")
+	assert.JSONEq(t, `"acc-1"`, string(account), "Unexpected account data fetching existing account")
 }
 
 func TestFetchAccountNoData(t *testing.T) {
@@ -115,7 +115,7 @@ func TestFetchAccountNoData(t *testing.T) {
 
 	unknownAccount, errs := fetcher.FetchAccount(context.Background(), "unknown-acc")
 	assert.NotEmpty(t, errs, "Retrieving unknown account should have returned an error")
-	assert.Nil(t, unknownAccount)
+	assert.Nil(t, unknownAccount, "Retrieving unknown account should return nil json.RawMessage")
 }
 
 func TestErrResponse(t *testing.T) {

--- a/stored_requests/backends/http_fetcher/fetcher_test.go
+++ b/stored_requests/backends/http_fetcher/fetcher_test.go
@@ -19,8 +19,8 @@ func TestSingleReq(t *testing.T) {
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, nil)
 	assertMapKeys(t, reqData, "req-1")
-	assertMapKeys(t, impData)
-	assertErrLength(t, errs, 0)
+	assert.Empty(t, impData)
+	assert.Empty(t, errs)
 }
 
 func TestSeveralReqs(t *testing.T) {
@@ -29,8 +29,8 @@ func TestSeveralReqs(t *testing.T) {
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, nil)
 	assertMapKeys(t, reqData, "req-1", "req-2")
-	assertMapKeys(t, impData)
-	assertErrLength(t, errs, 0)
+	assert.Empty(t, impData)
+	assert.Empty(t, errs)
 }
 
 func TestSingleImp(t *testing.T) {
@@ -38,9 +38,9 @@ func TestSingleImp(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1"})
-	assertMapKeys(t, reqData)
+	assert.Empty(t, reqData)
 	assertMapKeys(t, impData, "imp-1")
-	assertErrLength(t, errs, 0)
+	assert.Empty(t, errs)
 }
 
 func TestSeveralImps(t *testing.T) {
@@ -48,9 +48,9 @@ func TestSeveralImps(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1", "imp-2"})
-	assertMapKeys(t, reqData)
+	assert.Empty(t, reqData)
 	assertMapKeys(t, impData, "imp-1", "imp-2")
-	assertErrLength(t, errs, 0)
+	assert.Empty(t, errs)
 }
 
 func TestReqsAndImps(t *testing.T) {
@@ -60,7 +60,7 @@ func TestReqsAndImps(t *testing.T) {
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, []string{"imp-1"})
 	assertMapKeys(t, reqData, "req-1")
 	assertMapKeys(t, impData, "imp-1")
-	assertErrLength(t, errs, 0)
+	assert.Empty(t, errs)
 }
 
 func TestMissingValues(t *testing.T) {
@@ -68,9 +68,9 @@ func TestMissingValues(t *testing.T) {
 	defer close()
 
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, []string{"imp-1"})
-	assertMapKeys(t, reqData)
-	assertMapKeys(t, impData)
-	assertErrLength(t, errs, 3)
+	assert.Empty(t, reqData)
+	assert.Empty(t, impData)
+	assert.Len(t, errs, 3)
 }
 
 func TestFetchAccounts(t *testing.T) {
@@ -124,7 +124,7 @@ func TestErrResponse(t *testing.T) {
 	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, []string{"imp-1"})
 	assertMapKeys(t, reqData)
 	assertMapKeys(t, impData)
-	assertErrLength(t, errs, 1)
+	assert.Len(t, errs, 1)
 }
 
 func assertSameContents(t *testing.T, expected map[string]json.RawMessage, actual map[string]json.RawMessage) {
@@ -336,13 +336,5 @@ func assertMapKeys(t *testing.T, m map[string]json.RawMessage, keys ...string) {
 		if _, ok := m[key]; !ok {
 			t.Errorf("Map missing expected key %s. Data was %v", key, m)
 		}
-	}
-}
-
-func assertErrLength(t *testing.T, errs []error, expected int) {
-	t.Helper()
-
-	if len(errs) != expected {
-		t.Errorf("Expected %d errors. Got: %v", expected, errs)
 	}
 }

--- a/stored_requests/backends/http_fetcher/fetcher_test.go
+++ b/stored_requests/backends/http_fetcher/fetcher_test.go
@@ -63,21 +63,32 @@ func TestReqsAndImps(t *testing.T) {
 	assertErrLength(t, errs, 0)
 }
 
+func TestMissingValues(t *testing.T) {
+	fetcher, close := newEmptyFetcher(t, []string{"req-1", "req-2"}, []string{"imp-1"})
+	defer close()
+
+	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, []string{"imp-1"})
+	assertMapKeys(t, reqData)
+	assertMapKeys(t, impData)
+	assertErrLength(t, errs, 3)
+}
+
 func TestFetchAccounts(t *testing.T) {
 	fetcher, close := newTestAccountFetcher(t, []string{"acc-1", "acc-2"})
 	defer close()
 
 	accData, errs := fetcher.FetchAccounts(context.Background(), []string{"acc-1", "acc-2"})
+	assert.Empty(t, errs)
 	assertMapKeys(t, accData, "acc-1", "acc-2")
-	assertErrLength(t, errs, 0)
 }
 
 func TestFetchAccountsNoData(t *testing.T) {
 	fetcher, close := newFetcherBrokenBackend()
 	defer close()
+
 	accData, errs := fetcher.FetchAccounts(context.Background(), []string{"req-1"})
-	assertMapKeys(t, accData)
-	assertErrLength(t, errs, 1)
+	assert.Len(t, errs, 1)
+	assert.Nil(t, accData)
 }
 
 func TestFetchAccount(t *testing.T) {
@@ -86,7 +97,7 @@ func TestFetchAccount(t *testing.T) {
 
 	account, errs := fetcher.FetchAccount(context.Background(), "acc-1")
 	assert.Empty(t, errs, "Unexpected error fetching existing account")
-	assert.JSONEq(t, `"acc-1"`, string(account))
+	assert.JSONEq(t, `"acc-1"`, string(account), "Unexpected account data returned")
 }
 
 func TestFetchAccountNoData(t *testing.T) {


### PR DESCRIPTION
This works the same way as the API for stored requests,
preserving the ability to query multiple ids, so the
same API endpoint can be extended to support accounts.

