### PR TITLE
Add warning that gdpr checks will be skipped when gdpr.host_vendor_id…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -211,7 +211,7 @@ func (cfg *GDPR) validate(errs []error) []error {
 		errs = append(errs, fmt.Errorf("gdpr.host_vendor_id must be in the range [0, %d]. Got %d", 0xffff, cfg.HostVendorID))
 	}
 	if cfg.HostVendorID == 0 {
-		glog.Warning("gdpr.host_vendor_id not specified -- will skip host company GDPR checks")
+		glog.Warning("gdpr.host_vendor_id was not specified. Host company GDPR checks will be skipped.")
 	}
 	if cfg.AMPException == true {
 		glog.Warning("gdpr.amp_exception is deprecated and will be removed in a future version. If you need to disable GDPR for AMP, you may do so per-account (gdpr.integration_enabled.amp) or at the host level for the default account (account_defaults.gdpr.integration_enabled.amp).")

--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,9 @@ func (cfg *GDPR) validate(errs []error) []error {
 	if cfg.HostVendorID < 0 || cfg.HostVendorID > 0xffff {
 		errs = append(errs, fmt.Errorf("gdpr.host_vendor_id must be in the range [0, %d]. Got %d", 0xffff, cfg.HostVendorID))
 	}
+	if cfg.HostVendorID == 0 {
+		glog.Warning("gdpr.host_vendor_id not specified -- will skip host company GDPR checks")
+	}
 	if cfg.AMPException == true {
 		glog.Warning("gdpr.amp_exception is deprecated and will be removed in a future version. If you need to disable GDPR for AMP, you may do so per-account (gdpr.integration_enabled.amp) or at the host level for the default account (account_defaults.gdpr.integration_enabled.amp).")
 	}


### PR DESCRIPTION
… is zero

Related issue: https://github.com/prebid/prebid-server/issues/1393

Items 1 and 2 in that issue are already in place. `host_vendor_id` is set to zero by default which means the checks are skipped. This is accomplished by setting the permissions object to `AlwaysAllow` instead of `permissionsImpl`.

I'm opening a new ticket to consider defaulting to no consent instead of consent which is the implied desired behavior in the linked issue.