### PR TITLE
Adding Support for Macro {{UUID}} to Support Feature: Generate Unique Bidrequest ID

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -348,7 +348,7 @@ func (deps *endpointDeps) loadRequestJSONForAmp(httpRequest *http.Request) (req 
 		return
 	}
 
-	if deps.cfg.GenerateRequestID {
+	if deps.cfg.GenerateRequestID || req.ID == "{{UUID}}" {
 		newBidRequestId, err := deps.uuidGenerator.Generate()
 		if err != nil {
 			errs = []error{err}

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -1304,9 +1304,15 @@ func TestIdGeneration(t *testing.T) {
 			expectedID:             "ThisID",
 		},
 		{
-			description:            "The givenGenerateRequestID flag is true, and if the id field isn't included in the stored request",
+			description:            "The givenGenerateRequestID flag is true, and the id field isn't included in the stored request, we should still generate a uuid",
 			givenInStoredRequest:   json.RawMessage(`{"site":{"page":"prebid.org"},"imp":[{"id":"some-imp-id","banner":{"format":[{"w":300,"h":250}]},"ext":{"appnexus":{"placementId":1}}}],"tmax":1}`),
 			givenGenerateRequestID: true,
+			expectedID:             uuid,
+		},
+		{
+			description:            "The givenGenerateRequestID flag is false, but id field is the macro option {{UUID}}, we should generate a uuid",
+			givenInStoredRequest:   json.RawMessage(`{"id":"{{UUID}}","site":{"page":"prebid.org"},"imp":[{"id":"some-imp-id","banner":{"format":[{"w":300,"h":250}]},"ext":{"appnexus":{"placementId":1}}}],"tmax":1}`),
+			givenGenerateRequestID: false,
 			expectedID:             uuid,
 		},
 	}

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -1315,6 +1315,12 @@ func TestIdGeneration(t *testing.T) {
 			givenGenerateRequestID: false,
 			expectedID:             uuid,
 		},
+		{
+			description:            "Macro ID case sensitivity check. The id is {{uuid}}, but we should only generate an id if it's all uppercase {{UUID}}. So the ID shouldn't change.",
+			givenInStoredRequest:   json.RawMessage(`{"id":"{{uuid}}","site":{"page":"prebid.org"},"imp":[{"id":"some-imp-id","banner":{"format":[{"w":300,"h":250}]},"ext":{"appnexus":{"placementId":1}}}],"tmax":1}`),
+			givenGenerateRequestID: false,
+			expectedID:             "{{uuid}}",
+		},
 	}
 
 	request := httptest.NewRequest("GET", "/openrtb2/auction/amp?tag_id=test", nil)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1352,11 +1352,11 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 	}
 
 	storedRequests, storedImps, errs := deps.storedReqFetcher.FetchRequests(ctx, storedReqIds, impStoredReqIds)
+
 	if len(errs) != 0 {
 		return nil, nil, errs
 	}
-
-	bidRequestID, err := getBidRequestID(requestJson)
+	bidRequestID, err := getBidRequestID(storedRequests[storedBidRequestId])
 	if err != nil {
 		return nil, nil, []error{err}
 	}
@@ -1507,7 +1507,7 @@ func getStoredRequestId(data []byte) (string, bool, error) {
 	return string(storedRequestId), true, nil
 }
 
-func getBidRequestID(data []byte) (string, error) {
+func getBidRequestID(data json.RawMessage) (string, error) {
 	bidRequestID, dataType, _, err := jsonparser.Get(data, "id")
 	if dataType == jsonparser.NotExist {
 		return "", nil

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1356,10 +1356,15 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 		return nil, nil, errs
 	}
 
+	bidRequestID, err := getBidRequestID(requestJson)
+	if err != nil {
+		return nil, nil, []error{err}
+	}
+
 	// Apply the Stored BidRequest, if it exists
 	resolvedRequest := requestJson
 
-	if deps.cfg.GenerateRequestID {
+	if deps.cfg.GenerateRequestID || bidRequestID == "{{UUID}}" {
 		isAppRequest, err := checkIfAppRequest(requestJson)
 		if err != nil {
 			return nil, nil, []error{err}
@@ -1500,6 +1505,17 @@ func getStoredRequestId(data []byte) (string, bool, error) {
 		return "", true, errors.New("ext.prebid.storedrequest.id must be a string")
 	}
 	return string(storedRequestId), true, nil
+}
+
+func getBidRequestID(data []byte) (string, error) {
+	bidRequestID, dataType, _, err := jsonparser.Get(data, "id")
+	if dataType == jsonparser.NotExist {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(bidRequestID), nil
 }
 
 // setIPImplicitly sets the IP address on bidReq, if it's not explicitly defined and we can figure it out.

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1215,6 +1215,12 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 			givenGenerateRequestID: true,
 			expectedID:             "ThisID",
 		},
+		{
+			description:            "Macro ID {{UUID}} case sensitivity check meaning a macro that is lowercase {{uuid}} shouldn't generate a uuid",
+			givenRawData:           testBidRequests[2],
+			givenGenerateRequestID: false,
+			expectedID:             "ThisID",
+		},
 	}
 
 	for _, test := range testCases {
@@ -3113,6 +3119,7 @@ func (e *brokenExchange) HoldAuction(ctx context.Context, r exchange.AuctionRequ
 var testStoredRequestData = map[string]json.RawMessage{
 	"1": json.RawMessage(`{"id": "{{UUID}}"}`),
 	"2": json.RawMessage(`{
+		"id": "{{uuid}}",
 		"tmax": 500,
 		"ext": {
 			"prebid": {

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1180,9 +1180,15 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 		expectedID             string
 	}{
 		{
-			description:            "GenerateRequestID is true, rawData is an app request, and stored bid we should generate uuid",
+			description:            "GenerateRequestID is true, rawData is an app request and has stored bid we should generate uuid",
 			givenRawData:           testStoredRequestsUuid[2],
 			givenGenerateRequestID: true,
+			expectedID:             uuid,
+		},
+		{
+			description:            "GenerateRequestID is false, rawData is an app request and has stored bid, but bidrequestID is the macro {{UUID}}, so we should generate uuid",
+			givenRawData:           testStoredRequestsUuid[2],
+			givenGenerateRequestID: false,
 			expectedID:             uuid,
 		},
 		{
@@ -1192,7 +1198,7 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 			expectedID:             "ThisID",
 		},
 		{
-			description:            "GenerateRequestID is false so we should not generate uuid",
+			description:            "GenerateRequestID is false and macro ID is not present, so we should not generate uuid",
 			givenRawData:           testStoredRequestsUuid[0],
 			givenGenerateRequestID: false,
 			expectedID:             "ThisID",
@@ -3616,7 +3622,7 @@ var testStoredRequestsUuid = []string{
 		}
 	}`,
 	`{
-		"id": "ThisID",
+		"id": "{{UUID}}",
 		"app": {
 			"id": "123"
 		},

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1186,6 +1186,12 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 			expectedID:             uuid,
 		},
 		{
+			description:            "GenerateRequestID is true, rawData is an app request, has stored bid, and bidrequestID is not the macro {{UUID}}, we should generate uuid",
+			givenRawData:           testStoredRequestsUuid[3],
+			givenGenerateRequestID: true,
+			expectedID:             uuid,
+		},
+		{
 			description:            "GenerateRequestID is false, rawData is an app request and has stored bid, but bidrequestID is the macro {{UUID}}, so we should generate uuid",
 			givenRawData:           testStoredRequestsUuid[2],
 			givenGenerateRequestID: false,
@@ -3623,6 +3629,33 @@ var testStoredRequestsUuid = []string{
 	}`,
 	`{
 		"id": "{{UUID}}",
+		"app": {
+			"id": "123"
+		},
+		"imp": [
+			{
+				"ext": {
+					"prebid": {
+						"storedrequest": {
+							"id": "2"
+						},
+						"options": {
+							"echovideoattrs": false
+						}
+					}
+				}
+			}
+		],
+		"ext": {
+			"prebid": {
+				"storedrequest": {
+					"id": "2"
+				}
+			}
+		}
+	}`,
+	`{
+		"id": "ThisID",
 		"app": {
 			"id": "123"
 		},

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1180,38 +1180,38 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 		expectedID             string
 	}{
 		{
-			description:            "GenerateRequestID is true, rawData is an app request and has stored bid we should generate uuid",
-			givenRawData:           testStoredRequestsUuid[2],
+			description:            "GenerateRequestID is true, rawData is an app request and has stored bid request we should generate uuid",
+			givenRawData:           testBidRequests[2],
 			givenGenerateRequestID: true,
 			expectedID:             uuid,
 		},
 		{
-			description:            "GenerateRequestID is true, rawData is an app request, has stored bid, and bidrequestID is not the macro {{UUID}}, we should generate uuid",
-			givenRawData:           testStoredRequestsUuid[3],
+			description:            "GenerateRequestID is true, rawData is an app request, has stored bid, and stored bidrequestID is not the macro {{UUID}}, we should generate uuid",
+			givenRawData:           testBidRequests[3],
 			givenGenerateRequestID: true,
 			expectedID:             uuid,
 		},
 		{
-			description:            "GenerateRequestID is false, rawData is an app request and has stored bid, but bidrequestID is the macro {{UUID}}, so we should generate uuid",
-			givenRawData:           testStoredRequestsUuid[2],
+			description:            "GenerateRequestID is false, rawData is an app request and has stored bid, but stored bidrequestID is the macro {{UUID}}, so we should generate uuid",
+			givenRawData:           testBidRequests[4],
 			givenGenerateRequestID: false,
 			expectedID:             uuid,
 		},
 		{
 			description:            "GenerateRequestID is true, rawData is an app request, but no stored bid, we should not generate uuid",
-			givenRawData:           testStoredRequestsUuid[0],
+			givenRawData:           testBidRequests[0],
 			givenGenerateRequestID: true,
 			expectedID:             "ThisID",
 		},
 		{
 			description:            "GenerateRequestID is false and macro ID is not present, so we should not generate uuid",
-			givenRawData:           testStoredRequestsUuid[0],
+			givenRawData:           testBidRequests[0],
 			givenGenerateRequestID: false,
 			expectedID:             "ThisID",
 		},
 		{
 			description:            "GenerateRequestID is true, but rawData is a site request, we should not generate uuid",
-			givenRawData:           testStoredRequestsUuid[1],
+			givenRawData:           testBidRequests[1],
 			givenGenerateRequestID: true,
 			expectedID:             "ThisID",
 		},
@@ -3111,8 +3111,9 @@ func (e *brokenExchange) HoldAuction(ctx context.Context, r exchange.AuctionRequ
 // first below is valid JSON
 // second below is identical to first but with extra '}' for invalid JSON
 var testStoredRequestData = map[string]json.RawMessage{
+	"1": json.RawMessage(`{"id": "{{UUID}}"}`),
 	"2": json.RawMessage(`{
-"tmax": 500,
+		"tmax": 500,
 		"ext": {
 			"prebid": {
 				"targeting": {
@@ -3122,7 +3123,7 @@ var testStoredRequestData = map[string]json.RawMessage{
 		}
 	}`),
 	"3": json.RawMessage(`{
-"tmax": 500,
+		"tmax": 500,
 				"ext": {
 						"prebid": {
 								"targeting": {
@@ -3557,7 +3558,7 @@ var testStoredImps = []string{
 	``,
 }
 
-var testStoredRequestsUuid = []string{
+var testBidRequests = []string{
 	`{
 		"id": "ThisID",
 		"app": {
@@ -3628,7 +3629,7 @@ var testStoredRequestsUuid = []string{
 		}
 	}`,
 	`{
-		"id": "{{UUID}}",
+		"id": "ThisID",
 		"app": {
 			"id": "123"
 		},
@@ -3677,6 +3678,33 @@ var testStoredRequestsUuid = []string{
 			"prebid": {
 				"storedrequest": {
 					"id": "2"
+				}
+			}
+		}
+	}`,
+	`{
+		"id": "ThisID",
+		"app": {
+			"id": "123"
+		},
+		"imp": [
+			{
+				"ext": {
+					"prebid": {
+						"storedrequest": {
+							"id": "1"
+						},
+						"options": {
+							"echovideoattrs": false
+						}
+					}
+				}
+			}
+		],
+		"ext": {
+			"prebid": {
+				"storedrequest": {
+					"id": "1"
 				}
 			}
 		}


### PR DESCRIPTION
In the original issue https://github.com/prebid/prebid-server/issues/1507, there was a request to add support for a macro ID, where if Prebid Server sees {{UUID}} then resolve to a UUID.

I didn't include this feature in the already merged issue https://github.com/prebid/prebid-server/pull/1938

So this pull request is to add support for that feature. 