### PR TITLE
Friendlier Startup Error Messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,12 +34,12 @@ func main() {
 
 	cfg, err := loadConfig()
 	if err != nil {
-		glog.Fatalf("Configuration could not be loaded or did not pass validation: %v", err)
+		glog.Exitf("Configuration could not be loaded or did not pass validation: %v", err)
 	}
 
 	err = serve(Rev, cfg)
 	if err != nil {
-		glog.Errorf("prebid-server failed: %v", err)
+		glog.Exitf("prebid-server failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Small change to omit the stack trace when startup errors are found. The stack trace just points to `main.go`, and is therefore useless. `glog.Exitf` exists immediately with a status code of 1. Previously the status code was 255.