### PR TITLE
Collect Prometheus Go process metrics

### DIFF
--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -1,6 +1,7 @@
 package prometheusmetrics
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -8,11 +9,13 @@ import (
 	"github.com/prebid/prebid-server/metrics"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prometheus/client_golang/prometheus"
+	promCollector "github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 // Metrics defines the Prometheus metrics backing the MetricsEngine implementation.
 type Metrics struct {
-	Registry *prometheus.Registry
+	Registerer prometheus.Registerer
+	Gatherer   *prometheus.Registry
 
 	// General Metrics
 	connectionsClosed            prometheus.Counter
@@ -133,245 +136,252 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	queuedRequestTimeBuckets := []float64{0, 1, 5, 30, 60, 120, 180, 240, 300}
 
 	metrics := Metrics{}
-	metrics.Registry = prometheus.NewRegistry()
+	reg := prometheus.NewRegistry()
 	metrics.metricsDisabled = disabledMetrics
 
-	metrics.connectionsClosed = newCounterWithoutLabels(cfg, metrics.Registry,
+	metrics.connectionsClosed = newCounterWithoutLabels(cfg, reg,
 		"connections_closed",
 		"Count of successful connections closed to Prebid Server.")
 
-	metrics.connectionsError = newCounter(cfg, metrics.Registry,
+	metrics.connectionsError = newCounter(cfg, reg,
 		"connections_error",
 		"Count of errors for connection open and close attempts to Prebid Server labeled by type.",
 		[]string{connectionErrorLabel})
 
-	metrics.connectionsOpened = newCounterWithoutLabels(cfg, metrics.Registry,
+	metrics.connectionsOpened = newCounterWithoutLabels(cfg, reg,
 		"connections_opened",
 		"Count of successful connections opened to Prebid Server.")
 
-	metrics.cookieSync = newCounter(cfg, metrics.Registry,
+	metrics.cookieSync = newCounter(cfg, reg,
 		"cookie_sync_requests",
 		"Count of cookie sync requests to Prebid Server.",
 		[]string{statusLabel})
 
-	metrics.setUid = newCounter(cfg, metrics.Registry,
+	metrics.setUid = newCounter(cfg, reg,
 		"setuid_requests",
 		"Count of set uid requests to Prebid Server.",
 		[]string{statusLabel})
 
-	metrics.impressions = newCounter(cfg, metrics.Registry,
+	metrics.impressions = newCounter(cfg, reg,
 		"impressions_requests",
 		"Count of requested impressions to Prebid Server labeled by type.",
 		[]string{isBannerLabel, isVideoLabel, isAudioLabel, isNativeLabel})
 
-	metrics.impressionsLegacy = newCounterWithoutLabels(cfg, metrics.Registry,
+	metrics.impressionsLegacy = newCounterWithoutLabels(cfg, reg,
 		"impressions_requests_legacy",
 		"Count of requested impressions to Prebid Server using the legacy endpoint.")
 
-	metrics.prebidCacheWriteTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.prebidCacheWriteTimer = newHistogramVec(cfg, reg,
 		"prebidcache_write_time_seconds",
 		"Seconds to write to Prebid Cache labeled by success or failure. Failure timing is limited by Prebid Server enforced timeouts.",
 		[]string{successLabel},
 		cacheWriteTimeBuckets)
 
-	metrics.requests = newCounter(cfg, metrics.Registry,
+	metrics.requests = newCounter(cfg, reg,
 		"requests",
 		"Count of total requests to Prebid Server labeled by type and status.",
 		[]string{requestTypeLabel, requestStatusLabel})
 
-	metrics.requestsTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.requestsTimer = newHistogramVec(cfg, reg,
 		"request_time_seconds",
 		"Seconds to resolve successful Prebid Server requests labeled by type.",
 		[]string{requestTypeLabel},
 		standardTimeBuckets)
 
-	metrics.requestsWithoutCookie = newCounter(cfg, metrics.Registry,
+	metrics.requestsWithoutCookie = newCounter(cfg, reg,
 		"requests_without_cookie",
 		"Count of total requests to Prebid Server without a cookie labeled by type.",
 		[]string{requestTypeLabel})
 
-	metrics.storedImpressionsCacheResult = newCounter(cfg, metrics.Registry,
+	metrics.storedImpressionsCacheResult = newCounter(cfg, reg,
 		"stored_impressions_cache_performance",
 		"Count of stored impression cache requests attempts by hits or miss.",
 		[]string{cacheResultLabel})
 
-	metrics.storedRequestCacheResult = newCounter(cfg, metrics.Registry,
+	metrics.storedRequestCacheResult = newCounter(cfg, reg,
 		"stored_request_cache_performance",
 		"Count of stored request cache requests attempts by hits or miss.",
 		[]string{cacheResultLabel})
 
-	metrics.accountCacheResult = newCounter(cfg, metrics.Registry,
+	metrics.accountCacheResult = newCounter(cfg, reg,
 		"account_cache_performance",
 		"Count of account cache lookups by hits or miss.",
 		[]string{cacheResultLabel})
 
-	metrics.storedAccountFetchTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.storedAccountFetchTimer = newHistogramVec(cfg, reg,
 		"stored_account_fetch_time_seconds",
 		"Seconds to fetch stored accounts labeled by fetch type",
 		[]string{storedDataFetchTypeLabel},
 		standardTimeBuckets)
 
-	metrics.storedAccountErrors = newCounter(cfg, metrics.Registry,
+	metrics.storedAccountErrors = newCounter(cfg, reg,
 		"stored_account_errors",
 		"Count of stored account errors by error type",
 		[]string{storedDataErrorLabel})
 
-	metrics.storedAMPFetchTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.storedAMPFetchTimer = newHistogramVec(cfg, reg,
 		"stored_amp_fetch_time_seconds",
 		"Seconds to fetch stored AMP requests labeled by fetch type",
 		[]string{storedDataFetchTypeLabel},
 		standardTimeBuckets)
 
-	metrics.storedAMPErrors = newCounter(cfg, metrics.Registry,
+	metrics.storedAMPErrors = newCounter(cfg, reg,
 		"stored_amp_errors",
 		"Count of stored AMP errors by error type",
 		[]string{storedDataErrorLabel})
 
-	metrics.storedCategoryFetchTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.storedCategoryFetchTimer = newHistogramVec(cfg, reg,
 		"stored_category_fetch_time_seconds",
 		"Seconds to fetch stored categories labeled by fetch type",
 		[]string{storedDataFetchTypeLabel},
 		standardTimeBuckets)
 
-	metrics.storedCategoryErrors = newCounter(cfg, metrics.Registry,
+	metrics.storedCategoryErrors = newCounter(cfg, reg,
 		"stored_category_errors",
 		"Count of stored category errors by error type",
 		[]string{storedDataErrorLabel})
 
-	metrics.storedRequestFetchTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.storedRequestFetchTimer = newHistogramVec(cfg, reg,
 		"stored_request_fetch_time_seconds",
 		"Seconds to fetch stored requests labeled by fetch type",
 		[]string{storedDataFetchTypeLabel},
 		standardTimeBuckets)
 
-	metrics.storedRequestErrors = newCounter(cfg, metrics.Registry,
+	metrics.storedRequestErrors = newCounter(cfg, reg,
 		"stored_request_errors",
 		"Count of stored request errors by error type",
 		[]string{storedDataErrorLabel})
 
-	metrics.storedVideoFetchTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.storedVideoFetchTimer = newHistogramVec(cfg, reg,
 		"stored_video_fetch_time_seconds",
 		"Seconds to fetch stored video labeled by fetch type",
 		[]string{storedDataFetchTypeLabel},
 		standardTimeBuckets)
 
-	metrics.storedVideoErrors = newCounter(cfg, metrics.Registry,
+	metrics.storedVideoErrors = newCounter(cfg, reg,
 		"stored_video_errors",
 		"Count of stored video errors by error type",
 		[]string{storedDataErrorLabel})
 
-	metrics.timeoutNotifications = newCounter(cfg, metrics.Registry,
+	metrics.timeoutNotifications = newCounter(cfg, reg,
 		"timeout_notification",
 		"Count of timeout notifications triggered, and if they were successfully sent.",
 		[]string{successLabel})
 
-	metrics.dnsLookupTimer = newHistogram(cfg, metrics.Registry,
+	metrics.dnsLookupTimer = newHistogram(cfg, reg,
 		"dns_lookup_time",
 		"Seconds to resolve DNS",
 		standardTimeBuckets)
 
-	metrics.tlsHandhakeTimer = newHistogram(cfg, metrics.Registry,
+	metrics.tlsHandhakeTimer = newHistogram(cfg, reg,
 		"tls_handshake_time",
 		"Seconds to perform TLS Handshake",
 		standardTimeBuckets)
 
-	metrics.privacyCCPA = newCounter(cfg, metrics.Registry,
+	metrics.privacyCCPA = newCounter(cfg, reg,
 		"privacy_ccpa",
 		"Count of total requests to Prebid Server where CCPA was provided by source and opt-out .",
 		[]string{sourceLabel, optOutLabel})
 
-	metrics.privacyCOPPA = newCounter(cfg, metrics.Registry,
+	metrics.privacyCOPPA = newCounter(cfg, reg,
 		"privacy_coppa",
 		"Count of total requests to Prebid Server where the COPPA flag was set by source",
 		[]string{sourceLabel})
 
-	metrics.privacyTCF = newCounter(cfg, metrics.Registry,
+	metrics.privacyTCF = newCounter(cfg, reg,
 		"privacy_tcf",
 		"Count of TCF versions for requests where GDPR was enforced by source and version.",
 		[]string{versionLabel, sourceLabel})
 
-	metrics.privacyLMT = newCounter(cfg, metrics.Registry,
+	metrics.privacyLMT = newCounter(cfg, reg,
 		"privacy_lmt",
 		"Count of total requests to Prebid Server where the LMT flag was set by source",
 		[]string{sourceLabel})
 
 	if !metrics.metricsDisabled.AdapterGDPRRequestBlocked {
-		metrics.adapterGDPRBlockedRequests = newCounter(cfg, metrics.Registry,
+		metrics.adapterGDPRBlockedRequests = newCounter(cfg, reg,
 			"adapter_gdpr_requests_blocked",
 			"Count of total bidder requests blocked due to unsatisfied GDPR purpose 2 legal basis",
 			[]string{adapterLabel})
 	}
 
-	metrics.adapterBids = newCounter(cfg, metrics.Registry,
+	metrics.adapterBids = newCounter(cfg, reg,
 		"adapter_bids",
 		"Count of bids labeled by adapter and markup delivery type (adm or nurl).",
 		[]string{adapterLabel, markupDeliveryLabel})
 
-	metrics.adapterErrors = newCounter(cfg, metrics.Registry,
+	metrics.adapterErrors = newCounter(cfg, reg,
 		"adapter_errors",
 		"Count of errors labeled by adapter and error type.",
 		[]string{adapterLabel, adapterErrorLabel})
 
-	metrics.adapterPanics = newCounter(cfg, metrics.Registry,
+	metrics.adapterPanics = newCounter(cfg, reg,
 		"adapter_panics",
 		"Count of panics labeled by adapter.",
 		[]string{adapterLabel})
 
-	metrics.adapterPrices = newHistogramVec(cfg, metrics.Registry,
+	metrics.adapterPrices = newHistogramVec(cfg, reg,
 		"adapter_prices",
 		"Monetary value of the bids labeled by adapter.",
 		[]string{adapterLabel},
 		priceBuckets)
 
-	metrics.adapterRequests = newCounter(cfg, metrics.Registry,
+	metrics.adapterRequests = newCounter(cfg, reg,
 		"adapter_requests",
 		"Count of requests labeled by adapter, if has a cookie, and if it resulted in bids.",
 		[]string{adapterLabel, cookieLabel, hasBidsLabel})
 
 	if !metrics.metricsDisabled.AdapterConnectionMetrics {
-		metrics.adapterCreatedConnections = newCounter(cfg, metrics.Registry,
+		metrics.adapterCreatedConnections = newCounter(cfg, reg,
 			"adapter_connection_created",
 			"Count that keeps track of new connections when contacting adapter bidder endpoints.",
 			[]string{adapterLabel})
 
-		metrics.adapterReusedConnections = newCounter(cfg, metrics.Registry,
+		metrics.adapterReusedConnections = newCounter(cfg, reg,
 			"adapter_connection_reused",
 			"Count that keeps track of reused connections when contacting adapter bidder endpoints.",
 			[]string{adapterLabel})
 
-		metrics.adapterConnectionWaitTime = newHistogramVec(cfg, metrics.Registry,
+		metrics.adapterConnectionWaitTime = newHistogramVec(cfg, reg,
 			"adapter_connection_wait",
 			"Seconds from when the connection was requested until it is either created or reused",
 			[]string{adapterLabel},
 			standardTimeBuckets)
 	}
 
-	metrics.adapterRequestsTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.adapterRequestsTimer = newHistogramVec(cfg, reg,
 		"adapter_request_time_seconds",
 		"Seconds to resolve each successful request labeled by adapter.",
 		[]string{adapterLabel},
 		standardTimeBuckets)
 
-	metrics.syncerRequests = newCounter(cfg, metrics.Registry,
+	metrics.syncerRequests = newCounter(cfg, reg,
 		"syncer_requests",
 		"Count of cookie sync requests where a syncer is a candidate to be synced labeled by syncer key and status.",
 		[]string{syncerLabel, statusLabel})
 
-	metrics.syncerSets = newCounter(cfg, metrics.Registry,
+	metrics.syncerSets = newCounter(cfg, reg,
 		"syncer_sets",
 		"Count of setuid set requests for a syncer labeled by syncer key and status.",
 		[]string{syncerLabel, statusLabel})
 
-	metrics.accountRequests = newCounter(cfg, metrics.Registry,
+	metrics.accountRequests = newCounter(cfg, reg,
 		"account_requests",
 		"Count of total requests to Prebid Server labeled by account.",
 		[]string{accountLabel})
 
-	metrics.requestsQueueTimer = newHistogramVec(cfg, metrics.Registry,
+	metrics.requestsQueueTimer = newHistogramVec(cfg, reg,
 		"request_queue_time",
 		"Seconds request was waiting in queue",
 		[]string{requestTypeLabel, requestStatusLabel},
 		queuedRequestTimeBuckets)
+
+	metrics.Gatherer = reg
+
+	metricsPrefix := fmt.Sprintf("%s_%s_", cfg.Namespace, cfg.Subsystem)
+
+	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)
+	metrics.Registerer.MustRegister(promCollector.NewGoCollector())
 
 	preloadLabelValues(&metrics, syncerKeys)
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -26,7 +26,7 @@ func TestMetricCountGatekeeping(t *testing.T) {
 	m := createMetricsForTesting()
 
 	// Gather All Metrics
-	metricFamilies, err := m.Registry.Gather()
+	metricFamilies, err := m.Gatherer.Gather()
 	assert.NoError(t, err, "gather metics")
 
 	// Summarize By Adapter Cardinality

--- a/server/prometheus.go
+++ b/server/prometheus.go
@@ -19,7 +19,7 @@ func newPrometheusServer(cfg *config.Configuration, metrics *metricsconfig.Detai
 	}
 	return &http.Server{
 		Addr: cfg.Host + ":" + strconv.Itoa(cfg.Metrics.Prometheus.Port),
-		Handler: promhttp.HandlerFor(proMetrics.Registry, promhttp.HandlerOpts{
+		Handler: promhttp.HandlerFor(proMetrics.Gatherer, promhttp.HandlerOpts{
 			ErrorLog:            loggerForPrometheus{},
 			MaxRequestsInFlight: 5,
 			Timeout:             cfg.Metrics.Prometheus.Timeout(),


### PR DESCRIPTION
This pull request modifies Prebid Server's Prometheus metrics adapter. It adds the ability to collect data about the system's Go process such as memory stats that Prometheus' `GoCollector` provides (documentation of Prometheus GoCollector [here](https://github.com/prometheus/client_golang/blob/6d5cf25fcc344ed30a0623e36c73639bfac112b4/prometheus/go_collector.go)). In a similar fashion to Prebid Server custom-defined metrics, these newly added Go process metrics will also come prefixed with `prebid_server_`.

Prometheus endpoint output after changes implemented in this PR:
```
   # TYPE prebid_server_account_cache_performance counter
   prebid_server_account_cache_performance{cache_result="hit"} 0
   prebid_server_account_cache_performance{cache_result="miss"} 0
   # HELP prebid_server_adapter_bids Count of bids labeled by adapter and markup delivery type (adm or nurl).
   # TYPE prebid_server_adapter_bids counter
   prebid_server_adapter_bids{adapter="33across",delivery="adm"} 0
   prebid_server_adapter_bids{adapter="33across",delivery="nurl"} 0
      .
      .
   prebid_server_dns_lookup_time_bucket{le="+Inf"} 0
   prebid_server_dns_lookup_time_sum 0
   prebid_server_dns_lookup_time_count 0
 + # HELP prebid_server_go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 + # TYPE prebid_server_go_gc_duration_seconds summary
 + prebid_server_go_gc_duration_seconds{quantile="0"} 3.1718e-05
 + prebid_server_go_gc_duration_seconds{quantile="0.25"} 3.4872e-05
 + prebid_server_go_gc_duration_seconds{quantile="0.5"} 4.7144e-05
 + prebid_server_go_gc_duration_seconds{quantile="0.75"} 5.0752e-05
 + prebid_server_go_gc_duration_seconds{quantile="1"} 7.2693e-05
 + prebid_server_go_gc_duration_seconds_sum 0.000430668
 + prebid_server_go_gc_duration_seconds_count 9
 + # HELP prebid_server_go_goroutines Number of goroutines that currently exist.
 + # TYPE prebid_server_go_goroutines gauge
 + prebid_server_go_goroutines 19
 + # HELP prebid_server_go_info Information about the Go environment.
 + # TYPE prebid_server_go_info gauge
 + prebid_server_go_info{version="go1.15.7"} 1
 + # HELP prebid_server_go_memstats_alloc_bytes Number of bytes allocated and still in use.
 + # TYPE prebid_server_go_memstats_alloc_bytes gauge
 + prebid_server_go_memstats_alloc_bytes 8.239408e+06
 + # HELP prebid_server_go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
 + # TYPE prebid_server_go_memstats_alloc_bytes_total counter
 + prebid_server_go_memstats_alloc_bytes_total 2.5249528e+07
 + # HELP prebid_server_go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
 + # TYPE prebid_server_go_memstats_buck_hash_sys_bytes gauge
 + prebid_server_go_memstats_buck_hash_sys_bytes 1.453995e+06
 + # HELP prebid_server_go_memstats_frees_total Total number of frees.
 + # TYPE prebid_server_go_memstats_frees_total counter
 + prebid_server_go_memstats_frees_total 330332
 + # HELP prebid_server_go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
 + # TYPE prebid_server_go_memstats_gc_cpu_fraction gauge
 + prebid_server_go_memstats_gc_cpu_fraction 0.004450995461694631
 + # HELP prebid_server_go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
 + # TYPE prebid_server_go_memstats_gc_sys_bytes gauge
 + prebid_server_go_memstats_gc_sys_bytes 5.556832e+06
 + # HELP prebid_server_go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
 + # TYPE prebid_server_go_memstats_heap_alloc_bytes gauge
 + prebid_server_go_memstats_heap_alloc_bytes 8.239408e+06
 + # HELP prebid_server_go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
 + # TYPE prebid_server_go_memstats_heap_idle_bytes gauge
 + prebid_server_go_memstats_heap_idle_bytes 5.5730176e+07
 + # HELP prebid_server_go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
 + # TYPE prebid_server_go_memstats_heap_inuse_bytes gauge
 + prebid_server_go_memstats_heap_inuse_bytes 1.0395648e+07
 + # HELP prebid_server_go_memstats_heap_objects Number of allocated objects.
 + # TYPE prebid_server_go_memstats_heap_objects gauge
 + prebid_server_go_memstats_heap_objects 83762
 + # HELP prebid_server_go_memstats_heap_released_bytes Number of heap bytes released to OS.
 + # TYPE prebid_server_go_memstats_heap_released_bytes gauge
 + prebid_server_go_memstats_heap_released_bytes 5.5558144e+07
 + # HELP prebid_server_go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
 + # TYPE prebid_server_go_memstats_heap_sys_bytes gauge
 + prebid_server_go_memstats_heap_sys_bytes 6.6125824e+07
 + # HELP prebid_server_go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
 + # TYPE prebid_server_go_memstats_last_gc_time_seconds gauge
 + prebid_server_go_memstats_last_gc_time_seconds 1.6384276154002712e+09
 + # HELP prebid_server_go_memstats_lookups_total Total number of pointer lookups.
 + # TYPE prebid_server_go_memstats_lookups_total counter
 + prebid_server_go_memstats_lookups_total 0
 + # HELP prebid_server_go_memstats_mallocs_total Total number of mallocs.
 + # TYPE prebid_server_go_memstats_mallocs_total counter
 + prebid_server_go_memstats_mallocs_total 414094
 + # HELP prebid_server_go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
 + # TYPE prebid_server_go_memstats_mcache_inuse_bytes gauge
 + prebid_server_go_memstats_mcache_inuse_bytes 20832
 + # HELP prebid_server_go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
 + # TYPE prebid_server_go_memstats_mcache_sys_bytes gauge
 + prebid_server_go_memstats_mcache_sys_bytes 32768
 + # HELP prebid_server_go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
 + # TYPE prebid_server_go_memstats_mspan_inuse_bytes gauge
 + prebid_server_go_memstats_mspan_inuse_bytes 235552
 + # HELP prebid_server_go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
 + # TYPE prebid_server_go_memstats_mspan_sys_bytes gauge
 + prebid_server_go_memstats_mspan_sys_bytes 245760
 + # HELP prebid_server_go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
 + # TYPE prebid_server_go_memstats_next_gc_bytes gauge
 + prebid_server_go_memstats_next_gc_bytes 1.1201072e+07
 + # HELP prebid_server_go_memstats_other_sys_bytes Number of bytes used for other system allocations.
 + # TYPE prebid_server_go_memstats_other_sys_bytes gauge
 + prebid_server_go_memstats_other_sys_bytes 2.230773e+06
 + # HELP prebid_server_go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
 + # TYPE prebid_server_go_memstats_stack_inuse_bytes gauge
 + prebid_server_go_memstats_stack_inuse_bytes 983040
 + # HELP prebid_server_go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
 + # TYPE prebid_server_go_memstats_stack_sys_bytes gauge
 + prebid_server_go_memstats_stack_sys_bytes 983040
 + # HELP prebid_server_go_memstats_sys_bytes Number of bytes obtained from system.
 + # TYPE prebid_server_go_memstats_sys_bytes gauge
 + prebid_server_go_memstats_sys_bytes 7.6628992e+07
 + # HELP prebid_server_go_threads Number of OS threads created.
 + # TYPE prebid_server_go_threads gauge
 + prebid_server_go_threads 16
   # HELP prebid_server_impressions_requests Count of requested impressions to Prebid Server labeled by type.
   # TYPE prebid_server_impressions_requests counter
   prebid_server_impressions_requests{audio="false",banner="false",native="false",video="false"} 0
   .
   .
```