### PR TITLE
Add accounts to and refactor http cache events

### DIFF
--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -15,6 +15,7 @@ type DataType string
 
 const (
 	RequestDataType    DataType = "Request"
+	ImpDataType        DataType = "Imp"
 	CategoryDataType   DataType = "Category"
 	VideoDataType      DataType = "Video"
 	AMPRequestDataType DataType = "AMP Request"
@@ -25,6 +26,7 @@ const (
 func (dataType DataType) Section() string {
 	return map[DataType]string{
 		RequestDataType:    "stored_requests",
+		ImpDataType:        "stored_requests",
 		CategoryDataType:   "categories",
 		VideoDataType:      "stored_video_req",
 		AMPRequestDataType: "stored_amp_req",

--- a/stored_requests/events/api/api_test.go
+++ b/stored_requests/events/api/api_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestGoodRequests(t *testing.T) {
 	cache := stored_requests.Cache{
-		Requests: memory.NewCache(256*1024, -1, "Requests"),
-		Imps:     memory.NewCache(256*1024, -1, "Imps"),
+		Requests: memory.NewCache(256*1024, -1, "Request"),
+		Imps:     memory.NewCache(256*1024, -1, "Imp"),
+		Accounts: memory.NewCache(256*1024, -1, "Account"),
 	}
 	id := "1"
 	config := fmt.Sprintf(`{"id": "%s"}`, id)

--- a/stored_requests/events/events.go
+++ b/stored_requests/events/events.go
@@ -11,12 +11,14 @@ import (
 type Save struct {
 	Requests map[string]json.RawMessage `json:"requests"`
 	Imps     map[string]json.RawMessage `json:"imps"`
+	Accounts map[string]json.RawMessage `json:"accounts"`
 }
 
 // Invalidation represents a bulk invalidation
 type Invalidation struct {
 	Requests []string `json:"requests"`
 	Imps     []string `json:"imps"`
+	Accounts []string `json:"accounts"`
 }
 
 // EventProducer will produce cache update and invalidation events on its channels
@@ -63,12 +65,14 @@ func (e *EventListener) Listen(cache stored_requests.Cache, events EventProducer
 		case save := <-events.Saves():
 			cache.Requests.Save(context.Background(), save.Requests)
 			cache.Imps.Save(context.Background(), save.Imps)
+			cache.Accounts.Save(context.Background(), save.Accounts)
 			if e.onSave != nil {
 				e.onSave()
 			}
 		case invalidation := <-events.Invalidations():
 			cache.Requests.Invalidate(context.Background(), invalidation.Requests)
 			cache.Imps.Invalidate(context.Background(), invalidation.Imps)
+			cache.Accounts.Invalidate(context.Background(), invalidation.Accounts)
 			if e.onInvalidate != nil {
 				e.onInvalidate()
 			}


### PR DESCRIPTION
Add account support for refresh events for #1395, after #1545 and #1519 were merged. 
Potentially supersedes #1553 if we choose to go this route.

Refactored events:
- Make Save and Invalidate events generic and single-typed: `{DataType, Data}`. They were previously a `{RequestsData, ImpData}` combo.
- Add ImpDataType to DataTypes (to avoid creating yet another selector key for these types of data)
- Add tests for Account
- Refactored http startup tests into a list of testcases.
