### PR TITLE
Openx: use bidfloor if set - prebid.js adapter behavior 

### DIFF
--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -130,7 +130,9 @@ func preprocess(imp *openrtb.Imp, reqExt *openxReqExt) error {
 	reqExt.Platform = openxExt.Platform
 
 	imp.TagID = openxExt.Unit
-	imp.BidFloor = openxExt.CustomFloor
+	if imp.BidFloor == 0 && openxExt.CustomFloor > 0 {
+		imp.BidFloor = openxExt.CustomFloor
+	}
 	imp.Ext = nil
 
 	if openxExt.CustomParams != nil {

--- a/adapters/openx/openxtest/exemplary/optional-params.json
+++ b/adapters/openx/openxtest/exemplary/optional-params.json
@@ -16,6 +16,21 @@
             "customParams": {"foo": "bar"}
           }
         }
+      },
+      {
+        "bidfloor": 0.5,
+        "id": "test-imp-id",
+        "banner": {
+          "format": [{"w": 728, "h": 90}]
+        },
+        "ext": {
+          "bidder": {
+            "unit": "539439964",
+            "delDomain": "se-demo-d.openx.net",
+            "platform": "PLATFORM",
+            "customFloor": 0.1
+          }
+        }
       }
     ]
   },
@@ -37,6 +52,14 @@
               "ext": {
                 "customParams": {"foo": "bar"}
               }
+            },
+            {
+              "id":"test-imp-id",
+              "banner": {
+                "format": [{"w": 728, "h": 90}]
+              },
+              "tagid": "539439964",
+              "bidfloor": 0.5
             }
           ],
           "ext": {


### PR DESCRIPTION
- Fixes bug that set bidfloor to 0 when customFloor not given (so almost always)
- Implements behavior in https://github.com/prebid/Prebid.js/blob/master/modules/openxBidAdapter.js#L495
- for #1787 