### PR TITLE
Don't Load GVL v1 for TCF2 (+ TCF1 Cleanup)

### DIFF
--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -42,8 +42,8 @@ func NewPermissions(ctx context.Context, cfg config.GDPR, vendorIDs map[openrtb_
 		cfg:       cfg,
 		vendorIDs: vendorIDs,
 		fetchVendorList: map[uint8]func(ctx context.Context, id uint16) (vendorlist.VendorList, error){
-			tcf1SpecVersion: newVendorListFetcher(ctx, cfg, client, vendorListURLMaker, tcf1SpecVersion),
-			tcf2SpecVersion: newVendorListFetcher(ctx, cfg, client, vendorListURLMaker, tcf2SpecVersion)},
+			tcf1SpecVersion: newVendorListFetcherTCF1(cfg),
+			tcf2SpecVersion: newVendorListFetcherTCF2(ctx, cfg, client, vendorListURLMaker)},
 	}
 
 	if cfg.HostVendorID == 0 {

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -88,7 +88,7 @@ func makeVendorListNotFoundError(vendorListVersion uint16) error {
 // preloadCache saves all the known versions of the vendor list for future use.
 func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16) string, saver saveVendors) {
 	latestVersion := saveOne(ctx, client, urlMaker(0), saver)
-	firstVersion := uint16(2) // The GVL for TCF2 has no vendors defined and is very unlikely to be used. Don't load it.
+	firstVersion := uint16(2) // The first version of the GVL for TCF2 has no vendors defined and is very unlikely to be used. Don't preload it.
 
 	for i := firstVersion; i < latestVersion; i++ {
 		saveOne(ctx, client, urlMaker(i), saver)

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -88,9 +88,11 @@ func makeVendorListNotFoundError(vendorListVersion uint16) error {
 // preloadCache saves all the known versions of the vendor list for future use.
 func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16) string, saver saveVendors) {
 	latestVersion := saveOne(ctx, client, urlMaker(0), saver)
-	firstVersion := uint16(2) // The first version of the GVL for TCF2 has no vendors defined and is very unlikely to be used. Don't preload it.
 
-	for i := firstVersion; i < latestVersion; i++ {
+	// The GVL for TCF2 has no vendors defined in its first version. It's very unlikely to be used, so don't preload it.
+	firstVersionToLoad := uint16(2)
+
+	for i := firstVersionToLoad; i < latestVersion; i++ {
 		saveOne(ctx, client, urlMaker(i), saver)
 	}
 }

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -26,30 +26,40 @@ type saveVendors func(uint16, api.VendorList)
 //
 // Nothing in this file is exported. Public APIs can be found in gdpr.go
 
-func newVendorListFetcher(initCtx context.Context, cfg config.GDPR, client *http.Client, urlMaker func(uint16, uint8) string, tcfSpecVersion uint8) func(ctx context.Context, id uint16) (vendorlist.VendorList, error) {
-	var fallback api.VendorList
-
-	if tcfSpecVersion == tcf1SpecVersion && len(cfg.TCF1.FallbackGVLPath) == 0 {
-		return func(ctx context.Context, vendorListVersion uint16) (vendorlist.VendorList, error) {
+func newVendorListFetcherTCF1(cfg config.GDPR) func(ctx context.Context, id uint16) (vendorlist.VendorList, error) {
+	if len(cfg.TCF1.FallbackGVLPath) == 0 {
+		return func(_ context.Context, vendorListVersion uint16) (vendorlist.VendorList, error) {
 			return nil, makeVendorListNotFoundError(vendorListVersion)
 		}
 	}
 
-	if tcfSpecVersion == tcf1SpecVersion {
-		fallback = loadFallbackGVL(cfg.TCF1.FallbackGVLPath)
+	fallback := loadFallbackGVLForTCF1(cfg.TCF1.FallbackGVLPath)
+	return func(_ context.Context, _ uint16) (vendorlist.VendorList, error) {
+		return fallback, nil
+	}
+}
 
-		return func(ctx context.Context, vendorListVersion uint16) (vendorlist.VendorList, error) {
-			return fallback, nil
-		}
+func loadFallbackGVLForTCF1(fallbackGVLPath string) vendorlist.VendorList {
+	fallbackContents, err := ioutil.ReadFile(fallbackGVLPath)
+	if err != nil {
+		glog.Fatalf("Error reading from file %s: %v", fallbackGVLPath, err)
 	}
 
-	cacheSave, cacheLoad := newVendorListCache(fallback)
+	fallback, err := vendorlist.ParseEagerly(fallbackContents)
+	if err != nil {
+		glog.Fatalf("Error processing default GVL from %s: %v", fallbackGVLPath, err)
+	}
+	return fallback
+}
+
+func newVendorListFetcherTCF2(initCtx context.Context, cfg config.GDPR, client *http.Client, urlMaker func(uint16) string) func(ctx context.Context, id uint16) (vendorlist.VendorList, error) {
+	cacheSave, cacheLoad := newVendorListCache()
 
 	preloadContext, cancel := context.WithTimeout(initCtx, cfg.Timeouts.InitTimeout())
 	defer cancel()
-	preloadCache(preloadContext, client, urlMaker, cacheSave, tcfSpecVersion)
+	preloadCache(preloadContext, client, urlMaker, cacheSave)
 
-	saveOneRateLimited := newOccasionalSaver(cfg.Timeouts.ActiveTimeout(), tcfSpecVersion)
+	saveOneRateLimited := newOccasionalSaver(cfg.Timeouts.ActiveTimeout())
 	return func(ctx context.Context, vendorListVersion uint16) (vendorlist.VendorList, error) {
 		// Attempt To Load From Cache
 		if list := cacheLoad(vendorListVersion); list != nil {
@@ -58,17 +68,12 @@ func newVendorListFetcher(initCtx context.Context, cfg config.GDPR, client *http
 
 		// Attempt To Download
 		// - May not add to cache immediately.
-		saveOneRateLimited(ctx, client, urlMaker(vendorListVersion, tcfSpecVersion), cacheSave)
+		saveOneRateLimited(ctx, client, urlMaker(vendorListVersion), cacheSave)
 
 		// Attempt To Load From Cache Again
 		// - May have been added by the call to saveOneRateLimited.
 		if list := cacheLoad(vendorListVersion); list != nil {
 			return list, nil
-		}
-
-		// Attempt To Use Hardcoded Fallback
-		if fallback != nil {
-			return fallback, nil
 		}
 
 		// Give Up
@@ -81,27 +86,22 @@ func makeVendorListNotFoundError(vendorListVersion uint16) error {
 }
 
 // preloadCache saves all the known versions of the vendor list for future use.
-func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16, uint8) string, saver saveVendors, tcfSpecVersion uint8) {
-	latestVersion := saveOne(ctx, client, urlMaker(0, tcfSpecVersion), saver, tcfSpecVersion)
+func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16) string, saver saveVendors) {
+	latestVersion := saveOne(ctx, client, urlMaker(0), saver)
+	firstVersion := uint16(2) // The GVL for TCF2 has no vendors defined and is very unlikely to be used. Don't load it.
 
-	for i := uint16(1); i < latestVersion; i++ {
-		saveOne(ctx, client, urlMaker(i, tcfSpecVersion), saver, tcfSpecVersion)
+	for i := firstVersion; i < latestVersion; i++ {
+		saveOne(ctx, client, urlMaker(i), saver)
 	}
 }
 
 // Make a URL which can be used to fetch a given version of the Global Vendor List. If the version is 0,
 // this will fetch the latest version.
-func vendorListURLMaker(vendorListVersion uint16, tcfSpecVersion uint8) string {
-	if tcfSpecVersion == tcf2SpecVersion {
-		if vendorListVersion == 0 {
-			return "https://vendor-list.consensu.org/v2/vendor-list.json"
-		}
-		return "https://vendor-list.consensu.org/v2/archives/vendor-list-v" + strconv.Itoa(int(vendorListVersion)) + ".json"
-	}
+func vendorListURLMaker(vendorListVersion uint16) string {
 	if vendorListVersion == 0 {
-		return "https://vendor-list.consensu.org/vendorlist.json"
+		return "https://vendor-list.consensu.org/v2/vendor-list.json"
 	}
-	return "https://vendor-list.consensu.org/v-" + strconv.Itoa(int(vendorListVersion)) + "/vendorlist.json"
+	return "https://vendor-list.consensu.org/v2/archives/vendor-list-v" + strconv.Itoa(int(vendorListVersion)) + ".json"
 }
 
 // newOccasionalSaver returns a wrapped version of saveOne() which only activates every few minutes.
@@ -109,7 +109,7 @@ func vendorListURLMaker(vendorListVersion uint16, tcfSpecVersion uint8) string {
 // The goal here is to update quickly when new versions of the VendorList are released, but not wreck
 // server performance if a bad CMP starts sending us malformed consent strings that advertize a version
 // that doesn't exist yet.
-func newOccasionalSaver(timeout time.Duration, tcfSpecVersion uint8) func(ctx context.Context, client *http.Client, url string, saver saveVendors) {
+func newOccasionalSaver(timeout time.Duration) func(ctx context.Context, client *http.Client, url string, saver saveVendors) {
 	lastSaved := &atomic.Value{}
 	lastSaved.Store(time.Time{})
 
@@ -120,13 +120,13 @@ func newOccasionalSaver(timeout time.Duration, tcfSpecVersion uint8) func(ctx co
 		if timeSinceLastSave.Minutes() > 10 {
 			withTimeout, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
-			saveOne(withTimeout, client, url, saver, tcfSpecVersion)
+			saveOne(withTimeout, client, url, saver)
 			lastSaved.Store(now)
 		}
 	}
 }
 
-func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors, tcfSpecVersion uint8) uint16 {
+func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors) uint16 {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		glog.Errorf("Failed to build GET %s request. Cookie syncs may be affected: %v", url, err)
@@ -150,11 +150,7 @@ func saveOne(ctx context.Context, client *http.Client, url string, saver saveVen
 		return 0
 	}
 	var newList api.VendorList
-	if tcfSpecVersion == tcf2SpecVersion {
-		newList, err = vendorlist2.ParseEagerly(respBody)
-	} else {
-		newList, err = vendorlist.ParseEagerly(respBody)
-	}
+	newList, err = vendorlist2.ParseEagerly(respBody)
 	if err != nil {
 		glog.Errorf("GET %s returned malformed JSON. Cookie syncs may be affected. Error was %v. Body was %s", url, err, string(respBody))
 		return 0
@@ -164,7 +160,7 @@ func saveOne(ctx context.Context, client *http.Client, url string, saver saveVen
 	return newList.Version()
 }
 
-func newVendorListCache(fallbackVL api.VendorList) (save func(vendorListVersion uint16, list api.VendorList), load func(vendorListVersion uint16) api.VendorList) {
+func newVendorListCache() (save func(vendorListVersion uint16, list api.VendorList), load func(vendorListVersion uint16) api.VendorList) {
 	cache := &sync.Map{}
 
 	save = func(vendorListVersion uint16, list api.VendorList) {
@@ -179,17 +175,4 @@ func newVendorListCache(fallbackVL api.VendorList) (save func(vendorListVersion 
 		return nil
 	}
 	return
-}
-
-func loadFallbackGVL(fallbackGVLPath string) vendorlist.VendorList {
-	fallbackContents, err := ioutil.ReadFile(fallbackGVLPath)
-	if err != nil {
-		glog.Fatalf("Error reading from file %s: %v", fallbackGVLPath, err)
-	}
-
-	fallback, err := vendorlist.ParseEagerly(fallbackContents)
-	if err != nil {
-		glog.Fatalf("Error processing default GVL from %s: %v", fallbackGVLPath, err)
-	}
-	return fallback
 }

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -66,67 +66,13 @@ func TestTCF1FetcherInitialLoad(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		runTest(t, test, tcf1SpecVersion, server)
-	}
-}
-
-func TestTCF2FetcherInitialLoad(t *testing.T) {
-	// Loads two vendor lists during initialization by setting the latest vendor list version to 2.
-	// Ensures TCF1 fetch settings have no effect on TCF2.
-
-	server := httptest.NewServer(http.HandlerFunc(mockServer(serverSettings{
-		vendorListLatestVersion: 2,
-		vendorLists: map[int]string{
-			1: tcf2VendorList1,
-			2: tcf2VendorList2,
-		},
-	})))
-	defer server.Close()
-
-	testCases := []test{
-		{
-			description: "Fallback - Vendor List 1",
-			setup: testSetup{
-				enableTCF1Fallback: true,
-				vendorListVersion:  1,
-			},
-			expected: vendorList1Expected,
-		},
-		{
-			description: "Fallback - Vendor List 2",
-			setup: testSetup{
-				enableTCF1Fallback: true,
-				vendorListVersion:  2,
-			},
-			expected: vendorList2Expected,
-		},
-		{
-			description: "No Fallback - Vendor List 1",
-			setup: testSetup{
-				enableTCF1Fallback: false,
-				vendorListVersion:  1,
-			},
-			expected: vendorList1Expected,
-		},
-		{
-			description: "No Fallback - Vendor List 2",
-			setup: testSetup{
-				enableTCF1Fallback: false,
-				vendorListVersion:  2,
-			},
-			expected: vendorList2Expected,
-		},
-	}
-
-	for _, test := range testCases {
-		runTest(t, test, tcf2SpecVersion, server)
+		runTestTCF1(t, test, server)
 	}
 }
 
 func TestTCF2FetcherDynamicLoadListExists(t *testing.T) {
 	// Loads the first vendor list during initialization by setting the latest vendor list version to 1.
 	// All other vendor lists will be dynamically loaded.
-	// Ensures TCF1 fetch settings have no effect on TCF2.
 
 	server := httptest.NewServer(http.HandlerFunc(mockServer(serverSettings{
 		vendorListLatestVersion: 1,
@@ -137,34 +83,20 @@ func TestTCF2FetcherDynamicLoadListExists(t *testing.T) {
 	})))
 	defer server.Close()
 
-	testCases := []test{
-		{
-			description: "Fallback - Vendor List 2",
-			setup: testSetup{
-				enableTCF1Fallback: true,
-				vendorListVersion:  2,
-			},
-			expected: vendorList2Expected,
+	test := test{
+		description: "Dynamic Load - List Exists",
+		setup: testSetup{
+			vendorListVersion: 2,
 		},
-		{
-			description: "No Fallback - Vendor List 2",
-			setup: testSetup{
-				enableTCF1Fallback: false,
-				vendorListVersion:  2,
-			},
-			expected: vendorList2Expected,
-		},
+		expected: vendorList2Expected,
 	}
 
-	for _, test := range testCases {
-		runTest(t, test, tcf2SpecVersion, server)
-	}
+	runTestTCF2(t, test, server)
 }
 
 func TestTCF2FetcherDynamicLoadListDoesntExist(t *testing.T) {
 	// Loads the first vendor list during initialization by setting the latest vendor list version to 1.
 	// All other vendor list load attempts will be done dynamically.
-	// Ensures TCF1 fetch settings have no effect on TCF2.
 
 	server := httptest.NewServer(http.HandlerFunc(mockServer(serverSettings{
 		vendorListLatestVersion: 1,
@@ -174,32 +106,17 @@ func TestTCF2FetcherDynamicLoadListDoesntExist(t *testing.T) {
 	})))
 	defer server.Close()
 
-	testCases := []test{
-		{
-			description: "Fallback - Vendor Doesn't Exist",
-			setup: testSetup{
-				enableTCF1Fallback: true,
-				vendorListVersion:  2,
-			},
-			expected: testExpected{
-				errorMessage: "gdpr vendor list version 2 does not exist, or has not been loaded yet. Try again in a few minutes",
-			},
+	test := test{
+		description: "No Fallback - Vendor Doesn't Exist",
+		setup: testSetup{
+			vendorListVersion: 2,
 		},
-		{
-			description: "No Fallback - Vendor Doesn't Exist",
-			setup: testSetup{
-				enableTCF1Fallback: false,
-				vendorListVersion:  2,
-			},
-			expected: testExpected{
-				errorMessage: "gdpr vendor list version 2 does not exist, or has not been loaded yet. Try again in a few minutes",
-			},
+		expected: testExpected{
+			errorMessage: "gdpr vendor list version 2 does not exist, or has not been loaded yet. Try again in a few minutes",
 		},
 	}
 
-	for _, test := range testCases {
-		runTest(t, test, tcf2SpecVersion, server)
-	}
+	runTestTCF2(t, test, server)
 }
 
 func TestTCF2FetcherThrottling(t *testing.T) {
@@ -222,7 +139,7 @@ func TestTCF2FetcherThrottling(t *testing.T) {
 	})))
 	defer server.Close()
 
-	fetcher := newVendorListFetcher(context.Background(), testConfig(), server.Client(), testURLMaker(server), tcf2SpecVersion)
+	fetcher := newVendorListFetcherTCF2(context.Background(), testConfig(), server.Client(), testURLMaker(server))
 
 	// Dynamically Load List 2 Successfully
 	_, errList1 := fetcher(context.Background(), 2)
@@ -243,7 +160,7 @@ func TestTCF2MalformedVendorlist(t *testing.T) {
 	})))
 	defer server.Close()
 
-	fetcher := newVendorListFetcher(context.Background(), testConfig(), server.Client(), testURLMaker(server), tcf2SpecVersion)
+	fetcher := newVendorListFetcherTCF2(context.Background(), testConfig(), server.Client(), testURLMaker(server))
 	_, err := fetcher(context.Background(), 1)
 
 	// Fetching should fail since vendor list could not be unmarshalled.
@@ -254,9 +171,9 @@ func TestTCF2ServerUrlInvalid(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	server.Close()
 
-	invalidURLGenerator := func(uint16, uint8) string { return " http://invalid-url-has-leading-whitespace" }
+	invalidURLGenerator := func(uint16) string { return " http://invalid-url-has-leading-whitespace" }
 
-	fetcher := newVendorListFetcher(context.Background(), testConfig(), server.Client(), invalidURLGenerator, tcf2SpecVersion)
+	fetcher := newVendorListFetcherTCF2(context.Background(), testConfig(), server.Client(), invalidURLGenerator)
 	_, err := fetcher(context.Background(), 1)
 
 	assert.EqualError(t, err, "gdpr vendor list version 1 does not exist, or has not been loaded yet. Try again in a few minutes")
@@ -266,7 +183,7 @@ func TestTCF2ServerUnavailable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	server.Close()
 
-	fetcher := newVendorListFetcher(context.Background(), testConfig(), server.Client(), testURLMaker(server), tcf2SpecVersion)
+	fetcher := newVendorListFetcherTCF2(context.Background(), testConfig(), server.Client(), testURLMaker(server))
 	_, err := fetcher(context.Background(), 1)
 
 	assert.EqualError(t, err, "gdpr vendor list version 1 does not exist, or has not been loaded yet. Try again in a few minutes")
@@ -275,38 +192,23 @@ func TestTCF2ServerUnavailable(t *testing.T) {
 func TestVendorListURLMaker(t *testing.T) {
 	testCases := []struct {
 		description       string
-		tcfSpecVersion    uint8
 		vendorListVersion uint16
 		expectedURL       string
 	}{
 		{
-			description:       "TCF1 - Latest",
-			tcfSpecVersion:    1,
-			vendorListVersion: 0, // Forces latest version.
-			expectedURL:       "https://vendor-list.consensu.org/vendorlist.json",
-		},
-		{
-			description:       "TCF1 - Specific",
-			tcfSpecVersion:    1,
-			vendorListVersion: 42,
-			expectedURL:       "https://vendor-list.consensu.org/v-42/vendorlist.json",
-		},
-		{
-			description:       "TCF2 - Latest",
-			tcfSpecVersion:    2,
-			vendorListVersion: 0, // Forces latest version.
+			description:       "Latest",
+			vendorListVersion: 0,
 			expectedURL:       "https://vendor-list.consensu.org/v2/vendor-list.json",
 		},
 		{
-			description:       "TCF2 - Specific",
-			tcfSpecVersion:    2,
+			description:       "Specific",
 			vendorListVersion: 42,
 			expectedURL:       "https://vendor-list.consensu.org/v2/archives/vendor-list-v42.json",
 		},
 	}
 
 	for _, test := range testCases {
-		result := vendorListURLMaker(test.vendorListVersion, test.tcfSpecVersion)
+		result := vendorListURLMaker(test.vendorListVersion)
 		assert.Equal(t, test.expectedURL, result)
 	}
 }
@@ -320,12 +222,6 @@ var tcf2VendorList1 = tcf2MarshalVendorList(tcf2VendorList{
 	VendorListVersion: 1,
 	Vendors:           map[string]*tcf2Vendor{"12": {ID: 12, Purposes: []int{2}}},
 })
-
-var vendorList1Expected = testExpected{
-	vendorListVersion: 1,
-	vendorID:          12,
-	vendorPurposes:    map[int]bool{1: false, 2: true, 3: false},
-}
 
 var tcf1VendorList2 = tcf1MarshalVendorList(tcf1VendorList{
 	VendorListVersion: 2,
@@ -438,13 +334,13 @@ type testExpected struct {
 	vendorPurposes    map[int]bool
 }
 
-func runTest(t *testing.T, test test, tcfSpecVersion uint8, server *httptest.Server) {
+func runTestTCF1(t *testing.T, test test, server *httptest.Server) {
 	config := testConfig()
 	if test.setup.enableTCF1Fallback {
 		config.TCF1.FallbackGVLPath = "../static/tcf1/fallback_gvl.json"
 	}
 
-	fetcher := newVendorListFetcher(context.Background(), config, server.Client(), testURLMaker(server), tcfSpecVersion)
+	fetcher := newVendorListFetcherTCF1(config)
 	vendorList, err := fetcher(context.Background(), test.setup.vendorListVersion)
 
 	if test.expected.errorMessage != "" {
@@ -460,9 +356,31 @@ func runTest(t *testing.T, test test, tcfSpecVersion uint8, server *httptest.Ser
 	}
 }
 
-func testURLMaker(server *httptest.Server) func(uint16, uint8) string {
+func runTestTCF2(t *testing.T, test test, server *httptest.Server) {
+	config := testConfig()
+	if test.setup.enableTCF1Fallback {
+		config.TCF1.FallbackGVLPath = "../static/tcf1/fallback_gvl.json"
+	}
+
+	fetcher := newVendorListFetcherTCF2(context.Background(), config, server.Client(), testURLMaker(server))
+	vendorList, err := fetcher(context.Background(), test.setup.vendorListVersion)
+
+	if test.expected.errorMessage != "" {
+		assert.EqualError(t, err, test.expected.errorMessage, test.description+":error")
+	} else {
+		assert.NoError(t, err, test.description+":vendorlist")
+		assert.Equal(t, test.expected.vendorListVersion, vendorList.Version(), test.description+":vendorlistid")
+		vendor := vendorList.Vendor(test.expected.vendorID)
+		for id, expected := range test.expected.vendorPurposes {
+			result := vendor.Purpose(consentconstants.Purpose(id))
+			assert.Equalf(t, expected, result, "%s:vendor-%d:purpose-%d", test.description, vendorList.Version(), id)
+		}
+	}
+}
+
+func testURLMaker(server *httptest.Server) func(uint16) string {
 	url := server.URL
-	return func(vendorListVersion uint16, tcfSpecVersion uint8) string {
+	return func(vendorListVersion uint16) string {
 		return url + "?version=" + strconv.Itoa(int(vendorListVersion))
 	}
 }

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -358,10 +358,6 @@ func runTestTCF1(t *testing.T, test test, server *httptest.Server) {
 
 func runTestTCF2(t *testing.T, test test, server *httptest.Server) {
 	config := testConfig()
-	if test.setup.enableTCF1Fallback {
-		config.TCF1.FallbackGVLPath = "../static/tcf1/fallback_gvl.json"
-	}
-
 	fetcher := newVendorListFetcherTCF2(context.Background(), config, server.Client(), testURLMaker(server))
 	vendorList, err := fetcher(context.Background(), test.setup.vendorListVersion)
 


### PR DESCRIPTION
Partially addresses https://github.com/prebid/prebid-server/issues/1689 and separates the TCF1 vs TCF2 fetchers for easy removal of TCF2 in the near future and removal now for TCF1 url construction.