### PR TITLE
Kidoz: Update JSON Schema Reference To Type String

### DIFF
--- a/static/bidder-params/kidoz.json
+++ b/static/bidder-params/kidoz.json
@@ -5,18 +5,14 @@
     "type": "object",
     "properties": {
         "access_token": {
-            "$ref": "#/definitions/non-empty-string",
+            "type": "string",
+            "minLength": 1,
             "description": "Kidoz access_token"
         },
         "publisher_id": {
-            "$ref": "#/definitions/non-empty-string",
-            "description": "Kidoz publisher_id"
-        }
-    },
-    "definitions": {
-        "non-empty-string": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Kidoz publisher_id"
         }
     },
     "required": [


### PR DESCRIPTION
Remove definitions object from schema and define types and other parameters directly in properties objects to ensure compatibility with more downstream systems that use this schema.