### PR TITLE
Yeahmobi: Fix Shared Memory Overwriting

### DIFF
--- a/adapters/yeahmobi/yeahmobi.go
+++ b/adapters/yeahmobi/yeahmobi.go
@@ -95,7 +95,9 @@ func transform(request *openrtb.BidRequest) {
 					continue
 				}
 
-				request.Imp[i].Native.Request = string(nativeReqByte)
+				nativeCopy := *request.Imp[i].Native
+				nativeCopy.Request = string(nativeReqByte)
+				request.Imp[i].Native = &nativeCopy
 			}
 		}
 	}


### PR DESCRIPTION
Copy of reference field `Native` needed to be made inside `adapters/yeahmobi/yeahmobi.go` in order to avoid a data race on shared memory. Authors of source code should be notified and encourage to make any changes to this PR if they disagree with the proposed approach.