### PR TITLE
Pangle: add appid & placementid to bidder param

### DIFF
--- a/adapters/pangle/pangletest/exemplary/app_banner.json
+++ b/adapters/pangle/pangletest/exemplary/app_banner.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/exemplary/app_native.json
+++ b/adapters/pangle/pangletest/exemplary/app_native.json
@@ -52,6 +52,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/exemplary/app_video_instl.json
+++ b/adapters/pangle/pangletest/exemplary/app_video_instl.json
@@ -76,6 +76,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/exemplary/app_video_rewarded.json
+++ b/adapters/pangle/pangletest/exemplary/app_video_rewarded.json
@@ -79,6 +79,7 @@
                   "is_rewarded_inventory": 1,
                   "storedrequest": null
                 },
+                "is_prebid": true,
                 "bidder": {
                   "token": "123"
                 }

--- a/adapters/pangle/pangletest/params/race/banner.json
+++ b/adapters/pangle/pangletest/params/race/banner.json
@@ -1,3 +1,5 @@
 {
-    "token": "123"
+    "token": "123",
+    "appid": "123",
+    "placementid": "123"
 }

--- a/adapters/pangle/pangletest/params/race/native.json
+++ b/adapters/pangle/pangletest/params/race/native.json
@@ -1,3 +1,5 @@
 {
-    "token": "123"
+    "token": "123",
+    "appid": "123",
+    "placementid": "123"
 }

--- a/adapters/pangle/pangletest/params/race/video.json
+++ b/adapters/pangle/pangletest/params/race/video.json
@@ -1,3 +1,5 @@
 {
-    "token": "123"
+    "token": "123",
+    "appid": "123",
+    "placementid": "123"
 }

--- a/adapters/pangle/pangletest/supplemental/appid_placementid_check.json
+++ b/adapters/pangle/pangletest/supplemental/appid_placementid_check.json
@@ -10,18 +10,28 @@
     "imp": [
       {
         "id": "test-imp-id",
-        "banner": {
-          "format": [
-            {
-              "w": 300,
-              "h": 250
-            }
-          ]
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "protocols": [
+            2,
+            5
+          ],
+          "w": 1024,
+          "h": 576,
+          "ext": {
+            "foo": "bar"
+          }
         },
-        "instl": 1,
         "ext": {
+          "prebid": {
+            "is_rewarded_inventory": 1
+          },
           "bidder": {
-            "token": "123"
+            "token": "123",
+            "appid": "123456",
+            "placementid": "78910"
           }
         }
       }
@@ -50,22 +60,37 @@
           "imp": [
             {
               "id": "test-imp-id",
-              "banner": {
-                "format": [
-                  {
-                    "w": 300,
-                    "h": 250
-                  }
-                ]
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "protocols": [
+                  2,
+                  5
+                ],
+                "w": 1024,
+                "h": 576,
+                "ext": {
+                  "foo": "bar"
+                }
               },
-              "instl": 1,
               "ext": {
-                "adtype": 2,
-                "bidder": {
-                  "token": "123"
+                "adtype": 7,
+                "prebid": {
+                  "bidder": null,
+                  "is_rewarded_inventory": 1,
+                  "storedrequest": null
                 },
                 "is_prebid": true,
-                "prebid": null
+                "networkids": {
+                  "appid": "123456",
+                  "placementid": "78910"
+                },
+                "bidder": {
+                  "token": "123",
+                  "appid": "123456",
+                  "placementid": "78910"
+                }
               }
             }
           ]
@@ -90,7 +115,7 @@
                   "w": 300,
                   "ext": {
                     "pangle": {
-                      "adtype": 2
+                      "adtype": 7
                     }
                   }
                 }
@@ -118,11 +143,11 @@
             "h": 250,
             "ext": {
               "pangle": {
-                "adtype": 2
+                "adtype": 7
               }
             }
           },
-          "type": "banner"
+          "type": "video"
         }
       ]
     }

--- a/adapters/pangle/pangletest/supplemental/missing_appid_or_placementid.json
+++ b/adapters/pangle/pangletest/supplemental/missing_appid_or_placementid.json
@@ -1,0 +1,47 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.prebid"
+    },
+    "device": {
+      "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "protocols": [
+            2,
+            5
+          ],
+          "w": 1024,
+          "h": 576,
+          "ext": {
+            "foo": "bar"
+          }
+        },
+        "ext": {
+          "prebid": {
+            "is_rewarded_inventory": 1
+          },
+          "bidder": {
+            "token": "123",
+            "placementid": "78910"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "only one of appid or placementid is provided",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/pangle/pangletest/supplemental/pangle_ext_check.json
+++ b/adapters/pangle/pangletest/supplemental/pangle_ext_check.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/supplemental/response_code_204.json
+++ b/adapters/pangle/pangletest/supplemental/response_code_204.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/supplemental/response_code_400.json
+++ b/adapters/pangle/pangletest/supplemental/response_code_400.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/supplemental/response_code_non_200.json
+++ b/adapters/pangle/pangletest/supplemental/response_code_non_200.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/pangletest/supplemental/unrecognized_adtype.json
+++ b/adapters/pangle/pangletest/supplemental/unrecognized_adtype.json
@@ -62,6 +62,7 @@
                 "bidder": {
                   "token": "123"
                 },
+                "is_prebid": true,
                 "prebid": null
               }
             }

--- a/adapters/pangle/param_test.go
+++ b/adapters/pangle/param_test.go
@@ -9,6 +9,7 @@ import (
 
 var validParams = []string{
 	`{"token": "SomeAccessToken"}`,
+	`{"token": "SomeAccessToken", "appid": "12345", "placementid": "12345"}`,
 }
 
 var invalidParams = []string{
@@ -16,6 +17,12 @@ var invalidParams = []string{
 	`{"token": 42}`,
 	`{"token": null}`,
 	`{}`,
+	// appid & placementid
+	`{"appid": "12345", "placementid": "12345"}`,
+	`{"token": "SomeAccessToken", "appid": "12345"}`,
+	`{"token": "SomeAccessToken", "placementid": "12345"}`,
+	`{"token": "SomeAccessToken", "appid": 12345, "placementid": 12345}`,
+	`{"token": "SomeAccessToken", "appid": null, "placementid": null}`,
 }
 
 func TestValidParams(t *testing.T) {

--- a/openrtb_ext/imp_pangle.go
+++ b/openrtb_ext/imp_pangle.go
@@ -1,5 +1,7 @@
 package openrtb_ext
 
 type ImpExtPangle struct {
-	Token string `json:"token"`
+	Token       string `json:"token"`
+	AppID       string `json:"appid,omitempty"`
+	PlacementID string `json:"placementid,omitempty"`
 }

--- a/static/bidder-params/pangle.json
+++ b/static/bidder-params/pangle.json
@@ -8,9 +8,27 @@
       "type": "string",
       "description": "Access Token",
       "pattern": ".+"
+    },
+    "appid": {
+      "type": "string",
+      "description": "App ID",
+      "pattern": "[0-9]+"
+    },
+    "placementid": {
+      "type": "string",
+      "description": "Placement ID",
+      "pattern": "[0-9]+"
     }
   },
   "required": [
     "token"
-  ]
+  ],
+  "dependencies": {
+    "placementid": [
+      "appid"
+    ],
+    "appid": [
+      "placementid"
+    ]
+  }
 }


### PR DESCRIPTION
doc PR: https://github.com/prebid/prebid.github.io/pull/2942

changes:
- add the optional appid and placementid (which when used, must be used in conjunction) to bidder param, then use them to form networkids in imp.ext
- add a true is_prebid flag for the auto recognition of prebid requests on our side