### PR TITLE
Revert "Fix race condition in 33across.go (#1757)"

### DIFF
--- a/adapters/33across/33across.go
+++ b/adapters/33across/33across.go
@@ -228,7 +228,7 @@ func (a *TtxAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalReque
 }
 
 func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, error) {
-	videoCopy := *video
+	videoCopy := video
 	if videoCopy.W == 0 ||
 		videoCopy.H == 0 ||
 		videoCopy.Protocols == nil ||
@@ -252,7 +252,7 @@ func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, err
 		}
 	}
 
-	return &videoCopy, nil
+	return videoCopy, nil
 }
 
 func getBidType(ext bidExt) openrtb_ext.BidType {


### PR DESCRIPTION
This reverts commit bdf1e7b3e13bdf87d3282bf74472fc66504537d5. I merged it in too early.