### PR TITLE
Update adagio.json

### DIFF
--- a/static/bidder-params/adagio.json
+++ b/static/bidder-params/adagio.json
@@ -46,11 +46,15 @@
     },
     "features": {
       "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z_]": { "type": "string" }
+      "properties": {
+        "???": {
+          "pattern": "^[a-zA-Z_]",
+          "type": "string",
+          "description": "???"
+        }
       }
     },
-    "prebidVersion:": {
+    "prebidVersion": {
       "type": "string",
       "description": "Name to identify the version of Prebid.js"
     },


### PR DESCRIPTION
It looks like "^[a-zA-Z_]" is an invalid field name. Made a format edit to the param "features" based on the formating of other adapters, the question marks would need to be filled in with relevant strings. 

Also, deleted extra colon for param: "prebidVersion"