### PR TITLE
Beachfront: Fix Shared Memory Overwriting

### DIFF
--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -407,12 +407,11 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 		bfReqs[i].Request = *request
 		var secure int8
 
-		var deviceCopy *openrtb.Device
+		var deviceCopy openrtb.Device
 		if bfReqs[i].Request.Device == nil {
-			deviceCopy = &openrtb.Device{}
+			deviceCopy = openrtb.Device{}
 		} else {
-			device := *bfReqs[i].Request.Device
-			deviceCopy = &device
+			deviceCopy = *bfReqs[i].Request.Device
 		}
 
 		if beachfrontExt.VideoResponseType == "nurl" {
@@ -443,11 +442,11 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 			}
 		}
 
-		if deviceCopy != nil && deviceCopy.DeviceType == 0 {
+		if deviceCopy.DeviceType == 0 {
 			// More fine graned deviceType methods will be added in the future
 			deviceCopy.DeviceType = fallBackDeviceType(request)
 		}
-		bfReqs[i].Request.Device = deviceCopy
+		bfReqs[i].Request.Device = &deviceCopy
 
 		imp := request.Imp[i]
 

--- a/adapters/beachfront/beachfront.go
+++ b/adapters/beachfront/beachfront.go
@@ -407,8 +407,12 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 		bfReqs[i].Request = *request
 		var secure int8
 
+		var deviceCopy *openrtb.Device
 		if bfReqs[i].Request.Device == nil {
-			bfReqs[i].Request.Device = &openrtb.Device{}
+			deviceCopy = &openrtb.Device{}
+		} else {
+			device := *bfReqs[i].Request.Device
+			deviceCopy = &device
 		}
 
 		if beachfrontExt.VideoResponseType == "nurl" {
@@ -416,13 +420,15 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 		} else {
 			bfReqs[i].VideoResponseType = "adm"
 
-			if bfReqs[i].Request.Device.IP == "" {
-				bfReqs[i].Request.Device.IP = fakeIP
+			if deviceCopy.IP == "" {
+				deviceCopy.IP = fakeIP
 			}
 		}
 
 		if bfReqs[i].Request.Site != nil && bfReqs[i].Request.Site.Domain == "" && bfReqs[i].Request.Site.Page != "" {
-			bfReqs[i].Request.Site.Domain = getDomain(bfReqs[i].Request.Site.Page)
+			siteCopy := *bfReqs[i].Request.Site
+			siteCopy.Domain = getDomain(bfReqs[i].Request.Site.Page)
+			bfReqs[i].Request.Site = &siteCopy
 			secure = isSecure(bfReqs[i].Request.Site.Page)
 		}
 
@@ -437,10 +443,11 @@ func getVideoRequests(request *openrtb.BidRequest) ([]beachfrontVideoRequest, []
 			}
 		}
 
-		if bfReqs[i].Request.Device != nil && bfReqs[i].Request.Device.DeviceType == 0 {
+		if deviceCopy != nil && deviceCopy.DeviceType == 0 {
 			// More fine graned deviceType methods will be added in the future
-			bfReqs[i].Request.Device.DeviceType = fallBackDeviceType(request)
+			deviceCopy.DeviceType = fallBackDeviceType(request)
 		}
+		bfReqs[i].Request.Device = deviceCopy
 
 		imp := request.Imp[i]
 


### PR DESCRIPTION
The Beachfront adapter seems to be writting to shared memory inside the `getVideoRequests` function, particulartly to the `bfReqs[i].Request.Device` and the `bfReqs[i].Request.Site` fields. This pull request proposes changes to stop the race conditions, but authors of the beachfront adapter source code should be notified and encouraged to make any changes to this PR if they disagree with the proposed approach.