### PR TITLE
requestheaders: new parameter inside debug.httpcalls.<BIDDER> to log request header details

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -308,17 +308,19 @@ func getAssetByID(id int64, assets []nativeRequests.Asset) (nativeRequests.Asset
 func makeExt(httpInfo *httpCallInfo) *openrtb_ext.ExtHttpCall {
 	if httpInfo.err == nil {
 		return &openrtb_ext.ExtHttpCall{
-			Uri:          httpInfo.request.Uri,
-			RequestBody:  string(httpInfo.request.Body),
-			ResponseBody: string(httpInfo.response.Body),
-			Status:       httpInfo.response.StatusCode,
+			Uri:            httpInfo.request.Uri,
+			RequestBody:    string(httpInfo.request.Body),
+			ResponseBody:   string(httpInfo.response.Body),
+			Status:         httpInfo.response.StatusCode,
+			RequestHeaders: httpInfo.request.Headers,
 		}
 	} else if httpInfo.request == nil {
 		return &openrtb_ext.ExtHttpCall{}
 	} else {
 		return &openrtb_ext.ExtHttpCall{
-			Uri:         httpInfo.request.Uri,
-			RequestBody: string(httpInfo.request.Body),
+			Uri:            httpInfo.request.Uri,
+			RequestBody:    string(httpInfo.request.Body),
+			RequestHeaders: httpInfo.request.Headers,
 		}
 	}
 }

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -886,6 +886,9 @@ func TestBadRequestLogging(t *testing.T) {
 	if ext.Status != 0 {
 		t.Errorf("The Status code should be 0. Got %d", ext.Status)
 	}
+	if nil != ext.RequestHeaders || len(ext.RequestHeaders) > 0 {
+		t.Errorf("The request headers should be empty. Got %s", ext.RequestHeaders)
+	}
 }
 
 // TestBadResponseLogging makes sure that openrtb_ext works properly if we don't get a sensible HTTP response.
@@ -894,6 +897,9 @@ func TestBadResponseLogging(t *testing.T) {
 		request: &adapters.RequestData{
 			Uri:  "test.com",
 			Body: []byte("request body"),
+			Headers: http.Header{
+				"header-1": []string{"value-1"},
+			},
 		},
 		err: errors.New("Bad response"),
 	}
@@ -910,6 +916,7 @@ func TestBadResponseLogging(t *testing.T) {
 	if ext.Status != 0 {
 		t.Errorf("The Status code should be 0. Got %d", ext.Status)
 	}
+	assert.Equal(t, info.request.Headers, http.Header(ext.RequestHeaders), "The request headers should be \"header-1:value-1\"")
 }
 
 // TestSuccessfulResponseLogging makes sure that openrtb_ext works properly if the HTTP request is successful.
@@ -918,6 +925,9 @@ func TestSuccessfulResponseLogging(t *testing.T) {
 		request: &adapters.RequestData{
 			Uri:  "test.com",
 			Body: []byte("request body"),
+			Headers: http.Header{
+				"header-1": []string{"value-1", "value-2"},
+			},
 		},
 		response: &adapters.ResponseData{
 			StatusCode: 200,
@@ -937,6 +947,7 @@ func TestSuccessfulResponseLogging(t *testing.T) {
 	if ext.Status != info.response.StatusCode {
 		t.Errorf("The Status code should be 0. Got %d", ext.Status)
 	}
+	assert.Equal(t, info.request.Headers, http.Header(ext.RequestHeaders), "The request headers should be \"%s\". Got %s", info.request.Headers, ext.RequestHeaders)
 }
 
 func TestMobileNativeTypes(t *testing.T) {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -886,7 +886,7 @@ func TestBadRequestLogging(t *testing.T) {
 	if ext.Status != 0 {
 		t.Errorf("The Status code should be 0. Got %d", ext.Status)
 	}
-	if nil != ext.RequestHeaders || len(ext.RequestHeaders) > 0 {
+	if len(ext.RequestHeaders) > 0 {
 		t.Errorf("The request headers should be empty. Got %s", ext.RequestHeaders)
 	}
 }

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1340,6 +1340,9 @@ func TestSetDebugContextKey(t *testing.T) {
 func TestExchangeJSON(t *testing.T) {
 	if specFiles, err := ioutil.ReadDir("./exchangetest"); err == nil {
 		for _, specFile := range specFiles {
+			if specFile.Name() != "request-multi-bidders-debug-info.json" {
+				continue
+			}
 			fileName := "./exchangetest/" + specFile.Name()
 			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
 			specData, err := loadFile(fileName)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1340,9 +1340,6 @@ func TestSetDebugContextKey(t *testing.T) {
 func TestExchangeJSON(t *testing.T) {
 	if specFiles, err := ioutil.ReadDir("./exchangetest"); err == nil {
 		for _, specFile := range specFiles {
-			if specFile.Name() != "request-multi-bidders-debug-info.json" {
-				continue
-			}
 			fileName := "./exchangetest/" + specFile.Name()
 			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
 			specData, err := loadFile(fileName)

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -65,7 +65,7 @@
           {
             "uri": "appnexusTest.com",
             "requestbody": "appnexusTestRequestBody",
-            "requestheaders": null,
+            "requestheaders": { "header_1" : ["value_11", "value_12"], "header_2" : ["value_21"] },
             "responsebody": "appnexusTestResponseBody",
             "status": 200
           }
@@ -153,7 +153,7 @@
               "requestbody": "appnexusTestRequestBody",
               "responsebody": "appnexusTestResponseBody",
               "status": 200,
-              "requestheaders": null
+              "requestheaders": { "header_1" : ["value_11", "value_12"], "header_2" : ["value_21"] }
             }
           ],
           "audienceNetwork": [

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -95,9 +95,9 @@
           {
             "uri": "audienceNetworkTest.com",
             "requestbody": "audienceNetworkTestRequestBody",
+            "requestheaders": null,
             "responsebody": "audienceNetworkTestResponseBody",
-            "status": 200,
-            "requestheaders": null
+            "status": 200
           }
         ]
       }
@@ -151,18 +151,18 @@
             {
               "uri": "appnexusTest.com",
               "requestbody": "appnexusTestRequestBody",
+              "requestheaders": { "header_1" : ["value_11", "value_12"], "header_2" : ["value_21"] },
               "responsebody": "appnexusTestResponseBody",
-              "status": 200,
-              "requestheaders": { "header_1" : ["value_11", "value_12"], "header_2" : ["value_21"] }
+              "status": 200
             }
           ],
           "audienceNetwork": [
             {
               "uri": "audienceNetworkTest.com",
               "requestbody": "audienceNetworkTestRequestBody",
+              "requestheaders": null,
               "responsebody": "audienceNetworkTestResponseBody",
-              "status": 200,
-              "requestheaders": null
+              "status": 200
             }
           ]
         },

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -65,6 +65,7 @@
           {
             "uri": "appnexusTest.com",
             "requestbody": "appnexusTestRequestBody",
+            "requestheaders": null,
             "responsebody": "appnexusTestResponseBody",
             "status": 200
           }
@@ -95,7 +96,8 @@
             "uri": "audienceNetworkTest.com",
             "requestbody": "audienceNetworkTestRequestBody",
             "responsebody": "audienceNetworkTestResponseBody",
-            "status": 200
+            "status": 200,
+            "requestheaders": null
           }
         ]
       }
@@ -150,7 +152,8 @@
               "uri": "appnexusTest.com",
               "requestbody": "appnexusTestRequestBody",
               "responsebody": "appnexusTestResponseBody",
-              "status": 200
+              "status": 200,
+              "requestheaders": null
             }
           ],
           "audienceNetwork": [
@@ -158,7 +161,8 @@
               "uri": "audienceNetworkTest.com",
               "requestbody": "audienceNetworkTestRequestBody",
               "responsebody": "audienceNetworkTestResponseBody",
-              "status": 200
+              "status": 200,
+              "requestheaders": null
             }
           ]
         },

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -55,10 +55,11 @@ type ExtBidderError struct {
 
 // ExtHttpCall defines the contract for a bidresponse.ext.debug.httpcalls.{bidder}[i]
 type ExtHttpCall struct {
-	Uri          string `json:"uri"`
-	RequestBody  string `json:"requestbody"`
-	ResponseBody string `json:"responsebody"`
-	Status       int    `json:"status"`
+	Uri            string              `json:"uri"`
+	RequestBody    string              `json:"requestbody"`
+	ResponseBody   string              `json:"responsebody"`
+	Status         int                 `json:"status"`
+	RequestHeaders map[string][]string `json:"requestheaders"`
 }
 
 // CookieStatus describes the allowed values for bidresponse.ext.usersync.{bidder}.status

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -57,9 +57,9 @@ type ExtBidderError struct {
 type ExtHttpCall struct {
 	Uri            string              `json:"uri"`
 	RequestBody    string              `json:"requestbody"`
+	RequestHeaders map[string][]string `json:"requestheaders"`
 	ResponseBody   string              `json:"responsebody"`
 	Status         int                 `json:"status"`
-	RequestHeaders map[string][]string `json:"requestheaders"`
 }
 
 // CookieStatus describes the allowed values for bidresponse.ext.usersync.{bidder}.status


### PR DESCRIPTION
httpcalls.\<BIDDER>.**_requestheaders_** - New Debug parameter

@SyntaxNode, Please review and approve this PR.

It will be useful to log a set of request headers sent to the actual Bidder. This will help in verifying if required request headers are correctly getting sent to the actual Bidder.

This parameter will be visible only when query parameter _debug=1_ is set. For example,
> http://localhost:8000/openrtb2/video?debug=1
> <img width="1355" alt="image" src="https://user-images.githubusercontent.com/9314645/105181655-16a09280-5b52-11eb-9a61-1bb377b7d535.png">


In above example **requestheaders** indicating 2 headers are sent to appnexus bidder.

1.  "Accept": ["application/json"],
2. "Content-Type": ["application/json;charset=utf-8"]

****
