### PR TITLE
Renamed FetchRequests to Fetch

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -332,7 +332,7 @@ func (deps *endpointDeps) loadRequestJSONForAmp(httpRequest *http.Request) (req 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(storedRequestTimeoutMillis)*time.Millisecond)
 	defer cancel()
 
-	storedRequests, _, errs := deps.storedReqFetcher.FetchRequests(ctx, []string{ampParams.StoredRequestID}, nil)
+	storedRequests, _, errs := deps.storedReqFetcher.Fetch(ctx, []string{ampParams.StoredRequestID}, nil)
 	if len(errs) > 0 {
 		return nil, errs
 	}

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -939,7 +939,7 @@ type mockAmpStoredReqFetcher struct {
 	data map[string]json.RawMessage
 }
 
-func (cf *mockAmpStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+func (cf *mockAmpStoredReqFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	return cf.data, nil, nil
 }
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1364,7 +1364,7 @@ func (deps *endpointDeps) processStoredRequests(ctx context.Context, requestJson
 		}
 	}
 
-	storedRequests, storedImps, errs := deps.storedReqFetcher.FetchRequests(ctx, storedReqIds, impStoredReqIds)
+	storedRequests, storedImps, errs := deps.storedReqFetcher.Fetch(ctx, storedReqIds, impStoredReqIds)
 
 	if len(errs) != 0 {
 		return nil, nil, errs

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -3819,7 +3819,7 @@ var testBidRequests = []string{
 type mockStoredReqFetcher struct {
 }
 
-func (cf mockStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+func (cf mockStoredReqFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	return testStoredRequestData, testStoredImpData, nil
 }
 

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -452,7 +452,7 @@ func (deps *endpointDeps) loadStoredImp(storedImpId string) (openrtb2.Imp, []err
 	defer cancel()
 
 	impr := openrtb2.Imp{}
-	_, imp, err := deps.storedReqFetcher.FetchRequests(ctx, []string{}, []string{storedImpId})
+	_, imp, err := deps.storedReqFetcher.Fetch(ctx, []string{}, []string{storedImpId})
 	if err != nil {
 		return impr, err
 	}
@@ -556,7 +556,7 @@ func findAdPod(podInd int64, pods []*openrtb_ext.AdPod) *openrtb_ext.AdPod {
 }
 
 func (deps *endpointDeps) loadStoredVideoRequest(ctx context.Context, storedRequestId string) ([]byte, []error) {
-	storedRequests, _, errs := deps.videoFetcher.FetchRequests(ctx, []string{storedRequestId}, []string{})
+	storedRequests, _, errs := deps.videoFetcher.Fetch(ctx, []string{storedRequestId}, []string{})
 	jsonString := storedRequests[storedRequestId]
 	return jsonString, errs
 }

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -1338,7 +1338,7 @@ func (m *mockCacheClient) GetExtCacheData() (scheme string, host string, path st
 type mockVideoStoredReqFetcher struct {
 }
 
-func (cf mockVideoStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+func (cf mockVideoStoredReqFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	return testVideoStoredRequestData, testVideoStoredImpData, nil
 }
 

--- a/stored_requests/backends/db_fetcher/fetcher.go
+++ b/stored_requests/backends/db_fetcher/fetcher.go
@@ -30,7 +30,7 @@ type dbFetcher struct {
 	queryMaker func(numReqs int, numImps int) (query string)
 }
 
-func (fetcher *dbFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
+func (fetcher *dbFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
 	if len(requestIDs) < 1 && len(impIDs) < 1 {
 		return nil, nil, nil
 	}

--- a/stored_requests/backends/empty_fetcher/fetcher.go
+++ b/stored_requests/backends/empty_fetcher/fetcher.go
@@ -11,7 +11,7 @@ import (
 // If PBS is configured to use this, then all the OpenRTB request data must be sent in the HTTP request.
 type EmptyFetcher struct{}
 
-func (fetcher EmptyFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+func (fetcher EmptyFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	errs = make([]error, 0, len(requestIDs)+len(impIDs))
 	for _, id := range requestIDs {
 		errs = append(errs, stored_requests.NotFoundError{

--- a/stored_requests/backends/empty_fetcher/fetcher_test.go
+++ b/stored_requests/backends/empty_fetcher/fetcher_test.go
@@ -8,7 +8,7 @@ import (
 func TestErrorLength(t *testing.T) {
 	fetcher := EmptyFetcher{}
 
-	storedReqs, storedImps, errs := fetcher.FetchRequests(context.Background(), []string{"a", "b"}, []string{"c"})
+	storedReqs, storedImps, errs := fetcher.Fetch(context.Background(), []string{"a", "b"}, []string{"c"})
 	if len(storedReqs) != 0 {
 		t.Errorf("The empty fetcher should never return stored requests. Got %d", len(storedReqs))
 	}

--- a/stored_requests/backends/file_fetcher/fetcher.go
+++ b/stored_requests/backends/file_fetcher/fetcher.go
@@ -25,7 +25,7 @@ type eagerFetcher struct {
 	Categories map[string]map[string]stored_requests.Category
 }
 
-func (fetcher *eagerFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
+func (fetcher *eagerFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
 	storedRequests := fetcher.FileSystem.Directories["stored_requests"].Files
 	storedImpressions := fetcher.FileSystem.Directories["stored_imps"].Files
 	errs := appendErrors("Request", requestIDs, storedRequests, nil)

--- a/stored_requests/backends/file_fetcher/fetcher_test.go
+++ b/stored_requests/backends/file_fetcher/fetcher_test.go
@@ -16,7 +16,7 @@ func TestFileFetcher(t *testing.T) {
 		t.Errorf("Failed to create a Fetcher: %v", err)
 	}
 
-	storedReqs, storedImps, errs := fetcher.FetchRequests(context.Background(), []string{"1", "2"}, []string{"some-imp"})
+	storedReqs, storedImps, errs := fetcher.Fetch(context.Background(), []string{"1", "2"}, []string{"some-imp"})
 	assertErrorCount(t, 0, errs)
 
 	validateStoredReqOne(t, storedReqs)

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -77,7 +77,7 @@ type HttpFetcher struct {
 	Categories map[string]map[string]stored_requests.Category
 }
 
-func (fetcher *HttpFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+func (fetcher *HttpFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	if len(requestIDs) == 0 && len(impIDs) == 0 {
 		return nil, nil, nil
 	}

--- a/stored_requests/backends/http_fetcher/fetcher_test.go
+++ b/stored_requests/backends/http_fetcher/fetcher_test.go
@@ -16,7 +16,7 @@ func TestSingleReq(t *testing.T) {
 	fetcher, close := newTestFetcher(t, []string{"req-1"}, nil)
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, nil)
+	reqData, impData, errs := fetcher.Fetch(context.Background(), []string{"req-1"}, nil)
 	assert.Empty(t, errs, "Unexpected errors fetching known requests")
 	assertMapKeys(t, reqData, "req-1")
 	assert.Empty(t, impData, "Unexpected imps returned fetching just requests")
@@ -26,7 +26,7 @@ func TestSeveralReqs(t *testing.T) {
 	fetcher, close := newTestFetcher(t, []string{"req-1", "req-2"}, nil)
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, nil)
+	reqData, impData, errs := fetcher.Fetch(context.Background(), []string{"req-1", "req-2"}, nil)
 	assert.Empty(t, errs, "Unexpected errors fetching known requests")
 	assertMapKeys(t, reqData, "req-1", "req-2")
 	assert.Empty(t, impData, "Unexpected imps returned fetching just requests")
@@ -36,7 +36,7 @@ func TestSingleImp(t *testing.T) {
 	fetcher, close := newTestFetcher(t, nil, []string{"imp-1"})
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1"})
+	reqData, impData, errs := fetcher.Fetch(context.Background(), nil, []string{"imp-1"})
 	assert.Empty(t, errs, "Unexpected errors fetching known imps")
 	assert.Empty(t, reqData, "Unexpected requests returned fetching just imps")
 	assertMapKeys(t, impData, "imp-1")
@@ -46,7 +46,7 @@ func TestSeveralImps(t *testing.T) {
 	fetcher, close := newTestFetcher(t, nil, []string{"imp-1", "imp-2"})
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), nil, []string{"imp-1", "imp-2"})
+	reqData, impData, errs := fetcher.Fetch(context.Background(), nil, []string{"imp-1", "imp-2"})
 	assert.Empty(t, errs, "Unexpected errors fetching known imps")
 	assert.Empty(t, reqData, "Unexpected requests returned fetching just imps")
 	assertMapKeys(t, impData, "imp-1", "imp-2")
@@ -56,7 +56,7 @@ func TestReqsAndImps(t *testing.T) {
 	fetcher, close := newTestFetcher(t, []string{"req-1"}, []string{"imp-1"})
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, []string{"imp-1"})
+	reqData, impData, errs := fetcher.Fetch(context.Background(), []string{"req-1"}, []string{"imp-1"})
 	assert.Empty(t, errs, "Unexpected errors fetching known reqs and imps")
 	assertMapKeys(t, reqData, "req-1")
 	assertMapKeys(t, impData, "imp-1")
@@ -66,7 +66,7 @@ func TestMissingValues(t *testing.T) {
 	fetcher, close := newEmptyFetcher(t, []string{"req-1", "req-2"}, []string{"imp-1"})
 	defer close()
 
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1", "req-2"}, []string{"imp-1"})
+	reqData, impData, errs := fetcher.Fetch(context.Background(), []string{"req-1", "req-2"}, []string{"imp-1"})
 	assert.Empty(t, reqData, "Fetching unknown reqs should return no reqs")
 	assert.Empty(t, impData, "Fetching unknown imps should return no imps")
 	assert.Len(t, errs, 3, "Fetching 3 unknown reqs+imps should return 3 errors")
@@ -160,7 +160,7 @@ func TestFetchAccountNoIDProvided(t *testing.T) {
 func TestErrResponse(t *testing.T) {
 	fetcher, close := newFetcherBrokenBackend()
 	defer close()
-	reqData, impData, errs := fetcher.FetchRequests(context.Background(), []string{"req-1"}, []string{"imp-1"})
+	reqData, impData, errs := fetcher.Fetch(context.Background(), []string{"req-1"}, []string{"imp-1"})
 	assertMapKeys(t, reqData)
 	assertMapKeys(t, impData)
 	assert.Len(t, errs, 1)

--- a/stored_requests/fetcher_test.go
+++ b/stored_requests/fetcher_test.go
@@ -50,7 +50,7 @@ func TestPerfectCache(t *testing.T) {
 	metricsEngine.AssertExpectations(t)
 	assert.JSONEq(t, `{"req":true}`, string(reqData["req-id"]), "Fetch requests should fetch the right request data")
 	assert.JSONEq(t, `{}`, string(impData["known"]), "Fetch should fetch the right imp data")
-	assert.Len(t, errs, 0, "FetchRequest shouldn't return any errors")
+	assert.Len(t, errs, 0, "Fetch shouldn't return any errors")
 }
 
 func TestImperfectCache(t *testing.T) {
@@ -90,7 +90,7 @@ func TestImperfectCache(t *testing.T) {
 	assert.Len(t, reqData, 0, "Fetch requests should return nil if no request IDs were passed")
 	assert.JSONEq(t, `true`, string(impData["cached"]), "Fetch should fetch the right imp data")
 	assert.JSONEq(t, `false`, string(impData["uncached"]), "Fetch should fetch the right imp data")
-	assert.Len(t, errs, 0, "FetchRequest shouldn't return any errors")
+	assert.Len(t, errs, 0, "Fetch shouldn't return any errors")
 }
 
 func TestMissingData(t *testing.T) {

--- a/stored_requests/fetcher_test.go
+++ b/stored_requests/fetcher_test.go
@@ -42,14 +42,14 @@ func TestPerfectCache(t *testing.T) {
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheHit, 1)
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheMiss, 0)
 
-	reqData, impData, errs := aFetcherWithCache.FetchRequests(ctx, reqIDs, impIDs)
+	reqData, impData, errs := aFetcherWithCache.Fetch(ctx, reqIDs, impIDs)
 
 	reqCache.AssertExpectations(t)
 	impCache.AssertExpectations(t)
 	fetcher.AssertExpectations(t)
 	metricsEngine.AssertExpectations(t)
 	assert.JSONEq(t, `{"req":true}`, string(reqData["req-id"]), "Fetch requests should fetch the right request data")
-	assert.JSONEq(t, `{}`, string(impData["known"]), "FetchRequests should fetch the right imp data")
+	assert.JSONEq(t, `{}`, string(impData["known"]), "Fetch should fetch the right imp data")
 	assert.Len(t, errs, 0, "FetchRequest shouldn't return any errors")
 }
 
@@ -65,7 +65,7 @@ func TestImperfectCache(t *testing.T) {
 	reqCache.On("Get", ctx, []string(nil)).Return(
 		map[string]json.RawMessage{})
 
-	fetcher.On("FetchRequests", ctx, []string{}, []string{"uncached"}).Return(
+	fetcher.On("Fetch", ctx, []string{}, []string{"uncached"}).Return(
 		map[string]json.RawMessage{},
 		map[string]json.RawMessage{
 			"uncached": json.RawMessage(`false`),
@@ -82,14 +82,14 @@ func TestImperfectCache(t *testing.T) {
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheHit, 1)
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheMiss, 1)
 
-	reqData, impData, errs := aFetcherWithCache.FetchRequests(ctx, nil, impIDs)
+	reqData, impData, errs := aFetcherWithCache.Fetch(ctx, nil, impIDs)
 
 	impCache.AssertExpectations(t)
 	fetcher.AssertExpectations(t)
 	metricsEngine.AssertExpectations(t)
 	assert.Len(t, reqData, 0, "Fetch requests should return nil if no request IDs were passed")
-	assert.JSONEq(t, `true`, string(impData["cached"]), "FetchRequests should fetch the right imp data")
-	assert.JSONEq(t, `false`, string(impData["uncached"]), "FetchRequests should fetch the right imp data")
+	assert.JSONEq(t, `true`, string(impData["cached"]), "Fetch should fetch the right imp data")
+	assert.JSONEq(t, `false`, string(impData["uncached"]), "Fetch should fetch the right imp data")
 	assert.Len(t, errs, 0, "FetchRequest shouldn't return any errors")
 }
 
@@ -103,7 +103,7 @@ func TestMissingData(t *testing.T) {
 	)
 	reqCache.On("Get", ctx, []string(nil)).Return(
 		map[string]json.RawMessage{})
-	fetcher.On("FetchRequests", ctx, []string{}, impIDs).Return(
+	fetcher.On("Fetch", ctx, []string{}, impIDs).Return(
 		map[string]json.RawMessage{},
 		map[string]json.RawMessage{},
 		[]error{
@@ -121,15 +121,15 @@ func TestMissingData(t *testing.T) {
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheHit, 0)
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheMiss, 1)
 
-	reqData, impData, errs := aFetcherWithCache.FetchRequests(ctx, nil, impIDs)
+	reqData, impData, errs := aFetcherWithCache.Fetch(ctx, nil, impIDs)
 
 	reqCache.AssertExpectations(t)
 	impCache.AssertExpectations(t)
 	fetcher.AssertExpectations(t)
 	metricsEngine.AssertExpectations(t)
-	assert.Len(t, errs, 1, "FetchRequests for missing data should return an error")
-	assert.Len(t, reqData, 0, "FetchRequests for missing data shouldn't return anything")
-	assert.Len(t, impData, 0, "FetchRequests for missing data shouldn't return anything")
+	assert.Len(t, errs, 1, "Fetch for missing data should return an error")
+	assert.Len(t, reqData, 0, "Fetch for missing data shouldn't return anything")
+	assert.Len(t, impData, 0, "Fetch for missing data shouldn't return anything")
 }
 
 // Prevents #311
@@ -149,14 +149,14 @@ func TestCacheSaves(t *testing.T) {
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheHit, 2)
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheMiss, 0)
 
-	_, impData, errs := aFetcherWithCache.FetchRequests(ctx, nil, []string{"abc", "abc"})
+	_, impData, errs := aFetcherWithCache.Fetch(ctx, nil, []string{"abc", "abc"})
 
 	impCache.AssertExpectations(t)
 	fetcher.AssertExpectations(t)
 	metricsEngine.AssertExpectations(t)
-	assert.Len(t, impData, 1, "FetchRequests should return data only once for duplicate requests")
-	assert.JSONEq(t, `{}`, string(impData["abc"]), "FetchRequests should fetch the right imp data")
-	assert.Len(t, errs, 0, "FetchRequests with duplicate IDs shouldn't return an error")
+	assert.Len(t, impData, 1, "Fetch should return data only once for duplicate requests")
+	assert.JSONEq(t, `{}`, string(impData["abc"]), "Fetch should fetch the right imp data")
+	assert.Len(t, errs, 0, "Fetch with duplicate IDs shouldn't return an error")
 }
 
 func setupAccountFetcherWithCacheDeps() (*mockCache, *mockFetcher, AllFetcher, *metrics.MetricsEngineMock) {
@@ -247,7 +247,7 @@ func TestComposedCache(t *testing.T) {
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheHit, 0)
 	metricsEngine.On("RecordStoredImpCacheResult", metrics.CacheMiss, 0)
 
-	reqData, impData, errs := aFetcherWithCache.FetchRequests(ctx, reqIDs, impIDs)
+	reqData, impData, errs := aFetcherWithCache.Fetch(ctx, reqIDs, impIDs)
 
 	c1.AssertExpectations(t)
 	c2.AssertExpectations(t)
@@ -255,19 +255,19 @@ func TestComposedCache(t *testing.T) {
 	impCache.AssertExpectations(t)
 	fetcher.AssertExpectations(t)
 	metricsEngine.AssertExpectations(t)
-	assert.Len(t, reqData, len(reqIDs), "FetchRequests should be able to return all request data from a composed cache")
-	assert.Len(t, impData, len(impIDs), "FetchRequests should be able to return all imp data from a composed cache")
-	assert.Len(t, errs, 0, "FetchRequests shouldn't return an error when trying to use a composed cache")
-	assert.JSONEq(t, `{"id": "1"}`, string(reqData["1"]), "FetchRequests should fetch the right req data")
-	assert.JSONEq(t, `{"id": "2"}`, string(reqData["2"]), "FetchRequests should fetch the right req data")
-	assert.JSONEq(t, `{"id": "3"}`, string(reqData["3"]), "FetchRequests should fetch the right req data")
+	assert.Len(t, reqData, len(reqIDs), "Fetch should be able to return all request data from a composed cache")
+	assert.Len(t, impData, len(impIDs), "Fetch should be able to return all imp data from a composed cache")
+	assert.Len(t, errs, 0, "Fetch shouldn't return an error when trying to use a composed cache")
+	assert.JSONEq(t, `{"id": "1"}`, string(reqData["1"]), "Fetch should fetch the right req data")
+	assert.JSONEq(t, `{"id": "2"}`, string(reqData["2"]), "Fetch should fetch the right req data")
+	assert.JSONEq(t, `{"id": "3"}`, string(reqData["3"]), "Fetch should fetch the right req data")
 }
 
 type mockFetcher struct {
 	mock.Mock
 }
 
-func (f *mockFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
+func (f *mockFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (map[string]json.RawMessage, map[string]json.RawMessage, []error) {
 	args := f.Called(ctx, requestIDs, impIDs)
 	return args.Get(0).(map[string]json.RawMessage), args.Get(1).(map[string]json.RawMessage), args.Get(2).([]error)
 }

--- a/stored_requests/multifetcher.go
+++ b/stored_requests/multifetcher.go
@@ -9,8 +9,8 @@ import (
 // MultiFetcher is a Fetcher composed of multiple sub-Fetchers that are all polled for results.
 type MultiFetcher []AllFetcher
 
-// FetchRequests implements the Fetcher interface for MultiFetcher
-func (mf MultiFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+// Fetch implements the Fetcher interface for MultiFetcher
+func (mf MultiFetcher) Fetch(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	requestData = make(map[string]json.RawMessage, len(requestIDs))
 	impData = make(map[string]json.RawMessage, len(impIDs))
 
@@ -21,7 +21,7 @@ func (mf MultiFetcher) FetchRequests(ctx context.Context, requestIDs []string, i
 		remainingImpIDs := filter(impIDs, impData)
 		impIDs = remainingImpIDs
 
-		theseRequestData, theseImpData, rerrs := f.FetchRequests(ctx, remainingRequestIDs, remainingImpIDs)
+		theseRequestData, theseImpData, rerrs := f.Fetch(ctx, remainingRequestIDs, remainingImpIDs)
 		// Drop NotFound errors, as other fetchers may have them. Also don't want multiple NotFound errors per ID.
 		rerrs = dropMissingIDs(rerrs)
 		if len(rerrs) > 0 {

--- a/stored_requests/multifetcher_test.go
+++ b/stored_requests/multifetcher_test.go
@@ -17,7 +17,7 @@ func TestMultiFetcher(t *testing.T) {
 	reqIDs := []string{"abc", "def"}
 	impIDs := []string{"imp-1", "imp-2"}
 
-	f1.On("FetchRequests", ctx, reqIDs, impIDs).Return(
+	f1.On("Fetch", ctx, reqIDs, impIDs).Return(
 		map[string]json.RawMessage{
 			"abc": json.RawMessage(`{"req_id": "abc"}`),
 		},
@@ -26,7 +26,7 @@ func TestMultiFetcher(t *testing.T) {
 		},
 		[]error{NotFoundError{"def", "Request"}, NotFoundError{"imp-2", "Imp"}},
 	)
-	f2.On("FetchRequests", ctx, []string{"def"}, []string{"imp-2"}).Return(
+	f2.On("Fetch", ctx, []string{"def"}, []string{"imp-2"}).Return(
 		map[string]json.RawMessage{
 			"def": json.RawMessage(`{"req_id": "def"}`),
 		},
@@ -36,7 +36,7 @@ func TestMultiFetcher(t *testing.T) {
 		[]error{},
 	)
 
-	reqData, impData, errs := fetcher.FetchRequests(ctx, reqIDs, impIDs)
+	reqData, impData, errs := fetcher.Fetch(ctx, reqIDs, impIDs)
 
 	f1.AssertExpectations(t)
 	f2.AssertExpectations(t)
@@ -57,7 +57,7 @@ func TestMissingID(t *testing.T) {
 	reqIDs := []string{"abc", "def", "ghi"}
 	impIDs := []string{"imp-1", "imp-2", "imp-3"}
 
-	f1.On("FetchRequests", ctx, reqIDs, impIDs).Return(
+	f1.On("Fetch", ctx, reqIDs, impIDs).Return(
 		map[string]json.RawMessage{
 			"abc": json.RawMessage(`{"req_id": "abc"}`),
 		},
@@ -66,7 +66,7 @@ func TestMissingID(t *testing.T) {
 		},
 		[]error{NotFoundError{"def", "Request"}, NotFoundError{"imp-2", "Imp"}},
 	)
-	f2.On("FetchRequests", ctx, []string{"def", "ghi"}, []string{"imp-2", "imp-3"}).Return(
+	f2.On("Fetch", ctx, []string{"def", "ghi"}, []string{"imp-2", "imp-3"}).Return(
 		map[string]json.RawMessage{
 			"def": json.RawMessage(`{"req_id": "def"}`),
 		},
@@ -76,7 +76,7 @@ func TestMissingID(t *testing.T) {
 		[]error{},
 	)
 
-	reqData, impData, errs := fetcher.FetchRequests(ctx, reqIDs, impIDs)
+	reqData, impData, errs := fetcher.Fetch(ctx, reqIDs, impIDs)
 
 	f1.AssertExpectations(t)
 	f2.AssertExpectations(t)
@@ -97,14 +97,14 @@ func TestOtherError(t *testing.T) {
 	reqIDs := []string{"abc", "def"}
 	impIDs := []string{"imp-1"}
 
-	f1.On("FetchRequests", ctx, reqIDs, impIDs).Return(
+	f1.On("Fetch", ctx, reqIDs, impIDs).Return(
 		map[string]json.RawMessage{
 			"abc": json.RawMessage(`{"req_id": "abc"}`),
 		},
 		map[string]json.RawMessage{},
 		[]error{NotFoundError{"def", "Request"}, errors.New("Other error")},
 	)
-	f2.On("FetchRequests", ctx, []string{"def"}, []string{"imp-1"}).Return(
+	f2.On("Fetch", ctx, []string{"def"}, []string{"imp-1"}).Return(
 		map[string]json.RawMessage{
 			"def": json.RawMessage(`{"req_id": "def"}`),
 		},
@@ -114,7 +114,7 @@ func TestOtherError(t *testing.T) {
 		[]error{},
 	)
 
-	reqData, impData, errs := fetcher.FetchRequests(ctx, reqIDs, impIDs)
+	reqData, impData, errs := fetcher.Fetch(ctx, reqIDs, impIDs)
 
 	f1.AssertExpectations(t)
 	f2.AssertExpectations(t)


### PR DESCRIPTION
This PR is a part of future response fetcher integration. 
Initial code contains only a code related to `FetchRequest` function rename to `Fetch`. 
Do we want to remane package name as well? 
If yes - what name this should be? 
If yes - it has a dependency in configs, like `PBS_STORED_REQUESTS_HTTP_EVENTS_AMP_ENDPOINT: "serviceURL/prebid/stored-requests"` - do we want to rename this in configs? 
Do we also want to remane data structured in config.go? 