### PR TITLE
Remove Hook Scripts

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,6 +1,0 @@
-#!/bin/sh
-#To install this hook, run this from project root directory:
-#ln -s -f ../../hooks/pre-push .git/hooks/pre-push
-echo "running pre push hook validations"
-./validate.sh
-exit $?


### PR DESCRIPTION
The `/hooks` folder predates my involvement with the project. It looks like git hooks, but needs to be copied into the `.git` folder to be meaningful. I'm not aware of anyone using these currently. We discussed this internally and propose it's complete removal.

This is unrelated to the validate script or the validate GitHub Action.