### PR TITLE
IX: Set bidVideo when category and duration is available

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -402,9 +402,23 @@ func (a *IxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReque
 			if !ok {
 				errs = append(errs, fmt.Errorf("Unmatched impression id: %s.", bid.ImpID))
 			}
+
+			var bidExtVideo *openrtb_ext.ExtBidPrebidVideo
+			var bidExt openrtb_ext.ExtBid
+			if bidType == openrtb_ext.BidTypeVideo {
+				unmarshalExtErr := json.Unmarshal(bid.Ext, &bidExt)
+				if unmarshalExtErr == nil && bidExt.Prebid != nil && bidExt.Prebid.Video != nil {
+					bidExtVideo = &openrtb_ext.ExtBidPrebidVideo{
+						Duration:        bidExt.Prebid.Video.Duration,
+						PrimaryCategory: bidExt.Prebid.Video.PrimaryCategory,
+					}
+				}
+			}
+
 			bidderResponse.Bids = append(bidderResponse.Bids, &adapters.TypedBid{
-				Bid:     &bid,
-				BidType: bidType,
+				Bid:      &bid,
+				BidType:  bidType,
+				BidVideo: bidExtVideo,
 			})
 		}
 	}

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -722,3 +722,80 @@ func TestIxMaxRequests(t *testing.T) {
 		t.Fatalf("Should have received %d bid", adapter.maxRequests)
 	}
 }
+
+func TestIxMakeBidsWithCategory(t *testing.T) {
+	bidder := &IxAdapter{}
+
+	mockedReq := &openrtb2.BidRequest{
+		Imp: []openrtb2.Imp{{
+			ID: "1_1",
+			Video: &openrtb2.Video{
+				W:           640,
+				H:           360,
+				MIMEs:       []string{"video/mp4"},
+				MaxDuration: 60,
+				Protocols:   []openrtb2.Protocol{2, 3, 5, 6},
+			},
+			Ext: json.RawMessage(
+				`{
+					"prebid": {},
+					"bidder": {
+						"siteID": 123456
+					}
+				}`,
+			)},
+		},
+	}
+	mockedExtReq := &adapters.RequestData{}
+	mockedBidResponse := &openrtb2.BidResponse{
+		ID: "test-1",
+		SeatBid: []openrtb2.SeatBid{{
+			Seat: "Buyer",
+			Bid: []openrtb2.Bid{{
+				ID:    "1",
+				ImpID: "1_1",
+				Price: 1.23,
+				AdID:  "123",
+				Ext: json.RawMessage(
+					`{
+						"prebid": {
+							"video": {
+							"duration": 60,
+							"primary_category": "IAB18-1"
+							}
+						}
+					}`,
+				),
+			}},
+		}},
+	}
+	body, _ := json.Marshal(mockedBidResponse)
+	mockedRes := &adapters.ResponseData{
+		StatusCode: 200,
+		Body:       body,
+	}
+
+	expectedBidCount := 1
+	expectedBidType := openrtb_ext.BidTypeVideo
+	expectedBidDuration := 60
+	expectedBidCategory := "IAB18-1"
+	expectedErrorCount := 0
+
+	bidResponse, errors := bidder.MakeBids(mockedReq, mockedExtReq, mockedRes)
+
+	if len(bidResponse.Bids) != expectedBidCount {
+		t.Errorf("should have 1 bid, bids=%v", bidResponse.Bids)
+	}
+	if bidResponse.Bids[0].BidType != expectedBidType {
+		t.Errorf("bid type should be video, bidType=%s", bidResponse.Bids[0].BidType)
+	}
+	if bidResponse.Bids[0].BidVideo.Duration != expectedBidDuration {
+		t.Errorf("video duration should be set")
+	}
+	if bidResponse.Bids[0].BidVideo.PrimaryCategory != expectedBidCategory {
+		t.Errorf("video category should be set")
+	}
+	if len(errors) != expectedErrorCount {
+		t.Errorf("should not have any errors, errors=%v", errors)
+	}
+}

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -723,7 +723,7 @@ func TestIxMaxRequests(t *testing.T) {
 	}
 }
 
-func TestIxMakeBidsWithCategory(t *testing.T) {
+func TestIxMakeBidsWithCategoryDuration(t *testing.T) {
 	bidder := &IxAdapter{}
 
 	mockedReq := &openrtb2.BidRequest{
@@ -760,8 +760,8 @@ func TestIxMakeBidsWithCategory(t *testing.T) {
 					`{
 						"prebid": {
 							"video": {
-							"duration": 60,
-							"primary_category": "IAB18-1"
+								"duration": 60,
+								"primary_category": "IAB18-1"
 							}
 						}
 					}`,


### PR DESCRIPTION
- Update IX adapter to set bidVideo if category and duration is available from response for video supply. 