### PR TITLE
Flip usersync_if_ambiguous Default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -922,7 +922,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("amp_timeout_adjustment_ms", 0)
 	v.SetDefault("gdpr.enabled", true)
 	v.SetDefault("gdpr.host_vendor_id", 0)
-	v.SetDefault("gdpr.usersync_if_ambiguous", false)
+	v.SetDefault("gdpr.usersync_if_ambiguous", true)
 	v.SetDefault("gdpr.timeouts_ms.init_vendorlist_fetches", 0)
 	v.SetDefault("gdpr.timeouts_ms.active_vendorlist_fetch", 0)
 	v.SetDefault("gdpr.non_standard_publishers", []string{""})


### PR DESCRIPTION
Addresses: https://github.com/prebid/prebid-server/issues/1783

The `usersync_if_ambiguous` forces TCF enforcement on any bid request this doesn't explicitly set the `regs.ext.gdpr` field. This is not a good default and has caused several complaints. Setting this to `true` is a better default value which only enforces TCF if the bid request includes `regs.ext.gdpr` set to `1`.

We'll follow-up with a separate PR to rename the `usersync_if_ambiguous` config value to something more descriptive, as it controls much more than user sync.