### PR TITLE
Remove time.Now() as the first parameter of NewRates()

### DIFF
--- a/currency/aggregate_conversions_test.go
+++ b/currency/aggregate_conversions_test.go
@@ -3,7 +3,6 @@ package currency
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,14 +10,14 @@ import (
 func TestGroupedGetRate(t *testing.T) {
 
 	// Setup:
-	customRates := NewRates(time.Now(), map[string]map[string]float64{
+	customRates := NewRates(map[string]map[string]float64{
 		"USD": {
 			"GBP": 3.00,
 			"EUR": 2.00,
 		},
 	})
 
-	pbsRates := NewRates(time.Now(), map[string]map[string]float64{
+	pbsRates := NewRates(map[string]map[string]float64{
 		"USD": {
 			"GBP": 4.00,
 			"MXN": 10.00,

--- a/currency/rate_converter_test.go
+++ b/currency/rate_converter_test.go
@@ -143,7 +143,6 @@ func TestReadWriteRates(t *testing.T) {
 		} else {
 			rates := currencyConverter.Rates().(*Rates)
 			assert.Equal(t, tt.wantConversions, (*rates).Conversions, tt.description)
-			assert.Equal(t, tt.wantDataAsOf, (*rates).DataAsOf, tt.description)
 		}
 
 		lastUpdated := currencyConverter.LastUpdated()
@@ -169,7 +168,6 @@ func TestRateStaleness(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	expectedRates := &Rates{
-		DataAsOf: time.Date(2018, time.September, 12, 0, 0, 0, 0, time.UTC),
 		Conversions: map[string]map[string]float64{
 			"USD": {
 				"GBP": 0.77208,
@@ -257,7 +255,6 @@ func TestRatesAreNeverConsideredStale(t *testing.T) {
 	defer mockedHttpServer.Close()
 
 	expectedRates := &Rates{
-		DataAsOf: time.Date(2018, time.September, 12, 0, 0, 0, 0, time.UTC),
 		Conversions: map[string]map[string]float64{
 			"USD": {
 				"GBP": 0.77208,

--- a/currency/rate_converter_test.go
+++ b/currency/rate_converter_test.go
@@ -54,7 +54,6 @@ func TestReadWriteRates(t *testing.T) {
 		wantUpdateErr     bool
 		wantConstantRates bool
 		wantLastUpdated   time.Time
-		wantDataAsOf      time.Time
 		wantConversions   map[string]map[string]float64
 	}{
 		{
@@ -63,7 +62,6 @@ func TestReadWriteRates(t *testing.T) {
 			giveMockResponse: getMockRates(),
 			giveMockStatus:   200,
 			wantLastUpdated:  time.Date(2018, time.September, 12, 30, 0, 0, 0, time.UTC),
-			wantDataAsOf:     time.Date(2018, time.September, 12, 0, 0, 0, 0, time.UTC),
 			wantConversions:  map[string]map[string]float64{"USD": {"GBP": 0.77208}, "GBP": {"USD": 1.2952}},
 		},
 		{
@@ -72,7 +70,6 @@ func TestReadWriteRates(t *testing.T) {
 			giveMockResponse: []byte("{}"),
 			giveMockStatus:   200,
 			wantLastUpdated:  time.Date(2018, time.September, 12, 30, 0, 0, 0, time.UTC),
-			wantDataAsOf:     time.Time{},
 			wantConversions:  nil,
 		},
 		{

--- a/currency/rates.go
+++ b/currency/rates.go
@@ -1,9 +1,7 @@
 package currency
 
 import (
-	"encoding/json"
 	"errors"
-	"time"
 
 	"golang.org/x/text/currency"
 )
@@ -12,36 +10,14 @@ import (
 // note that `DataAsOfRaw` field is needed when parsing remote JSON as the date format if not standard and requires
 // custom parsing to be properly set as Golang time.Time
 type Rates struct {
-	DataAsOf    time.Time                     `json:"dataAsOf"`
 	Conversions map[string]map[string]float64 `json:"conversions"`
 }
 
 // NewRates creates a new Rates object holding currencies rates
-func NewRates(dataAsOf time.Time, conversions map[string]map[string]float64) *Rates {
+func NewRates(conversions map[string]map[string]float64) *Rates {
 	return &Rates{
-		DataAsOf:    dataAsOf,
 		Conversions: conversions,
 	}
-}
-
-// UnmarshalJSON unmarshal raw JSON bytes to Rates object
-func (r *Rates) UnmarshalJSON(b []byte) error {
-	c := &struct {
-		DataAsOf    string                        `json:"dataAsOf"`
-		Conversions map[string]map[string]float64 `json:"conversions"`
-	}{}
-	if err := json.Unmarshal(b, &c); err != nil {
-		return err
-	}
-
-	r.Conversions = c.Conversions
-
-	layout := "2006-01-02"
-	if date, err := time.Parse(layout, c.DataAsOf); err == nil {
-		r.DataAsOf = date
-	}
-
-	return nil
 }
 
 // GetRate returns the conversion rate between two currencies or:

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -2774,7 +2774,7 @@ func (e *mockBidExchange) getAuctionCurrencyRates(customRates *openrtb_ext.ExtRe
 	if customRates == nil {
 		// The timestamp is required for the function signature, but is not used and its
 		// value has no significance in the tests
-		return currency.NewRates(time.Now(), e.pbsRates)
+		return currency.NewRates(e.pbsRates)
 	}
 
 	usePbsRates := true
@@ -2785,18 +2785,18 @@ func (e *mockBidExchange) getAuctionCurrencyRates(customRates *openrtb_ext.ExtRe
 	if !usePbsRates {
 		// The timestamp is required for the function signature, but is not used and its
 		// value has no significance in the tests
-		return currency.NewRates(time.Now(), customRates.ConversionRates)
+		return currency.NewRates(customRates.ConversionRates)
 	}
 
 	// Both PBS and custom rates can be used, check if ConversionRates is not empty
 	if len(customRates.ConversionRates) == 0 {
 		// Custom rates map is empty, use PBS rates only
-		return currency.NewRates(time.Now(), e.pbsRates)
+		return currency.NewRates(e.pbsRates)
 	}
 
 	// Return an AggregateConversions object that includes both custom and PBS currency rates but will
 	// prioritize custom rates over PBS rates whenever a currency rate is found in both
-	return currency.NewAggregateConversions(currency.NewRates(time.Time{}, customRates.ConversionRates), currency.NewRates(time.Now(), e.pbsRates))
+	return currency.NewAggregateConversions(currency.NewRates(customRates.ConversionRates), currency.NewRates(e.pbsRates))
 }
 
 // mockBidExchange is a well-behaved exchange that lists the bidders found in every bidRequest.Imp[i].Ext

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -424,7 +424,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "USD", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -449,7 +448,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -474,7 +472,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "EUR", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -499,7 +496,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "GBP", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -524,7 +520,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "GBP", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -549,7 +544,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "GBP", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -575,7 +569,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "DKK", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -600,7 +593,6 @@ func TestMultiCurrencies(t *testing.T) {
 				{currency: "CCC", price: 1.3},
 			},
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"GBP": {
 						"USD": 1.3050530256,
@@ -858,7 +850,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "EUR",
 			expectedError:          false,
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"JPY": {
 						"USD": 0.0089,
@@ -879,7 +870,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "JPY",
 			expectedError:          false,
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"JPY": {
 						"USD": 0.0089,
@@ -894,7 +884,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "USD",
 			expectedError:          false,
 			rates: currency.Rates{
-				DataAsOf: time.Now(),
 				Conversions: map[string]map[string]float64{
 					"JPY": {
 						"USD": 0.0089,
@@ -915,7 +904,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "",
 			expectedError:          true,
 			rates: currency.Rates{
-				DataAsOf:    time.Now(),
 				Conversions: map[string]map[string]float64{},
 			},
 			description: "Case 4 - None allowed currencies in bid request are known, an error is returned",
@@ -926,7 +914,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "USD",
 			expectedError:          false,
 			rates: currency.Rates{
-				DataAsOf:    time.Now(),
 				Conversions: map[string]map[string]float64{},
 			},
 			description: "Case 5 - None allowed currencies in bid request are known but the default one (`USD`), no rates are set but default currency will be picked",
@@ -937,7 +924,6 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			expectedPickedCurrency: "USD",
 			expectedError:          false,
 			rates: currency.Rates{
-				DataAsOf:    time.Now(),
 				Conversions: map[string]map[string]float64{},
 			},
 			description: "Case 6 - No allowed currencies specified in bid request, default one is picked: `USD`",

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1015,7 +1015,7 @@ func (e *exchange) getAuctionCurrencyRates(requestRates *openrtb_ext.ExtRequestC
 		// At this point, we can safely assume the ConversionRates map is not empty because
 		// validateCustomRates(bidReqCurrencyRates *openrtb_ext.ExtRequestCurrency) would have
 		// thrown an error under such conditions.
-		return currency.NewRates(time.Time{}, requestRates.ConversionRates)
+		return currency.NewRates(requestRates.ConversionRates)
 	}
 
 	// Both PBS and custom rates can be used, check if ConversionRates is not empty
@@ -1026,7 +1026,7 @@ func (e *exchange) getAuctionCurrencyRates(requestRates *openrtb_ext.ExtRequestC
 
 	// Return an AggregateConversions object that includes both custom and PBS currency rates but will
 	// prioritize custom rates over PBS rates whenever a currency rate is found in both
-	return currency.NewAggregateConversions(currency.NewRates(time.Time{}, requestRates.ConversionRates), e.currencyConverter.Rates())
+	return currency.NewAggregateConversions(currency.NewRates(requestRates.ConversionRates), e.currencyConverter.Rates())
 }
 
 func findCacheID(bid *pbsOrtbBid, auction *auction) (string, bool) {


### PR DESCRIPTION
The `DataAsOf time.Time` field of the `Rates struct` found in `currency/rates.go` has no use in practice because `(rc *RateConverter) update()` method sets the `RateConverter`'s `lastUpdated` field to `time.Now()` in line 82 shown below and ignores the `rates.DataAsOf` field that the `fetch()` function unmarshals in line 79. This pull request removes the `DataAsOf` field entirely which is useful in order to simplify the code specially in the numerous `NewRates()` calls throughout the codebase.
```
 77 // Update updates the internal currencies rates from remote sources
 78 func (rc *RateConverter) update() error {
 79     rates, err := rc.fetch()
 80     if err == nil {
 81         rc.rates.Store(rates)
 82         rc.lastUpdated.Store(rc.time.Now())
 83     } else {
 84         if rc.checkStaleRates() {
 85             rc.clearRates()
 86             glog.Errorf("Error updating conversion rates, falling back to constant rates: %v", err)
 87         } else {
 88             glog.Errorf("Error updating conversion rates: %v", err)
 89         }
 90     }
 91
 92     return err
 93 }
 94
 95 func (rc *RateConverter) Run() error {
 96     return rc.update()
 97 }
currency/rate_converter.go
```