### PR TITLE
Smaato: Add TCF 2.0 vendor id

### DIFF
--- a/static/bidder-info/smaato.yaml
+++ b/static/bidder-info/smaato.yaml
@@ -1,5 +1,6 @@
 maintainer:
   email: "prebid@smaato.com"
+gvlVendorID: 82
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Updating the Bidder Info file with the Smaato TCF 2.0 vendor id
https://iabeurope.eu/vendor-list-tcf-v2-0/