### PR TITLE
IX: Set category in bid.cat

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -411,7 +411,7 @@ func (a *IxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReque
 					bidExtVideo = &openrtb_ext.ExtBidPrebidVideo{
 						Duration: bidExt.Prebid.Video.Duration,
 					}
-					if bid.Cat == nil || len(bid.Cat) == 0 {
+					if len(bid.Cat) == 0 {
 						bid.Cat = []string{bidExt.Prebid.Video.PrimaryCategory}
 					}
 				}

--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -409,8 +409,10 @@ func (a *IxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReque
 				unmarshalExtErr := json.Unmarshal(bid.Ext, &bidExt)
 				if unmarshalExtErr == nil && bidExt.Prebid != nil && bidExt.Prebid.Video != nil {
 					bidExtVideo = &openrtb_ext.ExtBidPrebidVideo{
-						Duration:        bidExt.Prebid.Video.Duration,
-						PrimaryCategory: bidExt.Prebid.Video.PrimaryCategory,
+						Duration: bidExt.Prebid.Video.Duration,
+					}
+					if bid.Cat == nil || len(bid.Cat) == 0 {
+						bid.Cat = []string{bidExt.Prebid.Video.PrimaryCategory}
 					}
 				}
 			}

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -792,8 +792,8 @@ func TestIxMakeBidsWithCategoryDuration(t *testing.T) {
 	if bidResponse.Bids[0].BidVideo.Duration != expectedBidDuration {
 		t.Errorf("video duration should be set")
 	}
-	if bidResponse.Bids[0].BidVideo.PrimaryCategory != expectedBidCategory {
-		t.Errorf("video category should be set")
+	if bidResponse.Bids[0].Bid.Cat[0] != expectedBidCategory {
+		t.Errorf("bid category should be set")
 	}
 	if len(errors) != expectedErrorCount {
 		t.Errorf("should not have any errors, errors=%v", errors)


### PR DESCRIPTION
From context in https://prebid.slack.com/archives/C7UCUKKB8/p1619639305041100, we should be setting bid.cat, not PrimaryCategory in order to utilize category translation.
Update adapter to accept both for compatibility as we fully migrate to bid.cat in exchange response.