### PR TITLE
33across: Fix Shared Memory Overwriting

### DIFF
--- a/adapters/33across/33across.go
+++ b/adapters/33across/33across.go
@@ -228,7 +228,7 @@ func (a *TtxAdapter) MakeBids(internalRequest *openrtb.BidRequest, externalReque
 }
 
 func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, error) {
-	videoCopy := video
+	videoCopy := *video
 	if videoCopy.W == 0 ||
 		videoCopy.H == 0 ||
 		videoCopy.Protocols == nil ||
@@ -252,7 +252,7 @@ func validateVideoParams(video *openrtb.Video, prod string) (*openrtb.Video, err
 		}
 	}
 
-	return videoCopy, nil
+	return &videoCopy, nil
 }
 
 func getBidType(ext bidExt) openrtb_ext.BidType {


### PR DESCRIPTION
@curlyblueeagle,
Recently coded pull request #1756 is meant to enable Prebid Server to find data race conditions in adapter bidder source code. According to this newly coded feature, your adapter might be writing to shared memory and this PR implements an approach to prevent it. Please let us know whether or not you agree with the changes proposed in this pull request or if you rather want to code the fix yourself.

When it comes to adapters' source code improvements, we usually wait a week for owners to come back to us. If we get no feedback, we will go ahead to review and merge this pull request ourselves.

We'd love to hear your take on this issue.