### PR TITLE
AMX Bid Adapter: Loop Variable Bug

### DIFF
--- a/adapters/amx/amx.go
+++ b/adapters/amx/amx.go
@@ -147,10 +147,9 @@ func (adapter *AMXAdapter) MakeBids(request *openrtb.BidRequest, externalRequest
 
 	bidResponse := adapters.NewBidderResponseWithBidsCapacity(5)
 
-	for _, seatbid := range bidResp.SeatBid {
-		sb := seatbid
-		for _, bidExternal := range sb.Bid {
-			bid := bidExternal
+	for _, sb := range bidResp.SeatBid {
+		for _, bid := range sb.Bid {
+			bid := bid
 			bidExt, bidExtErr := getBidExt(bid.Ext)
 			if bidExtErr != nil {
 				errs = append(errs, bidExtErr)

--- a/adapters/amx/amx.go
+++ b/adapters/amx/amx.go
@@ -17,7 +17,7 @@ import (
 const vastImpressionFormat = "<Impression><![CDATA[%s]]></Impression>"
 const vastSearchPoint = "</Impression>"
 const nbrHeaderName = "x-nbr"
-const adapterVersion = "pbs1.0"
+const adapterVersion = "pbs1.1"
 
 // AMXAdapter is the AMX bid adapter
 type AMXAdapter struct {
@@ -147,8 +147,10 @@ func (adapter *AMXAdapter) MakeBids(request *openrtb.BidRequest, externalRequest
 
 	bidResponse := adapters.NewBidderResponseWithBidsCapacity(5)
 
-	for _, sb := range bidResp.SeatBid {
-		for _, bid := range sb.Bid {
+	for _, seatbid := range bidResp.SeatBid {
+		sb := seatbid
+		for _, bidExternal := range sb.Bid {
+			bid := bidExternal
 			bidExt, bidExtErr := getBidExt(bid.Ext)
 			if bidExtErr != nil {
 				errs = append(errs, bidExtErr)
@@ -165,11 +167,12 @@ func (adapter *AMXAdapter) MakeBids(request *openrtb.BidRequest, externalRequest
 				// remove the NURL so a client/player doesn't fire it twice
 				b.Bid.NURL = ""
 			}
+
 			bidResponse.Bids = append(bidResponse.Bids, b)
 		}
 	}
-	return bidResponse, errs
 
+	return bidResponse, errs
 }
 
 func getBidExt(ext json.RawMessage) (amxBidExt, error) {

--- a/adapters/amx/amxtest/exemplary/app-simple.json
+++ b/adapters/amx/amxtest/exemplary/app-simple.json
@@ -64,7 +64,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.0",
+        "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.1",
         "body": {
           "app": {
             "bundle": "639881495",

--- a/adapters/amx/amxtest/exemplary/display-multiple.json
+++ b/adapters/amx/amxtest/exemplary/display-multiple.json
@@ -213,15 +213,12 @@
                 "cid": "668",
                 "crid": "253510977",
                 "ext": {
-                  "dp": 0.475762,
-                  "lid": 142443,
-                  "sbid": "668"
                 },
                 "h": 250,
                 "id": "8911104898220857797",
                 "impid": "6a362d3a9db4eba300x250",
-                "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=8911104898220857797&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.14811014298411188&pp=1481&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
-                "price": 0.14811014298411188,
+                "nurl": "https://1x1.a-mo.net/hbx/bwin",
+                "price": 0.50,
                 "w": 300
               },
               {
@@ -232,16 +229,12 @@
                 ],
                 "cid": "668",
                 "crid": "253510977",
-                "ext": {
-                  "dp": 0.437403,
-                  "lid": 142443,
-                  "sbid": "668"
-                },
+                "ext": {},
                 "h": 250,
                 "id": "430444686086263488",
                 "impid": "6a362d3a9db4eba300x250",
-                "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=430444686086263488&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.1361685482902785&pp=1361&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
-                "price": 0.1361685482902785,
+                "nurl": "https://1x1.a-mo.net/hbx/bwin",
+                "price": 0.50,
                 "w": 300
               }
             ],
@@ -264,16 +257,12 @@
             ],
             "cid": "668",
             "crid": "253510977",
-            "ext": {
-              "dp": 0.475762,
-              "lid": 142443,
-              "sbid": "668"
-            },
+            "ext": {},
             "h": 250,
             "id": "8911104898220857797",
             "impid": "6a362d3a9db4eba300x250",
-            "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=8911104898220857797&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.14811014298411188&pp=1481&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
-            "price": 0.14811014298411188,
+            "nurl": "https://1x1.a-mo.net/hbx/bwin",
+            "price": 0.50,
             "w": 300
           },
           "type": "banner"
@@ -287,16 +276,12 @@
             ],
             "cid": "668",
             "crid": "253510977",
-            "ext": {
-              "dp": 0.437403,
-              "lid": 142443,
-              "sbid": "668"
-            },
+            "ext": {},
             "h": 250,
             "id": "430444686086263488",
             "impid": "6a362d3a9db4eba300x250",
-            "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=430444686086263488&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.1361685482902785&pp=1361&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
-            "price": 0.1361685482902785,
+            "nurl": "https://1x1.a-mo.net/hbx/bwin",
+            "price": 0.50,
             "w": 300
           },
           "type": "banner"

--- a/adapters/amx/amxtest/exemplary/display-multiple.json
+++ b/adapters/amx/amxtest/exemplary/display-multiple.json
@@ -112,7 +112,6 @@
         "id": "TL3JS6F43CKNDQFY",
         "imp": [
           {
-            "tagid": "example-tag-id",
             "banner": {
               "format": [
                 {
@@ -129,6 +128,7 @@
                 "tagId": "cHJlYmlkLm9yZw"
               }
             },
+            "tagid": "example-tag-id",
             "id": "1",
             "secure": 1
           }
@@ -199,43 +199,104 @@
     "mockResponse": {
       "status": 200,
       "body": {
-        "id": "WQ5V2DWVTMNXABDD",
-        "seatbid": [{
-          "bid": [{
-            "id": "TEST",
-            "impid": "1",
-            "price": 10.0,
-            "adid": "1",
-            "adm": "<script src=\"https://assets.a-mo.net/tmode.v1.js\"></script>",
-            "adomain": ["amxrtb.com"],
-            "iurl": "https://assets.a-mo.net/300x250.v2.png",
-            "cid": "1",
-            "crid": "1",
-            "h": 600,
-            "w": 300
-          }]
-        }],
-        "cur": "USD"
+        "cur": "USD",
+        "id": "os4jorvupkyaa===",
+        "seatbid": [
+          {
+            "bid": [
+              {
+                "adid": "253510977",
+                "adm": "<i></i><script>_c=[];</script><script src=\"https://assets.a-mo.net/js/c.js\"></script>",
+                "adomain": [
+                  "dell.com.au"
+                ],
+                "cid": "668",
+                "crid": "253510977",
+                "ext": {
+                  "dp": 0.475762,
+                  "lid": 142443,
+                  "sbid": "668"
+                },
+                "h": 250,
+                "id": "8911104898220857797",
+                "impid": "6a362d3a9db4eba300x250",
+                "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=8911104898220857797&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.14811014298411188&pp=1481&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
+                "price": 0.14811014298411188,
+                "w": 300
+              },
+              {
+                "adid": "253510977",
+                "adm": "<i></i><script>_c=[];</script><script src=\"https://assets.a-mo.net/js/c.js\"></script>",
+                "adomain": [
+                  "dell.com.au"
+                ],
+                "cid": "668",
+                "crid": "253510977",
+                "ext": {
+                  "dp": 0.437403,
+                  "lid": 142443,
+                  "sbid": "668"
+                },
+                "h": 250,
+                "id": "430444686086263488",
+                "impid": "6a362d3a9db4eba300x250",
+                "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=430444686086263488&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.1361685482902785&pp=1361&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
+                "price": 0.1361685482902785,
+                "w": 300
+              }
+            ],
+            "group": 0
+          }
+        ]
       }
     }
   }],
-
   "expectedBidResponses": [
     {
       "currency": "USD",
       "bids": [
         {
           "bid": {
-            "id": "TEST",
-            "impid": "1",
-            "price": 10.0,
-            "adid": "1",
-            "adm": "<script src=\"https://assets.a-mo.net/tmode.v1.js\"></script>",
-            "adomain": ["amxrtb.com"],
-            "iurl": "https://assets.a-mo.net/300x250.v2.png",
-            "cid": "1",
-            "crid": "1",
-            "h": 600,
+            "adid": "253510977",
+            "adm": "<i></i><script>_c=[];</script><script src=\"https://assets.a-mo.net/js/c.js\"></script>",
+            "adomain": [
+              "dell.com.au"
+            ],
+            "cid": "668",
+            "crid": "253510977",
+            "ext": {
+              "dp": 0.475762,
+              "lid": 142443,
+              "sbid": "668"
+            },
+            "h": 250,
+            "id": "8911104898220857797",
+            "impid": "6a362d3a9db4eba300x250",
+            "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=8911104898220857797&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.14811014298411188&pp=1481&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
+            "price": 0.14811014298411188,
+            "w": 300
+          },
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "adid": "253510977",
+            "adm": "<i></i><script>_c=[];</script><script src=\"https://assets.a-mo.net/js/c.js\"></script>",
+            "adomain": [
+              "dell.com.au"
+            ],
+            "cid": "668",
+            "crid": "253510977",
+            "ext": {
+              "dp": 0.437403,
+              "lid": 142443,
+              "sbid": "668"
+            },
+            "h": 250,
+            "id": "430444686086263488",
+            "impid": "6a362d3a9db4eba300x250",
+            "nurl": "https://1x1.a-mo.net/hbx/bwin?A=an&B=142443&D=&a=redflagdeals%2Fhotdeals_home&ad=dell.com.au&ai=12601&aid=_dax0tpmca&aud=1&av=&b=forums.redflagdeals.com&bid=430444686086263488&ci=668&cn=&cn3=9&cr=253510977&ct=0&cv=f0ca0bda&do=forums.redflagdeals.com&h=250&i=1&mid=c29ydGFibGUuY29t&p=0.1361685482902785&pp=1361&r=0&uf=&v=&w=300&wv=aas-1f823e18-a&np=${AUCTION_PRICE}",
+            "price": 0.1361685482902785,
             "w": 300
           },
           "type": "banner"

--- a/adapters/amx/amxtest/exemplary/video-simple.json
+++ b/adapters/amx/amxtest/exemplary/video-simple.json
@@ -93,7 +93,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.0",
+      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.1",
       "body": {
         "device": {
           "dnt": 0,

--- a/adapters/amx/amxtest/supplemental/204-response.json
+++ b/adapters/amx/amxtest/supplemental/204-response.json
@@ -47,7 +47,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.0",
+      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.1",
       "body": {
         "device": {
           "dnt": 0,

--- a/adapters/amx/amxtest/supplemental/400-response.json
+++ b/adapters/amx/amxtest/supplemental/400-response.json
@@ -47,7 +47,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.0",
+      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.1",
       "body": {
         "device": {
           "dnt": 0,

--- a/adapters/amx/amxtest/supplemental/500-response.json
+++ b/adapters/amx/amxtest/supplemental/500-response.json
@@ -47,7 +47,7 @@
   },
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.0",
+      "uri": "http://pbs-dev.amxrtb.com/auction/openrtb?v=pbs1.1",
       "body": {
         "device": {
           "dnt": 0,


### PR DESCRIPTION
This is a bugfix for an issue affecting the AMX Bid adapter. When the AMX RTB server responds with multiple (N) bids, the adapter will parse this as the first bid, repeated N times.

This is due to the fact that we store a pointer to the `bid` variable in the `TypedBid` which is changed with each iteration of the loop.

- added test `display-multiple.json` to reproduce
- refactored to add temporary loop variable
- bumped amx version string