### PR TITLE
Unruly: changes to the correct user sync url

### DIFF
--- a/static/bidder-info/unruly.yaml
+++ b/static/bidder-info/unruly.yaml
@@ -11,6 +11,6 @@ capabilities:
       - banner
       - video
 userSync:
-  iframe:
-    url: "https://usermatch.targeting.unrulymedia.com/pbsync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&rurl={{.RedirectURL}}"
-    userMacro: "$UID"
+  redirect:
+    url: "https://sync.1rx.io/usersync2/rmphb?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[RX_UUID]"


### PR DESCRIPTION
there was a mistake in the url for the user sync last time here is a fix for it to the correct one