### PR TITLE
Fix UserSync Config Case Sensitivity Issue

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -337,7 +337,9 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 
 func applyBidderInfoConfigOverrides(bidderInfos config.BidderInfos, adaptersCfg map[string]config.Adapter) error {
 	for bidderName, bidderInfo := range bidderInfos {
-		if adapterCfg, exists := adaptersCfg[bidderName]; exists {
+		// bidder name from bidderInfos is case-sensitive, but bidder name from adaptersCfg
+		// is always expressed as lower case. need to adapt for the difference here.
+		if adapterCfg, exists := adaptersCfg[strings.ToLower(bidderName)]; exists {
 			bidderInfo.Syncer = adapterCfg.Syncer.Override(bidderInfo.Syncer)
 
 			// validate and try to apply the legacy usersync_url configuration in attempt to provide

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -89,6 +89,14 @@ func TestApplyBidderInfoConfigOverrides(t *testing.T) {
 			expectedBidderInfos: config.BidderInfos{"a": {Syncer: &config.Syncer{Key: "override"}}},
 		},
 		{
+			// Adapter Configs use a lower case bidder name, but the Bidder Infos follow the official
+			// bidder name casing.
+			description:         "Syncer Override - Case Sensitivity",
+			givenBidderInfos:    config.BidderInfos{"A": {Syncer: &config.Syncer{Key: "original"}}},
+			givenAdaptersCfg:    map[string]config.Adapter{"a": {Syncer: &config.Syncer{Key: "override"}}},
+			expectedBidderInfos: config.BidderInfos{"A": {Syncer: &config.Syncer{Key: "override"}}},
+		},
+		{
 			description:         "UserSyncURL Override IFrame",
 			givenBidderInfos:    config.BidderInfos{"a": {Syncer: &config.Syncer{IFrame: &config.SyncerEndpoint{URL: "original"}}}},
 			givenAdaptersCfg:    map[string]config.Adapter{"a": {UserSyncURL: "override"}},


### PR DESCRIPTION
Fixes an issue where the host configured user sync override is ignored due to a case sensitivity issue between the adapter config (always lower case) and bidder info config (potentially mixed case).