### PR TITLE
VIS.X: mediatype handling fix for complex requests

### DIFF
--- a/adapters/visx/visx.go
+++ b/adapters/visx/visx.go
@@ -16,16 +16,29 @@ type VisxAdapter struct {
 	endpoint string
 }
 
+type visxBidExtPrebidMeta struct {
+	MediaType openrtb_ext.BidType `json:"mediaType"`
+}
+
+type visxBidExtPrebid struct {
+	Meta visxBidExtPrebidMeta `json:"meta"`
+}
+
+type visxBidExt struct {
+	Prebid visxBidExtPrebid `json:"prebid"`
+}
+
 type visxBid struct {
-	ImpID   string   `json:"impid"`
-	Price   float64  `json:"price"`
-	UID     int      `json:"auid"`
-	CrID    string   `json:"crid,omitempty"`
-	AdM     string   `json:"adm,omitempty"`
-	ADomain []string `json:"adomain,omitempty"`
-	DealID  string   `json:"dealid,omitempty"`
-	W       uint64   `json:"w,omitempty"`
-	H       uint64   `json:"h,omitempty"`
+	ImpID   string          `json:"impid"`
+	Price   float64         `json:"price"`
+	UID     int             `json:"auid"`
+	CrID    string          `json:"crid,omitempty"`
+	AdM     string          `json:"adm,omitempty"`
+	ADomain []string        `json:"adomain,omitempty"`
+	DealID  string          `json:"dealid,omitempty"`
+	W       uint64          `json:"w,omitempty"`
+	H       uint64          `json:"h,omitempty"`
+	Ext     json.RawMessage `json:"ext,omitempty"`
 }
 
 type visxSeatBid struct {
@@ -101,8 +114,9 @@ func (a *VisxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReq
 			bid.H = int64(sb.Bid[i].H)
 			bid.ADomain = sb.Bid[i].ADomain
 			bid.DealID = sb.Bid[i].DealID
+			bid.Ext = sb.Bid[i].Ext
 
-			bidType, err := getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp)
+			bidType, err := getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp, sb.Bid[i])
 			if err != nil {
 				return nil, []error{err}
 			}
@@ -117,9 +131,19 @@ func (a *VisxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReq
 
 }
 
-func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType, error) {
+func getMediaTypeForImp(impID string, imps []openrtb2.Imp, bid visxBid) (openrtb_ext.BidType, error) {
 	for _, imp := range imps {
 		if imp.ID == impID {
+			var ext visxBidExt
+			if err := json.Unmarshal(bid.Ext, &ext); err == nil {
+				if ext.Prebid.Meta.MediaType == openrtb_ext.BidTypeBanner {
+					return openrtb_ext.BidTypeBanner, nil
+				}
+				if ext.Prebid.Meta.MediaType == openrtb_ext.BidTypeVideo {
+					return openrtb_ext.BidTypeVideo, nil
+				}
+			}
+
 			if imp.Banner != nil {
 				return openrtb_ext.BidTypeBanner, nil
 			}


### PR DESCRIPTION
There is an issue when a request with banner and video objects is received in case if the adapter will respond with video bid it will have its mediatype set as banner, instead of the video. The following change will fix it.