### PR TITLE
GDPR: pass geo based on special feature 1 opt-in

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -287,7 +287,7 @@ type TCF2 struct {
 	Purpose8            TCF2Purpose             `mapstructure:"purpose8"`
 	Purpose9            TCF2Purpose             `mapstructure:"purpose9"`
 	Purpose10           TCF2Purpose             `mapstructure:"purpose10"`
-	SpecialPurpose1     TCF2Purpose             `mapstructure:"special_purpose1"`
+	SpecialFeature1     TCF2SpecialFeature      `mapstructure:"special_feature1"`
 	PurposeOneTreatment TCF2PurposeOneTreatment `mapstructure:"purpose_one_treatment"`
 }
 
@@ -296,6 +296,13 @@ type TCF2Purpose struct {
 	Enabled        bool   `mapstructure:"enabled"` // Deprecated: Use enforce_purpose instead
 	EnforcePurpose string `mapstructure:"enforce_purpose"`
 	EnforceVendors bool   `mapstructure:"enforce_vendors"`
+	// Array of vendor exceptions that is used to create the hash table VendorExceptionMap so vendor names can be instantly accessed
+	VendorExceptions   []openrtb_ext.BidderName `mapstructure:"vendor_exceptions"`
+	VendorExceptionMap map[openrtb_ext.BidderName]struct{}
+}
+
+type TCF2SpecialFeature struct {
+	Enforce bool `mapstructure:"enforce"`
 	// Array of vendor exceptions that is used to create the hash table VendorExceptionMap so vendor names can be instantly accessed
 	VendorExceptions   []openrtb_ext.BidderName `mapstructure:"vendor_exceptions"`
 	VendorExceptionMap map[openrtb_ext.BidderName]struct{}
@@ -556,7 +563,6 @@ func New(v *viper.Viper) (*Configuration, error) {
 		&c.GDPR.TCF2.Purpose8,
 		&c.GDPR.TCF2.Purpose9,
 		&c.GDPR.TCF2.Purpose10,
-		&c.GDPR.TCF2.SpecialPurpose1,
 	}
 	for c := 0; c < len(purposeConfigs); c++ {
 		purposeConfigs[c].VendorExceptionMap = make(map[openrtb_ext.BidderName]struct{})
@@ -565,6 +571,14 @@ func New(v *viper.Viper) (*Configuration, error) {
 			bidderName := purposeConfigs[c].VendorExceptions[v]
 			purposeConfigs[c].VendorExceptionMap[bidderName] = struct{}{}
 		}
+	}
+
+	// To look for a special feature's vendor exceptions in O(1) time, we fill this hash table with bidders located in the
+	// VendorExceptions field of the GDPR.TCF2.SpecialFeature1 struct defined in this file
+	c.GDPR.TCF2.SpecialFeature1.VendorExceptionMap = make(map[openrtb_ext.BidderName]struct{})
+	for v := 0; v < len(c.GDPR.TCF2.SpecialFeature1.VendorExceptions); v++ {
+		bidderName := c.GDPR.TCF2.SpecialFeature1.VendorExceptions[v]
+		c.GDPR.TCF2.SpecialFeature1.VendorExceptionMap[bidderName] = struct{}{}
 	}
 
 	// To look for a request's app_id in O(1) time, we fill this hash table located in the
@@ -950,8 +964,6 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("gdpr.tcf2.purpose8.vendor_exceptions", []openrtb_ext.BidderName{})
 	v.SetDefault("gdpr.tcf2.purpose9.vendor_exceptions", []openrtb_ext.BidderName{})
 	v.SetDefault("gdpr.tcf2.purpose10.vendor_exceptions", []openrtb_ext.BidderName{})
-	v.SetDefault("gdpr.tcf2.special_purpose1.enabled", true)
-	v.SetDefault("gdpr.tcf2.special_purpose1.vendor_exceptions", []openrtb_ext.BidderName{})
 	v.SetDefault("gdpr.amp_exception", false)
 	v.SetDefault("gdpr.eea_countries", []string{"ALA", "AUT", "BEL", "BGR", "HRV", "CYP", "CZE", "DNK", "EST",
 		"FIN", "FRA", "GUF", "DEU", "GIB", "GRC", "GLP", "GGY", "HUN", "ISL", "IRL", "IMN", "ITA", "JEY", "LVA",
@@ -1008,6 +1020,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	// Migrate config settings to maintain compatibility with old configs
 	migrateConfig(v)
 	migrateConfigPurposeOneTreatment(v)
+	migrateConfigSpecialFeature1(v)
 	migrateConfigTCF2PurposeEnabledFlags(v)
 
 	// These defaults must be set after the migrate functions because those functions look for the presence of these
@@ -1035,6 +1048,8 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("gdpr.tcf2.purpose10.enforce_purpose", TCF2FullEnforcement)
 	v.SetDefault("gdpr.tcf2.purpose_one_treatment.enabled", true)
 	v.SetDefault("gdpr.tcf2.purpose_one_treatment.access_allowed", true)
+	v.SetDefault("gdpr.tcf2.special_feature1.enforce", true)
+	v.SetDefault("gdpr.tcf2.special_feature1.vendor_exceptions", []openrtb_ext.BidderName{})
 }
 
 func migrateConfig(v *viper.Viper) {
@@ -1058,6 +1073,19 @@ func migrateConfigPurposeOneTreatment(v *viper.Viper) {
 			glog.Warning("gdpr.tcf2.purpose_one_treatement.enabled should be changed to gdpr.tcf2.purpose_one_treatment.enabled")
 			glog.Warning("gdpr.tcf2.purpose_one_treatement.access_allowed should be changed to gdpr.tcf2.purpose_one_treatment.access_allowed")
 			v.Set("gdpr.tcf2.purpose_one_treatment", oldConfig)
+		}
+	}
+}
+
+func migrateConfigSpecialFeature1(v *viper.Viper) {
+	if oldConfig, ok := v.Get("gdpr.tcf2.special_purpose1").(map[string]interface{}); ok {
+		if v.IsSet("gdpr.tcf2.special_feature1") {
+			glog.Warning("using gdpr.tcf2.special_feature1 and ignoring deprecated gdpr.tcf2.special_purpose1")
+		} else {
+			glog.Warning("gdpr.tcf2.special_purpose1.enabled is deprecated and should be changed to gdpr.tcf2.special_feature1.enforce")
+			glog.Warning("gdpr.tcf2.special_purpose1.vendor_exceptions is deprecated and should be changed to gdpr.tcf2.special_feature1.vendor_exceptions")
+			v.Set("gdpr.tcf2.special_feature1.enforce", oldConfig["enabled"])
+			v.Set("gdpr.tcf2.special_feature1.vendor_exceptions", oldConfig["vendor_exceptions"])
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -835,6 +835,18 @@ func TestMigrateConfigSpecialFeature1(t *testing.T) {
 			assert.Nil(t, v.Get("gdpr.tcf2.special_feature1.enforce"), tt.description)
 			assert.Nil(t, v.Get("gdpr.tcf2.special_feature1.vendor_exceptions"), tt.description)
 		}
+
+		var c Configuration
+		err := v.Unmarshal(&c)
+		assert.NoError(t, err, tt.description)
+		assert.Equal(t, tt.wantSpecialFeature1Enforce, c.GDPR.TCF2.SpecialFeature1.Enforce, tt.description)
+
+		// convert expected vendor exceptions to type BidderName
+		expectedVendorExceptions := make([]openrtb_ext.BidderName, 0, 0)
+		for _, ve := range tt.wantSpecialFeature1VendorExceptions {
+			expectedVendorExceptions = append(expectedVendorExceptions, openrtb_ext.BidderName(ve))
+		}
+		assert.ElementsMatch(t, expectedVendorExceptions, c.GDPR.TCF2.SpecialFeature1.VendorExceptions, tt.description)
 	}
 }
 

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -132,9 +132,9 @@ func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, 
 		return
 	}
 
-	if p.cfg.TCF2.SpecialPurpose1.Enabled {
-		vendorException := p.isSpecialPurposeVendorException(bidder)
-		passGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialPurpose(1) || weakVendorEnforcement))
+	if p.cfg.TCF2.SpecialFeature1.Enforce {
+		vendorException := p.isSpecialFeatureVendorException(bidder)
+		passGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement))
 	} else {
 		passGeo = true
 	}
@@ -162,8 +162,8 @@ func (p *permissionsImpl) isVendorException(purpose consentconstants.Purpose, bi
 	return
 }
 
-func (p *permissionsImpl) isSpecialPurposeVendorException(bidder openrtb_ext.BidderName) (vendorException bool) {
-	if _, ok := p.cfg.TCF2.SpecialPurpose1.VendorExceptionMap[bidder]; ok {
+func (p *permissionsImpl) isSpecialFeatureVendorException(bidder openrtb_ext.BidderName) (vendorException bool) {
+	if _, ok := p.cfg.TCF2.SpecialFeature1.VendorExceptionMap[bidder]; ok {
 		vendorException = true
 	}
 	return
@@ -293,6 +293,9 @@ func (v vendorTrue) LegitimateInterest(purposeID consentconstants.Purpose) bool 
 	return true
 }
 func (v vendorTrue) LegitimateInterestStrict(purposeID consentconstants.Purpose) bool {
+	return true
+}
+func (v vendorTrue) SpecialFeature(featureID consentconstants.SpecialFeature) (hasSpecialFeature bool) {
 	return true
 }
 func (v vendorTrue) SpecialPurpose(purposeID consentconstants.Purpose) (hasSpecialPurpose bool) {

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -341,7 +341,7 @@ func buildVendorList34() vendorList {
 				ID:               6,
 				Purposes:         []int{1, 2, 4},
 				LegIntPurposes:   []int{7},
-				SpecialPurposes:  []int{1},
+				SpecialFeatures:  []int{1},
 				FlexiblePurposes: []int{1, 2, 4, 7},
 			},
 			"8": {
@@ -352,7 +352,7 @@ func buildVendorList34() vendorList {
 			"10": {
 				ID:              10,
 				Purposes:        []int{2, 4, 7},
-				SpecialPurposes: []int{1},
+				SpecialFeatures: []int{1},
 			},
 			"20": {
 				ID:               20,
@@ -384,7 +384,7 @@ func allPurposesEnabledPermissions() (perms permissionsImpl) {
 				Purpose8:        config.TCF2Purpose{EnforcePurpose: config.TCF2FullEnforcement, EnforceVendors: true},
 				Purpose9:        config.TCF2Purpose{EnforcePurpose: config.TCF2FullEnforcement, EnforceVendors: true},
 				Purpose10:       config.TCF2Purpose{EnforcePurpose: config.TCF2FullEnforcement, EnforceVendors: true},
-				SpecialPurpose1: config.TCF2Purpose{Enabled: true, EnforceVendors: true},
+				SpecialFeature1: config.TCF2SpecialFeature{Enforce: true},
 			},
 		},
 	}
@@ -431,7 +431,7 @@ func TestAllowActivitiesGeoAndID(t *testing.T) {
 		}),
 	}
 
-	// COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA : full consents to purposes and vendors 2, 6, 8
+	// COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA : full consents to purposes and vendors 2, 6, 8 and special feature 1 opt-in
 	testDefs := []testDef{
 		{
 			description: "Appnexus vendor test, insufficient purposes claimed",
@@ -536,7 +536,7 @@ func TestAllowActivitiesPubRestrict(t *testing.T) {
 	}
 
 	// COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA - vendors 1-10 legit interest only,
-	// Pub restriction on purpose 7, consent only ... no allowPI will pass, no Special purpose 1 consent
+	// Pub restriction on purpose 7, consent only ... no allowPI will pass, no special feature 1 consent
 	testDefs := []testDef{
 		{
 			description: "Appnexus vendor test, insufficient purposes claimed",
@@ -840,7 +840,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 	testDefs := []struct {
 		description           string
 		p2VendorExceptionMap  map[openrtb_ext.BidderName]struct{}
-		sp1VendorExceptionMap map[openrtb_ext.BidderName]struct{}
+		sf1VendorExceptionMap map[openrtb_ext.BidderName]struct{}
 		bidder                openrtb_ext.BidderName
 		consent               string
 		allowBid              bool
@@ -859,7 +859,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 		{
 			description:           "Bid/ID allowed by vendor exception - p2 enabled with p2 vendor exception, pub restricts none",
 			p2VendorExceptionMap:  map[openrtb_ext.BidderName]struct{}{openrtb_ext.BidderAppnexus: {}},
-			sp1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{},
+			sf1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{},
 			bidder:                openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
 			allowBid:              true,
@@ -867,9 +867,9 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			passID:                true,
 		},
 		{
-			description:           "Geo blocked - sp1 enabled but no consent",
+			description:           "Geo blocked - sf1 enabled but no consent",
 			p2VendorExceptionMap:  map[openrtb_ext.BidderName]struct{}{},
-			sp1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{},
+			sf1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{},
 			bidder:                openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
 			allowBid:              false,
@@ -877,9 +877,9 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			passID:                false,
 		},
 		{
-			description:           "Geo allowed by vendor exception - sp1 enabled with sp1 vendor exception",
+			description:           "Geo allowed by vendor exception - sf1 enabled with sf1 vendor exception",
 			p2VendorExceptionMap:  map[openrtb_ext.BidderName]struct{}{},
-			sp1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{openrtb_ext.BidderAppnexus: {}},
+			sf1VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{openrtb_ext.BidderAppnexus: {}},
 			bidder:                openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
 			allowBid:              false,
@@ -896,7 +896,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 				TCF2: config.TCF2{
 					Enabled:         true,
 					Purpose2:        config.TCF2Purpose{EnforcePurpose: config.TCF2FullEnforcement, VendorExceptionMap: td.p2VendorExceptionMap},
-					SpecialPurpose1: config.TCF2Purpose{Enabled: true, VendorExceptionMap: td.sp1VendorExceptionMap},
+					SpecialFeature1: config.TCF2SpecialFeature{Enforce: true, VendorExceptionMap: td.sf1VendorExceptionMap},
 				},
 			},
 			vendorIDs: map[openrtb_ext.BidderName]uint16{

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -189,7 +189,7 @@ type vendor struct {
 	Purposes         []int  `json:"purposes"`
 	LegIntPurposes   []int  `json:"legIntPurposes"`
 	FlexiblePurposes []int  `json:"flexiblePurposes"`
-	SpecialPurposes  []int  `json:"specialPurposes"`
+	SpecialFeatures  []int  `json:"specialFeatures"`
 }
 
 func MarshalVendorList(vendorList vendorList) string {


### PR DESCRIPTION
This PR fixes a GDPR bug and depends on https://github.com/prebid/go-gdpr/pull/34.
We currently determine if geo information should be passed in a bid request based on whether special purpose 1 is set in the GVL for the vendor which is incorrect. Instead we should be looking at whether special feature 1 is set for the vendor. The main change is here in `impl.go` on line 137:
`passGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement))`

Special purposes are defined in the TCF2 spec but they are not used by PBS. As a result, all references to special purpose 1 have been renamed to eliminate confusion.