### PR TITLE
Stored Request A/B Testing POC #1645

### DIFF
--- a/stored_requests/ab_fetcher.go
+++ b/stored_requests/ab_fetcher.go
@@ -1,0 +1,110 @@
+package stored_requests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+
+	"github.com/buger/jsonparser"
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/prebid/prebid-server/metrics"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+// ABFetcher is a request-aware AllFetcher implementing the A/B experiment selection rules
+// The results from this fetcher MUST NOT be cached for the distribution rules to work.
+// This fetcher SHOULD be in front of a caching fetcher to take advantage of caching on refetch.
+type ABFetcher struct {
+	fetcher       AllFetcher
+	metricsEngine metrics.MetricsEngine
+}
+
+// WithABFetcher returns an AllFetcher that may replace requested requests
+func WithABFetcher(fetcher AllFetcher, metricsEngine metrics.MetricsEngine) AllFetcher {
+	return &ABFetcher{
+		fetcher:       fetcher,
+		metricsEngine: metricsEngine,
+	}
+}
+
+// FetchRequests applies A/B experiment rules and refetches alternate stored requests if
+// triggered by ext.prebid.storedrequest.ab_config existence as a map of testKey: percent
+func (f *ABFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	if requestData, impData, errs = f.fetcher.FetchRequests(ctx, requestIDs, impIDs); len(errs) > 0 || len(requestIDs) != 1 || len(requestData) == 0 {
+		return
+	}
+	requestID := requestIDs[0]
+	storedRequest := requestData[requestID]
+	value, dataType, _, err := jsonparser.Get(storedRequest, "ext", openrtb_ext.PrebidExtKey, "storedrequest", "ab_config")
+	if dataType == jsonparser.NotExist {
+		return
+	}
+	if err != nil {
+		return
+	}
+	if dataType != jsonparser.Object {
+		errs = append(errs, fmt.Errorf("ext.prebid.storedrequest.ab_config should be a map in storedrequest id=%s", requestIDs[0]))
+		return
+	}
+	newRequestID, err := runABSelection(value)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to parse ext.prebid.storedrequest.ab_config in storedrequest id=%s: %v", requestIDs[0], err))
+		return
+	}
+	if newRequestID == "" || newRequestID == requestIDs[0] {
+		// main branch selected, nothing to do (or we could patch "ab_selected" ?)
+		return
+	}
+	// load and replace selected stored request
+	newRequestData, _, newErrs := f.fetcher.FetchRequests(ctx, []string{newRequestID}, []string{})
+	if len(newErrs) > 0 || newRequestData[newRequestID] == nil {
+		errs = append(errs, newErrs...)
+		return
+	}
+	// patch loaded stored request with ab_config info, for analytics
+	analyticsInfo := json.RawMessage(
+		fmt.Sprintf(`{"ext":{"%s":{"storedrequest":{"ab_config":%s,"ab_selected":"%s"}}}}`,
+			openrtb_ext.PrebidExtKey, value, newRequestID))
+	if enrichedRequest, err := jsonpatch.MergePatch(newRequestData[newRequestID], analyticsInfo); err == nil {
+		requestData[requestID] = enrichedRequest
+	} else {
+		errs = append(errs, fmt.Errorf(`Cannot patch ext.prebid.storedrequest.ab_config in storedrequest id %s: %s`, newRequestID, err))
+		// we can replace the request, but can't add the analytics info, so it will not be useful
+		return
+	}
+	// augment requestData["imp"] with selected key
+	return
+}
+
+// FetchAccount is just a pass-through to the underlying AllFetcher
+func (f *ABFetcher) FetchAccount(ctx context.Context, accountID string) (account json.RawMessage, errs []error) {
+	return f.fetcher.FetchAccount(ctx, accountID)
+}
+
+// FetchCategories is just a pass-through to the underlying AllFetcher
+func (f *ABFetcher) FetchCategories(ctx context.Context, primaryAdServer, publisherId, iabCategory string) (string, error) {
+	return f.fetcher.FetchCategories(ctx, primaryAdServer, publisherId, iabCategory)
+}
+
+// runABSelection receives distribution rules in the form of a `{key: probability}` json map
+// and returns the randomly selected key applying the rules.
+func runABSelection(abConfig []byte) (selected string, err error) {
+	throw := 100 * rand.Float64()
+	t := 0.0
+	err = jsonparser.ObjectEach(abConfig, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+		//if t > 100 {
+		//	return fmt.Errorf(`ab_config sum of probabilities %.1f greater than 100%%`, t)
+		//}
+		if percent, err := jsonparser.GetFloat(value); err != nil {
+			return err
+		} else {
+			t += percent
+			if throw < t && len(selected) == 0 {
+				selected = string(key)
+			}
+		}
+		return nil
+	})
+	return
+}

--- a/stored_requests/ab_fetcher_test.go
+++ b/stored_requests/ab_fetcher_test.go
@@ -1,0 +1,34 @@
+package stored_requests
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runABSelectionDistribution(t *testing.T) {
+	repeatCount := 100000
+	rules := map[string]float64{
+		"main":   80,
+		"test5":  5.0,
+		"test15": 15.0,
+	}
+	rulesBytes, _ := json.Marshal(rules)
+	counts := map[string]int{}
+	allowedDeviation := 0.02
+	for i := 0; i < repeatCount; i++ {
+		gotSelected, err := runABSelection(rulesBytes)
+		counts[gotSelected]++
+		assert.NoError(t, err)
+	}
+	for key, val := range rules {
+		got := counts[key]
+		expected := int(val * float64(repeatCount) / 100)
+		deviation := math.Abs(1 - float64(got)/float64(expected))
+		assert.True(t, deviation <= allowedDeviation,
+			fmt.Sprintf("Case %s: Got %d, wanted %d, deviation %.2f%% > expected %.2f%%", key, got, expected, deviation*100, allowedDeviation*100))
+	}
+}

--- a/stored_requests/ab_fetcher_test.go
+++ b/stored_requests/ab_fetcher_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,24 +12,107 @@ import (
 
 func Test_runABSelectionDistribution(t *testing.T) {
 	repeatCount := 100000
-	rules := map[string]float64{
-		"main":   80,
-		"test5":  5.0,
-		"test15": 15.0,
+	rules := []ABConfig{
+		{
+			Code:      "main",
+			Ratio:     80,
+			RequestID: "main-request-id",
+		},
+		{
+			Code:  "test5",
+			Ratio: 5,
+			ImpIDs: map[string]string{
+				"imp-id":   "test5-imp-id",
+				"other-id": "test5-other-id",
+			},
+		},
+		{
+			Code:      "test15",
+			Ratio:     15,
+			RequestID: "test15-request-id",
+			ImpIDs: map[string]string{
+				"imp-id": "test15-imp-id",
+			},
+		},
 	}
 	rulesBytes, _ := json.Marshal(rules)
 	counts := map[string]int{}
 	allowedDeviation := 0.02
 	for i := 0; i < repeatCount; i++ {
-		gotSelected, err := runABSelection(rulesBytes)
-		counts[gotSelected]++
+		abConfig, err := runABSelection(rulesBytes)
+		counts[abConfig.Code]++
 		assert.NoError(t, err)
 	}
-	for key, val := range rules {
-		got := counts[key]
-		expected := int(val * float64(repeatCount) / 100)
+	for _, val := range rules {
+		got := counts[val.Code]
+		expected := int(val.Ratio * float64(repeatCount) / 100)
 		deviation := math.Abs(1 - float64(got)/float64(expected))
 		assert.True(t, deviation <= allowedDeviation,
-			fmt.Sprintf("Case %s: Got %d, wanted %d, deviation %.2f%% > expected %.2f%%", key, got, expected, deviation*100, allowedDeviation*100))
+			fmt.Sprintf("Case %s: Got %d, wanted %d, deviation %.2f%% > expected %.2f%%", val.Code, got, expected, deviation*100, allowedDeviation*100))
+	}
+}
+
+func Test_unmarshalABConfig(t *testing.T) {
+	type args struct {
+		abConfigJSON []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ABConfig
+		wantErr bool
+	}{
+		{
+			name: "code required",
+			args: args{
+				abConfigJSON: []byte(`{}`),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "one of imp_ids request_ids required",
+			args: args{
+				abConfigJSON: []byte(`{"code":"test"}`),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "request_id only should work",
+			args: args{
+				abConfigJSON: []byte(`{"code":"test", "request_id": "req-id"}`),
+			},
+			want:    &ABConfig{Code: "test", RequestID: "req-id", ImpIDs: map[string]string{}},
+			wantErr: false,
+		},
+		{
+			name: "imp_ids only should work",
+			args: args{
+				abConfigJSON: []byte(`{"code":"test", "imp_ids": {"imp-1": "repl-imp-1"}}`),
+			},
+			want:    &ABConfig{Code: "test", ImpIDs: map[string]string{"imp-1": "repl-imp-1"}},
+			wantErr: false,
+		},
+		{
+			name: "normal use",
+			args: args{
+				abConfigJSON: []byte(`{"code":"test", "request_id": "req-id", "imp_ids": {"imp-1": "repl-imp-1"}}`),
+			},
+			want:    &ABConfig{Code: "test", RequestID: "req-id", ImpIDs: map[string]string{"imp-1": "repl-imp-1"}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalABConfig(tt.args.abConfigJSON)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unmarshalABConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unmarshalABConfig() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/stored_requests/config/config.go
+++ b/stored_requests/config/config.go
@@ -121,6 +121,14 @@ func NewStoredRequests(cfg *config.Configuration, metricsEngine metrics.MetricsE
 	fetcher4, shutdown4 := CreateStoredRequests(&cfg.StoredVideo, metricsEngine, client, router, &dbc)
 	fetcher5, shutdown5 := CreateStoredRequests(&cfg.Accounts, metricsEngine, client, router, &dbc)
 
+	if true { // FIXME: add config setting to enable ab testing
+		fetcher1 = stored_requests.WithABFetcher(fetcher1, metricsEngine)
+		fetcher2 = stored_requests.WithABFetcher(fetcher2, metricsEngine)
+		fetcher3 = stored_requests.WithABFetcher(fetcher3, metricsEngine)
+		fetcher4 = stored_requests.WithABFetcher(fetcher4, metricsEngine)
+		fetcher5 = stored_requests.WithABFetcher(fetcher5, metricsEngine)
+	}
+
 	db = dbc.db
 
 	fetcher = fetcher1.(stored_requests.Fetcher)


### PR DESCRIPTION
This is a functional proof of concept for stored request A/B testing via remapping rules provided in the stored request.
It is a separate AllFetcher component intended to be placed in front of the rest of the fetchers in a composite
configuration, which means it can work for all auction endpoints and requires no changes to any of them.

If the default config is: `FetcherWithCache` → `Backend fetchers`
With A/B we will have: `ABFetcher` → `FetcherWithCache` → `Backend fetchers`

Some pieces missing from this POC are
-  fetcher unit testing until the implementation solidifies, as it is dependent on it.
- config - would be driven by a flag which goes here: https://github.com/prebid/prebid-server/compare/master...openx:ab?expand=1#diff-7abdb4226bb8e2194a2c424477150835fd9a8e6730e088af7dc5f1c88eb79b43R124
- metrics

The remapping rule would be provided in the stored request under `ext.prebid.storedrequest.ab_config` as a list of "experiment" configs:
```json
[
	{
		"code": "add_new_bidder_test_1",
		"ratio": 15.0,
		"request_id": "ABCD-0123-4567-111111", ⬅ this is the replacement stored request id
		"imp_ids": {
			"DCBA-3333-4444-012345": "DCBA-3333-4444-111111", ⬅ replacement stored imp id
			"DCBA-4444-5555-666666": "DCBA-4444-9999-222222", ⬅ replacement stored imp id
			...
		}
	},
	...
]
```

Fixes #1645 
