### PR TITLE
interactiveoffers: Updating contact info

### DIFF
--- a/static/bidder-info/interactiveoffers.yaml
+++ b/static/bidder-info/interactiveoffers.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "dev@interactiveoffers.com"
+  email: "support@interactiveoffers.com"
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
dev@interactiveoffers.com bounced. Confirmed with interactiveoffers that support is the right address