### PR TITLE
Fix external cache host validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ func (data *ExternalCache) validate(errs []error) []error {
 	if strings.HasSuffix(data.Host, "/") {
 		return append(errs, errors.New(fmt.Sprintf("External cache Host '%s' must not end with a path separator", data.Host)))
 	}
-	if strings.ContainsAny(data.Host, "://") {
+	if strings.Contains(data.Host, "://") {
 		return append(errs, errors.New(fmt.Sprintf("External cache Host must not specify a protocol. '%s'", data.Host)))
 	}
 	if !strings.HasPrefix(data.Path, "/") {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,11 @@ func TestExternalCacheURLValidate(t *testing.T) {
 			data:      ExternalCache{Scheme: "https", Host: "www.google.com", Path: "/path/v1"},
 			expErrors: 0,
 		},
+		{
+			desc:      "Host with port",
+			data:      ExternalCache{Scheme: "https", Host: "localhost:2424", Path: "/path/v1"},
+			expErrors: 0,
+		},
 	}
 	for _, test := range testCases {
 		errs := test.data.validate([]error{})


### PR DESCRIPTION
Hey!

This PR fixes the external cache host validation to support having a host with a port (useful for local development)