### PR TITLE
Fix Yieldlab video bid

### DIFF
--- a/adapters/yieldlab/yieldlab.go
+++ b/adapters/yieldlab/yieldlab.go
@@ -238,7 +238,7 @@ func (a *YieldlabAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 
 		if internalRequest.Imp[i].Video != nil {
 			bidType = openrtb_ext.BidTypeVideo
-			responseBid.NURL = a.makeAdSourceURL(internalRequest, req, bid)
+			responseBid.AdM = a.makeAdSourceURL(internalRequest, req, bid)
 
 		} else if internalRequest.Imp[i].Banner != nil {
 			bidType = openrtb_ext.BidTypeBanner

--- a/adapters/yieldlab/yieldlabtest/exemplary/video.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/video.json
@@ -123,7 +123,7 @@
             "dealid": "1234",
             "id": "12345",
             "impid": "test-imp-id",
-            "nurl": "https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing",
+            "adm": "https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing",
             "price": 2.01,
             "w": 728,
             "h": 90

--- a/adapters/yieldlab/yieldlabtest/exemplary/video_app.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/video_app.json
@@ -123,7 +123,7 @@
             "dealid": "1234",
             "id": "12345",
             "impid": "test-imp-id",
-            "nurl": "https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing",
+            "adm": "https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing",
             "price": 2.01,
             "w": 728,
             "h": 90


### PR DESCRIPTION
It seems like we wrongly assumed nurl was the correct way of sending out a VAST URI. PSP does not seem to support this (probably rightly so) and we are switching to adm for video bids.