### PR TITLE
Outbrain: transform native eventtrackers to imptrackers and jstracker

### DIFF
--- a/adapters/outbrain/outbrain.go
+++ b/adapters/outbrain/outbrain.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/mxmCherry/openrtb/v15/native1"
+	nativeResponse "github.com/mxmCherry/openrtb/v15/native1/response"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
@@ -118,6 +120,20 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 				errs = append(errs, err)
 				continue
 			}
+			if bidType == openrtb_ext.BidTypeNative {
+				var nativePayload nativeResponse.Response
+				if err := json.Unmarshal(json.RawMessage(bid.AdM), &nativePayload); err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				transformEventTrackers(&nativePayload)
+				nativePayloadJson, err := json.Marshal(nativePayload)
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				bid.AdM = string(nativePayloadJson)
+			}
 
 			b := &adapters.TypedBid{
 				Bid:     &bid,
@@ -144,4 +160,21 @@ func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType,
 	return "", &errortypes.BadInput{
 		Message: fmt.Sprintf("Failed to find native/banner impression \"%s\" ", impID),
 	}
+}
+
+func transformEventTrackers(nativePayload *nativeResponse.Response) {
+	// the native-trk.js library used to trigger the trackers currently doesn't support the native 1.2 eventtrackers,
+	// so transform them to the deprecated imptrackers and jstracker
+	for _, eventTracker := range nativePayload.EventTrackers {
+		if eventTracker.Event != native1.EventTypeImpression {
+			continue
+		}
+		switch eventTracker.Method {
+		case native1.EventTrackingMethodImage:
+			nativePayload.ImpTrackers = append(nativePayload.ImpTrackers, eventTracker.URL)
+		case native1.EventTrackingMethodJS:
+			nativePayload.JSTracker = fmt.Sprintf("<script src=\"%s\"></script>", eventTracker.URL)
+		}
+	}
+	nativePayload.EventTrackers = nil
 }

--- a/adapters/outbrain/outbraintest/exemplary/native.json
+++ b/adapters/outbrain/outbraintest/exemplary/native.json
@@ -73,7 +73,7 @@
                   "impid": "test-imp-id",
                   "price": 1000,
                   "nurl": "http://example.com/win/1000",
-                  "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":3,\"required\":1,\"img\":{\"url\":\"http://example.com/img/url\",\"w\":120,\"h\":100}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Test title\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://example.com/click/url\"},\"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
+                  "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":3,\"required\":1,\"img\":{\"url\":\"http://example.com/img/url\",\"w\":120,\"h\":100}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Test title\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://example.com/click/url\"},\"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"},{\"event\":1,\"method\":2,\"url\":\"http://example.com/impression\"}]}",
                   "adomain": [
                     "example.com"
                   ],
@@ -81,9 +81,7 @@
                   "crid": "test-crid",
                   "cat": [
                     "IAB13-4"
-                  ],
-                  "w": 300,
-                  "h": 250
+                  ]
                 }
               ],
               "seat": "acc-1876"
@@ -105,7 +103,7 @@
             "impid": "test-imp-id",
             "price": 1000,
             "nurl": "http://example.com/win/1000",
-            "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":3,\"required\":1,\"img\":{\"url\":\"http://example.com/img/url\",\"w\":120,\"h\":100}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Test title\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://example.com/click/url\"},\"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
+            "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":3,\"required\":1,\"img\":{\"url\":\"http://example.com/img/url\",\"w\":120,\"h\":100}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Test title\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://example.com/click/url\"},\"imptrackers\":[\"http://example.com/impression\"],\"jstracker\":\"\\u003cscript src=\\\"http://example.com/impression\\\"\\u003e\\u003c/script\\u003e\"}",
             "adomain": [
               "example.com"
             ],
@@ -113,9 +111,7 @@
             "crid": "test-crid",
             "cat": [
               "IAB13-4"
-            ],
-            "w": 300,
-            "h": 250
+            ]
           },
           "type": "native"
         }


### PR DESCRIPTION
Since the PUC native-trk library doesn't support eventtrackers, this PR transforms them to the deprecated imptrackers and jstracker for the outbrain adapter.