### PR TITLE
Bidmachine: Update JSON Schema Reference To Type String

### DIFF
--- a/static/bidder-params/bidmachine.json
+++ b/static/bidder-params/bidmachine.json
@@ -5,22 +5,19 @@
     "type": "object",
     "properties": {
         "host": {
-            "$ref": "#/definitions/non-empty-string",
+            "type": "string",
+            "minLength": 1,
             "description": "Host"
         },
         "path": {
-            "$ref": "#/definitions/non-empty-string",
+            "type": "string",
+            "minLength": 1,
             "description": "URL path"
         },
         "seller_id": {
-            "$ref": "#/definitions/non-empty-string",
-            "description": "Seller Identifier"
-        }
-    },
-    "definitions": {
-        "non-empty-string": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Seller Identifier"
         }
     },
     "required": [


### PR DESCRIPTION
Remove definitions object from schema and define types and other parameters directly in properties objects to ensure compatibility with more downstream systems that use this schema.