### PR TITLE
Added integration type support for host company

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,9 @@ type Configuration struct {
 	GenerateBidID bool `mapstructure:"generate_bid_id"`
 	// GenerateRequestID overrides the bidrequest.id in an AMP Request or an App Stored Request with a generated UUID if set to true. The default is false.
 	GenerateRequestID bool `mapstructure:"generate_request_id"`
+	// IntegrationTypes will hold the integration type values that the host will allow.
+	// Map structure isn't included here because the integration type feature is still being worked on, but once complete, this variable will be updated
+	IntegrationTypes map[string]bool
 }
 
 const MIN_COOKIE_SIZE_BYTES = 500

--- a/config/config.go
+++ b/config/config.go
@@ -84,9 +84,9 @@ type Configuration struct {
 	GenerateBidID bool `mapstructure:"generate_bid_id"`
 	// GenerateRequestID overrides the bidrequest.id in an AMP Request or an App Stored Request with a generated UUID if set to true. The default is false.
 	GenerateRequestID bool `mapstructure:"generate_request_id"`
-	// IntegrationTypes will hold the integration type values that the host will allow.
+	// IntegrationTypesMap will hold the integration type values that the host will allow.
 	// Map structure isn't included here because the integration type feature is still being worked on, but once complete, this variable will be updated
-	IntegrationTypes map[string]bool
+	IntegrationTypesMap map[string]struct{}
 }
 
 const MIN_COOKIE_SIZE_BYTES = 500

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/prebid/prebid-server/firstpartydata"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -14,8 +13,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prebid/prebid-server/firstpartydata"
+
 	"github.com/buger/jsonparser"
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/gofrs/uuid"
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
@@ -1652,4 +1653,24 @@ func checkIfAppRequest(request []byte) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func getIntegrationTypeFromRequest(req *openrtb_ext.RequestWrapper) (string, error) {
+	reqExt, err := req.GetRequestExt()
+	if err != nil {
+		return "", err
+	}
+	reqPrebid := reqExt.GetPrebid()
+	return reqPrebid.IntegrationType, nil
+}
+
+func validateIntegrationType(req *openrtb_ext.RequestWrapper, integrationTypes map[string]bool) error {
+	integrationType, err := getIntegrationTypeFromRequest(req)
+	if err != nil {
+		return err
+	}
+	if _, ok := integrationTypes[integrationType]; ok {
+		return nil
+	}
+	return errors.New("Integration value is invalid because it's not in allowed list from host company")
 }

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1661,16 +1661,19 @@ func getIntegrationTypeFromRequest(req *openrtb_ext.RequestWrapper) (string, err
 		return "", err
 	}
 	reqPrebid := reqExt.GetPrebid()
-	return reqPrebid.IntegrationType, nil
+	if reqPrebid == nil {
+		return "", nil // TODO: Default Integration value will be utilized here in future PR
+	}
+	return reqPrebid.Integration, nil
 }
 
-func validateIntegrationType(req *openrtb_ext.RequestWrapper, integrationTypes map[string]bool) error {
+func validateIntegrationType(req *openrtb_ext.RequestWrapper, integrationTypesMap map[string]*struct{}) error {
 	integrationType, err := getIntegrationTypeFromRequest(req)
 	if err != nil {
 		return err
 	}
-	if _, ok := integrationTypes[integrationType]; ok {
-		return nil
+	if _, ok := integrationTypesMap[integrationType]; ok {
+		return nil // TODO: Default Integration value will be utilized here in future PR
 	}
 	return errors.New("Integration value is invalid because it's not in allowed list from host company")
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1254,7 +1254,7 @@ func TestStoredRequestGenerateUuid(t *testing.T) {
 
 func TestValidateIntegrationType(t *testing.T) {
 	hostAllowedIntegrationTypes := make(map[string]bool)
-	hostAllowedIntegrationTypes["ValidIntegrationType1"] = true
+	hostAllowedIntegrationTypes["ValidIntegrationType"] = true
 
 	testCases := []struct {
 		description      string
@@ -1268,8 +1268,8 @@ func TestValidateIntegrationType(t *testing.T) {
 		},
 		{
 			description:      "Integration type found in request is NOT in allowed list of host",
-			givenRequestData: testBidRequests[6],
-			expectedError:    errors.New("Invalid integration value!"),
+			givenRequestData: testBidRequests[3],
+			expectedError:    errors.New("Integration value is invalid because it's not in allowed list from host company"),
 		},
 	}
 
@@ -3755,7 +3755,7 @@ var testBidRequests = []string{
 		],
 		"ext": {
 			"prebid": {
-				"integration" : "ValidIntegrationType1",
+				"integration" : "ValidIntegrationType",
 				"storedrequest": {
 					"id": "2"
 				}
@@ -3783,6 +3783,7 @@ var testBidRequests = []string{
 		],
 		"ext": {
 			"prebid": {
+				"integration" : "InvalidIntegrationType",
 				"storedrequest": {
 					"id": "2"
 				}
@@ -3848,36 +3849,6 @@ var testBidRequests = []string{
 	  "site": {
 		"page": "https://example.com"
 	  }
-	}`,
-	`{
-		"id": "some-request-id20",
-		"site": {
-			"page": "prebid.org"
-		},
-		"imp": [{
-			"id": "some-impression-id",
-			"banner": {
-				"format": [{
-						"w": 600,
-						"h": 500
-					},
-					{
-						"w": 300,
-						"h": 600
-					}
-				]
-			},
-			"ext": {
-				"appnexus": {
-					"placementId": 12883451
-				}
-			}
-		}],
-		"ext": {
-			"prebid": {
-				"integration" : "Invalid"
-			}
-		}
 	}`,
 }
 

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -33,7 +33,7 @@ type ExtRequestPrebid struct {
 	Data                 *ExtRequestPrebidData     `json:"data,omitempty"`
 	Debug                bool                      `json:"debug,omitempty"`
 	Events               json.RawMessage           `json:"events,omitempty"`
-	IntegrationType      string                    `json:"integration,omitempty"`
+	Integration          string                    `json:"integration,omitempty"`
 	SChains              []*ExtRequestPrebidSChain `json:"schains,omitempty"`
 	StoredRequest        *ExtStoredRequest         `json:"storedrequest,omitempty"`
 	SupportDeals         bool                      `json:"supportdeals,omitempty"`

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -33,6 +33,7 @@ type ExtRequestPrebid struct {
 	Data                 *ExtRequestPrebidData     `json:"data,omitempty"`
 	Debug                bool                      `json:"debug,omitempty"`
 	Events               json.RawMessage           `json:"events,omitempty"`
+	IntegrationType      string                    `json:"integration,omitempty"`
 	SChains              []*ExtRequestPrebidSChain `json:"schains,omitempty"`
 	StoredRequest        *ExtStoredRequest         `json:"storedrequest,omitempty"`
 	SupportDeals         bool                      `json:"supportdeals,omitempty"`


### PR DESCRIPTION
This PR partially addresses the Integration Type and Channel issue https://github.com/prebid/prebid-server/issues/1428

There will be a series of smaller PRs to address this issue, another PR is currently out for adding channel support here https://github.com/prebid/prebid-server/pull/2037

This PR is the first one dedicated towards the Integration part of the issue. What this PR does is it adds the functions that allow us to get the integration type (`getIntegrationTypeFromRequest()`) value found in a openRTB request, and to validate that the integration value in the request is allowed by the host company (`validateIntegrationType()`).

Future integration type focused PRs will add support for publishers to define a `defaultIntegration` value, and if that value can be overridden. 