### PR TITLE
Corrected response for empty array return from banner endpoint (Issue #1728)

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -483,8 +483,6 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	var bids []openrtb.Bid
 
-	// The case of response status == 200 and response body length == 2 below covers the case of the banner endpoint returning
-	// an empty JSON array ('[]'), which is functionally no content.
 	if response.StatusCode == http.StatusNoContent {
 		return nil, []error{&errortypes.BadInput{
 			Message: fmt.Sprintf("no content received from server. status code %d from %s. Run with request.debug = 1 for more info", response.StatusCode, externalRequest.Uri),

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -492,7 +492,6 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 	}
 
 	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 {
-
 		response.StatusCode = http.StatusNoContent
 		return nil, []error{&errortypes.BadInput{
 			Message: fmt.Sprintf("truncated content received from server. status code %d has been corrected to %d from %s. Run with request.debug = 1 for more info",

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -485,9 +485,20 @@ func (a *BeachfrontAdapter) MakeBids(internalRequest *openrtb.BidRequest, extern
 
 	// The case of response status == 200 and response body length == 2 below covers the case of the banner endpoint returning
 	// an empty JSON array ('[]'), which is functionally no content.
-	if response.StatusCode == http.StatusNoContent || (response.StatusCode == http.StatusOK && len(response.Body) <= 2) {
+	if response.StatusCode == http.StatusNoContent {
 		return nil, []error{&errortypes.BadInput{
-			Message: fmt.Sprintf("no content or truncated content received from server. status code %d from %s. Run with request.debug = 1 for more info", response.StatusCode, externalRequest.Uri),
+			Message: fmt.Sprintf("no content received from server. status code %d from %s. Run with request.debug = 1 for more info", response.StatusCode, externalRequest.Uri),
+		}}
+	}
+
+	if response.StatusCode == http.StatusOK && len(response.Body) <= 2 {
+
+		response.StatusCode = http.StatusNoContent
+		return nil, []error{&errortypes.BadInput{
+			Message: fmt.Sprintf("truncated content received from server. status code %d has been corrected to %d from %s. Run with request.debug = 1 for more info",
+				http.StatusOK,
+				response.StatusCode,
+				externalRequest.Uri),
 		}}
 	}
 

--- a/adapters/beachfront/beachfronttest/supplemental/banner-204.json
+++ b/adapters/beachfront/beachfronttest/supplemental/banner-204.json
@@ -63,8 +63,7 @@
         }
       },
       "mockResponse": {
-        "status": 204,
-        "body": []
+        "status": 204
       }
     }
   ],

--- a/adapters/beachfront/beachfronttest/supplemental/banner-empty_array-204.json
+++ b/adapters/beachfront/beachfronttest/supplemental/banner-empty_array-204.json
@@ -63,7 +63,7 @@
         }
       },
       "mockResponse": {
-        "status": 200,
+        "status": 204,
         "body": []
       }
     }
@@ -73,7 +73,7 @@
 
   "expectedMakeBidsErrors": [
     {
-      "value": "truncated content received from server. status code 200 has been corrected to 204 from https://qa.beachrtb.com/prebid_display. Run with request.debug = 1 for more info",
+      "value": "no content received from server. status code 204 from https://qa.beachrtb.com/prebid_display. Run with request.debug = 1 for more info",
       "comparison": "literal"
     }
   ]


### PR DESCRIPTION
This covers issue #1728 