### PR TITLE
Improve GitHub Actions Validation

### DIFF
--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -1,0 +1,24 @@
+name: Validate Merge
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  validate-merge:
+    runs-on: ubuntu-18.04
+    
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.2
+
+    - name: Checkout Merged Branch
+      uses: actions/checkout@v2
+
+    - name: Validate
+      run: |
+        ./validate.sh --nofmt
+      env:
+        GO111MODULE: "on"

--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -19,6 +19,6 @@ jobs:
 
     - name: Validate
       run: |
-        ./validate.sh --nofmt
+        ./validate.sh --nofmt --cov --race 10
       env:
         GO111MODULE: "on"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Branch
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.milestone.title }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,26 +1,29 @@
+name: Validate
+
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
-  release:
-    types:
-      - created
-name: Validate
+
 jobs:
-  Go:
+  validate:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x]
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
+    
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
+
+    - name: Checkout Branch
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Validate
       run: |
         ./validate.sh --nofmt --cov --race 10

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Branch
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.fake }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Branch
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.fake }}
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Branch
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.milestone.title }}
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
 
 jobs:
   validate:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Checkout Branch
       uses: actions/checkout@v2
       with:
+        # Resolves to empty string for push events and falls back to HEAD.
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - '1.13'
   - '1.14.2'
+  - '1.15'
 
 go_import_path: github.com/prebid/prebid-server
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information, see:
 
 ## Installation
 
-First install [Go](https://golang.org/doc/install) version 1.13 or newer.
+First install [Go](https://golang.org/doc/install) version 1.14 or newer.
 
 Note that prebid-server is using [Go modules](https://blog.golang.org/using-go-modules).
 We officially support the most recent two major versions of the Go runtime. However, if you'd like to use a version <1.13 and are inside GOPATH `GO111MODULE` needs to be set to `GO111MODULE=on`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prebid/prebid-server
 
-go 1.13
+go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
@@ -35,7 +35,7 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/prebid/go-gdpr v0.8.3
-	github.com/prebid/prebid-cache v0.0.0-20200218152159-6d6d678c1caf
+	github.com/prebid/prebid-cache v0.0.0-20200218152159-6d6d678c1caf // indirect
 	github.com/prometheus/client_golang v0.0.0-20180623155954-77e8f2ddcfed
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect


### PR DESCRIPTION
- Formatting updated.
- Validate workflow no longer runs on release creation. I don't see a need for this.
- Validate workflow now validates just the branch to match what TravisCI did.
- Validate Merge workflow added to validate things are still good after the auto-merge occurs.
- Dropped Go 1.13 build targets / support.
- Upgraded go.mod to 1.14.