### PR TITLE
New Adapter: Criteo

### DIFF
--- a/adapters/criteo/criteo.go
+++ b/adapters/criteo/criteo.go
@@ -1,0 +1,106 @@
+package criteo
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/mxmCherry/openrtb/v14/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type adapter struct {
+	uri             string
+	slotIDGenerator slotIDGenerator
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, extraRequestInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	criteoRequest, errs := newCriteoRequest(a.slotIDGenerator, request)
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	jsonRequest, err := json.Marshal(criteoRequest)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	rqData := adapters.RequestData{
+		Method:  "POST",
+		Uri:     a.uri,
+		Body:    jsonRequest,
+		Headers: getCriteoRequestHeaders(&criteoRequest),
+	}
+
+	return []*adapters.RequestData{&rqData}, nil
+}
+
+func getCriteoRequestHeaders(criteoRequest *criteoRequest) http.Header {
+	headers := http.Header{}
+
+	// criteoRequest is known not to be nil
+	// If there was an error generating it from newCriteoRequest, the errors will be returned immediately
+	// and this method won't be called
+
+	if criteoRequest.User.CookieID != "" {
+		headers.Add("Cookie", "uid="+criteoRequest.User.CookieID)
+	}
+
+	if criteoRequest.User.IP != "" {
+		headers.Add("X-Forwarded-For", criteoRequest.User.IP)
+	}
+
+	if criteoRequest.User.IPv6 != "" {
+		headers.Add("X-Forwarded-For", criteoRequest.User.IPv6)
+	}
+
+	if criteoRequest.User.UA != "" {
+		headers.Add("User-Agent", criteoRequest.User.UA)
+	}
+
+	return headers
+}
+
+func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if response.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	bidResponse, err := newCriteoResponseFromBytes(response.Body)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	bidderResponse := adapters.NewBidderResponse()
+	bidderResponse.Bids = make([]*adapters.TypedBid, len(bidResponse.Slots))
+
+	for i := 0; i < len(bidResponse.Slots); i++ {
+		bidderResponse.Bids[i] = &adapters.TypedBid{
+			Bid: &openrtb2.Bid{
+				ID:    bidResponse.Slots[i].ID,
+				ImpID: bidResponse.Slots[i].ImpID,
+				Price: bidResponse.Slots[i].CPM,
+				AdM:   bidResponse.Slots[i].Creative,
+				W:     bidResponse.Slots[i].Width,
+				H:     bidResponse.Slots[i].Height,
+				CrID:  bidResponse.Slots[i].CreativeID,
+			},
+			BidType: openrtb_ext.BidTypeBanner,
+		}
+	}
+
+	return bidderResponse, nil
+}
+
+// Builder builds a new instance of the Criteo adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters.Bidder, error) {
+	return builderWithGuidGenerator(bidderName, config, newRandomSlotIDGenerator())
+}
+
+func builderWithGuidGenerator(bidderName openrtb_ext.BidderName, config config.Adapter, slotIDGenerator slotIDGenerator) (adapters.Bidder, error) {
+	return &adapter{
+		uri:             config.Endpoint,
+		slotIDGenerator: slotIDGenerator,
+	}, nil
+}

--- a/adapters/criteo/criteo.go
+++ b/adapters/criteo/criteo.go
@@ -2,11 +2,13 @@ package criteo
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/mxmCherry/openrtb/v14/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
@@ -65,6 +67,12 @@ func getCriteoRequestHeaders(criteoRequest *criteoRequest) http.Header {
 func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	if response.StatusCode == http.StatusNoContent {
 		return nil, nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode),
+		}}
 	}
 
 	bidResponse, err := newCriteoResponseFromBytes(response.Body)

--- a/adapters/criteo/criteo_test.go
+++ b/adapters/criteo/criteo_test.go
@@ -1,0 +1,28 @@
+package criteo
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/adapters/adapterstest"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+
+	// Setup:
+	bidder, buildErr := builderWithGuidGenerator(
+		openrtb_ext.BidderCriteo,
+		config.Adapter{
+			Endpoint: "https://bidder.criteo.com/cdb?profileId=230",
+		},
+		newFakeGuidGenerator("00000000-0000-0000-00000000"),
+	)
+
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	// Execute & Verify:
+	adapterstest.RunJSONBidderTest(t, "criteotest", bidder)
+}

--- a/adapters/criteo/criteotest/exemplary/simple-banner-cookie-uid.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-cookie-uid.json
@@ -1,0 +1,115 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ip": "91.199.242.236",
+      "ua": "random user agent"
+    },
+    "user": {
+      "buyeruid": "criteo-user-id"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["91.199.242.236"],
+          "User-Agent": ["random user agent"],
+          "Cookie": ["uid=criteo-user-id"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "cookieuid": "criteo-user-id",
+            "ip": "91.199.242.236",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "300x250"
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-slot-id",
+            "impid": "test-imp-id",
+            "price": 0.1,
+            "crid": "creative-123",
+            "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+            "w": 300,
+            "h": 250
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}
+

--- a/adapters/criteo/criteotest/exemplary/simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-inapp.json
@@ -1,0 +1,110 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": ["91.199.242.236"],
+            "User-Agent": ["random user agent"]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "id": "test-request-id",
+            "slots": [
+              {
+                "id": "test-slot-id",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-slot-id",
+            "impid": "test-imp-id",
+            "price": 0.1,
+            "crid": "creative-123",
+            "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+            "w": 300,
+            "h": 250
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}
+  

--- a/adapters/criteo/criteotest/exemplary/simple-banner-uid.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-uid.json
@@ -1,0 +1,132 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ip": "91.199.242.236",
+      "ua": "random user agent"
+    },
+    "user": {
+      "ip": "91.199.242.236",
+      "ua": "random user agent",
+      "ext": {
+        "eids": [{
+          "source": "criteo.com",
+          "uids": [{
+            "id": "criteo-eid"
+          }]
+        }]
+      }
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["91.199.242.236"],
+          "User-Agent": ["random user agent"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "ip": "91.199.242.236",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "300x250"
+              ]
+            }
+          ],
+          "eids": [
+            {
+              "source": "criteo.com",
+              "uids": [
+                {
+                  "id": "criteo-eid"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-slot-id",
+            "impid": "test-imp-id",
+            "price": 0.1,
+            "crid": "creative-123",
+            "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+            "w": 300,
+            "h": 250
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}
+

--- a/adapters/criteo/criteotest/supplemental/204-response-from-target.json
+++ b/adapters/criteo/criteotest/supplemental/204-response-from-target.json
@@ -1,0 +1,81 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "os": "android"
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YYY"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": ["91.199.242.236"],
+            "User-Agent": ["random user agent"]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YYY",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 204
+        }
+      }
+    ],
+    "expectedMakeBidsErrors": []
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/400-response-from-target.json
+++ b/adapters/criteo/criteotest/supplemental/400-response-from-target.json
@@ -1,0 +1,86 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "os": "android"
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YYY"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": ["91.199.242.236"],
+            "User-Agent": ["random user agent"]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YYY",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 400
+        }
+      }
+    ],
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+        "comparison": "literal"
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/500-response-from-target.json
+++ b/adapters/criteo/criteotest/supplemental/500-response-from-target.json
@@ -1,0 +1,86 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "os": "android"
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YYY"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": ["91.199.242.236"],
+            "User-Agent": ["random user agent"]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YYY",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 500
+        }
+      }
+    ],
+    "expectedMakeBidsErrors": [
+      {
+        "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+        "comparison": "literal"
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-inapp.json
@@ -1,0 +1,115 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "os": "android"
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YYY"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": ["91.199.242.236"],
+            "User-Agent": ["random user agent"]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YYY",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-uid.json
@@ -1,0 +1,139 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YYY"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YYY"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/ccpa-without-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-without-consent-simple-banner-inapp.json
@@ -1,0 +1,85 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "os": "android"
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YNN"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YNN",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 204
+        }
+      }
+    ],
+    "expectedBidResponses": []
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/ccpa-without-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-without-consent-simple-banner-uid.json
@@ -1,0 +1,105 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "regs": {
+        "ext": {
+          "us_privacy": "1YNN"
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "uspIab": "1YNN"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 204
+        }
+      }
+    ],
+    "expectedBidResponses": []
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-inapp.json
@@ -1,0 +1,126 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "consent": "iabconsentstringwithconsent"
+        }
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 1
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {
+              "consentdata": "iabconsentstringwithconsent",
+              "gdprapplies": true
+            },
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-uid.json
@@ -1,0 +1,142 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "consent": "iabconsentstringwithconsent",
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 1
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid"
+            },
+            "gdprconsent": {
+              "consentdata": "iabconsentstringwithconsent",
+              "gdprapplies": true
+            },
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/gdpr-without-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-without-consent-simple-banner-inapp.json
@@ -1,0 +1,92 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ifa": "test-ifa-123456",
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "consent": "iabconsentstringwithnoconsent"
+        }
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 1
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {
+              "consentdata": "iabconsentstringwithnoconsent",
+              "gdprapplies": true
+            },
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 204
+        }
+      }
+    ],
+    "expectedBidResponses": []
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/gdpr-without-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-without-consent-simple-banner-uid.json
@@ -1,0 +1,108 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "consent": "iabconsentstringwithoutconsent",
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "regs": {
+        "ext": {
+          "gdpr": 1
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid"
+            },
+            "gdprconsent": {
+              "consentdata": "iabconsentstringwithoutconsent",
+              "gdprapplies": true
+            },
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 204
+        }
+      }
+    ],
+    "expectedBidResponses": []
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/multislots-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-simple-banner-inapp.json
@@ -1,0 +1,213 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "app": {
+        "bundle": "test.app.bundle"
+      },
+      "device": {
+        "ip": "91.199.242.236",
+        "ua": "random user agent",
+        "ifa": "test-ifa-123456",
+        "os": "android"
+      },
+      "imp": [
+        {
+          "id": "test-imp-id-1",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-2",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 7891011,
+              "networkid": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-3",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 121314,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "bundleid": "test.app.bundle",
+              "networkid": 78910
+            },
+            "user": {
+              "deviceid": "test-ifa-123456",
+              "deviceos": "android",
+              "deviceidtype": "gaid",
+              "ip": "91.199.242.236",
+              "ua": "random user agent"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id-1",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-2",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "cpm": 0.2,
+                "currency": "USD",
+                "width": 320,
+                "height": 50,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-3",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "cpm": 0.3,
+                "currency": "USD",
+                "width": 300,
+                "height": 600,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id-1",
+              "impid": "test-imp-id-1",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-2",
+              "impid": "test-imp-id-2",
+              "price": 0.2,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 320,
+              "h": 50
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-3",
+              "impid": "test-imp-id-3",
+              "price": 0.3,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 600
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid-different-network-ids.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid-different-network-ids.json
@@ -1,0 +1,84 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id-1",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-2",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 7891011,
+              "networkid": 123456
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-3",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 121314,
+              "networkid": 467890
+            }
+          }
+        }
+      ]
+    },
+      "expectedMakeRequestsErrors": [
+        {
+          "value": "Bid request has slots coming with several network IDs which is not allowed",
+          "comparison": "literal"
+        }
+      ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid.json
@@ -1,0 +1,233 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id-1",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 123456,
+              "networkid": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-2",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 7891011,
+              "networkid": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-3",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneid": 121314,
+              "networkid": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id-1",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-2",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "cpm": 0.2,
+                "currency": "USD",
+                "width": 320,
+                "height": 50,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-3",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "cpm": 0.3,
+                "currency": "USD",
+                "width": 300,
+                "height": 600,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id-1",
+              "impid": "test-imp-id-1",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-2",
+              "impid": "test-imp-id-2",
+              "price": 0.2,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 320,
+              "h": 50
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-3",
+              "impid": "test-imp-id-3",
+              "price": 0.3,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 600
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats-not-included.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats-not-included.json
@@ -1,0 +1,132 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ip": "91.199.242.236",
+      "ua": "random user agent"
+    },
+    "user": {
+      "ext": {
+        "eids": [{
+          "source": "criteo.com",
+          "uids": [{
+            "id": "criteo-eid"
+          }]
+        }]
+      }
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "w": 300,
+          "h": 250,
+          "format": [
+            {
+              "w": 250,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["91.199.242.236"],
+          "User-Agent": ["random user agent"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "ip": "91.199.242.236",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "250x250"
+              ]
+            }
+          ],
+          "eids": [
+            {
+              "source": "criteo.com",
+              "uids": [
+                {
+                  "id": "criteo-eid"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+  ]
+}
+

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats.json
@@ -1,0 +1,132 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ip": "91.199.242.236",
+      "ua": "random user agent"
+    },
+    "user": {
+      "ext": {
+        "eids": [{
+          "source": "criteo.com",
+          "uids": [{
+            "id": "criteo-eid"
+          }]
+        }]
+      }
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "w": 300,
+          "h": 250,
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["91.199.242.236"],
+          "User-Agent": ["random user agent"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "ip": "91.199.242.236",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "300x250"
+              ]
+            }
+          ],
+          "eids": [
+            {
+              "source": "criteo.com",
+              "uids": [
+                {
+                  "id": "criteo-eid"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+  ]
+}
+

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size.json
@@ -1,0 +1,126 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ip": "91.199.242.236",
+      "ua": "random user agent"
+    },
+    "user": {
+      "ext": {
+        "eids": [{
+          "source": "criteo.com",
+          "uids": [{
+            "id": "criteo-eid"
+          }]
+        }]
+      }
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "w": 300,
+          "h": 250
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["91.199.242.236"],
+          "User-Agent": ["random user agent"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "ip": "91.199.242.236",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "300x250"
+              ]
+            }
+          ],
+          "eids": [
+            {
+              "source": "criteo.com",
+              "uids": [
+                {
+                  "id": "criteo-eid"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+  ]
+}
+

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-ipv6.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-ipv6.json
@@ -1,0 +1,126 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "id": "site-id",
+      "page": "criteo.com"
+    },
+    "device": {
+      "os": "android",
+      "ipv6": "fd36:ce97:0fa1:dec0:0000:0000:0000:0000",
+      "ua": "random user agent"
+    },
+    "user": {
+      "ext": {
+        "eids": [{
+          "source": "criteo.com",
+          "uids": [{
+            "id": "criteo-eid"
+          }]
+        }]
+      }
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "w": 300,
+          "h": 250
+        },
+        "ext": {
+          "bidder": {
+            "zoneid": 123456,
+            "networkid": 78910
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bidder.criteo.com/cdb?profileId=230",
+        "headers": {
+          "X-Forwarded-For": ["fd36:ce97:0fa1:dec0:0000:0000:0000:0000"],
+          "User-Agent": ["random user agent"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "publisher": {
+            "siteid": "site-id",
+            "url": "criteo.com",
+            "networkid": 78910
+          },
+          "user": {
+            "ipv6": "fd36:ce97:0fa1:dec0:0000:0000:0000:0000",
+            "ua": "random user agent",
+            "deviceos": "android",
+            "deviceidtype": "gaid"
+          },
+          "gdprconsent": {},
+          "slots": [
+            {
+              "slotid": "00000000-0000-0000-00000000",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "sizes": [
+                "300x250"
+              ]
+            }
+          ],
+          "eids": [
+            {
+              "source": "criteo.com",
+              "uids": [
+                {
+                  "id": "criteo-eid"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "slots": [
+            {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "zoneid": 123456,
+              "networkid": 78910,
+              "cpm": 0.1,
+              "currency": "USD",
+              "width": 300,
+              "height": 250,
+              "creativeid": "creative-123",
+              "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+            }
+          ]
+        }
+      }
+    }
+  ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id",
+              "impid": "test-imp-id",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          }
+        ]
+      }
+  ]
+}
+

--- a/adapters/criteo/generators.go
+++ b/adapters/criteo/generators.go
@@ -1,0 +1,36 @@
+package criteo
+
+import "github.com/gofrs/uuid"
+
+type slotIDGenerator interface {
+	NewSlotID() (string, error)
+}
+
+type randomSlotIDGenerator struct{}
+
+func newRandomSlotIDGenerator() randomSlotIDGenerator {
+	return randomSlotIDGenerator{}
+}
+
+func (g randomSlotIDGenerator) NewSlotID() (string, error) {
+	guid, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+
+	return guid.String(), nil
+}
+
+type fakeSlotIDGenerator struct {
+	fakeSlotID string
+}
+
+func newFakeGuidGenerator(fakeSlotID string) fakeSlotIDGenerator {
+	return fakeSlotIDGenerator{
+		fakeSlotID,
+	}
+}
+
+func (f fakeSlotIDGenerator) NewSlotID() (string, error) {
+	return f.fakeSlotID, nil
+}

--- a/adapters/criteo/models.go
+++ b/adapters/criteo/models.go
@@ -1,0 +1,300 @@
+package criteo
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mxmCherry/openrtb/v14/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/errortypes"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type criteoRequest struct {
+	ID          string                   `json:"id,omitempty"`
+	Publisher   criteoPublisher          `json:"publisher,omitempty"`
+	User        criteoUser               `json:"user,omitempty"`
+	GdprConsent criteoGdprConsent        `json:"gdprconsent,omitempty"`
+	Slots       []criteoRequestSlot      `json:"slots,omitempty"`
+	Eids        []openrtb_ext.ExtUserEid `json:"eids,omitempty"`
+}
+
+func newCriteoRequest(slotIDGenerator slotIDGenerator, request *openrtb2.BidRequest) (criteoRequest, []error) {
+	var errs []error
+
+	// request cannot be nil by design
+
+	criteoRequest := criteoRequest{}
+
+	criteoRequest.ID = request.ID
+
+	// Extracting request slots
+	if len(request.Imp) > 0 {
+		criteoSlots, slotsErr := newCriteoRequestSlots(slotIDGenerator, request.Imp)
+		if len(slotsErr) > 0 {
+			return criteoRequest, slotsErr
+		}
+		criteoRequest.Slots = criteoSlots
+	}
+
+	var networkId *int64
+	for _, criteoSlot := range criteoRequest.Slots {
+		if networkId == nil && criteoSlot.NetworkID != nil && *criteoSlot.NetworkID > 0 {
+			networkId = criteoSlot.NetworkID
+		} else if networkId != nil && criteoSlot.NetworkID != nil && *criteoSlot.NetworkID != *networkId {
+			return criteoRequest, []error{&errortypes.BadInput{
+				Message: "Bid request has slots coming with several network IDs which is not allowed",
+			}}
+		}
+	}
+
+	criteoRequest.Publisher = newCriteoPublisher(networkId, request.App, request.Site)
+
+	var regsExt *openrtb_ext.ExtRegs
+	if request.Regs != nil && request.Regs.Ext != nil {
+		if err := json.Unmarshal(request.Regs.Ext, &regsExt); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	criteoRequest.User = newCriteoUser(request.User, request.Device, regsExt)
+
+	if gdprConsent, err := newCriteoGdprConsent(request.User, regsExt); err != nil {
+		errs = append(errs, err)
+	} else {
+		criteoRequest.GdprConsent = gdprConsent
+	}
+
+	if request.User != nil && request.User.Ext != nil {
+		var extUser openrtb_ext.ExtUser
+		if err := json.Unmarshal(request.User.Ext, &extUser); err != nil {
+			errs = append(errs, err)
+		} else {
+			criteoRequest.Eids = extUser.Eids
+		}
+	}
+
+	return criteoRequest, errs
+}
+
+type criteoPublisher struct {
+	SiteID    string `json:"siteid,omitempty"`
+	BundleID  string `json:"bundleid,omitempty"`
+	URL       string `json:"url,omitempty"`
+	NetworkID *int64 `json:"networkid,omitempty"`
+}
+
+func newCriteoPublisher(networkId *int64, app *openrtb2.App, site *openrtb2.Site) criteoPublisher {
+	// Both app and site cannot be nil at the same time by design in PBS
+
+	criteoPublisher := criteoPublisher{}
+
+	if networkId != nil && *networkId > 0 {
+		criteoPublisher.NetworkID = networkId
+	}
+
+	if app != nil {
+		criteoPublisher.BundleID = app.Bundle
+	}
+
+	if site != nil {
+		criteoPublisher.SiteID = site.ID
+		criteoPublisher.URL = site.Page
+	}
+
+	return criteoPublisher
+}
+
+type criteoUser struct {
+	DeviceID     string `json:"deviceid,omitempty"`
+	DeviceOS     string `json:"deviceos,omitempty"`
+	DeviceIDType string `json:"deviceidtype,omitempty"`
+	CookieID     string `json:"cookieuid,omitempty"`
+	UID          string `json:"uid,omitempty"`
+	IP           string `json:"ip,omitempty"`
+	IPv6         string `json:"ipv6,omitempty"`
+	UA           string `json:"ua,omitempty"`
+	UspIab       string `json:"uspIab,omitempty"`
+}
+
+func newCriteoUser(user *openrtb2.User, device *openrtb2.Device, regsExt *openrtb_ext.ExtRegs) criteoUser {
+	criteoUser := criteoUser{}
+
+	if user == nil && device == nil {
+		return criteoUser
+	}
+
+	if user != nil {
+		criteoUser.CookieID = user.BuyerUID
+	}
+
+	if device != nil {
+		deviceType := getDeviceType(device.OS)
+		criteoUser.DeviceIDType = deviceType
+
+		criteoUser.DeviceOS = device.OS
+		criteoUser.DeviceID = device.IFA
+		criteoUser.IP = device.IP
+		criteoUser.IPv6 = device.IPv6
+		criteoUser.UA = device.UA
+	}
+
+	if regsExt != nil {
+		criteoUser.UspIab = regsExt.USPrivacy // CCPA
+	}
+
+	return criteoUser
+}
+
+type criteoGdprConsent struct {
+	GdprApplies *bool  `json:"gdprapplies,omitempty"`
+	ConsentData string `json:"consentdata,omitempty"`
+}
+
+func newCriteoGdprConsent(user *openrtb2.User, regsExt *openrtb_ext.ExtRegs) (criteoGdprConsent, error) {
+	consent := criteoGdprConsent{}
+
+	if user == nil && regsExt == nil {
+		return consent, nil
+	}
+
+	if user != nil && user.Ext != nil {
+		var userExt *openrtb_ext.ExtUser
+		if err := json.Unmarshal(user.Ext, &userExt); err != nil {
+			return consent, err
+		}
+		consent.ConsentData = userExt.Consent
+	}
+
+	if regsExt != nil {
+		if regsExt.GDPR != nil {
+			gdprApplies := bool((*regsExt.GDPR & 1) == 1)
+			consent.GdprApplies = &gdprApplies
+		}
+	}
+
+	return consent, nil
+}
+
+type criteoRequestSlot struct {
+	SlotID      string              `json:"slotid,omitempty"`
+	ImpID       string              `json:"impid,omitempty"`
+	ZoneID      *int64              `json:"zoneid,omitempty"`
+	NetworkID   *int64              `json:"networkid,omitempty"`
+	PlacementID string              `json:"placement,omitempty"`
+	Sizes       []criteoRequestSize `json:"sizes,omitempty"`
+}
+
+func newCriteoRequestSlots(slotIDGenerator slotIDGenerator, impressions []openrtb2.Imp) ([]criteoRequestSlot, []error) {
+	var errs []error
+
+	// `impressions` known not to be nil or empty by design, PBS checks it upstream.
+
+	// Criteo slot should comes with any of (both are ok as well):
+	//   - `zoneid`
+	//   - `networkid`, `slotid`, `sizes`
+	//
+	// if not, criteo will reject the slot.
+
+	var criteoSlots = make([]criteoRequestSlot, len(impressions))
+
+	for i := 0; i < len(impressions); i++ {
+		criteoSlots[i] = criteoRequestSlot{}
+
+		criteoSlots[i].ImpID = impressions[i].ID
+
+		// Generating a random slot ID
+		generatedSlotID, err := slotIDGenerator.NewSlotID()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		criteoSlots[i].SlotID = generatedSlotID
+
+		if impressions[i].Banner != nil {
+			if impressions[i].Banner.Format != nil {
+				criteoSlots[i].Sizes = make([]criteoRequestSize, len(impressions[i].Banner.Format))
+				for idx, format := range impressions[i].Banner.Format {
+					criteoSlots[i].Sizes[idx] = newCriteoRequestSize(format.W, format.H)
+				}
+			} else if impressions[i].Banner.W != nil && *impressions[i].Banner.W > 0 && impressions[i].Banner.H != nil && *impressions[i].Banner.H > 0 {
+				criteoSlots[i].Sizes = make([]criteoRequestSize, 1)
+				criteoSlots[i].Sizes[0] = newCriteoRequestSize(*impressions[i].Banner.W, *impressions[i].Banner.H)
+			}
+		}
+
+		var bidderExt adapters.ExtImpBidder
+		if err := json.Unmarshal(impressions[i].Ext, &bidderExt); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if bidderExt.Bidder != nil {
+			var criteoExt openrtb_ext.ExtImpCriteo
+			if err := json.Unmarshal(bidderExt.Bidder, &criteoExt); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if criteoExt.ZoneID > 0 {
+				criteoSlots[i].ZoneID = &criteoExt.ZoneID
+			}
+			if criteoExt.NetworkID > 0 {
+				criteoSlots[i].NetworkID = &criteoExt.NetworkID
+			}
+		}
+	}
+
+	return criteoSlots, errs
+}
+
+type criteoRequestSize = string
+
+func newCriteoRequestSize(width int64, height int64) criteoRequestSize {
+	return fmt.Sprintf("%dx%d", width, height)
+}
+
+var deviceType = map[string]string{
+	"ios":     "idfa",
+	"android": "gaid",
+	"unknown": "unknown",
+}
+
+func getDeviceType(os string) string {
+	if os != "" {
+		if dtype, ok := deviceType[strings.ToLower(os)]; ok {
+			return dtype
+		}
+	}
+
+	return deviceType["unknown"]
+}
+
+type criteoResponse struct {
+	ID    string               `json:"id,omitempty"`
+	Slots []criteoResponseSlot `json:"slots,omitempty"`
+}
+
+func newCriteoResponseFromBytes(bytes []byte) (criteoResponse, error) {
+	var err error
+	var bidResponse criteoResponse
+
+	if err = json.Unmarshal(bytes, &bidResponse); err != nil {
+		return bidResponse, err
+	}
+
+	return bidResponse, nil
+}
+
+type criteoResponseSlot struct {
+	ID         string  `json:"id,omitempty"`
+	ImpID      string  `json:"impid,omitempty"`
+	ZoneID     int64   `json:"zoneid,omitempty"`
+	NetworkID  int64   `json:"networkid,omitempty"`
+	CPM        float64 `json:"cpm,omitempty"`
+	Currency   string  `json:"currency,omitempty"`
+	Width      int64   `json:"width,omitempty"`
+	Height     int64   `json:"height,omitempty"`
+	Creative   string  `json:"creative,omitempty"`
+	CreativeID string  `json:"creativeid,omitempty"`
+}

--- a/adapters/criteo/models.go
+++ b/adapters/criteo/models.go
@@ -178,12 +178,11 @@ func newCriteoGdprConsent(user *openrtb2.User, regsExt *openrtb_ext.ExtRegs) (cr
 }
 
 type criteoRequestSlot struct {
-	SlotID      string              `json:"slotid,omitempty"`
-	ImpID       string              `json:"impid,omitempty"`
-	ZoneID      *int64              `json:"zoneid,omitempty"`
-	NetworkID   *int64              `json:"networkid,omitempty"`
-	PlacementID string              `json:"placement,omitempty"`
-	Sizes       []criteoRequestSize `json:"sizes,omitempty"`
+	SlotID    string              `json:"slotid,omitempty"`
+	ImpID     string              `json:"impid,omitempty"`
+	ZoneID    *int64              `json:"zoneid,omitempty"`
+	NetworkID *int64              `json:"networkid,omitempty"`
+	Sizes     []criteoRequestSize `json:"sizes,omitempty"`
 }
 
 func newCriteoRequestSlots(slotIDGenerator slotIDGenerator, impressions []openrtb2.Imp) ([]criteoRequestSlot, []error) {

--- a/adapters/criteo/models_test.go
+++ b/adapters/criteo/models_test.go
@@ -1,0 +1,452 @@
+package criteo
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/mxmCherry/openrtb/v14/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+func TestGetDeviceType(t *testing.T) {
+
+	// Setup:
+	deviceTypeCases := []struct {
+		deviceType string
+		expected   string
+	}{
+		{"ios", "idfa"},
+		{"Ios", "idfa"},
+		{"IOS", "idfa"},
+		{"android", "gaid"},
+		{"unknown", "unknown"},
+		{"", "unknown"},
+		{"qwerty", "unknown"},
+		{"qWerty", "unknown"},
+		{"abc", "unknown"},
+	}
+
+	for _, uc := range deviceTypeCases {
+		// Execute:
+		result := getDeviceType(uc.deviceType)
+
+		// Verify:
+		if uc.expected != result {
+			t.Errorf("Bad getDeviceType for '%s'. Expected: %s, got %s", uc.deviceType, uc.expected, result)
+		}
+	}
+}
+
+func TestNewCriteoRequest(t *testing.T) {
+	// Setup:
+	var (
+		dummyRequestID         = "random request ID"
+		dummyPublisherBundleID = "bundleid"
+		dummyPublisherURL      = "test.com"
+		dummyPublisherSiteID   = "siteid"
+		dummyUserDeviceID      = "random-device-id"
+		dummyUserDeviceOS      = "android"
+		dummyUserDeviceIDType  = "gaid"
+		dummyUserCookieID      = "random-cookie-id"
+		dummyUserIP            = "1.1.1.1"
+		dummyUserUA            = "random UA"
+		dummyGdprApplies       = true
+		dummyGdprAppliesUint   = int8(1)
+		dummyGdprConsentData   = "randomconsentdata"
+		dummySlotID            = "11111111-1111-1111-11111111"
+		dummySlotImpID         = "fake-imp-id-1"
+		dummySlotZoneID        = int64(1)
+	)
+
+	fakeSlotIDGenerator := newFakeGuidGenerator(dummySlotID)
+
+	// The request doesn't make any sense but aims to fill every single criteo request fields
+	expectedCriteoRequest := criteoRequest{
+		ID: dummyRequestID,
+		Publisher: criteoPublisher{
+			SiteID:   dummyPublisherSiteID,
+			BundleID: dummyPublisherBundleID,
+			URL:      dummyPublisherURL,
+		},
+		User: criteoUser{
+			DeviceID:     dummyUserDeviceID,
+			DeviceOS:     dummyUserDeviceOS,
+			DeviceIDType: dummyUserDeviceIDType,
+			CookieID:     dummyUserCookieID,
+			IP:           dummyUserIP,
+			UA:           dummyUserUA,
+		},
+		GdprConsent: criteoGdprConsent{
+			GdprApplies: &dummyGdprApplies,
+			ConsentData: dummyGdprConsentData,
+		},
+		Slots: []criteoRequestSlot{
+			{
+				SlotID: dummySlotID,
+				ImpID:  dummySlotImpID,
+				ZoneID: &dummySlotZoneID,
+			},
+		},
+	}
+
+	userExtJSON, _ := json.Marshal(&openrtb_ext.ExtUser{
+		Consent: dummyGdprConsentData,
+	})
+	regsExtJSON, _ := json.Marshal(&openrtb_ext.ExtRegs{
+		GDPR: &dummyGdprAppliesUint,
+	})
+	bidderExtJSON, _ := json.Marshal(&openrtb_ext.ExtImpCriteo{
+		ZoneID: dummySlotZoneID,
+	})
+	impExtJSON, _ := json.Marshal(&adapters.ExtImpBidder{
+		Bidder: bidderExtJSON,
+	})
+	incomingRequest := &openrtb2.BidRequest{
+		ID: dummyRequestID,
+		App: &openrtb2.App{
+			Bundle: dummyPublisherBundleID,
+		},
+		Site: &openrtb2.Site{
+			ID:   dummyPublisherSiteID,
+			Page: dummyPublisherURL,
+		},
+		User: &openrtb2.User{
+			BuyerUID: dummyUserCookieID,
+			Ext:      userExtJSON,
+		},
+		Regs: &openrtb2.Regs{
+			Ext: regsExtJSON,
+		},
+		Device: &openrtb2.Device{
+			IFA: dummyUserDeviceID,
+			OS:  dummyUserDeviceOS,
+			IP:  dummyUserIP,
+			UA:  dummyUserUA,
+		},
+		Imp: []openrtb2.Imp{
+			{
+				ID:  dummySlotImpID,
+				Ext: impExtJSON,
+			},
+		},
+	}
+
+	// Execute:
+	result, err := newCriteoRequest(fakeSlotIDGenerator, incomingRequest)
+
+	// Verify:
+	if err != nil {
+		t.Errorf("newCriteoRequest has errors: %s", err)
+	}
+
+	if expectedCriteoRequest.ID != result.ID ||
+		!reflect.DeepEqual(expectedCriteoRequest, result) ||
+		!reflect.DeepEqual(expectedCriteoRequest.Publisher, result.Publisher) ||
+		!reflect.DeepEqual(expectedCriteoRequest.User, result.User) ||
+		!reflect.DeepEqual(expectedCriteoRequest.GdprConsent, result.GdprConsent) ||
+		len(expectedCriteoRequest.Slots) != len(result.Slots) ||
+		!reflect.DeepEqual(expectedCriteoRequest.Slots[0], result.Slots[0]) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("newCriteoRequest was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestGetGdprConsent(t *testing.T) {
+	// Setup:
+	var (
+		dummyGdprApplies     = true
+		dummyGdprConsentData = "randomconsentdata"
+		dummyGdprAppliesUint = int8(1)
+	)
+
+	expectedCriteoRequest := criteoRequest{
+		GdprConsent: criteoGdprConsent{
+			GdprApplies: &dummyGdprApplies,
+			ConsentData: dummyGdprConsentData,
+		},
+	}
+
+	userExtJSON, _ := json.Marshal(&openrtb_ext.ExtUser{
+		Consent: dummyGdprConsentData,
+	})
+	regsExtJSON, _ := json.Marshal(&openrtb_ext.ExtRegs{
+		GDPR: &dummyGdprAppliesUint,
+	})
+	incomingRequest := &openrtb2.BidRequest{
+		User: &openrtb2.User{
+			Ext: userExtJSON,
+		},
+		Regs: &openrtb2.Regs{
+			Ext: regsExtJSON,
+		},
+	}
+
+	var regsExt *openrtb_ext.ExtRegs
+	if incomingRequest.Regs != nil {
+		json.Unmarshal(incomingRequest.Regs.Ext, &regsExt)
+	}
+
+	// Execute:
+	gdprConsent, _ := newCriteoGdprConsent(incomingRequest.User, regsExt)
+	result := criteoRequest{
+		GdprConsent: gdprConsent,
+	}
+
+	// Verify:
+	if !reflect.DeepEqual(expectedCriteoRequest, result) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("getGdprConsent was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	// Setup:
+	var (
+		dummyUserDeviceID     = "random-device-id"
+		dummyUserDeviceOS     = "android"
+		dummyUserDeviceIDType = "gaid"
+		dummyUserCookieID     = "random-cookie-id"
+		dummyUserIP           = "1.1.1.1"
+		dummyUserUA           = "random UA"
+		dummyCcpaString       = "1YYY"
+	)
+	expectedCriteoRequest := &criteoRequest{
+		User: criteoUser{
+			DeviceID:     dummyUserDeviceID,
+			DeviceOS:     dummyUserDeviceOS,
+			DeviceIDType: dummyUserDeviceIDType,
+			CookieID:     dummyUserCookieID,
+			IP:           dummyUserIP,
+			UA:           dummyUserUA,
+			UspIab:       dummyCcpaString,
+		},
+	}
+
+	regsExt := &openrtb_ext.ExtRegs{
+		USPrivacy: dummyCcpaString,
+	}
+	regsExtData, err := json.Marshal(regsExt)
+	if err != nil {
+		t.Errorf("cannot marshal regsExt data")
+	}
+
+	incomingRequest := &openrtb2.BidRequest{
+		User: &openrtb2.User{
+			BuyerUID: dummyUserCookieID,
+		},
+		Device: &openrtb2.Device{
+			IFA: dummyUserDeviceID,
+			OS:  dummyUserDeviceOS,
+			IP:  dummyUserIP,
+			UA:  dummyUserUA,
+		},
+		Regs: &openrtb2.Regs{
+			Ext: regsExtData,
+		},
+	}
+
+	// Execute:
+	result := &criteoRequest{
+		User: newCriteoUser(incomingRequest.User, incomingRequest.Device, regsExt),
+	}
+
+	// Verify:
+	if !reflect.DeepEqual(expectedCriteoRequest.User, result.User) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("getUser was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestGetUser_NilUserAndDevice(t *testing.T) {
+	// Setup:
+	var dummyCcpaString = "1YYY"
+
+	expectedCriteoRequest := &criteoRequest{}
+
+	regsExt := &openrtb_ext.ExtRegs{
+		USPrivacy: dummyCcpaString,
+	}
+	regsExtData, err := json.Marshal(regsExt)
+	if err != nil {
+		t.Errorf("cannot marshal regsExt data")
+	}
+
+	incomingRequest := &openrtb2.BidRequest{
+		Regs: &openrtb2.Regs{
+			Ext: regsExtData,
+		},
+	}
+
+	// Execute:
+	result := &criteoRequest{
+		User: newCriteoUser(incomingRequest.User, incomingRequest.Device, regsExt),
+	}
+
+	// Verify:
+	if !reflect.DeepEqual(expectedCriteoRequest.User, result.User) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("getUser was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestPublisher(t *testing.T) {
+	// Setup:
+	var (
+		dummyPublisherSiteID         = "siteid"
+		dummyPublisherBundleID       = "bundleid"
+		dummyPublisherURL            = "test.com"
+		dummyNetworkID         int64 = 1234567
+	)
+	expectedCriteoRequest := &criteoRequest{
+		Publisher: criteoPublisher{
+			SiteID:    dummyPublisherSiteID,
+			BundleID:  dummyPublisherBundleID,
+			URL:       dummyPublisherURL,
+			NetworkID: &dummyNetworkID,
+		},
+	}
+
+	incomingRequest := &openrtb2.BidRequest{
+		App: &openrtb2.App{
+			Bundle: dummyPublisherBundleID,
+		},
+		Site: &openrtb2.Site{
+			ID:   dummyPublisherSiteID,
+			Page: dummyPublisherURL,
+		},
+	}
+
+	// Execute:
+	result := &criteoRequest{
+		Publisher: newCriteoPublisher(&dummyNetworkID, incomingRequest.App, incomingRequest.Site),
+	}
+
+	// Verify:
+	if !reflect.DeepEqual(expectedCriteoRequest.Publisher, result.Publisher) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("getPublisher was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestGetRequestSlots(t *testing.T) {
+	// Setup:
+	var (
+		dummySlotImpID  = "fake-imp-id-1"
+		dummySlotZoneID = int64(1)
+		dummySlotID     = "22222222-2222-2222-22222222"
+	)
+
+	fakeSlotIDGenerator := newFakeGuidGenerator(dummySlotID)
+
+	expectedCriteoRequest := &criteoRequest{
+		Slots: []criteoRequestSlot{
+			{
+				SlotID: dummySlotID,
+				ImpID:  dummySlotImpID,
+				ZoneID: &dummySlotZoneID,
+			},
+		},
+	}
+
+	bidderExtJSON, _ := json.Marshal(&openrtb_ext.ExtImpCriteo{
+		ZoneID: dummySlotZoneID,
+	})
+	impExtJSON, _ := json.Marshal(&adapters.ExtImpBidder{
+		Bidder: bidderExtJSON,
+	})
+	incomingRequest := &openrtb2.BidRequest{
+		Imp: []openrtb2.Imp{
+			{
+				ID:  dummySlotImpID,
+				Ext: impExtJSON,
+			},
+		},
+	}
+
+	// Execute:
+	slots, err := newCriteoRequestSlots(fakeSlotIDGenerator, incomingRequest.Imp)
+	result := &criteoRequest{
+		Slots: slots,
+	}
+
+	// Verify:
+	if err != nil {
+		t.Errorf("newCriteoRequestSlots has errors: %s", err)
+	}
+
+	if len(expectedCriteoRequest.Slots) != len(result.Slots) ||
+		!reflect.DeepEqual(expectedCriteoRequest.Slots[0], result.Slots[0]) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("newCriteoRequest was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}
+
+func TestGetRequestMultipleSlots(t *testing.T) {
+	// Setup:
+	dummySlots := []struct {
+		ID     string
+		ZoneID int64
+	}{
+		{"fake-imp-id-1", 1},
+		{"fake-imp-id-2", 2},
+		{"fake-imp-id-3", 3},
+		{"fake-imp-id-4", 4},
+		{"fake-imp-id-5", 5},
+	}
+
+	incomingRequest := &openrtb2.BidRequest{
+		Imp: make([]openrtb2.Imp, len(dummySlots)),
+	}
+	slots := make([]criteoRequestSlot, len(dummySlots))
+
+	for i := range dummySlots {
+		// Build expected slots
+		slots[i] = criteoRequestSlot{
+			ImpID:  dummySlots[i].ID,
+			ZoneID: &dummySlots[i].ZoneID,
+		}
+
+		// Build incoming request imps
+		bidderExtJSON, _ := json.Marshal(&openrtb_ext.ExtImpCriteo{
+			ZoneID: dummySlots[i].ZoneID,
+		})
+		impExtJSON, _ := json.Marshal(&adapters.ExtImpBidder{
+			Bidder: bidderExtJSON,
+		})
+		incomingRequest.Imp[i] = openrtb2.Imp{
+			ID:  dummySlots[i].ID,
+			Ext: impExtJSON,
+		}
+	}
+
+	expectedCriteoRequestSlots, err := newCriteoRequestSlots(newFakeGuidGenerator(""), incomingRequest.Imp)
+	expectedCriteoRequest := &criteoRequest{
+		Slots: expectedCriteoRequestSlots,
+	}
+
+	// Execute:
+	slotsResult, err := newCriteoRequestSlots(newFakeGuidGenerator(""), incomingRequest.Imp)
+	result := &criteoRequest{
+		Slots: slotsResult,
+	}
+
+	// Verify:
+	if err != nil {
+		t.Errorf("newCriteoRequestSlots has errors: %s", err)
+	}
+
+	if len(expectedCriteoRequest.Slots) != len(result.Slots) ||
+		!reflect.DeepEqual(expectedCriteoRequest.Slots, result.Slots) {
+		actualResultJSON, _ := json.Marshal(result)
+		expectedResultJSON, _ := json.Marshal(expectedCriteoRequest)
+		t.Errorf("newCriteoRequest was incorrect, got '%s', want '%s'.", actualResultJSON, expectedResultJSON)
+	}
+}

--- a/adapters/criteo/params_test.go
+++ b/adapters/criteo/params_test.go
@@ -1,0 +1,56 @@
+package criteo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+// This file actually intends to test static/bidder-params/criteo.json
+//
+// These also validate the format of the external API: request.imp[i].ext.criteo
+
+// TestValidParams makes sure that the criteo schema accepts all imp.ext fields which we intend to support.
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderCriteo, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected criteo params: %s", validParam)
+		}
+	}
+}
+
+// TestInvalidParams makes sure that the criteo schema rejects all the imp.ext fields we don't support.
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderCriteo, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"zoneid": 123456}`,
+	`{"networkid": 78910}`,
+	`{"zoneid": 123456, "networkid": 78910}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`4.2`,
+	`[]`,
+	`{}`,
+}

--- a/adapters/criteo/params_test.go
+++ b/adapters/criteo/params_test.go
@@ -43,6 +43,7 @@ var validParams = []string{
 	`{"zoneid": 123456}`,
 	`{"networkid": 78910}`,
 	`{"zoneid": 123456, "networkid": 78910}`,
+	`{"zoneid": 0, "networkid": 0}`,
 }
 
 var invalidParams = []string{
@@ -53,4 +54,10 @@ var invalidParams = []string{
 	`4.2`,
 	`[]`,
 	`{}`,
+	`{"zoneid": -123}`,
+	`{"networkid": -321}`,
+	`{"zoneid": -123, "networkid": -321}`,
+	`{"zoneid": -1}`,
+	`{"networkid": -1}`,
+	`{"zoneid": -1, "networkid": -1}`,
 }

--- a/adapters/criteo/usersync.go
+++ b/adapters/criteo/usersync.go
@@ -1,0 +1,14 @@
+package criteo
+
+import (
+	"text/template"
+
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/usersync"
+)
+
+// NewCriteoSyncer user syncer for Criteo
+// Criteo doesn't need user synchronization yet.
+func NewCriteoSyncer(temp *template.Template) usersync.Usersyncer {
+	return adapters.NewSyncer("criteo", temp, adapters.SyncTypeRedirect)
+}

--- a/adapters/criteo/usersync_test.go
+++ b/adapters/criteo/usersync_test.go
@@ -1,0 +1,26 @@
+package criteo
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/privacy"
+	"github.com/prebid/prebid-server/privacy/gdpr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCriteoSyncer(t *testing.T) {
+	url := "//prebidserver/getuid?https%3A%2F%2Fprebidserver%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dcriteo%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID"
+	temp := template.Must(template.New("sync-template").Parse(url))
+	syncer := NewCriteoSyncer(temp)
+	info, err := syncer.GetUsersyncInfo(privacy.Policies{
+		GDPR: gdpr.Policy{
+			Signal: "1",
+		},
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, adapters.SyncTypeRedirect, info.Type)
+	assert.Equal(t, false, info.SupportCORS)
+	assert.Equal(t, "//prebidserver/getuid?https%3A%2F%2Fprebidserver%2Fpbs%2Fv1%2Fsetuid%3Fbidder%3Dcriteo%26gdpr%3D1%26gdpr_consent%3D%26uid%3D%24UID", info.URL)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -835,6 +835,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.consumable.endpoint", "https://e.serverbid.com/api/v2")
 	v.SetDefault("adapters.conversant.endpoint", "http://api.hb.ad.cpe.dotomi.com/cvx/server/hb/ortb/25")
 	v.SetDefault("adapters.cpmstar.endpoint", "https://server.cpmstar.com/openrtbbidrq.aspx")
+	v.SetDefault("adapters.criteo.endpoint", "https://bidder.criteo.com/cdb?profileId=230")
 	v.SetDefault("adapters.datablocks.endpoint", "http://{{.Host}}/openrtb2?sid={{.SourceId}}")
 	v.SetDefault("adapters.decenterads.endpoint", "http://supply.decenterads.com/?c=o&m=rtb")
 	v.SetDefault("adapters.deepintent.endpoint", "https://prebid.deepintent.com/prebid")

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/consumable"
 	"github.com/prebid/prebid-server/adapters/conversant"
 	"github.com/prebid/prebid-server/adapters/cpmstar"
+	"github.com/prebid/prebid-server/adapters/criteo"
 	"github.com/prebid/prebid-server/adapters/datablocks"
 	"github.com/prebid/prebid-server/adapters/decenterads"
 	"github.com/prebid/prebid-server/adapters/deepintent"
@@ -143,6 +144,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderConsumable:       consumable.Builder,
 		openrtb_ext.BidderConversant:       conversant.Builder,
 		openrtb_ext.BidderCpmstar:          cpmstar.Builder,
+		openrtb_ext.BidderCriteo:           criteo.Builder,
 		openrtb_ext.BidderDatablocks:       datablocks.Builder,
 		openrtb_ext.BidderDecenterAds:      decenterads.Builder,
 		openrtb_ext.BidderDeepintent:       deepintent.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -106,6 +106,7 @@ const (
 	BidderConsumable       BidderName = "consumable"
 	BidderConversant       BidderName = "conversant"
 	BidderCpmstar          BidderName = "cpmstar"
+	BidderCriteo           BidderName = "criteo"
 	BidderDatablocks       BidderName = "datablocks"
 	BidderDmx              BidderName = "dmx"
 	BidderDecenterAds      BidderName = "decenterads"
@@ -214,6 +215,7 @@ func CoreBidderNames() []BidderName {
 		BidderConsumable,
 		BidderConversant,
 		BidderCpmstar,
+		BidderCriteo,
 		BidderDatablocks,
 		BidderDecenterAds,
 		BidderDeepintent,

--- a/openrtb_ext/imp_criteo.go
+++ b/openrtb_ext/imp_criteo.go
@@ -1,0 +1,7 @@
+package openrtb_ext
+
+// ExtImpCriteo defines the contract for bidrequest.imp[i].ext.criteo
+type ExtImpCriteo struct {
+	ZoneID    int64 `json:"zoneId"`
+	NetworkID int64 `json:"networkId"`
+}

--- a/static/bidder-info/criteo.yaml
+++ b/static/bidder-info/criteo.yaml
@@ -1,0 +1,10 @@
+maintainer:
+  email: "pi-direct@criteo.com"
+gvlVendorID: 91
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+  site:
+    mediaTypes:
+      - banner

--- a/static/bidder-params/criteo.json
+++ b/static/bidder-params/criteo.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Criteo adapter params",
+    "description": "The schema to validate Criteo specific params accepted by Criteo adapter",
+    "type": "object",
+    "properties": {
+        "zoneid": {
+            "type": "number",
+            "description": "Impression's zone ID.",
+            "minimum": 0
+        },
+        "networkid": {
+            "type": "number",
+            "description": "Impression's network ID.",
+            "minimum": 0
+        }
+    },
+    "anyOf": [
+        {
+            "required": [
+                "zoneid"
+            ]
+        },
+        {
+            "required": [
+                "networkid"
+            ]
+        }
+    ]
+}

--- a/usersync/usersyncers/syncer.go
+++ b/usersync/usersyncers/syncer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/consumable"
 	"github.com/prebid/prebid-server/adapters/conversant"
 	"github.com/prebid/prebid-server/adapters/cpmstar"
+	"github.com/prebid/prebid-server/adapters/criteo"
 	"github.com/prebid/prebid-server/adapters/datablocks"
 	"github.com/prebid/prebid-server/adapters/deepintent"
 	"github.com/prebid/prebid-server/adapters/dmx"
@@ -122,6 +123,7 @@ func NewSyncerMap(cfg *config.Configuration) map[openrtb_ext.BidderName]usersync
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderConnectAd, connectad.NewConnectAdSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderConsumable, consumable.NewConsumableSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderConversant, conversant.NewConversantSyncer)
+	insertIntoMap(cfg, syncers, openrtb_ext.BidderCriteo, criteo.NewCriteoSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderCpmstar, cpmstar.NewCpmstarSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderDatablocks, datablocks.NewDatablocksSyncer)
 	insertIntoMap(cfg, syncers, openrtb_ext.BidderDeepintent, deepintent.NewDeepintentSyncer)

--- a/usersync/usersyncers/syncer_test.go
+++ b/usersync/usersyncers/syncer_test.go
@@ -41,6 +41,7 @@ func TestNewSyncerMap(t *testing.T) {
 			string(openrtb_ext.BidderConsumable):       syncConfig,
 			string(openrtb_ext.BidderConversant):       syncConfig,
 			string(openrtb_ext.BidderCpmstar):          syncConfig,
+			string(openrtb_ext.BidderCriteo):           syncConfig,
 			string(openrtb_ext.BidderDatablocks):       syncConfig,
 			string(openrtb_ext.BidderDmx):              syncConfig,
 			string(openrtb_ext.BidderDeepintent):       syncConfig,


### PR DESCRIPTION
Hello PBS Team :)

This PR aims to plug Criteo's adapter. We still have couple things to test on our end but would love to have a review on this adapter in the meantime.

One question, we will be using `user.ext.eids` to retrieve Criteo's user ID. While testing locally, I was trying to get outgoing bid request to Criteo but somehow, I was never able to have anything populated inside PBS `user.ext.eids`, I might miss something here, if you have any idea it would help me to do an end to end test.

Here's the bid request I send to PBS:
```
{
   "id":"test-request-id",
   "site":{
      "id":"site-id",
      "page":"criteo.com"
   },
   "device":{
      "os":"android",
      "ip":"91.199.242.236",
      "ua":"random user agent"
   },
   "user":{
      "ext":{
         "eids":[
            {
               "source":"criteo.com",
               "uids":[
                  {
                     "id":"criteo-eid"
                  }
               ]
            },
            {
                "source": "pubcommon",
                "id":"11111111"
            }
         ]
      }
   },
   "imp":[
      {
         "id":"test-imp-id",
         "banner":{
            "format":[
               {
                  "w":300,
                  "h":250
               }
            ]
         },
         "ext":{
            "criteo":{
               "zoneid":123456,
               "networkid":78910
            }
         }
      }
   ]
}
```

Also, we would like to be off by default, and publishers we are already working / whiling to work with us would have to reach their Criteo point of contact. I guess this should be described in adapter's description on prebid documentation website, if so, I will edit the description and link it to this PR. 

Cheers !