### PR TITLE
Add Madvertise Adapter

### DIFF
--- a/adapters/madvertise/madvertise.go
+++ b/adapters/madvertise/madvertise.go
@@ -1,0 +1,170 @@
+package madvertise
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"text/template"
+
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/errortypes"
+	"github.com/prebid/prebid-server/macros"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type adapter struct {
+	endpointTemplate template.Template
+}
+
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters.Bidder, error) {
+	template, err := template.New("endpointTemplate").Parse(config.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse endpoint url template: %v", err)
+	}
+
+	bidder := &adapter{
+		endpointTemplate: *template,
+	}
+
+	return bidder, nil
+}
+
+func getHeaders(request *openrtb2.BidRequest) *http.Header {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+	headers.Add("X-Openrtb-Version", "2.5")
+
+	if request.Device != nil {
+		if len(request.Device.UA) > 0 {
+			headers.Add("User-Agent", request.Device.UA)
+		}
+
+		if len(request.Device.IP) > 0 {
+			headers.Add("X-Forwarded-For", request.Device.IP)
+		}
+	}
+
+	return &headers
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	placementID := ""
+	for _, imp := range request.Imp {
+		madvertiseExt, err := getImpressionExt(imp)
+		if err != nil {
+			return nil, []error{err}
+		}
+		if madvertiseExt.PlacementId != "" {
+			if placementID == "" {
+				placementID = madvertiseExt.PlacementId
+			} else if placementID != madvertiseExt.PlacementId {
+				return nil, []error{&errortypes.BadInput{
+					Message: "There must be only one placement ID",
+				}}
+			}
+		} else {
+			return nil, []error{&errortypes.BadInput{
+				Message: "The placement ID must not be empty",
+			}}
+		}
+		// request.Imp[idx].TagID = madvertiseExt.PlacementId
+	}
+
+	url, err := a.buildEndpointURL(placementID)
+	if err != nil {
+		return nil, []error{err}
+	}
+	var errors = make([]error, 0)
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		errors = append(errors, err)
+		return nil, errors
+	}
+
+	requestData := &adapters.RequestData{
+		Method:  "POST",
+		Uri:     url,
+		Body:    requestJSON,
+		Headers: *getHeaders(request),
+	}
+
+	return []*adapters.RequestData{requestData}, nil
+}
+
+func getImpressionExt(imp openrtb2.Imp) (*openrtb_ext.ExtImpMadvertise, error) {
+	var bidderExt adapters.ExtImpBidder
+	if err := json.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return nil, &errortypes.BadInput{
+			Message: "Bidder extension not provided or can't be unmarshalled",
+		}
+	}
+
+	var onetagExt openrtb_ext.ExtImpMadvertise
+	if err := json.Unmarshal(bidderExt.Bidder, &onetagExt); err != nil {
+		return nil, &errortypes.BadInput{
+			Message: "Error while unmarshaling bidder extension",
+		}
+	}
+
+	return &onetagExt, nil
+}
+
+func (a *adapter) buildEndpointURL(placementID string) (string, error) {
+	endpointParams := macros.EndpointTemplateParams{ZoneID: placementID}
+	return macros.ResolveMacros(a.endpointTemplate, endpointParams)
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if responseData.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	if responseData.StatusCode != http.StatusOK {
+		err := &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info", responseData.StatusCode),
+		}
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := json.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	bidResponse.Currency = response.Cur
+	for _, seatBid := range response.SeatBid {
+		for _, bid := range seatBid.Bid {
+			bidMediaType, err := getMediaTypeForBid(request.Imp, bid)
+			if err != nil {
+				return nil, []error{err}
+			}
+			b := &adapters.TypedBid{
+				Bid:     &bid,
+				BidType: bidMediaType,
+			}
+			bidResponse.Bids = append(bidResponse.Bids, b)
+		}
+	}
+	return bidResponse, nil
+}
+
+func getMediaTypeForBid(impressions []openrtb2.Imp, bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	for _, impression := range impressions {
+		if impression.ID == bid.ImpID {
+			if impression.Banner != nil {
+				return openrtb_ext.BidTypeBanner, nil
+			}
+			if impression.Video != nil {
+				return openrtb_ext.BidTypeVideo, nil
+			}
+		}
+	}
+
+	return "", &errortypes.BadServerResponse{
+		Message: fmt.Sprintf("The impression with ID %s is not present into the request", bid.ImpID),
+	}
+}

--- a/adapters/madvertise/madvertise_test.go
+++ b/adapters/madvertise/madvertise_test.go
@@ -1,0 +1,26 @@
+package madvertise
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/adapters/adapterstest"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointTemplateMalformed(t *testing.T) {
+	_, buildErr := Builder(openrtb_ext.BidderMadvertise, config.Adapter{
+		Endpoint: "{{Malformed}}"})
+
+	assert.Error(t, buildErr)
+}
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderMadvertise, config.Adapter{
+		Endpoint: "https://mobile-mng-ads.com/bidrequest{{.ZoneID}}"})
+
+	assert.NoError(t, buildErr, "Builder returned unexpected error %v", buildErr)
+
+	adapterstest.RunJSONBidderTest(t, "madvertisetest", bidder)
+}

--- a/adapters/madvertise/madvertisetest/exemplary/simple-banner.json
+++ b/adapters/madvertise/madvertisetest/exemplary/simple-banner.json
@@ -1,0 +1,203 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "tmax": 500,
+        "at": 1,
+        "cur": [
+            "EUR"
+        ],
+        "regs": {
+            "ext": {
+                "gdpr": 1
+            }
+        },
+        "user": {
+            "ext": {
+                "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+            }
+        },
+        "app": {
+            "id": "9561622",
+            "bundle": "com.madvertise.bluestack",
+            "name": "FR_BlueStack_App_Android_MNG",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack"
+        },
+        "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent",
+            "dnt": 0,
+            "lmt": 0,
+            "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+            "make": "Sony",
+            "model": "G8441",
+            "os": "Android",
+            "osv": "9.0",
+            "devicetype": 4,
+            "connectiontype": 6,
+            "js": 1,
+            "carrier": "Free",
+            "geo": {
+                "type": 2,
+                "country": "FRA"
+            }
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "secure": 1,
+                "bidfloor": 3,
+                "bidfloorcur": "EUR",
+                "instl": 0,
+                "banner": {
+                    "h": 50,
+                    "w": 320,
+                    "pos": 1
+                },
+                "ext": {
+                    "bidder": {
+                        "placementId": "/1111111/banner"
+                    }
+                }
+            }
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://mobile-mng-ads.com/bidrequest/1111111/banner",
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Openrtb-Version": [
+                        "2.5"
+                    ],
+                    "User-Agent": [
+                        "test-user-agent"
+                    ],
+                    "X-Forwarded-For": [
+                        "123.123.123.123"
+                    ]
+                },
+                "body": {
+                    "id": "test-request-id",
+                    "tmax": 500,
+                    "at": 1,
+                    "cur": [
+                        "EUR"
+                    ],
+                    "regs": {
+                        "ext": {
+                            "gdpr": 1
+                        }
+                    },
+                    "user": {
+                        "ext": {
+                            "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+                        }
+                    },
+                    "app": {
+                        "id": "9561622",
+                        "bundle": "com.madvertise.bluestack",
+                        "name": "FR_BlueStack_App_Android_MNG",
+                        "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack"
+                    },
+                    "device": {
+                        "ip": "123.123.123.123",
+                        "ua": "test-user-agent",
+                        "dnt": 0,
+                        "lmt": 0,
+                        "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+                        "make": "Sony",
+                        "model": "G8441",
+                        "os": "Android",
+                        "osv": "9.0",
+                        "devicetype": 4,
+                        "connectiontype": 6,
+                        "js": 1,
+                        "carrier": "Free",
+                        "geo": {
+                            "type": 2,
+                            "country": "FRA"
+                        }
+                    },
+                    "imp": [
+                        {
+                            "id": "test-imp-id",
+                            "secure": 1,
+                            "bidfloor": 3,
+                            "bidfloorcur": "EUR",
+                            "banner": {
+                                "h": 50,
+                                "w": 320,
+                                "pos": 1
+                            },
+                            "ext": {
+                                "bidder": {
+                                    "placementId": "/1111111/banner"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "test-request-id",
+                    "seatbid": [
+                        {
+                            "bid": [
+                                {
+                                    "id": "test_bid_id",
+                                    "impid": "test-imp-id",
+                                    "price": 0.27543,
+                                    "adm": "some-test-ad",
+                                    "cid": "test_cid",
+                                    "crid": "test_crid",
+                                    "dealid": "test_dealid",
+                                    "burl": "https://burl.com",
+                                    "adomain": [
+                                        "madvertise.com"
+                                    ],
+                                    "w": 320,
+                                    "h": 50
+                                }
+                            ],
+                            "seat": "adman"
+                        }
+                    ],
+                    "cur": "EUR"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "EUR",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "test_bid_id",
+                        "impid": "test-imp-id",
+                        "price": 0.27543,
+                        "adm": "some-test-ad",
+                        "cid": "test_cid",
+                        "crid": "test_crid",
+                        "dealid": "test_dealid",
+                        "burl": "https://burl.com",
+                        "adomain": [
+                            "madvertise.com"
+                        ],
+                        "w": 320,
+                        "h": 50
+                    },
+                    "type": "banner"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/madvertise/madvertisetest/exemplary/simple-video.json
+++ b/adapters/madvertise/madvertisetest/exemplary/simple-video.json
@@ -1,0 +1,254 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "tmax": 500,
+        "at": 2,
+        "cur": [
+            "EUR"
+        ],
+        "regs": {
+            "ext": {
+                "gdpr": 1
+            }
+        },
+        "user": {
+            "ext": {
+                "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+            }
+        },
+        "app": {
+            "id": "9561622",
+            "bundle": "com.madvertise.bluestack",
+            "name": "FR_BlueStack_App_Android_MNG",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+            "cat": [
+                "IAB6",
+                "IAB9",
+                "IAB10",
+                "IAB12",
+                "IAB14",
+                "IAB20"
+            ]
+        },
+        "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent",
+            "dnt": 0,
+            "lmt": 0,
+            "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+            "make": "Sony",
+            "model": "G8441",
+            "os": "Android",
+            "osv": "9.0",
+            "devicetype": 4,
+            "connectiontype": 6,
+            "js": 1,
+            "carrier": "Free",
+            "geo": {
+                "type": 2,
+                "country": "FRA"
+            }
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "secure": 1,
+                "bidfloor": 3,
+                "bidfloorcur": "EUR",
+                "instl": 0,
+                "video": {
+                    "mimes": [
+                        "video/mp4"
+                    ],
+                    "w": 320,
+                    "h": 480,
+                    "minduration": 2,
+                    "maxduration": 30,
+                    "playbackmethod": [
+                        1,
+                        3
+                    ],
+                    "boxingallowed": 0,
+                    "protocols": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6
+                    ],
+                    "placement": 5
+                },
+                "ext": {
+                    "bidder": {
+                        "placementId": "/1111111/banner"
+                    }
+                }
+            }
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://mobile-mng-ads.com/bidrequest/1111111/banner",
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Openrtb-Version": [
+                        "2.5"
+                    ],
+                    "User-Agent": [
+                        "test-user-agent"
+                    ],
+                    "X-Forwarded-For": [
+                        "123.123.123.123"
+                    ]
+                },
+                "body": {
+                    "id": "test-request-id",
+                    "tmax": 500,
+                    "at": 2,
+                    "cur": [
+                        "EUR"
+                    ],
+                    "regs": {
+                        "ext": {
+                            "gdpr": 1
+                        }
+                    },
+                    "user": {
+                        "ext": {
+                            "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+                        }
+                    },
+                    "app": {
+                        "id": "9561622",
+                        "bundle": "com.madvertise.bluestack",
+                        "name": "FR_BlueStack_App_Android_MNG",
+                        "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+                        "cat": [
+                            "IAB6",
+                            "IAB9",
+                            "IAB10",
+                            "IAB12",
+                            "IAB14",
+                            "IAB20"
+                        ]
+                    },
+                    "device": {
+                        "ip": "123.123.123.123",
+                        "ua": "test-user-agent",
+                        "dnt": 0,
+                        "lmt": 0,
+                        "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+                        "make": "Sony",
+                        "model": "G8441",
+                        "os": "Android",
+                        "osv": "9.0",
+                        "devicetype": 4,
+                        "connectiontype": 6,
+                        "js": 1,
+                        "carrier": "Free",
+                        "geo": {
+                            "type": 2,
+                            "country": "FRA"
+                        }
+                    },
+                    "imp": [
+                        {
+                            "id": "test-imp-id",
+                            "secure": 1,
+                            "bidfloor": 3,
+                            "bidfloorcur": "EUR",
+                            "video": {
+                                "mimes": [
+                                    "video/mp4"
+                                ],
+                                "w": 320,
+                                "h": 480,
+                                "minduration": 2,
+                                "maxduration": 30,
+                                "playbackmethod": [
+                                    1,
+                                    3
+                                ],
+                                "protocols": [
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "placement": 5
+                            },
+                            "ext": {
+                                "bidder": {
+                                    "placementId": "/1111111/banner"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "test-request-id",
+                    "seatbid": [
+                        {
+                            "bid": [
+                                {
+                                    "id": "test_bid_id",
+                                    "impid": "test-imp-id",
+                                    "price": 0.27543,
+                                    "adm": "some-test-ad",
+                                    "cid": "test_cid",
+                                    "crid": "test_crid",
+                                    "dealid": "test_dealid",
+                                    "burl": "https://burl.com",
+                                    "adomain": [
+                                        "madvertise.com"
+                                    ],
+                                    "w": 320,
+                                    "h": 480
+                                }
+                            ],
+                            "seat": "adman"
+                        }
+                    ],
+                    "cur": "EUR"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "EUR",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "test_bid_id",
+                        "impid": "test-imp-id",
+                        "price": 0.27543,
+                        "adm": "some-test-ad",
+                        "cid": "test_cid",
+                        "crid": "test_crid",
+                        "dealid": "test_dealid",
+                        "burl": "https://burl.com",
+                        "adomain": [
+                            "madvertise.com"
+                        ],
+                        "w": 320,
+                        "h": 480
+                    },
+                    "type": "video"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/madvertise/madvertisetest/params/race/banner.json
+++ b/adapters/madvertise/madvertisetest/params/race/banner.json
@@ -1,0 +1,4 @@
+{
+  "placementId": "/1111111/banner"
+}
+  

--- a/adapters/madvertise/madvertisetest/params/race/video.json
+++ b/adapters/madvertise/madvertisetest/params/race/video.json
@@ -1,0 +1,3 @@
+{
+  "placementId": "/1111111/video"
+}

--- a/adapters/madvertise/madvertisetest/supplemental/empty-placement-id.json
+++ b/adapters/madvertise/madvertisetest/supplemental/empty-placement-id.json
@@ -1,0 +1,29 @@
+{
+    "mockBidRequest": {
+        "id": "test-no-placement-id",
+        "imp": [
+            {
+                "id": "test-imp-id-no-placement-id",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 728,
+                            "h": 90
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "publisherId": "1"
+                    }
+                }
+            }
+        ]
+    },
+    "expectedMakeRequestsErrors": [
+        {
+            "value": "The placement ID must not be empty",
+            "comparison": "literal"
+        }
+    ]
+}

--- a/adapters/madvertise/madvertisetest/supplemental/request-no-bidder-object.json
+++ b/adapters/madvertise/madvertisetest/supplemental/request-no-bidder-object.json
@@ -1,0 +1,21 @@
+{
+  "mockBidRequest": {
+    "id": "test-no-bidder",
+    "imp": [
+      {
+        "id": "test-imp-id-no-bidder",
+        "banner": {
+          "format": [{"w": 728, "h": 90}]
+        },
+        "ext": {
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Error while unmarshaling bidder extension",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/madvertise/madvertisetest/supplemental/required-placement-id.json
+++ b/adapters/madvertise/madvertisetest/supplemental/required-placement-id.json
@@ -1,0 +1,27 @@
+{
+    "mockBidRequest": {
+        "id": "test-no-placement-id",
+        "imp": [
+            {
+                "id": "test-imp-id-no-placement-id",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 728,
+                            "h": 90
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {}
+                }
+            }
+        ]
+    },
+    "expectedMakeRequestsErrors": [
+        {
+            "value": "The placement ID must not be empty",
+            "comparison": "literal"
+        }
+    ]
+}

--- a/adapters/madvertise/madvertisetest/supplemental/response-204.json
+++ b/adapters/madvertise/madvertisetest/supplemental/response-204.json
@@ -1,0 +1,189 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "tmax": 500,
+        "at": 2,
+        "cur": [
+            "EUR"
+        ],
+        "regs": {
+            "ext": {
+                "gdpr": 1
+            }
+        },
+        "user": {
+            "ext": {
+                "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+            }
+        },
+        "app": {
+            "id": "9561622",
+            "bundle": "com.madvertise.bluestack",
+            "name": "FR_BlueStack_App_Android_MNG",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+            "cat": [
+                "IAB6",
+                "IAB9",
+                "IAB10",
+                "IAB12",
+                "IAB14",
+                "IAB20"
+            ]
+        },
+        "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent",
+            "dnt": 0,
+            "lmt": 0,
+            "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+            "make": "Sony",
+            "model": "G8441",
+            "os": "Android",
+            "osv": "9.0",
+            "devicetype": 4,
+            "connectiontype": 6,
+            "js": 1,
+            "carrier": "Free",
+            "geo": {
+                "type": 2,
+                "country": "FRA"
+            }
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "secure": 1,
+                "bidfloor": 3,
+                "bidfloorcur": "EUR",
+                "instl": 0,
+                "banner": {
+                    "format": [
+                        {
+                            "w": 320,
+                            "h": 50
+                        }
+                    ],
+                    "w": 320,
+                    "h": 50,
+                    "api": [
+                        3,
+                        5,
+                        6
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "placementId": "/1111111/banner"
+                    }
+                }
+            }
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://mobile-mng-ads.com/bidrequest/1111111/banner",
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Openrtb-Version": [
+                        "2.5"
+                    ],
+                    "User-Agent": [
+                        "test-user-agent"
+                    ],
+                    "X-Forwarded-For": [
+                        "123.123.123.123"
+                    ]
+                },
+                "body": {
+                    "id": "test-request-id",
+                    "tmax": 500,
+                    "at": 2,
+                    "cur": [
+                        "EUR"
+                    ],
+                    "regs": {
+                        "ext": {
+                            "gdpr": 1
+                        }
+                    },
+                    "user": {
+                        "ext": {
+                            "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+                        }
+                    },
+                    "app": {
+                        "id": "9561622",
+                        "bundle": "com.madvertise.bluestack",
+                        "name": "FR_BlueStack_App_Android_MNG",
+                        "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+                        "cat": [
+                            "IAB6",
+                            "IAB9",
+                            "IAB10",
+                            "IAB12",
+                            "IAB14",
+                            "IAB20"
+                        ]
+                    },
+                    "device": {
+                        "ip": "123.123.123.123",
+                        "ua": "test-user-agent",
+                        "dnt": 0,
+                        "lmt": 0,
+                        "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+                        "make": "Sony",
+                        "model": "G8441",
+                        "os": "Android",
+                        "osv": "9.0",
+                        "devicetype": 4,
+                        "connectiontype": 6,
+                        "js": 1,
+                        "carrier": "Free",
+                        "geo": {
+                            "type": 2,
+                            "country": "FRA"
+                        }
+                    },
+                    "imp": [
+                        {
+                            "id": "test-imp-id",
+                            "secure": 1,
+                            "bidfloor": 3,
+                            "bidfloorcur": "EUR",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 320,
+                                        "h": 50
+                                    }
+                                ],
+                                "w": 320,
+                                "h": 50,
+                                "api": [
+                                    3,
+                                    5,
+                                    6
+                                ]
+                            },
+                            "ext": {
+                                "bidder": {
+                                    "placementId": "/1111111/banner"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 204
+            }
+        }
+    ],
+    "expectedBidResponses": []
+}

--- a/adapters/madvertise/madvertisetest/supplemental/response-400.json
+++ b/adapters/madvertise/madvertisetest/supplemental/response-400.json
@@ -1,0 +1,194 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "tmax": 500,
+        "at": 2,
+        "cur": [
+            "EUR"
+        ],
+        "regs": {
+            "ext": {
+                "gdpr": 1
+            }
+        },
+        "user": {
+            "ext": {
+                "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+            }
+        },
+        "app": {
+            "id": "9561622",
+            "bundle": "com.madvertise.bluestack",
+            "name": "FR_BlueStack_App_Android_MNG",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+            "cat": [
+                "IAB6",
+                "IAB9",
+                "IAB10",
+                "IAB12",
+                "IAB14",
+                "IAB20"
+            ]
+        },
+        "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent",
+            "dnt": 0,
+            "lmt": 0,
+            "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+            "make": "Sony",
+            "model": "G8441",
+            "os": "Android",
+            "osv": "9.0",
+            "devicetype": 4,
+            "connectiontype": 6,
+            "js": 1,
+            "carrier": "Free",
+            "geo": {
+                "type": 2,
+                "country": "FRA"
+            }
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "secure": 1,
+                "bidfloor": 3,
+                "bidfloorcur": "EUR",
+                "instl": 0,
+                "banner": {
+                    "format": [
+                        {
+                            "w": 320,
+                            "h": 50
+                        }
+                    ],
+                    "w": 320,
+                    "h": 50,
+                    "api": [
+                        3,
+                        5,
+                        6
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "placementId": "/1111111/banner"
+                    }
+                }
+            }
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://mobile-mng-ads.com/bidrequest/1111111/banner",
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Openrtb-Version": [
+                        "2.5"
+                    ],
+                    "User-Agent": [
+                        "test-user-agent"
+                    ],
+                    "X-Forwarded-For": [
+                        "123.123.123.123"
+                    ]
+                },
+                "body": {
+                    "id": "test-request-id",
+                    "tmax": 500,
+                    "at": 2,
+                    "cur": [
+                        "EUR"
+                    ],
+                    "regs": {
+                        "ext": {
+                            "gdpr": 1
+                        }
+                    },
+                    "user": {
+                        "ext": {
+                            "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+                        }
+                    },
+                    "app": {
+                        "id": "9561622",
+                        "bundle": "com.madvertise.bluestack",
+                        "name": "FR_BlueStack_App_Android_MNG",
+                        "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+                        "cat": [
+                            "IAB6",
+                            "IAB9",
+                            "IAB10",
+                            "IAB12",
+                            "IAB14",
+                            "IAB20"
+                        ]
+                    },
+                    "device": {
+                        "ip": "123.123.123.123",
+                        "ua": "test-user-agent",
+                        "dnt": 0,
+                        "lmt": 0,
+                        "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+                        "make": "Sony",
+                        "model": "G8441",
+                        "os": "Android",
+                        "osv": "9.0",
+                        "devicetype": 4,
+                        "connectiontype": 6,
+                        "js": 1,
+                        "carrier": "Free",
+                        "geo": {
+                            "type": 2,
+                            "country": "FRA"
+                        }
+                    },
+                    "imp": [
+                        {
+                            "id": "test-imp-id",
+                            "secure": 1,
+                            "bidfloor": 3,
+                            "bidfloorcur": "EUR",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 320,
+                                        "h": 50
+                                    }
+                                ],
+                                "w": 320,
+                                "h": 50,
+                                "api": [
+                                    3,
+                                    5,
+                                    6
+                                ]
+                            },
+                            "ext": {
+                                "bidder": {
+                                    "placementId": "/1111111/banner"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 400
+            }
+        }
+    ],
+    "expectedMakeBidsErrors": [
+        {
+            "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+            "comparison": "literal"
+        }
+    ]
+}

--- a/adapters/madvertise/madvertisetest/supplemental/response-500.json
+++ b/adapters/madvertise/madvertisetest/supplemental/response-500.json
@@ -1,0 +1,194 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "tmax": 500,
+        "at": 2,
+        "cur": [
+            "EUR"
+        ],
+        "regs": {
+            "ext": {
+                "gdpr": 1
+            }
+        },
+        "user": {
+            "ext": {
+                "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+            }
+        },
+        "app": {
+            "id": "9561622",
+            "bundle": "com.madvertise.bluestack",
+            "name": "FR_BlueStack_App_Android_MNG",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+            "cat": [
+                "IAB6",
+                "IAB9",
+                "IAB10",
+                "IAB12",
+                "IAB14",
+                "IAB20"
+            ]
+        },
+        "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent",
+            "dnt": 0,
+            "lmt": 0,
+            "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+            "make": "Sony",
+            "model": "G8441",
+            "os": "Android",
+            "osv": "9.0",
+            "devicetype": 4,
+            "connectiontype": 6,
+            "js": 1,
+            "carrier": "Free",
+            "geo": {
+                "type": 2,
+                "country": "FRA"
+            }
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "secure": 1,
+                "bidfloor": 3,
+                "bidfloorcur": "EUR",
+                "instl": 0,
+                "banner": {
+                    "format": [
+                        {
+                            "w": 320,
+                            "h": 50
+                        }
+                    ],
+                    "w": 320,
+                    "h": 50,
+                    "api": [
+                        3,
+                        5,
+                        6
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "placementId": "/1111111/banner"
+                    }
+                }
+            }
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://mobile-mng-ads.com/bidrequest/1111111/banner",
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Openrtb-Version": [
+                        "2.5"
+                    ],
+                    "User-Agent": [
+                        "test-user-agent"
+                    ],
+                    "X-Forwarded-For": [
+                        "123.123.123.123"
+                    ]
+                },
+                "body": {
+                    "id": "test-request-id",
+                    "tmax": 500,
+                    "at": 2,
+                    "cur": [
+                        "EUR"
+                    ],
+                    "regs": {
+                        "ext": {
+                            "gdpr": 1
+                        }
+                    },
+                    "user": {
+                        "ext": {
+                            "consent": "CO-X2XiO_eyUoAsAxBFRBECsAP_AAH_AAAqIGMgB7CpERSNAYWApAOMAKYhfQAACAGAABAYIASgBQQBAMJQEkGAIMAjAAAAKAAAEACQAAAAgCAGAAAAAAAAAAQCMAAAAABAAACAAAAASAAAACAAACACSCAAQjAAAAAEAgAAAAAIF5wJwAFgAPAAqABcADIAHAAQAAqABiADQAHkARABFACeAFKALgAugBiADaAG8AOYAfwBCAClAGqANcAdQA_QCBgEIAIsARwAq4BgADZAHyAP-Aj0BUwC6gF5gCAoAYBEAC4AKpCQAwCIAFwAVSIgAgABFQAQAAg"
+                        }
+                    },
+                    "app": {
+                        "id": "9561622",
+                        "bundle": "com.madvertise.bluestack",
+                        "name": "FR_BlueStack_App_Android_MNG",
+                        "storeurl": "https://play.google.com/store/apps/details?id=com.madvertise.bluestack",
+                        "cat": [
+                            "IAB6",
+                            "IAB9",
+                            "IAB10",
+                            "IAB12",
+                            "IAB14",
+                            "IAB20"
+                        ]
+                    },
+                    "device": {
+                        "ip": "123.123.123.123",
+                        "ua": "test-user-agent",
+                        "dnt": 0,
+                        "lmt": 0,
+                        "ifa": "b879a967-cccc-bbbb-aaaa-1aa111111111",
+                        "make": "Sony",
+                        "model": "G8441",
+                        "os": "Android",
+                        "osv": "9.0",
+                        "devicetype": 4,
+                        "connectiontype": 6,
+                        "js": 1,
+                        "carrier": "Free",
+                        "geo": {
+                            "type": 2,
+                            "country": "FRA"
+                        }
+                    },
+                    "imp": [
+                        {
+                            "id": "test-imp-id",
+                            "secure": 1,
+                            "bidfloor": 3,
+                            "bidfloorcur": "EUR",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 320,
+                                        "h": 50
+                                    }
+                                ],
+                                "w": 320,
+                                "h": 50,
+                                "api": [
+                                    3,
+                                    5,
+                                    6
+                                ]
+                            },
+                            "ext": {
+                                "bidder": {
+                                    "placementId": "/1111111/banner"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 500
+            }
+        }
+    ],
+    "expectedMakeBidsErrors": [
+        {
+            "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+            "comparison": "literal"
+        }
+    ]
+}

--- a/adapters/madvertise/params_test.go
+++ b/adapters/madvertise/params_test.go
@@ -1,0 +1,54 @@
+package madvertise
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+// This file actually intends to test static/bidder-params/Madvertise.json
+//
+// These also validate the format of the external API: request.imp[i].ext.Madvertise
+
+// TestValidParams makes sure that the Madvertise schema accepts all imp.ext fields which we intend to support.
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderMadvertise, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected Madvertise params: %s \n Error: %s", validParam, err)
+		}
+	}
+}
+
+// TestInvalidParams makes sure that the Madvertise schema rejects all the imp.ext fields we don't support.
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderMadvertise, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"placementId":"/1753588/banner"}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`[]`,
+	`{}`,
+	`{"placementId":""}`,
+	`{"placementId":/1753588/banner`,
+}

--- a/config/config.go
+++ b/config/config.go
@@ -616,6 +616,7 @@ func (cfg *Configuration) setDerivedDefaults() {
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderLockerDome, "https://lockerdome.com/usync/prebidserver?pid="+cfg.Adapters["lockerdome"].PlatformID+"&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dlockerdome%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7B%7Buid%7D%7D")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderLogicad, "https://cr-p31.ladsp.jp/cookiesender/31?r=true&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ru="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dlogicad%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderLunaMedia, "https://api.lunamedia.io/xp/user-sync?redirect="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dlunamedia%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24UID")
+	// openrtb_ext.BidderMadvertise doesn't have a good default.
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderMarsmedia, "https://dmp.rtbsrv.com/dmp/profiles/cm?p_id=179&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dmarsmedia%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%24%7BUUID%7D")
 	// openrtb_ext.BidderMediafuse doesn't have a good default.
 	setDefaultUsersync(cfg.Adapters, openrtb_ext.BidderMgid, "https://cm.mgid.com/m?cdsp=363893&adu="+url.QueryEscape(externalURL)+"%2Fsetuid%3Fbidder%3Dmgid%26gdpr%3D{{.GDPR}}%26gdpr_consent%3D{{.GDPRConsent}}%26uid%3D%7Bmuidn%7D")
@@ -869,6 +870,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.lockerdome.endpoint", "https://lockerdome.com/ladbid/prebidserver/openrtb2")
 	v.SetDefault("adapters.logicad.endpoint", "https://pbs.ladsp.com/adrequest/prebidserver")
 	v.SetDefault("adapters.lunamedia.endpoint", "http://api.lunamedia.io/xp/get?pubid={{.PublisherID}}")
+	v.SetDefault("adapters.madvertise.endpoint", "https://mobile-mng-ads.com/bidrequest{{.ZoneID}}")
 	v.SetDefault("adapters.marsmedia.endpoint", "https://bid306.rtbsrv.com/bidder/?bid=f3xtet")
 	v.SetDefault("adapters.mediafuse.endpoint", "http://ghb.hbmp.mediafuse.com/pbs/ortb")
 	v.SetDefault("adapters.mgid.endpoint", "https://prebid.mgid.com/prebid/")

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -2,7 +2,7 @@ package exchange
 
 import (
 	"github.com/prebid/prebid-server/adapters"
-	ttx "github.com/prebid/prebid-server/adapters/33across"
+	"github.com/prebid/prebid-server/adapters/33across"
 	"github.com/prebid/prebid-server/adapters/acuityads"
 	"github.com/prebid/prebid-server/adapters/adf"
 	"github.com/prebid/prebid-server/adapters/adform"
@@ -62,6 +62,7 @@ import (
 	"github.com/prebid/prebid-server/adapters/lockerdome"
 	"github.com/prebid/prebid-server/adapters/logicad"
 	"github.com/prebid/prebid-server/adapters/lunamedia"
+	"github.com/prebid/prebid-server/adapters/madvertise"
 	"github.com/prebid/prebid-server/adapters/marsmedia"
 	"github.com/prebid/prebid-server/adapters/mgid"
 	"github.com/prebid/prebid-server/adapters/mobfoxpb"
@@ -175,6 +176,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderLockerDome:       lockerdome.Builder,
 		openrtb_ext.BidderLogicad:          logicad.Builder,
 		openrtb_ext.BidderLunaMedia:        lunamedia.Builder,
+		openrtb_ext.BidderMadvertise:       madvertise.Builder,
 		openrtb_ext.BidderMarsmedia:        marsmedia.Builder,
 		openrtb_ext.BidderMediafuse:        adtelligent.Builder,
 		openrtb_ext.BidderMgid:             mgid.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -134,6 +134,7 @@ const (
 	BidderLockerDome       BidderName = "lockerdome"
 	BidderLogicad          BidderName = "logicad"
 	BidderLunaMedia        BidderName = "lunamedia"
+	BidderMadvertise       BidderName = "madvertise"
 	BidderMarsmedia        BidderName = "marsmedia"
 	BidderMediafuse        BidderName = "mediafuse"
 	BidderMgid             BidderName = "mgid"
@@ -247,6 +248,7 @@ func CoreBidderNames() []BidderName {
 		BidderLockerDome,
 		BidderLogicad,
 		BidderLunaMedia,
+		BidderMadvertise,
 		BidderMarsmedia,
 		BidderMediafuse,
 		BidderMgid,

--- a/openrtb_ext/imp_madvertise.go
+++ b/openrtb_ext/imp_madvertise.go
@@ -1,0 +1,6 @@
+package openrtb_ext
+
+// ExtImpMadvertise defines the contract for bidrequest.imp[i].ext.madvertise
+type ExtImpMadvertise struct {
+	PlacementId string `json:"placementId"`
+}

--- a/static/bidder-info/madvertise.yaml
+++ b/static/bidder-info/madvertise.yaml
@@ -1,0 +1,11 @@
+maintainer:
+  email: "support@madvertise.com"
+gvlVendorID: 153
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+  site:
+    mediaTypes:
+      - banner

--- a/static/bidder-params/madvertise.json
+++ b/static/bidder-params/madvertise.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Madvertise Adapter Params",
+    "description": "A schema which validates params accepted by the Madvertise adapter",
+    "type": "object",
+    "properties": {
+        "placementId": {
+            "type": "string",
+            "minLength": 7,
+            "description": "The placement’s ID provided by Madvertise"
+        }
+    },
+    "required": [
+        "placementId"
+    ]
+}

--- a/usersync/usersyncers/syncer_test.go
+++ b/usersync/usersyncers/syncer_test.go
@@ -116,6 +116,7 @@ func TestNewSyncerMap(t *testing.T) {
 		openrtb_ext.BidderInMobi:       true,
 		openrtb_ext.BidderKidoz:        true,
 		openrtb_ext.BidderKubient:      true,
+		openrtb_ext.BidderMadvertise:   true,
 		openrtb_ext.BidderMobfoxpb:     true,
 		openrtb_ext.BidderMobileFuse:   true,
 		openrtb_ext.BidderOrbidder:     true,


### PR DESCRIPTION
Hello,

We Add Madvertise Prebid Server to existing Prebid.js adapter. PR linked to Add Prebid Server support for Madvertise Adapter #2925

See testing placementId

`curl --request POST \
 --url 'http://localhost:8000/openrtb2/auction' \
 --header 'Content-Type: application/json' \
 --header 'X-Openrtb-Version: 2.5' \
 --header 'X-Forwarded-For: 91.165.240.140' \
 --data '{
   "id": "some-request-id",
   "test": 1,
   "site": {
     "page": "prebid.org"
   },
   "imp": [{
     "id": "some-impression-id",
     "banner": {
       "format": [{
         "w": 600,
         "h": 500
       }, {
         "w": 300,
         "h": 600
       }]
     },
     "ext": {
       "prebid": {
         "bidder": {
           "madvertise": {
             "placementId": "/1753588/banner"
           }
         }
       }
     }
   }],
   "tmax": 1000
 }'
`