### PR TITLE
Add Accounts to http cache events

### DIFF
--- a/stored_requests/events/api/api_test.go
+++ b/stored_requests/events/api/api_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestGoodRequests(t *testing.T) {
 	cache := stored_requests.Cache{
-		Requests: memory.NewCache(256*1024, -1, "Requests"),
-		Imps:     memory.NewCache(256*1024, -1, "Imps"),
+		Requests: memory.NewCache(256*1024, -1, "Request"),
+		Imps:     memory.NewCache(256*1024, -1, "Imp"),
+		Accounts: memory.NewCache(256*1024, -1, "Account"),
 	}
 	id := "1"
 	config := fmt.Sprintf(`{"id": "%s"}`, id)

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -11,12 +11,14 @@ import (
 type Save struct {
 	Requests map[string]json.RawMessage `json:"requests"`
 	Imps     map[string]json.RawMessage `json:"imps"`
+	Accounts map[string]json.RawMessage `json:"accounts"`
 }
 
 // Invalidation represents a bulk invalidation
 type Invalidation struct {
 	Requests []string `json:"requests"`
 	Imps     []string `json:"imps"`
+	Accounts []string `json:"accounts"`
 }
 
 // EventProducer will produce cache update and invalidation events on its channels
@@ -63,12 +65,14 @@ func (e *EventListener) Listen(cache stored_requests.Cache, events EventProducer
 		case save := <-events.Saves():
 			cache.Requests.Save(context.Background(), save.Requests)
 			cache.Imps.Save(context.Background(), save.Imps)
+			cache.Accounts.Save(context.Background(), save.Accounts)
 			if e.onSave != nil {
 				e.onSave()
 			}
 		case invalidation := <-events.Invalidations():
 			cache.Requests.Invalidate(context.Background(), invalidation.Requests)
 			cache.Imps.Invalidate(context.Background(), invalidation.Imps)
+			cache.Accounts.Invalidate(context.Background(), invalidation.Accounts)
 			if e.onInvalidate != nil {
 				e.onInvalidate()
 			}


### PR DESCRIPTION
I just added Accounts alongside Requests and Imps in the events for minimal impact change.

We should consider replacing the event with a more generic `{dataType, data}` message in the future though, to support other data types through the same mechanism.