### PR TITLE
Syncer Level ExternalURL Override

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -102,13 +102,9 @@ func (s *Syncer) Override(original *Syncer) *Syncer {
 
 	if original == nil {
 		copy.IFrame = s.IFrame.Override(nil)
-	} else {
-		copy.IFrame = s.IFrame.Override(original.IFrame)
-	}
-
-	if original == nil {
 		copy.Redirect = s.Redirect.Override(nil)
 	} else {
+		copy.IFrame = s.IFrame.Override(original.IFrame)
 		copy.Redirect = s.Redirect.Override(original.Redirect)
 	}
 

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -68,6 +68,9 @@ type Syncer struct {
 	// endpoint in the Prebid.js project.
 	Redirect *SyncerEndpoint `yaml:"redirect" mapstructure:"redirect"`
 
+	// ExternalURL is available as a macro to the RedirectURL template.
+	ExternalURL string `yaml:"externalUrl" mapstructure:"external_url"`
+
 	// SupportCORS identifies if CORS is supported for the user syncing endpoints.
 	SupportCORS *bool `yaml:"supportCors" mapstructure:"support_cors"`
 }
@@ -107,6 +110,10 @@ func (s *Syncer) Override(original *Syncer) *Syncer {
 		copy.Redirect = s.Redirect.Override(nil)
 	} else {
 		copy.Redirect = s.Redirect.Override(original.Redirect)
+	}
+
+	if s.ExternalURL != "" {
+		copy.ExternalURL = s.ExternalURL
 	}
 
 	if s.SupportCORS != nil {
@@ -162,8 +169,8 @@ type SyncerEndpoint struct {
 	// `{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&f={{.SyncType}}&uid={{.UserMacro}}`
 	RedirectURL string `yaml:"redirectUrl" mapstructure:"redirect_url"`
 
-	// ExternalURL is available as a macro to the RedirectURL template. If not specified, the host configuration
-	// value is used.
+	// ExternalURL is available as a macro to the RedirectURL template. If not specified, either the syncer configuration
+	// value or the host configuration value is used.
 	ExternalURL string `yaml:"externalUrl" mapstructure:"external_url"`
 
 	// UserMacro is available as a macro to the RedirectURL template. This value is specific to the bidder server

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -227,6 +227,12 @@ func TestSyncerOverride(t *testing.T) {
 			expected:      &Syncer{Redirect: &SyncerEndpoint{URL: "override"}},
 		},
 		{
+			description:   "Override ExternalURL",
+			givenOriginal: &Syncer{ExternalURL: "original"},
+			givenOverride: &Syncer{ExternalURL: "override"},
+			expected:      &Syncer{ExternalURL: "override"},
+		},
+		{
 			description:   "Override SupportCORS",
 			givenOriginal: &Syncer{SupportCORS: &trueValue},
 			givenOverride: &Syncer{SupportCORS: &falseValue},

--- a/config/config.go
+++ b/config/config.go
@@ -1102,6 +1102,7 @@ func setBidderDefaults(v *viper.Viper, bidder string) {
 	v.BindEnv(adapterCfgPrefix + ".usersync.redirect.redirect_url")
 	v.BindEnv(adapterCfgPrefix + ".usersync.redirect.external_url")
 	v.BindEnv(adapterCfgPrefix + ".usersync.redirect.user_macro")
+	v.BindEnv(adapterCfgPrefix + ".usersync.external_url")
 	v.BindEnv(adapterCfgPrefix + ".usersync.support_cors")
 }
 

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -153,13 +153,7 @@ func buildTemplate(key, syncTypeValue string, hostConfig config.UserSync, syncer
 		redirectTemplate = hostConfig.RedirectURL
 	}
 
-	externalURL := syncerEndpoint.ExternalURL
-	if externalURL == "" {
-		externalURL = syncerExternalURL
-	}
-	if externalURL == "" {
-		externalURL = hostConfig.ExternalURL
-	}
+	externalURL := chooseExternalURL(syncerEndpoint.ExternalURL, syncerExternalURL, hostConfig.ExternalURL)
 
 	redirectURL := macroRegexSyncerKey.ReplaceAllLiteralString(redirectTemplate, key)
 	redirectURL = macroRegexSyncType.ReplaceAllLiteralString(redirectURL, syncTypeValue)
@@ -171,6 +165,19 @@ func buildTemplate(key, syncTypeValue string, hostConfig config.UserSync, syncer
 
 	templateName := strings.ToLower(key) + "_usersync_url"
 	return template.New(templateName).Parse(url)
+}
+
+// chooseExternalURL selects the external url to use for the template, where the most specific config wins.
+func chooseExternalURL(syncerEndpointURL, syncerURL, hostConfigURL string) string {
+	if syncerEndpointURL != "" {
+		return syncerEndpointURL
+	}
+
+	if syncerURL != "" {
+		return syncerURL
+	}
+
+	return hostConfigURL
 }
 
 // escapeTemplate url encodes a string template leaving the macro tags unaffected.

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -86,7 +86,7 @@ func NewSyncer(hostConfig config.UserSync, syncerConfig config.Syncer) (Syncer, 
 
 	if syncerConfig.IFrame != nil {
 		var err error
-		syncer.iframe, err = buildTemplate(syncerConfig.Key, setuidSyncTypeIFrame, hostConfig, *syncerConfig.IFrame)
+		syncer.iframe, err = buildTemplate(syncerConfig.Key, setuidSyncTypeIFrame, hostConfig, syncerConfig.ExternalURL, *syncerConfig.IFrame)
 		if err != nil {
 			return nil, fmt.Errorf("iframe %v", err)
 		}
@@ -97,7 +97,7 @@ func NewSyncer(hostConfig config.UserSync, syncerConfig config.Syncer) (Syncer, 
 
 	if syncerConfig.Redirect != nil {
 		var err error
-		syncer.redirect, err = buildTemplate(syncerConfig.Key, setuidSyncTypeRedirect, hostConfig, *syncerConfig.Redirect)
+		syncer.redirect, err = buildTemplate(syncerConfig.Key, setuidSyncTypeRedirect, hostConfig, syncerConfig.ExternalURL, *syncerConfig.Redirect)
 		if err != nil {
 			return nil, fmt.Errorf("redirect %v", err)
 		}
@@ -147,13 +147,16 @@ var (
 	macroRegex             = regexp.MustCompile(`{{\s*\..*?\s*}}`)
 )
 
-func buildTemplate(key, syncTypeValue string, hostConfig config.UserSync, syncerEndpoint config.SyncerEndpoint) (*template.Template, error) {
+func buildTemplate(key, syncTypeValue string, hostConfig config.UserSync, syncerExternalURL string, syncerEndpoint config.SyncerEndpoint) (*template.Template, error) {
 	redirectTemplate := syncerEndpoint.RedirectURL
 	if redirectTemplate == "" {
 		redirectTemplate = hostConfig.RedirectURL
 	}
 
 	externalURL := syncerEndpoint.ExternalURL
+	if externalURL == "" {
+		externalURL = syncerExternalURL
+	}
 	if externalURL == "" {
 		externalURL = hostConfig.ExternalURL
 	}

--- a/usersync/syncer_test.go
+++ b/usersync/syncer_test.go
@@ -384,6 +384,50 @@ func TestBuildTemplate(t *testing.T) {
 	}
 }
 
+func TestChooseExternalURL(t *testing.T) {
+	testCases := []struct {
+		description            string
+		givenSyncerEndpointURL string
+		givenSyncerURL         string
+		givenHostConfigURL     string
+		expected               string
+	}{
+		{
+			description:            "Syncer Endpoint Chosen",
+			givenSyncerEndpointURL: "a",
+			givenSyncerURL:         "b",
+			givenHostConfigURL:     "c",
+			expected:               "a",
+		},
+		{
+			description:            "Syncer Chosen",
+			givenSyncerEndpointURL: "",
+			givenSyncerURL:         "b",
+			givenHostConfigURL:     "c",
+			expected:               "b",
+		},
+		{
+			description:            "Host Config Chosen",
+			givenSyncerEndpointURL: "",
+			givenSyncerURL:         "",
+			givenHostConfigURL:     "c",
+			expected:               "c",
+		},
+		{
+			description:            "All Empty",
+			givenSyncerEndpointURL: "",
+			givenSyncerURL:         "",
+			givenHostConfigURL:     "",
+			expected:               "",
+		},
+	}
+
+	for _, test := range testCases {
+		result := chooseExternalURL(test.givenSyncerEndpointURL, test.givenSyncerURL, test.givenHostConfigURL)
+		assert.Equal(t, test.expected, result, test.description)
+	}
+}
+
 func TestEscapeTemplate(t *testing.T) {
 	testCases := []struct {
 		description string


### PR DESCRIPTION
Allows a host to override the external url at the syncer level in addition to the existing syncer endpoint level. This will make it easier for the host to configure an override since the endpoint type is no longer required, but is still available if different endpoints require different values.