### PR TITLE
Outbrain adapter: overwrite tagid only if it exists

### DIFF
--- a/adapters/outbrain/outbrain.go
+++ b/adapters/outbrain/outbrain.go
@@ -43,8 +43,10 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			errs = append(errs, err)
 			continue
 		}
-		imp.TagID = outbrainExt.TagId
-		reqCopy.Imp[i] = imp
+		if outbrainExt.TagId != "" {
+			imp.TagID = outbrainExt.TagId
+			reqCopy.Imp[i] = imp
+		}
 	}
 
 	publisher := &openrtb2.Publisher{

--- a/adapters/outbrain/outbraintest/supplemental/general_params.json
+++ b/adapters/outbrain/outbraintest/supplemental/general_params.json
@@ -12,23 +12,18 @@
             }
           ]
         },
-        "tagid": "should-be-overwritten",
+        "tagid": "tag-id",
         "ext": {
           "bidder": {
             "publisher": {
-              "id": "publisher-id",
-              "name": "publisher-name",
-              "domain": "publisher-domain.com"
-            },
-            "tagid": "tag-id",
-            "bcat": ["bad-category"],
-            "badv": ["bad-advertiser"]
+              "id": "publisher-id"
+            }
           }
         }
       }
     ],
-    "bcat": ["should-be-overwritten"],
-    "badv": ["should-be-overwritten"],
+    "bcat": ["bad-category"],
+    "badv": ["bad-advertiser"],
     "site": {
       "page": "http://example.com"
     },
@@ -59,13 +54,8 @@
               "ext": {
                 "bidder": {
                   "publisher": {
-                    "id": "publisher-id",
-                    "name": "publisher-name",
-                    "domain": "publisher-domain.com"
-                  },
-                  "tagid": "tag-id",
-                  "bcat": ["bad-category"],
-                  "badv": ["bad-advertiser"]
+                    "id": "publisher-id"
+                  }
                 }
               }
             }
@@ -75,9 +65,7 @@
           "site": {
             "page": "http://example.com",
             "publisher": {
-              "id": "publisher-id",
-              "name": "publisher-name",
-              "domain": "publisher-domain.com"
+              "id": "publisher-id"
             }
           },
           "device": {

--- a/adapters/outbrain/outbraintest/supplemental/optional_params.json
+++ b/adapters/outbrain/outbraintest/supplemental/optional_params.json
@@ -12,7 +12,7 @@
             }
           ]
         },
-        "tagid": "should-be-overwritten",
+        "tagid": "should-be-overwritten-tagid",
         "ext": {
           "bidder": {
             "publisher": {
@@ -27,8 +27,8 @@
         }
       }
     ],
-    "bcat": ["should-be-overwritten"],
-    "badv": ["should-be-overwritten"],
+    "bcat": ["should-be-overwritten-bcat"],
+    "badv": ["should-be-overwritten-badv"],
     "site": {
       "page": "http://example.com"
     },


### PR DESCRIPTION
Hey,

this PR changes the adapter so that the the imp tagid is overwritten with the ext tagid only if it exists.