### PR TITLE
Add account CCPA enabled and per-request-type enabled flags

### DIFF
--- a/config/accounts.go
+++ b/config/accounts.go
@@ -33,11 +33,7 @@ func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType)
 	if integrationEnabled := a.IntegrationEnabled.GetByIntegrationType(integrationType); integrationEnabled != nil {
 		return integrationEnabled
 	}
-	if a.Enabled != nil {
-		return a.Enabled
-	}
-
-	return nil
+	return a.Enabled
 }
 
 // AccountGDPR represents account-specific GDPR configuration
@@ -53,11 +49,7 @@ func (a *AccountGDPR) EnabledForIntegrationType(integrationType IntegrationType)
 	if integrationEnabled := a.IntegrationEnabled.GetByIntegrationType(integrationType); integrationEnabled != nil {
 		return integrationEnabled
 	}
-	if a.Enabled != nil {
-		return a.Enabled
-	}
-
-	return nil
+	return a.Enabled
 }
 
 // AccountIntegration indicates whether a particular privacy policy (GDPR, CCPA) is enabled for each integration type

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -23,8 +23,8 @@ type Account struct {
 
 // AccountCCPA represents account-specific CCPA configuration
 type AccountCCPA struct {
-	Enabled            *bool                  `mapstructure:"enabled" json:"enabled,omitempty"`
-	IntegrationEnabled AccountCCPAIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
+	Enabled            *bool              `mapstructure:"enabled" json:"enabled,omitempty"`
+	IntegrationEnabled AccountIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
 }
 
 // EnabledForIntegrationType indicates whether CCPA is turned on at the account level for the specified integration type
@@ -53,18 +53,10 @@ func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType)
 	return nil
 }
 
-// AccountCCPAIntegration indicates whether CCPA is enabled for each request type
-type AccountCCPAIntegration struct {
-	AMP   *bool `mapstructure:"amp" json:"amp,omitempty"`
-	App   *bool `mapstructure:"app" json:"app,omitempty"`
-	Video *bool `mapstructure:"video" json:"video,omitempty"`
-	Web   *bool `mapstructure:"web" json:"web,omitempty"`
-}
-
 // AccountGDPR represents account-specific GDPR configuration
 type AccountGDPR struct {
-	Enabled            *bool                  `mapstructure:"enabled" json:"enabled,omitempty"`
-	IntegrationEnabled AccountGDPRIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
+	Enabled            *bool              `mapstructure:"enabled" json:"enabled,omitempty"`
+	IntegrationEnabled AccountIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
 }
 
 // EnabledForIntegrationType indicates whether GDPR is turned on at the account level for the specified integration type
@@ -93,8 +85,8 @@ func (a *AccountGDPR) EnabledForIntegrationType(integrationType IntegrationType)
 	return nil
 }
 
-// AccountGDPRIntegration indicates whether GDPR is enabled for each integration type
-type AccountGDPRIntegration struct {
+// AccountIntegration indicates whether a particular privacy policy (GDPR, CCPA) is enabled for each integration type
+type AccountIntegration struct {
 	AMP   *bool `mapstructure:"amp" json:"amp,omitempty"`
 	App   *bool `mapstructure:"app" json:"app,omitempty"`
 	Video *bool `mapstructure:"video" json:"video,omitempty"`

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -17,7 +17,48 @@ type Account struct {
 	Disabled      bool        `mapstructure:"disabled" json:"disabled"`
 	CacheTTL      DefaultTTLs `mapstructure:"cache_ttl" json:"cache_ttl"`
 	EventsEnabled bool        `mapstructure:"events_enabled" json:"events_enabled"`
+	CCPA          AccountCCPA `mapstructure:"ccpa" json:"ccpa"`
 	GDPR          AccountGDPR `mapstructure:"gdpr" json:"gdpr"`
+}
+
+// AccountCCPA represents account-specific CCPA configuration
+type AccountCCPA struct {
+	Enabled            *bool                  `mapstructure:"enabled" json:"enabled,omitempty"`
+	IntegrationEnabled AccountCCPAIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
+}
+
+// EnabledForIntegrationType indicates whether CCPA is turned on at the account level for the specified integration type
+// by using the integration type setting if defined or the general CCPA setting if defined; otherwise it returns nil
+func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType) *bool {
+	var integrationEnabled *bool
+
+	switch integrationType {
+	case IntegrationTypeAMP:
+		integrationEnabled = a.IntegrationEnabled.AMP
+	case IntegrationTypeApp:
+		integrationEnabled = a.IntegrationEnabled.App
+	case IntegrationTypeVideo:
+		integrationEnabled = a.IntegrationEnabled.Video
+	case IntegrationTypeWeb:
+		integrationEnabled = a.IntegrationEnabled.Web
+	}
+
+	if integrationEnabled != nil {
+		return integrationEnabled
+	}
+	if a.Enabled != nil {
+		return a.Enabled
+	}
+
+	return nil
+}
+
+// AccountCCPAIntegration indicates whether CCPA is enabled for each request type
+type AccountCCPAIntegration struct {
+	AMP   *bool `mapstructure:"amp"   json:"amp,omitempty"`
+	App   *bool `mapstructure:"app"   json:"app,omitempty"`
+	Video *bool `mapstructure:"video" json:"video,omitempty"`
+	Web   *bool `mapstructure:"web"   json:"web,omitempty"`
 }
 
 // AccountGDPR represents account-specific GDPR configuration

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -23,8 +23,8 @@ type Account struct {
 
 // AccountCCPA represents account-specific CCPA configuration
 type AccountCCPA struct {
-	Enabled            *bool                  `json:"enabled,omitempty"`
-	IntegrationEnabled AccountCCPAIntegration `json:"integration_enabled"`
+	Enabled            *bool                  `mapstructure:"enabled" json:"enabled,omitempty"`
+	IntegrationEnabled AccountCCPAIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
 }
 
 // EnabledForIntegrationType indicates whether CCPA is turned on at the account level for the specified integration type
@@ -55,10 +55,10 @@ func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType)
 
 // AccountCCPAIntegration indicates whether CCPA is enabled for each request type
 type AccountCCPAIntegration struct {
-	AMP   *bool `json:"amp,omitempty"`
-	App   *bool `json:"app,omitempty"`
-	Video *bool `json:"video,omitempty"`
-	Web   *bool `json:"web,omitempty"`
+	AMP   *bool `mapstructure:"amp" json:"amp,omitempty"`
+	App   *bool `mapstructure:"app" json:"app,omitempty"`
+	Video *bool `mapstructure:"video" json:"video,omitempty"`
+	Web   *bool `mapstructure:"web" json:"web,omitempty"`
 }
 
 // AccountGDPR represents account-specific GDPR configuration

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -23,8 +23,8 @@ type Account struct {
 
 // AccountCCPA represents account-specific CCPA configuration
 type AccountCCPA struct {
-	Enabled            *bool                  `mapstructure:"enabled" json:"enabled,omitempty"`
-	IntegrationEnabled AccountCCPAIntegration `mapstructure:"integration_enabled" json:"integration_enabled"`
+	Enabled            *bool                  `json:"enabled,omitempty"`
+	IntegrationEnabled AccountCCPAIntegration `json:"integration_enabled"`
 }
 
 // EnabledForIntegrationType indicates whether CCPA is turned on at the account level for the specified integration type
@@ -55,10 +55,10 @@ func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType)
 
 // AccountCCPAIntegration indicates whether CCPA is enabled for each request type
 type AccountCCPAIntegration struct {
-	AMP   *bool `mapstructure:"amp"   json:"amp,omitempty"`
-	App   *bool `mapstructure:"app"   json:"app,omitempty"`
-	Video *bool `mapstructure:"video" json:"video,omitempty"`
-	Web   *bool `mapstructure:"web"   json:"web,omitempty"`
+	AMP   *bool `json:"amp,omitempty"`
+	App   *bool `json:"app,omitempty"`
+	Video *bool `json:"video,omitempty"`
+	Web   *bool `json:"web,omitempty"`
 }
 
 // AccountGDPR represents account-specific GDPR configuration

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -30,20 +30,7 @@ type AccountCCPA struct {
 // EnabledForIntegrationType indicates whether CCPA is turned on at the account level for the specified integration type
 // by using the integration type setting if defined or the general CCPA setting if defined; otherwise it returns nil
 func (a *AccountCCPA) EnabledForIntegrationType(integrationType IntegrationType) *bool {
-	var integrationEnabled *bool
-
-	switch integrationType {
-	case IntegrationTypeAMP:
-		integrationEnabled = a.IntegrationEnabled.AMP
-	case IntegrationTypeApp:
-		integrationEnabled = a.IntegrationEnabled.App
-	case IntegrationTypeVideo:
-		integrationEnabled = a.IntegrationEnabled.Video
-	case IntegrationTypeWeb:
-		integrationEnabled = a.IntegrationEnabled.Web
-	}
-
-	if integrationEnabled != nil {
+	if integrationEnabled := a.IntegrationEnabled.GetByIntegrationType(integrationType); integrationEnabled != nil {
 		return integrationEnabled
 	}
 	if a.Enabled != nil {
@@ -62,20 +49,8 @@ type AccountGDPR struct {
 // EnabledForIntegrationType indicates whether GDPR is turned on at the account level for the specified integration type
 // by using the integration type setting if defined or the general GDPR setting if defined; otherwise it returns nil
 func (a *AccountGDPR) EnabledForIntegrationType(integrationType IntegrationType) *bool {
-	var integrationEnabled *bool
 
-	switch integrationType {
-	case IntegrationTypeAMP:
-		integrationEnabled = a.IntegrationEnabled.AMP
-	case IntegrationTypeApp:
-		integrationEnabled = a.IntegrationEnabled.App
-	case IntegrationTypeVideo:
-		integrationEnabled = a.IntegrationEnabled.Video
-	case IntegrationTypeWeb:
-		integrationEnabled = a.IntegrationEnabled.Web
-	}
-
-	if integrationEnabled != nil {
+	if integrationEnabled := a.IntegrationEnabled.GetByIntegrationType(integrationType); integrationEnabled != nil {
 		return integrationEnabled
 	}
 	if a.Enabled != nil {
@@ -91,4 +66,22 @@ type AccountIntegration struct {
 	App   *bool `mapstructure:"app" json:"app,omitempty"`
 	Video *bool `mapstructure:"video" json:"video,omitempty"`
 	Web   *bool `mapstructure:"web" json:"web,omitempty"`
+}
+
+// GetByIntegrationType looks up the account integration enabled setting for the specified integration type
+func (a *AccountIntegration) GetByIntegrationType(integrationType IntegrationType) *bool {
+	var integrationEnabled *bool
+
+	switch integrationType {
+	case IntegrationTypeAMP:
+		integrationEnabled = a.AMP
+	case IntegrationTypeApp:
+		integrationEnabled = a.App
+	case IntegrationTypeVideo:
+		integrationEnabled = a.Video
+	case IntegrationTypeWeb:
+		integrationEnabled = a.Web
+	}
+
+	return integrationEnabled
 }

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -95,7 +95,7 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 		account := Account{
 			GDPR: AccountGDPR{
 				Enabled: tt.giveGDPREnabled,
-				IntegrationEnabled: AccountGDPRIntegration{
+				IntegrationEnabled: AccountIntegration{
 					AMP:   tt.giveAMPGDPREnabled,
 					App:   tt.giveAppGDPREnabled,
 					Video: tt.giveVideoGDPREnabled,
@@ -204,7 +204,7 @@ func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 		account := Account{
 			CCPA: AccountCCPA{
 				Enabled: tt.giveCCPAEnabled,
-				IntegrationEnabled: AccountCCPAIntegration{
+				IntegrationEnabled: AccountIntegration{
 					AMP:   tt.giveAMPCCPAEnabled,
 					App:   tt.giveAppCCPAEnabled,
 					Video: tt.giveVideoCCPAEnabled,

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -114,3 +114,110 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 		}
 	}
 }
+
+func TestAccountCCPAEnabledForRequestType(t *testing.T) {
+	tests := []struct {
+		description          string
+		giveRequestType      RequestType
+		giveCCPAEnabled      *bool
+		giveAMPCCPAEnabled   *bool
+		giveAppCCPAEnabled   *bool
+		giveVideoCCPAEnabled *bool
+		giveWebCCPAEnabled   *bool
+		wantEnabled          *bool
+	}{
+		{
+			description:        "CCPA AMP integration enabled, general CCPA disabled",
+			giveRequestType:    RequestTypeAMP,
+			giveCCPAEnabled:    &[]bool{false}[0],
+			giveAMPCCPAEnabled: &[]bool{true}[0],
+			wantEnabled:        &[]bool{true}[0],
+		},
+		{
+			description:        "CCPA App integration enabled, general CCPA disabled",
+			giveRequestType:    RequestTypeApp,
+			giveCCPAEnabled:    &[]bool{false}[0],
+			giveAppCCPAEnabled: &[]bool{true}[0],
+			wantEnabled:        &[]bool{true}[0],
+		},
+		{
+			description:          "CCPA Video integration enabled, general CCPA disabled",
+			giveRequestType:      RequestTypeVideo,
+			giveCCPAEnabled:      &[]bool{false}[0],
+			giveVideoCCPAEnabled: &[]bool{true}[0],
+			wantEnabled:          &[]bool{true}[0],
+		},
+		{
+			description:        "CCPA Web integration enabled, general CCPA disabled",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    &[]bool{false}[0],
+			giveWebCCPAEnabled: &[]bool{true}[0],
+			wantEnabled:        &[]bool{true}[0],
+		},
+		{
+			description:        "Web integration enabled, general CCPA unspecified",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    nil,
+			giveWebCCPAEnabled: &[]bool{true}[0],
+			wantEnabled:        &[]bool{true}[0],
+		},
+		{
+			description:        "CCPA Web integration disabled, general CCPA enabled",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    &[]bool{true}[0],
+			giveWebCCPAEnabled: &[]bool{false}[0],
+			wantEnabled:        &[]bool{false}[0],
+		},
+		{
+			description:        "CCPA Web integration disabled, general CCPA unspecified",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    nil,
+			giveWebCCPAEnabled: &[]bool{false}[0],
+			wantEnabled:        &[]bool{false}[0],
+		},
+		{
+			description:        "CCPA Web integration unspecified, general CCPA disabled",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    &[]bool{false}[0],
+			giveWebCCPAEnabled: nil,
+			wantEnabled:        &[]bool{false}[0],
+		},
+		{
+			description:        "CCPA Web integration unspecified, general CCPA enabled",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    &[]bool{true}[0],
+			giveWebCCPAEnabled: nil,
+			wantEnabled:        &[]bool{true}[0],
+		},
+		{
+			description:        "CCPA Web integration unspecified, general CCPA unspecified",
+			giveRequestType:    RequestTypeWeb,
+			giveCCPAEnabled:    nil,
+			giveWebCCPAEnabled: nil,
+			wantEnabled:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		account := Account{
+			CCPA: AccountCCPA{
+				Enabled: tt.giveCCPAEnabled,
+				IntegrationEnabled: AccountCCPAIntegration{
+					AMP:   tt.giveAMPCCPAEnabled,
+					App:   tt.giveAppCCPAEnabled,
+					Video: tt.giveVideoCCPAEnabled,
+					Web:   tt.giveWebCCPAEnabled,
+				},
+			},
+		}
+
+		enabled := account.CCPA.EnabledForRequestType(tt.giveRequestType)
+
+		if tt.wantEnabled == nil {
+			assert.Nil(t, enabled, tt.description)
+		} else {
+			assert.NotNil(t, enabled, tt.description)
+			assert.Equal(t, *tt.wantEnabled, *enabled, tt.description)
+		}
+	}
+}

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -115,12 +115,12 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 	}
 }
 
-func TestAccountCCPAEnabledForRequestType(t *testing.T) {
+func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 	trueValue, falseValue := true, false
 
 	tests := []struct {
 		description          string
-		giveRequestType      RequestType
+		giveIntegrationType  IntegrationType
 		giveCCPAEnabled      *bool
 		giveAMPCCPAEnabled   *bool
 		giveAppCCPAEnabled   *bool
@@ -129,74 +129,74 @@ func TestAccountCCPAEnabledForRequestType(t *testing.T) {
 		wantEnabled          *bool
 	}{
 		{
-			description:        "CCPA AMP integration enabled, general CCPA disabled",
-			giveRequestType:    RequestTypeAMP,
-			giveCCPAEnabled:    &falseValue,
-			giveAMPCCPAEnabled: &trueValue,
-			wantEnabled:        &trueValue,
+			description:         "CCPA AMP integration enabled, general CCPA disabled",
+			giveIntegrationType: IntegrationTypeAMP,
+			giveCCPAEnabled:     &falseValue,
+			giveAMPCCPAEnabled:  &trueValue,
+			wantEnabled:         &trueValue,
 		},
 		{
-			description:        "CCPA App integration enabled, general CCPA disabled",
-			giveRequestType:    RequestTypeApp,
-			giveCCPAEnabled:    &falseValue,
-			giveAppCCPAEnabled: &trueValue,
-			wantEnabled:        &trueValue,
+			description:         "CCPA App integration enabled, general CCPA disabled",
+			giveIntegrationType: IntegrationTypeApp,
+			giveCCPAEnabled:     &falseValue,
+			giveAppCCPAEnabled:  &trueValue,
+			wantEnabled:         &trueValue,
 		},
 		{
 			description:          "CCPA Video integration enabled, general CCPA disabled",
-			giveRequestType:      RequestTypeVideo,
+			giveIntegrationType:  IntegrationTypeVideo,
 			giveCCPAEnabled:      &falseValue,
 			giveVideoCCPAEnabled: &trueValue,
 			wantEnabled:          &trueValue,
 		},
 		{
-			description:        "CCPA Web integration enabled, general CCPA disabled",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &falseValue,
-			giveWebCCPAEnabled: &trueValue,
-			wantEnabled:        &trueValue,
+			description:         "CCPA Web integration enabled, general CCPA disabled",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     &falseValue,
+			giveWebCCPAEnabled:  &trueValue,
+			wantEnabled:         &trueValue,
 		},
 		{
-			description:        "Web integration enabled, general CCPA unspecified",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    nil,
-			giveWebCCPAEnabled: &trueValue,
-			wantEnabled:        &trueValue,
+			description:         "Web integration enabled, general CCPA unspecified",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     nil,
+			giveWebCCPAEnabled:  &trueValue,
+			wantEnabled:         &trueValue,
 		},
 		{
-			description:        "CCPA Web integration disabled, general CCPA enabled",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &trueValue,
-			giveWebCCPAEnabled: &falseValue,
-			wantEnabled:        &falseValue,
+			description:         "CCPA Web integration disabled, general CCPA enabled",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     &trueValue,
+			giveWebCCPAEnabled:  &falseValue,
+			wantEnabled:         &falseValue,
 		},
 		{
-			description:        "CCPA Web integration disabled, general CCPA unspecified",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    nil,
-			giveWebCCPAEnabled: &falseValue,
-			wantEnabled:        &falseValue,
+			description:         "CCPA Web integration disabled, general CCPA unspecified",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     nil,
+			giveWebCCPAEnabled:  &falseValue,
+			wantEnabled:         &falseValue,
 		},
 		{
-			description:        "CCPA Web integration unspecified, general CCPA disabled",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &falseValue,
-			giveWebCCPAEnabled: nil,
-			wantEnabled:        &falseValue,
+			description:         "CCPA Web integration unspecified, general CCPA disabled",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     &falseValue,
+			giveWebCCPAEnabled:  nil,
+			wantEnabled:         &falseValue,
 		},
 		{
-			description:        "CCPA Web integration unspecified, general CCPA enabled",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &trueValue,
-			giveWebCCPAEnabled: nil,
-			wantEnabled:        &trueValue,
+			description:         "CCPA Web integration unspecified, general CCPA enabled",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     &trueValue,
+			giveWebCCPAEnabled:  nil,
+			wantEnabled:         &trueValue,
 		},
 		{
-			description:        "CCPA Web integration unspecified, general CCPA unspecified",
-			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    nil,
-			giveWebCCPAEnabled: nil,
-			wantEnabled:        nil,
+			description:         "CCPA Web integration unspecified, general CCPA unspecified",
+			giveIntegrationType: IntegrationTypeWeb,
+			giveCCPAEnabled:     nil,
+			giveWebCCPAEnabled:  nil,
+			wantEnabled:         nil,
 		},
 	}
 
@@ -213,7 +213,7 @@ func TestAccountCCPAEnabledForRequestType(t *testing.T) {
 			},
 		}
 
-		enabled := account.CCPA.EnabledForRequestType(tt.giveRequestType)
+		enabled := account.CCPA.EnabledForIntegrationType(tt.giveIntegrationType)
 
 		if tt.wantEnabled == nil {
 			assert.Nil(t, enabled, tt.description)

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -116,6 +116,8 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 }
 
 func TestAccountCCPAEnabledForRequestType(t *testing.T) {
+	trueValue, falseValue := true, false
+
 	tests := []struct {
 		description          string
 		giveRequestType      RequestType
@@ -129,65 +131,65 @@ func TestAccountCCPAEnabledForRequestType(t *testing.T) {
 		{
 			description:        "CCPA AMP integration enabled, general CCPA disabled",
 			giveRequestType:    RequestTypeAMP,
-			giveCCPAEnabled:    &[]bool{false}[0],
-			giveAMPCCPAEnabled: &[]bool{true}[0],
-			wantEnabled:        &[]bool{true}[0],
+			giveCCPAEnabled:    &falseValue,
+			giveAMPCCPAEnabled: &trueValue,
+			wantEnabled:        &trueValue,
 		},
 		{
 			description:        "CCPA App integration enabled, general CCPA disabled",
 			giveRequestType:    RequestTypeApp,
-			giveCCPAEnabled:    &[]bool{false}[0],
-			giveAppCCPAEnabled: &[]bool{true}[0],
-			wantEnabled:        &[]bool{true}[0],
+			giveCCPAEnabled:    &falseValue,
+			giveAppCCPAEnabled: &trueValue,
+			wantEnabled:        &trueValue,
 		},
 		{
 			description:          "CCPA Video integration enabled, general CCPA disabled",
 			giveRequestType:      RequestTypeVideo,
-			giveCCPAEnabled:      &[]bool{false}[0],
-			giveVideoCCPAEnabled: &[]bool{true}[0],
-			wantEnabled:          &[]bool{true}[0],
+			giveCCPAEnabled:      &falseValue,
+			giveVideoCCPAEnabled: &trueValue,
+			wantEnabled:          &trueValue,
 		},
 		{
 			description:        "CCPA Web integration enabled, general CCPA disabled",
 			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &[]bool{false}[0],
-			giveWebCCPAEnabled: &[]bool{true}[0],
-			wantEnabled:        &[]bool{true}[0],
+			giveCCPAEnabled:    &falseValue,
+			giveWebCCPAEnabled: &trueValue,
+			wantEnabled:        &trueValue,
 		},
 		{
 			description:        "Web integration enabled, general CCPA unspecified",
 			giveRequestType:    RequestTypeWeb,
 			giveCCPAEnabled:    nil,
-			giveWebCCPAEnabled: &[]bool{true}[0],
-			wantEnabled:        &[]bool{true}[0],
+			giveWebCCPAEnabled: &trueValue,
+			wantEnabled:        &trueValue,
 		},
 		{
 			description:        "CCPA Web integration disabled, general CCPA enabled",
 			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &[]bool{true}[0],
-			giveWebCCPAEnabled: &[]bool{false}[0],
-			wantEnabled:        &[]bool{false}[0],
+			giveCCPAEnabled:    &trueValue,
+			giveWebCCPAEnabled: &falseValue,
+			wantEnabled:        &falseValue,
 		},
 		{
 			description:        "CCPA Web integration disabled, general CCPA unspecified",
 			giveRequestType:    RequestTypeWeb,
 			giveCCPAEnabled:    nil,
-			giveWebCCPAEnabled: &[]bool{false}[0],
-			wantEnabled:        &[]bool{false}[0],
+			giveWebCCPAEnabled: &falseValue,
+			wantEnabled:        &falseValue,
 		},
 		{
 			description:        "CCPA Web integration unspecified, general CCPA disabled",
 			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &[]bool{false}[0],
+			giveCCPAEnabled:    &falseValue,
 			giveWebCCPAEnabled: nil,
-			wantEnabled:        &[]bool{false}[0],
+			wantEnabled:        &falseValue,
 		},
 		{
 			description:        "CCPA Web integration unspecified, general CCPA enabled",
 			giveRequestType:    RequestTypeWeb,
-			giveCCPAEnabled:    &[]bool{true}[0],
+			giveCCPAEnabled:    &trueValue,
 			giveWebCCPAEnabled: nil,
-			wantEnabled:        &[]bool{true}[0],
+			wantEnabled:        &trueValue,
 		},
 		{
 			description:        "CCPA Web integration unspecified, general CCPA unspecified",

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -10,36 +10,12 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 	trueValue, falseValue := true, false
 
 	tests := []struct {
-		description          string
-		giveIntegrationType  IntegrationType
-		giveGDPREnabled      *bool
-		giveAMPGDPREnabled   *bool
-		giveAppGDPREnabled   *bool
-		giveVideoGDPREnabled *bool
-		giveWebGDPREnabled   *bool
-		wantEnabled          *bool
+		description         string
+		giveIntegrationType IntegrationType
+		giveGDPREnabled     *bool
+		giveWebGDPREnabled  *bool
+		wantEnabled         *bool
 	}{
-		{
-			description:         "GDPR AMP integration enabled, general GDPR disabled",
-			giveIntegrationType: IntegrationTypeAMP,
-			giveGDPREnabled:     &falseValue,
-			giveAMPGDPREnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
-			description:         "GDPR App integration enabled, general GDPR disabled",
-			giveIntegrationType: IntegrationTypeApp,
-			giveGDPREnabled:     &falseValue,
-			giveAppGDPREnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
-			description:          "GDPR Video integration enabled, general GDPR disabled",
-			giveIntegrationType:  IntegrationTypeVideo,
-			giveGDPREnabled:      &falseValue,
-			giveVideoGDPREnabled: &trueValue,
-			wantEnabled:          &trueValue,
-		},
 		{
 			description:         "GDPR Web integration enabled, general GDPR disabled",
 			giveIntegrationType: IntegrationTypeWeb,
@@ -48,23 +24,9 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 			wantEnabled:         &trueValue,
 		},
 		{
-			description:         "Web integration enabled, general GDPR unspecified",
-			giveIntegrationType: IntegrationTypeWeb,
-			giveGDPREnabled:     nil,
-			giveWebGDPREnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
 			description:         "GDPR Web integration disabled, general GDPR enabled",
 			giveIntegrationType: IntegrationTypeWeb,
 			giveGDPREnabled:     &trueValue,
-			giveWebGDPREnabled:  &falseValue,
-			wantEnabled:         &falseValue,
-		},
-		{
-			description:         "GDPR Web integration disabled, general GDPR unspecified",
-			giveIntegrationType: IntegrationTypeWeb,
-			giveGDPREnabled:     nil,
 			giveWebGDPREnabled:  &falseValue,
 			wantEnabled:         &falseValue,
 		},
@@ -96,10 +58,7 @@ func TestAccountGDPREnabledForIntegrationType(t *testing.T) {
 			GDPR: AccountGDPR{
 				Enabled: tt.giveGDPREnabled,
 				IntegrationEnabled: AccountIntegration{
-					AMP:   tt.giveAMPGDPREnabled,
-					App:   tt.giveAppGDPREnabled,
-					Video: tt.giveVideoGDPREnabled,
-					Web:   tt.giveWebGDPREnabled,
+					Web: tt.giveWebGDPREnabled,
 				},
 			},
 		}
@@ -119,36 +78,12 @@ func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 	trueValue, falseValue := true, false
 
 	tests := []struct {
-		description          string
-		giveIntegrationType  IntegrationType
-		giveCCPAEnabled      *bool
-		giveAMPCCPAEnabled   *bool
-		giveAppCCPAEnabled   *bool
-		giveVideoCCPAEnabled *bool
-		giveWebCCPAEnabled   *bool
-		wantEnabled          *bool
+		description         string
+		giveIntegrationType IntegrationType
+		giveCCPAEnabled     *bool
+		giveWebCCPAEnabled  *bool
+		wantEnabled         *bool
 	}{
-		{
-			description:         "CCPA AMP integration enabled, general CCPA disabled",
-			giveIntegrationType: IntegrationTypeAMP,
-			giveCCPAEnabled:     &falseValue,
-			giveAMPCCPAEnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
-			description:         "CCPA App integration enabled, general CCPA disabled",
-			giveIntegrationType: IntegrationTypeApp,
-			giveCCPAEnabled:     &falseValue,
-			giveAppCCPAEnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
-			description:          "CCPA Video integration enabled, general CCPA disabled",
-			giveIntegrationType:  IntegrationTypeVideo,
-			giveCCPAEnabled:      &falseValue,
-			giveVideoCCPAEnabled: &trueValue,
-			wantEnabled:          &trueValue,
-		},
 		{
 			description:         "CCPA Web integration enabled, general CCPA disabled",
 			giveIntegrationType: IntegrationTypeWeb,
@@ -157,23 +92,9 @@ func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 			wantEnabled:         &trueValue,
 		},
 		{
-			description:         "Web integration enabled, general CCPA unspecified",
-			giveIntegrationType: IntegrationTypeWeb,
-			giveCCPAEnabled:     nil,
-			giveWebCCPAEnabled:  &trueValue,
-			wantEnabled:         &trueValue,
-		},
-		{
 			description:         "CCPA Web integration disabled, general CCPA enabled",
 			giveIntegrationType: IntegrationTypeWeb,
 			giveCCPAEnabled:     &trueValue,
-			giveWebCCPAEnabled:  &falseValue,
-			wantEnabled:         &falseValue,
-		},
-		{
-			description:         "CCPA Web integration disabled, general CCPA unspecified",
-			giveIntegrationType: IntegrationTypeWeb,
-			giveCCPAEnabled:     nil,
 			giveWebCCPAEnabled:  &falseValue,
 			wantEnabled:         &falseValue,
 		},
@@ -205,10 +126,7 @@ func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 			CCPA: AccountCCPA{
 				Enabled: tt.giveCCPAEnabled,
 				IntegrationEnabled: AccountIntegration{
-					AMP:   tt.giveAMPCCPAEnabled,
-					App:   tt.giveAppCCPAEnabled,
-					Video: tt.giveVideoCCPAEnabled,
-					Web:   tt.giveWebCCPAEnabled,
+					Web: tt.giveWebCCPAEnabled,
 				},
 			},
 		}
@@ -220,6 +138,106 @@ func TestAccountCCPAEnabledForIntegrationType(t *testing.T) {
 		} else {
 			assert.NotNil(t, enabled, tt.description)
 			assert.Equal(t, *tt.wantEnabled, *enabled, tt.description)
+		}
+	}
+}
+
+func TestAccountIntegrationGetByIntegrationType(t *testing.T) {
+	trueValue, falseValue := true, false
+
+	tests := []struct {
+		description         string
+		giveAMPEnabled      *bool
+		giveAppEnabled      *bool
+		giveVideoEnabled    *bool
+		giveWebEnabled      *bool
+		giveIntegrationType IntegrationType
+		wantEnabled         *bool
+	}{
+		{
+			description:         "AMP integration setting unspecified, returns nil",
+			giveIntegrationType: IntegrationTypeAMP,
+			wantEnabled:         nil,
+		},
+		{
+			description:         "AMP integration disabled, returns false",
+			giveAMPEnabled:      &falseValue,
+			giveIntegrationType: IntegrationTypeAMP,
+			wantEnabled:         &falseValue,
+		},
+		{
+			description:         "AMP integration enabled, returns true",
+			giveAMPEnabled:      &trueValue,
+			giveIntegrationType: IntegrationTypeAMP,
+			wantEnabled:         &trueValue,
+		},
+		{
+			description:         "App integration setting unspecified, returns nil",
+			giveIntegrationType: IntegrationTypeApp,
+			wantEnabled:         nil,
+		},
+		{
+			description:         "App integration disabled, returns false",
+			giveAppEnabled:      &falseValue,
+			giveIntegrationType: IntegrationTypeApp,
+			wantEnabled:         &falseValue,
+		},
+		{
+			description:         "App integration enabled, returns true",
+			giveAppEnabled:      &trueValue,
+			giveIntegrationType: IntegrationTypeApp,
+			wantEnabled:         &trueValue,
+		},
+		{
+			description:         "Video integration setting unspecified, returns nil",
+			giveIntegrationType: IntegrationTypeVideo,
+			wantEnabled:         nil,
+		},
+		{
+			description:         "Video integration disabled, returns false",
+			giveVideoEnabled:    &falseValue,
+			giveIntegrationType: IntegrationTypeVideo,
+			wantEnabled:         &falseValue,
+		},
+		{
+			description:         "Video integration enabled, returns true",
+			giveVideoEnabled:    &trueValue,
+			giveIntegrationType: IntegrationTypeVideo,
+			wantEnabled:         &trueValue,
+		},
+		{
+			description:         "Web integration setting unspecified, returns nil",
+			giveIntegrationType: IntegrationTypeWeb,
+			wantEnabled:         nil,
+		},
+		{
+			description:         "Web integration disabled, returns false",
+			giveWebEnabled:      &falseValue,
+			giveIntegrationType: IntegrationTypeWeb,
+			wantEnabled:         &falseValue,
+		},
+		{
+			description:         "Web integration enabled, returns true",
+			giveWebEnabled:      &trueValue,
+			giveIntegrationType: IntegrationTypeWeb,
+			wantEnabled:         &trueValue,
+		},
+	}
+
+	for _, tt := range tests {
+		accountIntegration := AccountIntegration{
+			AMP:   tt.giveAMPEnabled,
+			App:   tt.giveAppEnabled,
+			Video: tt.giveVideoEnabled,
+			Web:   tt.giveWebEnabled,
+		}
+
+		result := accountIntegration.GetByIntegrationType(tt.giveIntegrationType)
+		if tt.wantEnabled == nil {
+			assert.Nil(t, result, tt.description)
+		} else {
+			assert.NotNil(t, result, tt.description)
+			assert.Equal(t, *tt.wantEnabled, *result, tt.description)
 		}
 	}
 }

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -83,7 +83,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 	consent := extractConsent(orig)
 	ampGDPRException := (labels.RType == pbsmetrics.ReqTypeAMP) && gDPR.AMPException()
 
-	ccpaEnforcer, err := extractCCPA(orig, privacyConfig, aliases)
+	ccpaEnforcer, err := extractCCPA(orig, privacyConfig, account, aliases, requestTypeMap[labels.RType])
 	if err != nil {
 		errs = append(errs, err)
 		return
@@ -144,7 +144,14 @@ func gdprEnabled(account *config.Account, privacyConfig config.Privacy, integrat
 	return privacyConfig.GDPR.Enabled
 }
 
-func extractCCPA(orig *openrtb.BidRequest, privacyConfig config.Privacy, aliases map[string]string) (privacy.PolicyEnforcer, error) {
+func ccpaEnabled(account *config.Account, privacyConfig config.Privacy, requestType config.RequestType) bool {
+	if accountEnabled := account.CCPA.EnabledForRequestType(requestType); accountEnabled != nil {
+		return *accountEnabled
+	}
+	return privacyConfig.CCPA.Enforce
+}
+
+func extractCCPA(orig *openrtb.BidRequest, privacyConfig config.Privacy, account *config.Account, aliases map[string]string, requestType config.RequestType) (privacy.PolicyEnforcer, error) {
 	ccpaPolicy, err := ccpa.ReadFromRequest(orig)
 	if err != nil {
 		return privacy.NilPolicyEnforcer{}, err
@@ -157,7 +164,7 @@ func extractCCPA(orig *openrtb.BidRequest, privacyConfig config.Privacy, aliases
 	}
 
 	ccpaEnforcer := privacy.EnabledPolicyEnforcer{
-		Enabled:        privacyConfig.CCPA.Enforce,
+		Enabled:        ccpaEnabled(account, privacyConfig, requestType),
 		PolicyEnforcer: ccpaParsedPolicy,
 	}
 	return ccpaEnforcer, nil

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -83,7 +83,7 @@ func cleanOpenRTBRequests(ctx context.Context,
 	consent := extractConsent(orig)
 	ampGDPRException := (labels.RType == pbsmetrics.ReqTypeAMP) && gDPR.AMPException()
 
-	ccpaEnforcer, err := extractCCPA(orig, privacyConfig, account, aliases, requestTypeMap[labels.RType])
+	ccpaEnforcer, err := extractCCPA(orig, privacyConfig, account, aliases, integrationTypeMap[labels.RType])
 	if err != nil {
 		errs = append(errs, err)
 		return
@@ -144,14 +144,14 @@ func gdprEnabled(account *config.Account, privacyConfig config.Privacy, integrat
 	return privacyConfig.GDPR.Enabled
 }
 
-func ccpaEnabled(account *config.Account, privacyConfig config.Privacy, requestType config.RequestType) bool {
-	if accountEnabled := account.CCPA.EnabledForRequestType(requestType); accountEnabled != nil {
+func ccpaEnabled(account *config.Account, privacyConfig config.Privacy, requestType config.IntegrationType) bool {
+	if accountEnabled := account.CCPA.EnabledForIntegrationType(requestType); accountEnabled != nil {
 		return *accountEnabled
 	}
 	return privacyConfig.CCPA.Enforce
 }
 
-func extractCCPA(orig *openrtb.BidRequest, privacyConfig config.Privacy, account *config.Account, aliases map[string]string, requestType config.RequestType) (privacy.PolicyEnforcer, error) {
+func extractCCPA(orig *openrtb.BidRequest, privacyConfig config.Privacy, account *config.Account, aliases map[string]string, requestType config.IntegrationType) (privacy.PolicyEnforcer, error) {
 	ccpaPolicy, err := ccpa.ReadFromRequest(orig)
 	if err != nil {
 		return privacy.NilPolicyEnforcer{}, err

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -100,7 +100,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		reqExt              json.RawMessage
 		ccpaConsent         string
 		ccpaAccountEnabled  *bool
-		enforceCCPA         bool
+		ccpaHostEnabled     bool
 		expectDataScrub     bool
 		expectPrivacyLabels pbsmetrics.PrivacyLabels
 	}{
@@ -108,7 +108,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - Opt Out",
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -119,7 +119,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - Opt In",
 			ccpaConsent:        "1-N-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -131,7 +131,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["*"]}}`),
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -143,7 +143,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["appnexus"]}}`),
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -155,7 +155,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["rubicon"]}}`),
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -166,7 +166,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature flags Account CCPA enabled, host CCPA disregarded - Opt Out",
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &trueValue,
-			enforceCCPA:        false,
+			ccpaHostEnabled:    false,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -177,7 +177,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature flags Account CCPA disabled, host CCPA disregarded",
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: &falseValue,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -188,7 +188,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature flags Account CCPA not specified, host CCPA enabled - Opt Out",
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: nil,
-			enforceCCPA:        true,
+			ccpaHostEnabled:    true,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -199,7 +199,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature flags Account CCPA not specified, host CCPA disabled",
 			ccpaConsent:        "1-Y-",
 			ccpaAccountEnabled: nil,
-			enforceCCPA:        false,
+			ccpaHostEnabled:    false,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -217,7 +217,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 
 		privacyConfig := config.Privacy{
 			CCPA: config.CCPA{
-				Enforce: test.enforceCCPA,
+				Enforce: test.ccpaHostEnabled,
 			},
 		}
 
@@ -1026,7 +1026,6 @@ func TestCleanOpenRTBRequestsGDPR(t *testing.T) {
 		gdpr                string
 		gdprConsent         string
 		gdprScrub           bool
-		enforceGDPR         bool
 		expectPrivacyLabels pbsmetrics.PrivacyLabels
 	}{
 		{

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -93,6 +93,8 @@ func TestCleanOpenRTBRequests(t *testing.T) {
 }
 
 func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
+	trueValue, falseValue := true, false
+
 	testCases := []struct {
 		description         string
 		reqExt              json.RawMessage
@@ -105,7 +107,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature Flags Enabled - Opt Out",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        true,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -116,7 +118,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature Flags Enabled - Opt In",
 			ccpaConsent:        "1-N-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -128,7 +130,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Star - Doesn't Scrub",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["*"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -140,7 +142,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Specific Bidder - Doesn't Scrub",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["appnexus"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -152,7 +154,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Different Bidder - Scrubs",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["rubicon"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        true,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -163,7 +165,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA enabled, host CCPA disregarded - Opt Out",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{true}[0],
+			ccpaAccountEnabled: &trueValue,
 			enforceCCPA:        false,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
@@ -174,7 +176,7 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA disabled, host CCPA disregarded",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &[]bool{false}[0],
+			ccpaAccountEnabled: &falseValue,
 			enforceCCPA:        true,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -99,16 +99,16 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		description         string
 		reqExt              json.RawMessage
 		ccpaConsent         string
-		ccpaAccountEnabled  *bool
 		ccpaHostEnabled     bool
+		ccpaAccountEnabled  *bool
 		expectDataScrub     bool
 		expectPrivacyLabels pbsmetrics.PrivacyLabels
 	}{
 		{
 			description:        "Feature Flags Enabled - Opt Out",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -118,8 +118,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature Flags Enabled - Opt In",
 			ccpaConsent:        "1-N-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -130,8 +130,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Star - Doesn't Scrub",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["*"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -142,8 +142,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Specific Bidder - Doesn't Scrub",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["appnexus"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -154,8 +154,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			description:        "Feature Flags Enabled - No Sale Different Bidder - Scrubs",
 			reqExt:             json.RawMessage(`{"prebid":{"nosale":["rubicon"]}}`),
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -165,8 +165,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA enabled, host CCPA disregarded - Opt Out",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &trueValue,
 			ccpaHostEnabled:    false,
+			ccpaAccountEnabled: &trueValue,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -176,8 +176,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA disabled, host CCPA disregarded",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: &falseValue,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: &falseValue,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -187,8 +187,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA not specified, host CCPA enabled - Opt Out",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: nil,
 			ccpaHostEnabled:    true,
+			ccpaAccountEnabled: nil,
 			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
@@ -198,8 +198,8 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		{
 			description:        "Feature flags Account CCPA not specified, host CCPA disabled",
 			ccpaConsent:        "1-Y-",
-			ccpaAccountEnabled: nil,
 			ccpaHostEnabled:    false,
+			ccpaAccountEnabled: nil,
 			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -97,68 +97,108 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 		description         string
 		reqExt              json.RawMessage
 		ccpaConsent         string
+		ccpaAccountEnabled  *bool
 		enforceCCPA         bool
 		expectDataScrub     bool
 		expectPrivacyLabels pbsmetrics.PrivacyLabels
 	}{
 		{
-			description:     "Feature Flag Enabled - Opt Out",
-			ccpaConsent:     "1-Y-",
-			enforceCCPA:     true,
-			expectDataScrub: true,
+			description:        "Feature Flags Enabled - Opt Out",
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: true,
 			},
 		},
 		{
-			description:     "Feature Flag Enabled - Opt In",
-			ccpaConsent:     "1-N-",
-			enforceCCPA:     true,
-			expectDataScrub: false,
+			description:        "Feature Flags Enabled - Opt In",
+			ccpaConsent:        "1-N-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: false,
 			},
 		},
 		{
-			description:     "Feature Flag Enabled - No Sale Star - Doesn't Scrub",
-			reqExt:          json.RawMessage(`{"prebid":{"nosale":["*"]}}`),
-			ccpaConsent:     "1-Y-",
-			enforceCCPA:     true,
-			expectDataScrub: false,
+			description:        "Feature Flags Enabled - No Sale Star - Doesn't Scrub",
+			reqExt:             json.RawMessage(`{"prebid":{"nosale":["*"]}}`),
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: false,
 			},
 		},
 		{
-			description:     "Feature Flag Enabled - No Sale Specific Bidder - Doesn't Scrub",
-			reqExt:          json.RawMessage(`{"prebid":{"nosale":["appnexus"]}}`),
-			ccpaConsent:     "1-Y-",
-			enforceCCPA:     true,
-			expectDataScrub: false,
+			description:        "Feature Flags Enabled - No Sale Specific Bidder - Doesn't Scrub",
+			reqExt:             json.RawMessage(`{"prebid":{"nosale":["appnexus"]}}`),
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: true,
 			},
 		},
 		{
-			description:     "Feature Flag Enabled - No Sale Different Bidder - Scrubs",
-			reqExt:          json.RawMessage(`{"prebid":{"nosale":["rubicon"]}}`),
-			ccpaConsent:     "1-Y-",
-			enforceCCPA:     true,
-			expectDataScrub: true,
+			description:        "Feature Flags Enabled - No Sale Different Bidder - Scrubs",
+			reqExt:             json.RawMessage(`{"prebid":{"nosale":["rubicon"]}}`),
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    true,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: true,
 			},
 		},
 		{
-			description:     "Feature Flag Disabled",
-			ccpaConsent:     "1-Y-",
-			enforceCCPA:     false,
-			expectDataScrub: false,
+			description:        "Feature flags Account CCPA enabled, host CCPA disregarded - Opt Out",
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{true}[0],
+			enforceCCPA:        false,
+			expectDataScrub:    true,
+			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
+				CCPAProvided: true,
+				CCPAEnforced: true,
+			},
+		},
+		{
+			description:        "Feature flags Account CCPA disabled, host CCPA disregarded",
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: &[]bool{false}[0],
+			enforceCCPA:        true,
+			expectDataScrub:    false,
+			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
+				CCPAProvided: true,
+				CCPAEnforced: false,
+			},
+		},
+		{
+			description:        "Feature flags Account CCPA not specified, host CCPA enabled - Opt Out",
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: nil,
+			enforceCCPA:        true,
+			expectDataScrub:    true,
+			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
+				CCPAProvided: true,
+				CCPAEnforced: true,
+			},
+		},
+		{
+			description:        "Feature flags Account CCPA not specified, host CCPA disabled",
+			ccpaConsent:        "1-Y-",
+			ccpaAccountEnabled: nil,
+			enforceCCPA:        false,
+			expectDataScrub:    false,
 			expectPrivacyLabels: pbsmetrics.PrivacyLabels{
 				CCPAProvided: true,
 				CCPAEnforced: false,
@@ -179,7 +219,23 @@ func TestCleanOpenRTBRequestsCCPA(t *testing.T) {
 			},
 		}
 
-		results, _, privacyLabels, errs := cleanOpenRTBRequests(context.Background(), req, nil, &emptyUsersync{}, map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels{}, pbsmetrics.Labels{}, &permissionsMock{personalInfoAllowed: true}, true, privacyConfig, &config.Account{})
+		accountConfig := config.Account{
+			CCPA: config.AccountCCPA{
+				Enabled: test.ccpaAccountEnabled,
+			},
+		}
+
+		results, _, privacyLabels, errs := cleanOpenRTBRequests(
+			context.Background(),
+			req,
+			nil,
+			&emptyUsersync{},
+			map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels{},
+			pbsmetrics.Labels{},
+			&permissionsMock{personalInfoAllowed: true},
+			true,
+			privacyConfig,
+			&accountConfig)
 		result := results["appnexus"]
 
 		assert.Nil(t, errs)


### PR DESCRIPTION
Similar to what we are doing for GDPR, as described in issue #1323 and PR #1564, this adds account-level CCPA configuration.

The order of precedence for determining whether CCPA is enabled is the same as for GDPR:

1. Use account-level request type setting if specified
2. Use account-level general setting if specified
3. Use host-level general setting
