### PR TITLE
Adform adapter lacked gross/net parameter support

### DIFF
--- a/adapters/adf/adf.go
+++ b/adapters/adf/adf.go
@@ -16,6 +16,10 @@ type adapter struct {
 	endpoint string
 }
 
+type adfRequestExt struct {
+	PriceType string `json:"pt"`
+}
+
 // Builder builds a new instance of the Adf adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters.Bidder, error) {
 	bidder := &adapter{
@@ -47,6 +51,15 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 
 		imp.TagID = adfImpExt.MasterTagID.String()
 		validImps = append(validImps, imp)
+
+		if adfImpExt.PriceType != "" {
+			requestExt := adfRequestExt{PriceType: adfImpExt.PriceType}
+			var err error
+			if request.Ext, err = json.Marshal(&requestExt); err != nil {
+				errors = append(errors, err)
+				continue
+			}
+		}
 	}
 
 	request.Imp = validImps

--- a/adapters/adf/adf.go
+++ b/adapters/adf/adf.go
@@ -62,18 +62,20 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 
 	if priceType != "" {
 		requestExt := adfRequestExt{}
+		var err error
 
 		if len(request.Ext) > 0 {
-			if err := json.Unmarshal(request.Ext, &requestExt); err != nil {
+			if err = json.Unmarshal(request.Ext, &requestExt); err != nil {
 				errors = append(errors, err)
 			}
 		}
 
-		requestExt.PriceType = priceType
+		if err == nil {
+			requestExt.PriceType = priceType
 
-		var err error
-		if request.Ext, err = json.Marshal(&requestExt); err != nil {
-			errors = append(errors, err)
+			if request.Ext, err = json.Marshal(&requestExt); err != nil {
+				errors = append(errors, err)
+			}
 		}
 	}
 

--- a/adapters/adf/adf.go
+++ b/adapters/adf/adf.go
@@ -17,6 +17,7 @@ type adapter struct {
 }
 
 type adfRequestExt struct {
+	openrtb_ext.ExtRequest
 	PriceType string `json:"pt"`
 }
 
@@ -53,7 +54,19 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		validImps = append(validImps, imp)
 
 		if adfImpExt.PriceType != "" {
-			requestExt := adfRequestExt{PriceType: adfImpExt.PriceType}
+			var requestExt adfRequestExt
+
+			if len(request.Ext) > 0 {
+				if err := json.Unmarshal(request.Ext, &requestExt); err != nil {
+					errors = append(errors, err)
+					continue
+				}
+			} else {
+				requestExt = adfRequestExt{}
+			}
+
+			requestExt.PriceType = adfImpExt.PriceType
+
 			var err error
 			if request.Ext, err = json.Marshal(&requestExt); err != nil {
 				errors = append(errors, err)

--- a/adapters/adf/adftest/exemplary/single-banner-pricetype-gross-extend-ext.json
+++ b/adapters/adf/adftest/exemplary/single-banner-pricetype-gross-extend-ext.json
@@ -1,6 +1,13 @@
 {
   "mockBidRequest": {
     "id": "test-request-id",
+    "ext":{
+      "prebid":{
+        "aliases":{
+          "adfalias": "adf"
+        }
+      }
+    },
     "imp": [{
       "id": "test-imp-id",
       "ext": {
@@ -33,7 +40,10 @@
       "body": {
         "id": "test-request-id",
         "ext": {
-          "prebid": {
+          "prebid":{
+            "aliases":{
+              "adfalias": "adf"
+            }
           },
           "pt": "gross"
         },

--- a/adapters/adf/adftest/exemplary/single-banner-pricetype-gross.json
+++ b/adapters/adf/adftest/exemplary/single-banner-pricetype-gross.json
@@ -1,0 +1,110 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [{
+      "id": "test-imp-id",
+      "ext": {
+        "bidder": {
+          "mid": "828782",
+          "priceType": "gross"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    }],
+    "site": {
+      "publisher": {
+        "id": "1"
+      },
+      "page": "some-page-url"
+    },
+    "device": {
+      "w": 1920,
+      "h": 800
+    }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://adx.adform.net/adx/openrtb",
+      "body": {
+        "id": "test-request-id",
+        "ext": {
+          "pt": "gross"
+        },
+        "imp": [{
+          "id": "test-imp-id",
+          "ext": {
+            "bidder": {
+              "mid": "828782",
+              "priceType": "gross"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828782"
+        }],
+        "site": {
+          "publisher": {
+            "id": "1"
+          },
+          "page": "some-page-url"
+        },
+        "device": {
+          "w": 1920,
+          "h": 800
+        }
+      }
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "test-request-id",
+        "seatbid": [{
+          "bid": [{
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 10,
+            "adm": "{banner html}",
+            "adomain": [ "test.com" ],
+            "crid": "test-creative-id",
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          }]
+        }],
+        "cur": "USD"
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [
+      {
+        "bid": {
+          "id": "test-bid-id",
+          "impid": "test-imp-id",
+          "price": 10,
+          "adm": "{banner html}",
+          "crid": "test-creative-id",
+          "adomain": [ "test.com" ],
+          "ext": {
+            "prebid": {
+              "type": "banner"
+            }
+          }
+        },
+        "type": "banner"
+      }
+    ]
+  }]
+}

--- a/adapters/adf/adftest/exemplary/single-banner-pricetype-net.json
+++ b/adapters/adf/adftest/exemplary/single-banner-pricetype-net.json
@@ -33,6 +33,8 @@
       "body": {
         "id": "test-request-id",
         "ext": {
+          "prebid": {
+          },
           "pt": "net"
         },
         "imp": [{

--- a/adapters/adf/adftest/exemplary/single-banner-pricetype-net.json
+++ b/adapters/adf/adftest/exemplary/single-banner-pricetype-net.json
@@ -1,0 +1,110 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [{
+      "id": "test-imp-id",
+      "ext": {
+        "bidder": {
+          "mid": "828782",
+          "priceType": "net"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    }],
+    "site": {
+      "publisher": {
+        "id": "1"
+      },
+      "page": "some-page-url"
+    },
+    "device": {
+      "w": 1920,
+      "h": 800
+    }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://adx.adform.net/adx/openrtb",
+      "body": {
+        "id": "test-request-id",
+        "ext": {
+          "pt": "net"
+        },
+        "imp": [{
+          "id": "test-imp-id",
+          "ext": {
+            "bidder": {
+              "mid": "828782",
+              "priceType": "net"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828782"
+        }],
+        "site": {
+          "publisher": {
+            "id": "1"
+          },
+          "page": "some-page-url"
+        },
+        "device": {
+          "w": 1920,
+          "h": 800
+        }
+      }
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "test-request-id",
+        "seatbid": [{
+          "bid": [{
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 10,
+            "adm": "{banner html}",
+            "adomain": [ "test.com" ],
+            "crid": "test-creative-id",
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          }]
+        }],
+        "cur": "USD"
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [
+      {
+        "bid": {
+          "id": "test-bid-id",
+          "impid": "test-imp-id",
+          "price": 10,
+          "adm": "{banner html}",
+          "crid": "test-creative-id",
+          "adomain": [ "test.com" ],
+          "ext": {
+            "prebid": {
+              "type": "banner"
+            }
+          }
+        },
+        "type": "banner"
+      }
+    ]
+  }]
+}

--- a/adapters/adf/adftest/exemplary/two-banners-different-pricetypes-extend-ext.json
+++ b/adapters/adf/adftest/exemplary/two-banners-different-pricetypes-extend-ext.json
@@ -1,0 +1,151 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "ext":{
+      "prebid":{
+        "aliases":{
+          "adfalias": "adf"
+        }
+      }
+    },
+    "imp": [{
+      "id": "test-imp-id",
+      "ext": {
+        "bidder": {
+          "mid": "828782",
+          "priceType": "gross"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    },{
+      "id": "test-imp-id2",
+      "ext": {
+        "bidder": {
+          "mid": "828783",
+          "priceType": "net"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    }],
+    "site": {
+      "publisher": {
+        "id": "1"
+      },
+      "page": "some-page-url"
+    },
+    "device": {
+      "w": 1920,
+      "h": 800
+    }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://adx.adform.net/adx/openrtb",
+      "body": {
+        "id": "test-request-id",
+        "ext": {
+          "prebid":{
+            "aliases":{
+              "adfalias": "adf"
+            }
+          },
+          "pt": "gross"
+        },
+        "imp": [{
+          "id": "test-imp-id",
+          "ext": {
+            "bidder": {
+              "mid": "828782",
+              "priceType": "gross"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828782"
+        },{
+          "id": "test-imp-id2",
+          "ext": {
+            "bidder": {
+              "mid": "828783",
+              "priceType": "net"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828783"
+        }],
+        "site": {
+          "publisher": {
+            "id": "1"
+          },
+          "page": "some-page-url"
+        },
+        "device": {
+          "w": 1920,
+          "h": 800
+        }
+      }
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "test-request-id",
+        "seatbid": [{
+          "bid": [{
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 10,
+            "adm": "{banner html}",
+            "adomain": [ "test.com" ],
+            "crid": "test-creative-id",
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          }]
+        }],
+        "cur": "USD"
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [
+      {
+        "bid": {
+          "id": "test-bid-id",
+          "impid": "test-imp-id",
+          "price": 10,
+          "adm": "{banner html}",
+          "crid": "test-creative-id",
+          "adomain": [ "test.com" ],
+          "ext": {
+            "prebid": {
+              "type": "banner"
+            }
+          }
+        },
+        "type": "banner"
+      }
+    ]
+  }]
+}

--- a/adapters/adf/adftest/exemplary/two-banners-different-pricetypes.json
+++ b/adapters/adf/adftest/exemplary/two-banners-different-pricetypes.json
@@ -1,0 +1,141 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [{
+      "id": "test-imp-id",
+      "ext": {
+        "bidder": {
+          "mid": "828782",
+          "priceType": "gross"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    },{
+      "id": "test-imp-id2",
+      "ext": {
+        "bidder": {
+          "mid": "828783",
+          "priceType": "net"
+        }
+      },
+      "banner": {
+        "format": [{
+          "w": 300,
+          "h": 250
+        }]
+      }
+    }],
+    "site": {
+      "publisher": {
+        "id": "1"
+      },
+      "page": "some-page-url"
+    },
+    "device": {
+      "w": 1920,
+      "h": 800
+    }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://adx.adform.net/adx/openrtb",
+      "body": {
+        "id": "test-request-id",
+        "ext": {
+          "prebid": {
+          },
+          "pt": "gross"
+        },
+        "imp": [{
+          "id": "test-imp-id",
+          "ext": {
+            "bidder": {
+              "mid": "828782",
+              "priceType": "gross"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828782"
+        },{
+          "id": "test-imp-id2",
+          "ext": {
+            "bidder": {
+              "mid": "828783",
+              "priceType": "net"
+            }
+          },
+          "banner": {
+            "format": [{
+              "w": 300,
+              "h": 250
+            }]
+          },
+          "tagid": "828783"
+        }],
+        "site": {
+          "publisher": {
+            "id": "1"
+          },
+          "page": "some-page-url"
+        },
+        "device": {
+          "w": 1920,
+          "h": 800
+        }
+      }
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "test-request-id",
+        "seatbid": [{
+          "bid": [{
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 10,
+            "adm": "{banner html}",
+            "adomain": [ "test.com" ],
+            "crid": "test-creative-id",
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          }]
+        }],
+        "cur": "USD"
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [
+      {
+        "bid": {
+          "id": "test-bid-id",
+          "impid": "test-imp-id",
+          "price": 10,
+          "adm": "{banner html}",
+          "crid": "test-creative-id",
+          "adomain": [ "test.com" ],
+          "ext": {
+            "prebid": {
+              "type": "banner"
+            }
+          }
+        },
+        "type": "banner"
+      }
+    ]
+  }]
+}

--- a/adapters/adf/params_test.go
+++ b/adapters/adf/params_test.go
@@ -46,6 +46,8 @@ var validParams = []string{
 	`{"inv":321,"mname":"12345"}`,
 	`{"mid":123,"inv":321,"mname":"pcl1"}`,
 	`{"mid":"123","inv":321,"mname":"pcl1"}`,
+	`{"mid":"123","priceType":"gross"}`,
+	`{"mid":"123","priceType":"net"}`,
 }
 
 var invalidParams = []string{
@@ -62,4 +64,5 @@ var invalidParams = []string{
 	`{"inv":321}`,
 	`{"inv":"321"}`,
 	`{"mname":"12345"}`,
+	`{"mid":"123","priceType":"GROSS"}`,
 }

--- a/openrtb_ext/imp_adf.go
+++ b/openrtb_ext/imp_adf.go
@@ -8,4 +8,5 @@ type ExtImpAdf struct {
 	MasterTagID       json.Number `json:"mid,omitempty"`
 	InventorySourceID int         `json:"inv,omitempty"`
 	PlacementName     string      `json:"mname,omitempty"`
+	PriceType         string      `json:"priceType,omitempty"`
 }

--- a/static/bidder-params/adf.json
+++ b/static/bidder-params/adf.json
@@ -16,6 +16,11 @@
     "mname": {
       "type": ["string"],
       "description": "A Name which identifies the placement selling the impression"
+    },
+    "priceType": {
+      "type": ["string"],
+      "description": "gross or net. Default is net.",
+      "pattern": "gross|net"
     }
   },
   "anyOf":[

--- a/static/bidder-params/adform.json
+++ b/static/bidder-params/adform.json
@@ -16,6 +16,11 @@
     "mname": {
       "type": ["string"],
       "description": "A Name which identifies the placement selling the impression"
+    },
+    "priceType": {
+      "type": ["string"],
+      "description": "gross or net. Default is net.",
+      "pattern": "gross|net"
     }
   },
   "anyOf":[


### PR DESCRIPTION
The client version of the Adform adapter supports choosing between returning gross or net via the priceType parameter.

As the new "adf" adapter defaults to net while the old "adform" adapter defaulted to gross, this can make the transition to the new adapter become quite a challenge if you are using plenty of bid conversion functions and the PBS adapter doesn't support selecting gross or net.

This PR adds the same priceType support as the client has.