### PR TITLE
Fix Shared Memory Corruption In EMX_Digital

### DIFF
--- a/adapters/emx_digital/emx_digital.go
+++ b/adapters/emx_digital/emx_digital.go
@@ -152,8 +152,10 @@ func buildImpVideo(imp *openrtb.Imp) error {
 		}
 	}
 
-	if imp.Video.Protocols != nil {
-		imp.Video.Protocols = cleanProtocol(imp.Video.Protocols)
+	if len(imp.Video.Protocols) > 0 {
+		videoCopy := *imp.Video
+		videoCopy.Protocols = cleanProtocol(imp.Video.Protocols)
+		imp.Video = &videoCopy
 	}
 
 	return nil


### PR DESCRIPTION
The adapter changes a shared video pointer without first making a copy. We have reason to believe this is causing occasional memory corruption issues when marshaling a request targeting multiple adapters.

@EMXDigital Can you please review?