### PR TITLE
Criteo: accept zoneId and networkId alternate case

### DIFF
--- a/adapters/criteo/criteotest/supplemental/multislots-alt-case.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-alt-case.json
@@ -1,0 +1,232 @@
+{
+    "mockBidRequest": {
+      "id": "test-request-id",
+      "site": {
+        "id": "site-id",
+        "page": "criteo.com"
+      },
+      "device": {
+        "os": "android",
+        "ip": "91.199.242.236",
+        "ua": "random user agent"
+      },
+      "user": {
+        "ext": {
+          "eids": [{
+            "source": "criteo.com",
+            "uids": [{
+              "id": "criteo-eid"
+            }]
+          }]
+        }
+      },
+      "imp": [
+        {
+          "id": "test-imp-id-1",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneId": 123456,
+              "networkId": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-2",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneId": 7891011,
+              "networkId": 78910
+            }
+          }
+        },
+        {
+          "id": "test-imp-id-3",
+          "banner": {
+            "format": [
+              {
+                "w": 300,
+                "h": 250
+              }
+            ]
+          },
+          "ext": {
+            "bidder": {
+              "zoneId": 121314,
+              "networkId": 78910
+            }
+          }
+        }
+      ]
+    },
+    "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://bidder.criteo.com/cdb?profileId=230",
+          "headers": {
+            "X-Forwarded-For": [
+              "91.199.242.236"
+            ],
+            "User-Agent": [
+              "random user agent"
+            ]
+          },
+          "body": {
+            "id": "test-request-id",
+            "publisher": {
+              "siteid": "site-id",
+              "url": "criteo.com",
+              "networkid": 78910
+            },
+            "user": {
+              "ip": "91.199.242.236",
+              "ua": "random user agent",
+              "deviceos": "android",
+              "deviceidtype": "gaid"
+            },
+            "gdprconsent": {},
+            "slots": [
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              },
+              {
+                "slotid": "00000000-0000-0000-00000000",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "sizes": [
+                  "300x250"
+                ]
+              }
+            ],
+            "eids": [
+              {
+                "source": "criteo.com",
+                "uids": [
+                  {
+                    "id": "criteo-eid"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "slots": [
+              {
+                "id": "test-slot-id-1",
+                "impid": "test-imp-id-1",
+                "zoneid": 123456,
+                "networkid": 78910,
+                "cpm": 0.1,
+                "currency": "USD",
+                "width": 300,
+                "height": 250,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-2",
+                "impid": "test-imp-id-2",
+                "zoneid": 7891011,
+                "networkid": 78910,
+                "cpm": 0.2,
+                "currency": "USD",
+                "width": 320,
+                "height": 50,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              },
+              {
+                "id": "test-slot-id-3",
+                "impid": "test-imp-id-3",
+                "zoneid": 121314,
+                "networkid": 78910,
+                "cpm": 0.3,
+                "currency": "USD",
+                "width": 300,
+                "height": 600,
+                "creativeid": "creative-123",
+                "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "test-slot-id-1",
+              "impid": "test-imp-id-1",
+              "price": 0.1,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 250
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-2",
+              "impid": "test-imp-id-2",
+              "price": 0.2,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 320,
+              "h": 50
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "test-slot-id-3",
+              "impid": "test-imp-id-3",
+              "price": 0.3,
+              "crid": "creative-123",
+              "adm": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>",
+              "w": 300,
+              "h": 600
+            },
+            "type": "banner"
+          }
+        ]
+      }
+    ]
+  }

--- a/adapters/criteo/params_test.go
+++ b/adapters/criteo/params_test.go
@@ -41,9 +41,13 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"zoneid": 123456}`,
+	`{"zoneId": 123456}`,
 	`{"networkid": 78910}`,
+	`{"networkId": 78910}`,
 	`{"zoneid": 123456, "networkid": 78910}`,
+	`{"zoneId": 123456, "networkId": 78910}`,
 	`{"zoneid": 0, "networkid": 0}`,
+	`{"zoneId": 0, "networkId": 0}`,
 }
 
 var invalidParams = []string{
@@ -55,8 +59,11 @@ var invalidParams = []string{
 	`[]`,
 	`{}`,
 	`{"zoneid": -123}`,
+	`{"zoneId": -123}`,
 	`{"networkid": -321}`,
+	`{"networkId": -321}`,
 	`{"zoneid": -123, "networkid": -321}`,
+	`{"zoneId": -123, "networkId": -321}`,
 	`{"zoneid": -1}`,
 	`{"networkid": -1}`,
 	`{"zoneid": -1, "networkid": -1}`,

--- a/static/bidder-params/criteo.json
+++ b/static/bidder-params/criteo.json
@@ -5,13 +5,23 @@
     "type": "object",
     "properties": {
         "zoneid": {
-            "type": "number",
+            "type": "integer",
             "description": "Impression's zone ID.",
             "minimum": 0
         },
+        "zoneId": {
+            "type": "integer",
+            "description": "Impression's zone ID, preferred.",
+            "minimum": 0
+        },
         "networkid": {
-            "type": "number",
+            "type": "integer",
             "description": "Impression's network ID.",
+            "minimum": 0
+        },
+        "networkId": {
+            "type": "integer",
+            "description": "Impression's network ID, preferred.",
             "minimum": 0
         }
     },
@@ -23,7 +33,17 @@
         },
         {
             "required": [
+                "zoneId"
+            ]
+        },
+        {
+            "required": [
                 "networkid"
+            ]
+        },
+        {
+            "required": [
+                "networkId"
             ]
         }
     ]


### PR DESCRIPTION
Our PBS adapter has been released initially accepting both **zoneid** and **networkid** (with that specific case).
However, our public Prebid documentation states that we are accepting **zoneId** and **networkId**, causing issues for publishers using both adapters.

So, we want our PBS adapter to accept both cases.