### PR TITLE
FPD: Allow imp.ext.data To Passthrough To Adapters

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -898,6 +898,8 @@ func isBidderToValidate(bidder string) bool {
 	switch openrtb_ext.BidderName(bidder) {
 	case openrtb_ext.BidderReservedContext:
 		return false
+	case openrtb_ext.BidderReservedData:
+		return false
 	case openrtb_ext.BidderReservedPrebid:
 		return false
 	case openrtb_ext.BidderReservedSKAdN:

--- a/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-ext-bidder.json
+++ b/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-ext-bidder.json
@@ -21,30 +21,29 @@
         "appnexus": {
           "placementId": 12883451
         },
+        "data": {
+          "keywords": "prebid server example"
+        },
         "context": {
           "data": {
-            "keywords": "prebid server example"
+            "keywords": "another prebid server example"
           }
         }
       }
     }]
   },
   "expectedBidResponse": {
-    "id":"some-request-id",
-    "seatbid": [
-      {
-        "bid": [
-          {
-            "id": "appnexus-bid",
-            "impid": "",
-            "price": 0
-          }
-        ],
-        "seat": "appnexus-bids"
-      }
-    ],
-    "bidid":"test bid id",
-    "nbr":0
+    "id": "some-request-id",
+    "seatbid": [{
+      "bid": [{
+        "id": "appnexus-bid",
+        "impid": "",
+        "price": 0
+      }],
+      "seat": "appnexus-bids"
+    }],
+    "bidid": "test bid id",
+    "nbr": 0
   },
   "expectedReturnCode": 200
 }

--- a/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-prebid-bidder.json
+++ b/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-prebid-bidder.json
@@ -25,6 +25,9 @@
             }
           }
         },
+        "data": {
+          "keywords": "prebid server example"
+        },
         "context": {
           "data": {
             "keywords": "prebid server example"
@@ -34,21 +37,17 @@
     }]
   },
   "expectedBidResponse": {
-    "id":"some-request-id",
-    "seatbid": [
-      {
-        "bid": [
-          {
-            "id": "appnexus-bid",
-            "impid": "",
-            "price": 0
-          }
-        ],
-        "seat": "appnexus-bids"
-      }
-    ],
-    "bidid":"test bid id",
-    "nbr":0
+    "id": "some-request-id",
+    "seatbid": [{
+      "bid": [{
+        "id": "appnexus-bid",
+        "impid": "",
+        "price": 0
+      }],
+      "seat": "appnexus-bids"
+    }],
+    "bidid": "test bid id",
+    "nbr": 0
   },
   "expectedReturnCode": 200
 }

--- a/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-prebid-bidder.json
+++ b/endpoints/openrtb2/sample-requests/first-party-data/valid-fpd-allowed-with-prebid-bidder.json
@@ -30,7 +30,7 @@
         },
         "context": {
           "data": {
-            "keywords": "prebid server example"
+            "keywords": "another prebid server example"
           }
         }
       }

--- a/exchange/exchangetest/firstpartydata-imp-ext-multiple-bidders.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-multiple-bidders.json
@@ -25,9 +25,12 @@
                         "siteId": 2,
                         "zoneId": 3
                     },
+                    "data": {
+                        "keywords": "prebid server example"
+                    },
                     "context": {
                         "data": {
-                            "keywords": "prebid server example"
+                            "keywords": "another prebid server example"
                         }
                     }
                 }
@@ -57,9 +60,12 @@
                             "bidder": {
                                 "placementId": 1
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }
@@ -107,9 +113,12 @@
                                 "siteId": 2,
                                 "zoneId": 3
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }

--- a/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json 
+++ b/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json 
@@ -29,9 +29,12 @@
                             }
                         }
                     },
+                    "data": {
+                        "keywords": "prebid server example"
+                    },
                     "context": {
                         "data": {
-                            "keywords": "prebid server example"
+                            "keywords": "another prebid server example"
                         }
                     }
                 }
@@ -61,9 +64,12 @@
                             "bidder": {
                                 "placementId": 1
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }
@@ -111,9 +117,12 @@
                                 "siteId": 2,
                                 "zoneId": 3
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }

--- a/exchange/exchangetest/firstpartydata-imp-ext-one-bidder.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-one-bidder.json
@@ -20,9 +20,12 @@
                     "appnexus": {
                         "placementId": 1
                     },
+                    "data": {
+                        "keywords": "prebid server example"
+                    },
                     "context": {
                         "data": {
-                            "keywords": "prebid server example"
+                            "keywords": "another prebid server example"
                         }
                     }
                 }
@@ -52,9 +55,12 @@
                             "bidder": {
                                 "placementId": 1
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }

--- a/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
@@ -24,9 +24,12 @@
                             }
                         }
                     },
+                    "data": {
+                        "keywords": "prebid server example"
+                    },
                     "context": {
                         "data": {
-                            "keywords": "prebid server example"
+                            "keywords": "another prebid server example"
                         }
                     }
                 }
@@ -56,9 +59,12 @@
                             "bidder": {
                                 "placementId": 1
                             },
+                            "data": {
+                                "keywords": "prebid server example"
+                            },
                             "context": {
                                 "data": {
-                                    "keywords": "prebid server example"
+                                    "keywords": "another prebid server example"
                                 }
                             }
                         }

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -423,6 +423,7 @@ func extractBidderExts(impExt, impExtPrebidBidders map[string]json.RawMessage) m
 
 func isSpecialField(bidder string) bool {
 	return bidder == openrtb_ext.FirstPartyDataContextExtKey ||
+		bidder == openrtb_ext.FirstPartyDataExtKey ||
 		bidder == openrtb_ext.SKAdNExtKey ||
 		bidder == openrtb_ext.PrebidExtKey
 }

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -384,6 +384,10 @@ func createSanitizedImpExt(impExt, impExtPrebid map[string]json.RawMessage) (map
 		}
 	}
 
+	if v, exists := impExt[openrtb_ext.FirstPartyDataExtKey]; exists {
+		sanitizedImpExt[openrtb_ext.FirstPartyDataExtKey] = v
+	}
+
 	if v, exists := impExt[openrtb_ext.FirstPartyDataContextExtKey]; exists {
 		sanitizedImpExt[openrtb_ext.FirstPartyDataContextExtKey] = v
 	}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -233,6 +233,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			description: "imp.ext.prebid - Bidders Only",
 			givenImpExt: map[string]json.RawMessage{
 				"prebid":  json.RawMessage(`"ignoredInFavorOfSeparatelyUnmarshalledImpExtPrebid"`),
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -240,6 +241,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 				"bidder": json.RawMessage(`"anyBidder"`),
 			},
 			expected: map[string]json.RawMessage{
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -249,6 +251,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			description: "imp.ext.prebid - Bidders + Other Values",
 			givenImpExt: map[string]json.RawMessage{
 				"prebid":  json.RawMessage(`"ignoredInFavorOfSeparatelyUnmarshalledImpExtPrebid"`),
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -258,6 +261,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			},
 			expected: map[string]json.RawMessage{
 				"prebid":  json.RawMessage(`{"someOther":"value"}`),
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -267,11 +271,13 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			description: "imp.ext",
 			givenImpExt: map[string]json.RawMessage{
 				"anyBidder": json.RawMessage(`"anyBidderValues"`),
+				"data":      json.RawMessage(`"anyData"`),
 				"context":   json.RawMessage(`"anyContext"`),
 				"skadn":     json.RawMessage(`"anySKAdNetwork"`),
 			},
 			givenImpExtPrebid: map[string]json.RawMessage{},
 			expected: map[string]json.RawMessage{
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -282,6 +288,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			givenImpExt: map[string]json.RawMessage{
 				"anyBidder": json.RawMessage(`"anyBidderValues"`),
 				"prebid":    json.RawMessage(`"ignoredInFavorOfSeparatelyUnmarshalledImpExtPrebid"`),
+				"data":      json.RawMessage(`"anyData"`),
 				"context":   json.RawMessage(`"anyContext"`),
 				"skadn":     json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -289,6 +296,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 				"bidder": json.RawMessage(`"anyBidder"`),
 			},
 			expected: map[string]json.RawMessage{
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -299,6 +307,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			givenImpExt: map[string]json.RawMessage{
 				"anyBidder": json.RawMessage(`"anyBidderValues"`),
 				"prebid":    json.RawMessage(`"ignoredInFavorOfSeparatelyUnmarshalledImpExtPrebid"`),
+				"data":      json.RawMessage(`"anyData"`),
 				"context":   json.RawMessage(`"anyContext"`),
 				"skadn":     json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -308,6 +317,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			},
 			expected: map[string]json.RawMessage{
 				"prebid":  json.RawMessage(`{"someOther":"value"}`),
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},
@@ -317,6 +327,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 			description: "Marshal Error - imp.ext.prebid",
 			givenImpExt: map[string]json.RawMessage{
 				"prebid":  json.RawMessage(`"ignoredInFavorOfSeparatelyUnmarshalledImpExtPrebid"`),
+				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 			},

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 )
 
-// FirstPartyDataContextExtKey defines the field name within request.ext reserved for first party data.
+// FirstPartyDataExtKey defines a field name within request.ext and request.imp.ext reserved for first party data.
+const FirstPartyDataExtKey = "data"
+
+// FirstPartyDataContextExtKey defines a field name within request.ext and request.imp.ext reserved for first party data.
 const FirstPartyDataContextExtKey = "context"
 
 // SKAdNExtKey defines the field name within request.ext reserved for Apple's SKAdNetwork.


### PR DESCRIPTION
All json fields within `request.imp[].ext` are expected to be bidder names. Exemptions need to be made for special cases, such as for First Party Data. Other parts of code enforce the bidder name "data" is forbidden making this a safe operation.

Implements https://github.com/prebid/prebid-server/issues/1768