### PR TITLE
Engagebdr: Remove GVL ID

### DIFF
--- a/static/bidder-info/engagebdr.yaml
+++ b/static/bidder-info/engagebdr.yaml
@@ -1,6 +1,5 @@
 maintainer:
   email: "tech@engagebdr.com"
-gvlVendorID: 62
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Per https://github.com/prebid/prebid-server/issues/1301

The Prebid Server Committee has decided to remove the EngageBDR GDPR GVL ID from their adapter configuration. It is listed as id 62 which is registered to "Justpremium BV". We are not aware of a business relationship between EngageBDR and Justpremium and we did not receive a response to our inquires to EngageBDR.