### PR TITLE
Address stored request not merging with UUID bug

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1368,12 +1368,12 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 	// Apply the Stored BidRequest, if it exists
 	resolvedRequest := requestJson
 
-	if deps.cfg.GenerateRequestID || bidRequestID == "{{UUID}}" {
+	if hasStoredBidRequest {
 		isAppRequest, err := checkIfAppRequest(requestJson)
 		if err != nil {
 			return nil, nil, []error{err}
 		}
-		if isAppRequest && hasStoredBidRequest {
+		if isAppRequest && (deps.cfg.GenerateRequestID || bidRequestID == "{{UUID}}") {
 			uuidPatch, err := generateUuidForBidRequest(deps.uuidGenerator)
 			if err != nil {
 				return nil, nil, []error{err}
@@ -1388,12 +1388,12 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 				errL := storedRequestErrorChecker(requestJson, storedRequests, storedBidRequestId)
 				return nil, nil, errL
 			}
-		}
-	} else if hasStoredBidRequest {
-		resolvedRequest, err = jsonpatch.MergePatch(storedRequests[storedBidRequestId], requestJson)
-		if err != nil {
-			errL := storedRequestErrorChecker(requestJson, storedRequests, storedBidRequestId)
-			return nil, nil, errL
+		} else {
+			resolvedRequest, err = jsonpatch.MergePatch(storedRequests[storedBidRequestId], requestJson)
+			if err != nil {
+				errL := storedRequestErrorChecker(requestJson, storedRequests, storedBidRequestId)
+				return nil, nil, errL
+			}
 		}
 	}
 

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1178,6 +1178,7 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 		givenRawData           string
 		givenGenerateRequestID bool
 		expectedID             string
+		expectedCur            string
 	}{
 		{
 			description:            "GenerateRequestID is true, rawData is an app request and has stored bid request we should generate uuid",
@@ -1221,6 +1222,20 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 			givenGenerateRequestID: false,
 			expectedID:             "ThisID",
 		},
+		{
+			description:            "Test to check that stored requests are being merged when Macro ID is present with a site rquest",
+			givenRawData:           testBidRequests[5],
+			givenGenerateRequestID: false,
+			expectedID:             "ThisID",
+			expectedCur:            "USD",
+		},
+		{
+			description:            "Test to check that stored requests are being merged when Generate Request ID flag with a site rquest",
+			givenRawData:           testBidRequests[5],
+			givenGenerateRequestID: true,
+			expectedID:             "ThisID",
+			expectedCur:            "USD",
+		},
 	}
 
 	for _, test := range testCases {
@@ -1232,6 +1247,9 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 
 		if err := json.Unmarshal(newRequest, req); err != nil {
 			t.Errorf("processStoredRequests Error: %s", err.Error())
+		}
+		if test.expectedCur != "" {
+			assert.Equalf(t, test.expectedCur, req.Cur[0], "The stored request wasn't merged properly: %s\n", test.description)
 		}
 		assert.Equalf(t, test.expectedID, req.ID, "The Bid Request ID is incorrect: %s\n", test.description)
 	}
@@ -3139,6 +3157,7 @@ var testStoredRequestData = map[string]json.RawMessage{
 						}
 				}}
 		}`),
+	"4": json.RawMessage(`{"id": "{{UUID}}", "cur": ["USD"]}`),
 }
 
 // Stored Imp Requests
@@ -3715,6 +3734,39 @@ var testBidRequests = []string{
 				}
 			}
 		}
+	}`,
+	`{
+		"id": "ThisID",
+		"imp": [{
+			"id": "some-impression-id",
+			"banner": {
+				"format": [{
+						"w": 600,
+						"h": 500
+					},
+					{
+						"w": 300,
+						"h": 600
+					}
+				]
+			},
+			"ext": {
+				"appnexus": {
+					"placementId": 12883451
+				}
+			}
+		}],
+		"ext": {
+			"prebid": {
+				"debug": true,
+				"storedrequest": {
+					"id": "4"
+				}
+			}
+		},
+	  "site": {
+		"page": "https://example.com"
+	  }
 	}`,
 }
 


### PR DESCRIPTION
Addressing the bug issue brought up here: https://github.com/prebid/prebid-server/issues/2045

The issue came with how the conditionals were set up when deciding when to generate a UUID. Since we first check whether the GenerateRequestId flag is true or if the macro {{"UUID"}} is set, if either of those conditions are true, and then the request is a site request, we won't generate an id, but we also won't perform any of the stored request merging operations. By re-arranging the conditionals, we now can avoid this bug. 

Tests were added as well to check for this bug. 