### PR TITLE
33Across: Fix Shared Memory Overwriting

### DIFF
--- a/adapters/33across/33across.go
+++ b/adapters/33across/33across.go
@@ -228,7 +228,7 @@ func (a *TtxAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalReque
 }
 
 func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, error) {
-	videoCopy := video
+	videoCopy := *video
 	if videoCopy.W == 0 ||
 		videoCopy.H == 0 ||
 		videoCopy.Protocols == nil ||
@@ -252,7 +252,7 @@ func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, err
 		}
 	}
 
-	return videoCopy, nil
+	return &videoCopy, nil
 }
 
 func getBidType(ext bidExt) openrtb_ext.BidType {


### PR DESCRIPTION
Copies of reference fields needed to be made inside `adapters/33across/33across.go` in order to avoid a data race on shared memory. Authors of source code should be notified and encourage to make any changes to this PR if they disagree with the proposed approach.