### PR TITLE
Bugfix: default admin port is 6060

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN apt-get update && \
     apt-get install -y ca-certificates mtr && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EXPOSE 8000
-EXPOSE 8080
+EXPOSE 6060
 ENTRYPOINT ["/usr/local/bin/prebid-server"]
 CMD ["-v", "1", "-logtostderr"]


### PR DESCRIPTION
The Dockerfile exposes port 8080 that is not in use by the default prebid-server configuration. 
I guess this should expose the default admin port which is 6060 and which is not exposed in the file.  