### PR TITLE
Criteo: Fix fields mapping error when building bid from bidder response

### DIFF
--- a/adapters/criteo/criteo.go
+++ b/adapters/criteo/criteo.go
@@ -86,13 +86,13 @@ func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest
 	for i := 0; i < len(bidResponse.Slots); i++ {
 		bidderResponse.Bids[i] = &adapters.TypedBid{
 			Bid: &openrtb2.Bid{
-				ID:    bidResponse.Slots[i].ID,
+				ID:    bidResponse.Slots[i].ArbitrageID,
 				ImpID: bidResponse.Slots[i].ImpID,
 				Price: bidResponse.Slots[i].CPM,
 				AdM:   bidResponse.Slots[i].Creative,
 				W:     bidResponse.Slots[i].Width,
 				H:     bidResponse.Slots[i].Height,
-				CrID:  bidResponse.Slots[i].CreativeID,
+				CrID:  bidResponse.Slots[i].CreativeCode,
 			},
 			BidType: openrtb_ext.BidTypeBanner,
 		}

--- a/adapters/criteo/criteotest/exemplary/simple-banner-cookie-uid.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-cookie-uid.json
@@ -76,7 +76,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -84,7 +84,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/criteotest/exemplary/simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-inapp.json
@@ -71,7 +71,7 @@
             "id": "test-request-id",
             "slots": [
               {
-                "id": "test-slot-id",
+                "arbitrageid": "test-slot-id",
                 "impid": "test-imp-id",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -79,7 +79,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -107,4 +107,4 @@
     }
   ]
 }
-  
+

--- a/adapters/criteo/criteotest/exemplary/simple-banner-uid.json
+++ b/adapters/criteo/criteotest/exemplary/simple-banner-uid.json
@@ -93,7 +93,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -101,7 +101,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-inapp.json
@@ -76,7 +76,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id",
+                "arbitrageid": "test-slot-id",
                 "impid": "test-imp-id",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -84,7 +84,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -112,4 +112,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/ccpa-with-consent-simple-banner-uid.json
@@ -100,7 +100,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id",
+                "arbitrageid": "test-slot-id",
                 "impid": "test-imp-id",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -108,7 +108,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -136,4 +136,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-inapp.json
@@ -87,7 +87,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id",
+                "arbitrageid": "test-slot-id",
                 "impid": "test-imp-id",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -95,7 +95,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -123,4 +123,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/gdpr-with-consent-simple-banner-uid.json
@@ -103,7 +103,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id",
+                "arbitrageid": "test-slot-id",
                 "impid": "test-imp-id",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -111,7 +111,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -139,4 +139,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/multislots-alt-case.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-alt-case.json
@@ -146,7 +146,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id-1",
+                "arbitrageid": "test-slot-id-1",
                 "impid": "test-imp-id-1",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -154,11 +154,11 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-2",
+                "arbitrageid": "test-slot-id-2",
                 "impid": "test-imp-id-2",
                 "zoneid": 7891011,
                 "networkid": 78910,
@@ -166,11 +166,11 @@
                 "currency": "USD",
                 "width": 320,
                 "height": 50,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-3",
+                "arbitrageid": "test-slot-id-3",
                 "impid": "test-imp-id-3",
                 "zoneid": 121314,
                 "networkid": 78910,
@@ -178,7 +178,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 600,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]

--- a/adapters/criteo/criteotest/supplemental/multislots-simple-banner-inapp.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-simple-banner-inapp.json
@@ -126,7 +126,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id-1",
+                "arbitrageid": "test-slot-id-1",
                 "impid": "test-imp-id-1",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -134,11 +134,11 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-2",
+                "arbitrageid": "test-slot-id-2",
                 "impid": "test-imp-id-2",
                 "zoneid": 7891011,
                 "networkid": 78910,
@@ -146,11 +146,11 @@
                 "currency": "USD",
                 "width": 320,
                 "height": 50,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-3",
+                "arbitrageid": "test-slot-id-3",
                 "impid": "test-imp-id-3",
                 "zoneid": 121314,
                 "networkid": 78910,
@@ -158,7 +158,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 600,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -210,4 +210,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid.json
+++ b/adapters/criteo/criteotest/supplemental/multislots-simple-banner-uid.json
@@ -146,7 +146,7 @@
           "body": {
             "slots": [
               {
-                "id": "test-slot-id-1",
+                "arbitrageid": "test-slot-id-1",
                 "impid": "test-imp-id-1",
                 "zoneid": 123456,
                 "networkid": 78910,
@@ -154,11 +154,11 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 250,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-2",
+                "arbitrageid": "test-slot-id-2",
                 "impid": "test-imp-id-2",
                 "zoneid": 7891011,
                 "networkid": 78910,
@@ -166,11 +166,11 @@
                 "currency": "USD",
                 "width": 320,
                 "height": 50,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               },
               {
-                "id": "test-slot-id-3",
+                "arbitrageid": "test-slot-id-3",
                 "impid": "test-imp-id-3",
                 "zoneid": 121314,
                 "networkid": 78910,
@@ -178,7 +178,7 @@
                 "currency": "USD",
                 "width": 300,
                 "height": 600,
-                "creativeid": "creative-123",
+                "creativecode": "creative-123",
                 "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
               }
             ]
@@ -230,4 +230,3 @@
       }
     ]
   }
-  

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats-not-included.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats-not-included.json
@@ -93,7 +93,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -101,7 +101,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size-and-formats.json
@@ -93,7 +93,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -101,7 +101,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-direct-size.json
@@ -87,7 +87,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -95,7 +95,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/criteotest/supplemental/simple-banner-with-ipv6.json
+++ b/adapters/criteo/criteotest/supplemental/simple-banner-with-ipv6.json
@@ -87,7 +87,7 @@
           "id": "test-request-id",
           "slots": [
             {
-              "id": "test-slot-id",
+              "arbitrageid": "test-slot-id",
               "impid": "test-imp-id",
               "zoneid": 123456,
               "networkid": 78910,
@@ -95,7 +95,7 @@
               "currency": "USD",
               "width": 300,
               "height": 250,
-              "creativeid": "creative-123",
+              "creativecode": "creative-123",
               "creative": "<iframe id='789abc' name='789abc' src='http://creative-url.criteo.com'></iframe>"
             }
           ]

--- a/adapters/criteo/models.go
+++ b/adapters/criteo/models.go
@@ -286,14 +286,14 @@ func newCriteoResponseFromBytes(bytes []byte) (criteoResponse, error) {
 }
 
 type criteoResponseSlot struct {
-	ID         string  `json:"id,omitempty"`
-	ImpID      string  `json:"impid,omitempty"`
-	ZoneID     int64   `json:"zoneid,omitempty"`
-	NetworkID  int64   `json:"networkid,omitempty"`
-	CPM        float64 `json:"cpm,omitempty"`
-	Currency   string  `json:"currency,omitempty"`
-	Width      int64   `json:"width,omitempty"`
-	Height     int64   `json:"height,omitempty"`
-	Creative   string  `json:"creative,omitempty"`
-	CreativeID string  `json:"creativeid,omitempty"`
+	ArbitrageID  string  `json:"arbitrageid,omitempty"`
+	ImpID        string  `json:"impid,omitempty"`
+	ZoneID       int64   `json:"zoneid,omitempty"`
+	NetworkID    int64   `json:"networkid,omitempty"`
+	CPM          float64 `json:"cpm,omitempty"`
+	Currency     string  `json:"currency,omitempty"`
+	Width        int64   `json:"width,omitempty"`
+	Height       int64   `json:"height,omitempty"`
+	Creative     string  `json:"creative,omitempty"`
+	CreativeCode string  `json:"creativecode,omitempty"`
 }


### PR DESCRIPTION
We've detected an error in our adapter as the field mapped when handling bid responses from our bidder are not consistent with the actual naming of the fields used in our production bidder bid responses.