### PR TITLE
Pubnative: Fix Shared Memory Overwriting

### DIFF
--- a/adapters/pubnative/pubnative.go
+++ b/adapters/pubnative/pubnative.go
@@ -111,10 +111,9 @@ func convertBanner(banner *openrtb.Banner) (*openrtb.Banner, error) {
 			f := banner.Format[0]
 
 			bannerCopy := *banner
-			bannerCopy.W = new(uint64)
-			*bannerCopy.W = f.W
-			bannerCopy.H = new(uint64)
-			*bannerCopy.H = f.H
+
+			bannerCopy.W = openrtb.Uint64Ptr(f.W)
+			bannerCopy.H = openrtb.Uint64Ptr(f.H)
 
 			return &bannerCopy, nil
 		} else {

--- a/adapters/pubnative/pubnative.go
+++ b/adapters/pubnative/pubnative.go
@@ -94,29 +94,36 @@ func convertImpression(imp *openrtb.Imp) error {
 		}
 	}
 	if imp.Banner != nil {
-		err := convertBanner(imp.Banner)
+		bannerCopy, err := convertBanner(imp.Banner)
 		if err != nil {
 			return err
 		}
+		imp.Banner = bannerCopy
 	}
 
 	return nil
 }
 
 // make sure that banner has openrtb 2.3-compatible size information
-func convertBanner(banner *openrtb.Banner) error {
+func convertBanner(banner *openrtb.Banner) (*openrtb.Banner, error) {
 	if banner.W == nil || banner.H == nil || *banner.W == 0 || *banner.H == 0 {
 		if len(banner.Format) > 0 {
 			f := banner.Format[0]
-			banner.W = &f.W
-			banner.H = &f.H
+
+			bannerCopy := *banner
+			bannerCopy.W = new(uint64)
+			*bannerCopy.W = f.W
+			bannerCopy.H = new(uint64)
+			*bannerCopy.H = f.H
+
+			return &bannerCopy, nil
 		} else {
-			return &errortypes.BadInput{
+			return banner, &errortypes.BadInput{
 				Message: "Size information missing for banner",
 			}
 		}
 	}
-	return nil
+	return banner, nil
 }
 
 func (a *PubnativeAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {

--- a/adapters/pubnative/pubnative.go
+++ b/adapters/pubnative/pubnative.go
@@ -117,7 +117,7 @@ func convertBanner(banner *openrtb.Banner) (*openrtb.Banner, error) {
 
 			return &bannerCopy, nil
 		} else {
-			return banner, &errortypes.BadInput{
+			return nil, &errortypes.BadInput{
 				Message: "Size information missing for banner",
 			}
 		}


### PR DESCRIPTION
Copy of reference field `Banner` needed to be made inside `adapters/pubnative/pubnative.go` in order to avoid a data race on shared memory. Authors of source code should be notified and encourage to make any changes to this PR if they disagree with the proposed approach.