### PR TITLE
Add a garbage collection threshold

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ type Configuration struct {
 	CacheClient HTTPClient `mapstructure:"http_client_cache"`
 	AdminPort   int        `mapstructure:"admin_port"`
 	EnableGzip  bool       `mapstructure:"enable_gzip"`
-	// GarbageCollectorLimit will serve as a fixed cost of memory that is going to be held garbage
-	// before a garbage collection cycle is triggered
-	GarbageCollectorLimit int `mapstructure:"garbage_collector_limit"`
+	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
+	// serves as a hack to trigger the garbage collector only when the heap reaches at least this size.
+	GarbageCollectorThreshold int `mapstructure:"garbage_collector_threshold"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
 	StatusResponse    string          `mapstructure:"status_response"`
@@ -637,7 +637,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("port", 8000)
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)
-	v.SetDefault("garbage_collector_limit", 0)
+	v.SetDefault("garbage_collector_threshold", 0)
 	v.SetDefault("status_response", "")
 	v.SetDefault("auction_timeouts_ms.default", 0)
 	v.SetDefault("auction_timeouts_ms.max", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ type Configuration struct {
 	CacheClient HTTPClient `mapstructure:"http_client_cache"`
 	AdminPort   int        `mapstructure:"admin_port"`
 	EnableGzip  bool       `mapstructure:"enable_gzip"`
+	// GarbageCollectorLimit will serve as a fixed cost of memory that is going to be held garbage
+	// before a garbage collection cycle is triggered
+	GarbageCollectorLimit int `mapstructure:"garbage_collector_limit"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.
 	StatusResponse    string          `mapstructure:"status_response"`
@@ -634,6 +637,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("port", 8000)
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)
+	v.SetDefault("garbage_collector_limit", 0)
 	v.SetDefault("status_response", "")
 	v.SetDefault("auction_timeouts_ms.default", 0)
 	v.SetDefault("auction_timeouts_ms.max", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	EnableGzip  bool       `mapstructure:"enable_gzip"`
 	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
 	// serves as a hack to trigger the garbage collector only when the heap reaches at least this size.
+	// More info: https://github.com/golang/go/issues/48409
 	GarbageCollectorThreshold int `mapstructure:"garbage_collector_threshold"`
 	// StatusResponse is the string which will be returned by the /status endpoint when things are OK.
 	// If empty, it will return a 204 with no content.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -701,7 +701,7 @@ func TestGarbageCollectorThresholdFromEnv(t *testing.T) {
 	os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", "1")
 	cfg, _ := newDefaultConfig(t)
 
-	// Assert config value defers from the default value of 0
+	// Assert config value differs from the default value of 0
 	cmpInts(t, "garbage_collector_threshold", 1, cfg.GarbageCollectorThreshold)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -692,6 +692,17 @@ func TestMigrateConfigFromEnv(t *testing.T) {
 	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
 }
 
+func TestGarbageCollectorThresholdFromEnv(t *testing.T) {
+	if oldval, ok := os.LookupEnv("PBS_GARBAGE_COLLECTOR_THRESHOLD"); ok {
+		defer os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", oldval)
+	} else {
+		defer os.Unsetenv("PBS_GARBAGE_COLLECTOR_THRESHOLD")
+	}
+	os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", "1")
+	cfg, _ := newDefaultConfig(t)
+	cmpInts(t, "garbage_collector_threshold", 1, cfg.GarbageCollectorThreshold)
+}
+
 func TestMigrateConfigPurposeOneTreatment(t *testing.T) {
 	oldPurposeOneTreatmentConfig := []byte(`
       gdpr:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -700,6 +700,8 @@ func TestGarbageCollectorThresholdFromEnv(t *testing.T) {
 	}
 	os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", "1")
 	cfg, _ := newDefaultConfig(t)
+
+	// Assert config value defers from the default value of 0
 	cmpInts(t, "garbage_collector_threshold", 1, cfg.GarbageCollectorThreshold)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -692,19 +692,6 @@ func TestMigrateConfigFromEnv(t *testing.T) {
 	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
 }
 
-func TestGarbageCollectorThresholdFromEnv(t *testing.T) {
-	if oldval, ok := os.LookupEnv("PBS_GARBAGE_COLLECTOR_THRESHOLD"); ok {
-		defer os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", oldval)
-	} else {
-		defer os.Unsetenv("PBS_GARBAGE_COLLECTOR_THRESHOLD")
-	}
-	os.Setenv("PBS_GARBAGE_COLLECTOR_THRESHOLD", "1")
-	cfg, _ := newDefaultConfig(t)
-
-	// Assert config value differs from the default value of 0
-	cmpInts(t, "garbage_collector_threshold", 1, cfg.GarbageCollectorThreshold)
-}
-
 func TestMigrateConfigPurposeOneTreatment(t *testing.T) {
 	oldPurposeOneTreatmentConfig := []byte(`
       gdpr:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -289,6 +289,7 @@ external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
+garbage_collector_limit: 32768
 auction_timeouts_ms:
   max: 123
   default: 50
@@ -426,6 +427,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "host", cfg.Host, "prebid-server.prebid.org")
 	cmpInts(t, "port", cfg.Port, 1234)
 	cmpInts(t, "admin_port", cfg.AdminPort, 5678)
+	cmpInts(t, "garbage_collector_limit", cfg.GarbageCollectorLimit, 32768)
 	cmpInts(t, "auction_timeouts_ms.default", int(cfg.AuctionTimeouts.Default), 50)
 	cmpInts(t, "auction_timeouts_ms.max", int(cfg.AuctionTimeouts.Max), 123)
 	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -289,7 +289,7 @@ external_url: http://prebid-server.prebid.org/
 host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
-garbage_collector_limit: 32768
+garbage_collector_threshold: 1
 auction_timeouts_ms:
   max: 123
   default: 50
@@ -427,7 +427,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "host", cfg.Host, "prebid-server.prebid.org")
 	cmpInts(t, "port", cfg.Port, 1234)
 	cmpInts(t, "admin_port", cfg.AdminPort, 5678)
-	cmpInts(t, "garbage_collector_limit", cfg.GarbageCollectorLimit, 32768)
+	cmpInts(t, "garbage_collector_threshold", cfg.GarbageCollectorThreshold, 1)
 	cmpInts(t, "auction_timeouts_ms.default", int(cfg.AuctionTimeouts.Default), 50)
 	cmpInts(t, "auction_timeouts_ms.max", int(cfg.AuctionTimeouts.Max), 123)
 	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"math/rand"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/prebid/prebid-server/config"
@@ -20,8 +21,6 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-var garbageCollectionThreshold []byte
-
 func main() {
 	flag.Parse() // required for glog flags and testing package flags
 
@@ -35,7 +34,8 @@ func main() {
 	// of memory that is going to be held garbage before a garbage collection cycle is triggered.
 	// This amount of virtual memory won’t translate into physical memory allocation unless we attempt
 	// to read or write to the slice below, which PBS will not do.
-	garbageCollectionThreshold = make([]byte, cfg.GarbageCollectorThreshold)
+	garbageCollectionThreshold := make([]byte, cfg.GarbageCollectorThreshold)
+	defer runtime.KeepAlive(garbageCollectionThreshold)
 
 	err = serve(cfg)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-var garbageCollectionLimit []byte
+var garbageCollectionThreshold []byte
 
 func main() {
 	flag.Parse() // required for glog flags and testing package flags
@@ -31,11 +31,11 @@ func main() {
 	}
 
 	// Create a soft memory limit on the total amount of memory that PBS uses to tune the behavior
-	// of the Go garbage collector. In summary, `cfg.GarbageCollectorLimit` serves as a fixed cost
+	// of the Go garbage collector. In summary, `cfg.GarbageCollectorThreshold` serves as a fixed cost
 	// of memory that is going to be held garbage before a garbage collection cycle is triggered.
 	// This amount of virtual memory won’t translate into physical memory allocation unless we attempt
 	// to read or write to the slice below, which PBS will not do.
-	garbageCollectionLimit = make([]byte, cfg.GarbageCollectorLimit)
+	garbageCollectionThreshold = make([]byte, cfg.GarbageCollectorThreshold)
 
 	err = serve(cfg)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
+var garbageCollectionLimit []byte
+
 func main() {
 	flag.Parse() // required for glog flags and testing package flags
 
@@ -27,6 +29,13 @@ func main() {
 	if err != nil {
 		glog.Exitf("Configuration could not be loaded or did not pass validation: %v", err)
 	}
+
+	// Create a soft memory limit on the total amount of memory that PBS uses to tune the behavior
+	// of the Go garbage collector. In summary, `cfg.GarbageCollectorLimit` serves as a fixed cost
+	// of memory that is going to be held garbage before a garbage collection cycle is triggered.
+	// This amount of virtual memory won’t translate into physical memory allocation unless we attempt
+	// to read or write to the slice below, which PBS will not do.
+	garbageCollectionLimit = make([]byte, cfg.GarbageCollectorLimit)
 
 	err = serve(cfg)
 	if err != nil {


### PR DESCRIPTION
Pull request #2049 removed the legacy `/auction` endpoint. An unintended consequence of removing the legacy code was an increase in CPU time caused by garbage collection overhead. After a thorough investigation of the performance of the system, the Prebid Server Team found out that the initialization of a very large slice in the old code was preventing the garbage collection to be called repeatedly, saving CPU time. This pull request puts back a soft memory limit to save CPU performance and makes this value configurable.

Issue [#48409](https://github.com/golang/go/issues/48409) posted in the go development project better explains what happens behind the scenes, in summary, we are setting an amount of memory that is going to be held garbage before a garbage collection cycle gets triggered.
