### PR TITLE
Cookie refresh expiration date on/off

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -321,7 +321,7 @@ type HostCookie struct {
 	OptInURL           string `mapstructure:"opt_in_url"`
 	MaxCookieSizeBytes int    `mapstructure:"max_cookie_size_bytes"`
 	OptOutCookie       Cookie `mapstructure:"optout_cookie"`
-	Refresh            Bool   `mapstructure:"refresh"`
+	Refresh            bool   `mapstructure:"refresh"`
 	// Cookie timeout in days
 	TTL int64 `mapstructure:"ttl_days"`
 }
@@ -709,7 +709,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host_cookie.opt_out_url", "")
 	v.SetDefault("host_cookie.opt_in_url", "")
 	v.SetDefault("host_cookie.optout_cookie.name", "")
-	v.SetDefault("host_cookie.refresh", true)
+	v.SetDefault("host_cookie.refresh", false)
 	v.SetDefault("host_cookie.value", "")
 	v.SetDefault("host_cookie.ttl_days", 90)
 	v.SetDefault("host_cookie.max_cookie_size_bytes", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -321,6 +321,7 @@ type HostCookie struct {
 	OptInURL           string `mapstructure:"opt_in_url"`
 	MaxCookieSizeBytes int    `mapstructure:"max_cookie_size_bytes"`
 	OptOutCookie       Cookie `mapstructure:"optout_cookie"`
+	Refresh            Bool   `mapstructure:"refresh"`
 	// Cookie timeout in days
 	TTL int64 `mapstructure:"ttl_days"`
 }
@@ -708,6 +709,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host_cookie.opt_out_url", "")
 	v.SetDefault("host_cookie.opt_in_url", "")
 	v.SetDefault("host_cookie.optout_cookie.name", "")
+	v.SetDefault("host_cookie.refresh", true)
 	v.SetDefault("host_cookie.value", "")
 	v.SetDefault("host_cookie.ttl_days", 90)
 	v.SetDefault("host_cookie.max_cookie_size_bytes", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -709,7 +709,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("host_cookie.opt_out_url", "")
 	v.SetDefault("host_cookie.opt_in_url", "")
 	v.SetDefault("host_cookie.optout_cookie.name", "")
-	v.SetDefault("host_cookie.refresh", false)
+	v.SetDefault("host_cookie.refresh", true)
 	v.SetDefault("host_cookie.value", "")
 	v.SetDefault("host_cookie.ttl_days", 90)
 	v.SetDefault("host_cookie.max_cookie_size_bytes", 0)

--- a/usersync/cookie.go
+++ b/usersync/cookie.go
@@ -176,6 +176,9 @@ func (cookie *PBSCookie) GetId(bidderName openrtb_ext.BidderName) (id string, ex
 
 // SetCookieOnResponse is a shortcut for "ToHTTPCookie(); cookie.setDomain(domain); setCookie(w, cookie)"
 func (cookie *PBSCookie) SetCookieOnResponse(w http.ResponseWriter, setSiteCookie bool, cfg *config.HostCookie, ttl time.Duration) {
+	if !cfg.Refresh {
+		ttl = cookie.birthday.Add(ttl).Sub(time.Now())
+	}
 	httpCookie := cookie.ToHTTPCookie(ttl)
 	var domain string = cfg.Domain
 

--- a/usersync/cookie_test.go
+++ b/usersync/cookie_test.go
@@ -444,3 +444,16 @@ func TestSetCookieOnResponseForOlderChromeVersion(t *testing.T) {
 		t.Error("Set-Cookie should not contain SameSite=none")
 	}
 }
+
+func TestSetCookieOnResponseNorefresh(t *testing.T) {
+	cookie := newSampleCookie()
+	cookie.birthday.AddDate(0, -1, 0)
+	birthday := *cookie.birthday
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://www.prebid.com", nil)
+	ua := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"
+	req.Header.Set("User-Agent", ua)
+	hostCookie := &config.HostCookie{Domain: "mock-domain", Refresh: false}
+	cookie.SetCookieOnResponse(w, true, hostCookie, 90*24*time.Hour)
+	assert.Equal(t, *cookie.birthday, birthday, "cookie.birthday is no longer the same")
+}


### PR DESCRIPTION
In order to comply with the french interpretation of GDPR, and more specificaly about TCF v2.1, I need to be able to ensure that user sync won't refresh the cookie expiration date. In order to do that I've added a config field host_cookie.refresh which is set to true by default so the current behavior is not broke.

Then, when cookie is set, in host_cookie.refresh is set to false, the ttl value is updated to the duration that left based on the cookie birth date + normal duration (birthday + ttl - today).