### PR TITLE
AdForm: Fix Regs Parsing

### DIFF
--- a/adapters/adform/adform.go
+++ b/adapters/adform/adform.go
@@ -453,7 +453,7 @@ func openRtbToAdformRequest(request *openrtb.BidRequest) (*adformRequest, []erro
 
 	gdprApplies := ""
 	var extRegs openrtb_ext.ExtRegs
-	if request.Regs != nil {
+	if request.Regs != nil && request.Regs.Ext != nil {
 		if err := json.Unmarshal(request.Regs.Ext, &extRegs); err != nil {
 			errors = append(errors, &errortypes.BadInput{
 				Message: err.Error(),
@@ -466,7 +466,7 @@ func openRtbToAdformRequest(request *openrtb.BidRequest) (*adformRequest, []erro
 
 	eids := ""
 	consent := ""
-	if request.User != nil {
+	if request.User != nil && request.User.Ext != nil {
 		var extUser openrtb_ext.ExtUser
 		if err := json.Unmarshal(request.User.Ext, &extUser); err == nil {
 			consent = extUser.Consent

--- a/adapters/adform/adformtest/supplemental/regs-ext-nil.json
+++ b/adapters/adform/adformtest/supplemental/regs-ext-nil.json
@@ -1,0 +1,53 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "imp": [{
+            "id": "test-imp-id",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {
+                    "mid": 12345
+                }
+            }
+        }],
+        "regs": {}
+    },
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "https://adx.adform.net/adx?CC=1&fd=1&gdpr=&gdpr_consent=&ip=&rp=4&stid=&bWlkPTEyMzQ1JnJjdXI9VVNE"
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": [{
+                "response": "banner",
+                "banner": "<adm>",
+                "win_bid": 0.5,
+                "win_cur": "USD",
+                "width": 300,
+                "height": 250,
+                "deal_id": null,
+                "win_crid": "20078830"
+            }]
+        }
+    }],
+    "expectedBidResponses": [{
+        "currency": "USD",
+        "bids": [{
+            "bid": {
+                "id": "test-imp-id",
+                "impid": "test-imp-id",
+                "price": 0.5,
+                "adm": "<adm>",
+                "crid": "20078830",
+                "w": 300,
+                "h": 250
+            },
+            "type": "banner"
+        }]
+    }]
+}


### PR DESCRIPTION
The standard Go JSON parser will return an error if the input is nil. Adding a nil check and a test case.

@braizhas Could you please review?