### PR TITLE
Invibes Bid Adapter - replaced Host macro with ZoneID

### DIFF
--- a/adapters/invibes/invibes.go
+++ b/adapters/invibes/invibes.go
@@ -279,19 +279,17 @@ func (a *InvibesAdapter) makeParameter(invibesParams InvibesInternalParams, requ
 }
 
 func (a *InvibesAdapter) makeURL(request *openrtb2.BidRequest, domainID int) (string, error) {
-	host := "bid.videostep.com"
-	if domainID == 1 {
-		host = "adweb.videostepstage.com"
-	} else if domainID == 2 {
-		host = "adweb.invibesstage.com"
-	} else if domainID == 1001 {
-		host = "bid.videostep.com"
-	} else if domainID >= 1002 {
-		host = "bid" + strconv.Itoa(domainID-1000) + ".videostep.com"
+	subdomain := "bid"
+	if domainID == 0 || domainID == 1 || domainID == 1001 {
+		subdomain = "bid"
+	} else if domainID < 1002 {
+		subdomain = "bid" + strconv.Itoa(domainID)
+	} else {
+		subdomain = "bid" + strconv.Itoa(domainID-1000)
 	}
 
 	var endpointURL *url.URL
-	endpointParams := macros.EndpointTemplateParams{Host: host}
+	endpointParams := macros.EndpointTemplateParams{ZoneID: subdomain}
 	host, err := macros.ResolveMacros(a.EndpointTemplate, endpointParams)
 
 	if err == nil {

--- a/adapters/invibes/invibes.go
+++ b/adapters/invibes/invibes.go
@@ -279,7 +279,7 @@ func (a *InvibesAdapter) makeParameter(invibesParams InvibesInternalParams, requ
 }
 
 func (a *InvibesAdapter) makeURL(request *openrtb2.BidRequest, domainID int) (string, error) {
-	subdomain := "bid"
+	var subdomain string
 	if domainID == 0 || domainID == 1 || domainID == 1001 {
 		subdomain = "bid"
 	} else if domainID < 1002 {

--- a/adapters/invibes/invibes_test.go
+++ b/adapters/invibes/invibes_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderInvibes, config.Adapter{
-		Endpoint: "https://{{.Host}}/bid/ServerBidAdContent"})
+		Endpoint: "https://{{.ZoneID}}.videostep.com/bid/ServerBidAdContent"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/invibes/invibestest/exemplary/advanced-ad.json
+++ b/adapters/invibes/invibestest/exemplary/advanced-ad.json
@@ -44,7 +44,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://adweb.invibesstage.com/bid/ServerBidAdContent",
+        "uri": "https://bid2.videostep.com/bid/ServerBidAdContent",
         "body": {
           "BidParamsJson": "{\"PlacementIds\":[\"2eb6bd58-865c-47ce-af7f-a918108c3fd2\"],\"BidVersion\":\"4\",\"Properties\":{\"2eb6bd58-865c-47ce-af7f-a918108c3fd2\":{\"Formats\":[{\"w\":300,\"h\":150}],\"ImpId\":\"test-imp-id\"}}}",
           "Bvid": "",

--- a/adapters/invibes/invibestest/exemplary/test-ad.json
+++ b/adapters/invibes/invibestest/exemplary/test-ad.json
@@ -21,7 +21,7 @@
         "ext": {
           "bidder": {
             "placementId": "2eb6bd58-865c-47ce-af7f-a918108c3fd2",
-            "domainId": 1,
+            "domainId": 1005,
             "debug": {
               "testBvid": "111",
               "testLog": false
@@ -34,7 +34,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://adweb.videostepstage.com/bid/ServerBidAdContent",
+        "uri": "https://bid5.videostep.com/bid/ServerBidAdContent",
         "body": {
           "BidParamsJson": "{\"PlacementIds\":[\"2eb6bd58-865c-47ce-af7f-a918108c3fd2\"],\"BidVersion\":\"4\",\"Properties\":{\"2eb6bd58-865c-47ce-af7f-a918108c3fd2\":{\"Formats\":[{\"w\":300,\"h\":150}],\"ImpId\":\"test-imp-id\"}}}",
           "Bvid": "111",

--- a/config/config.go
+++ b/config/config.go
@@ -881,7 +881,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.jixie.endpoint", "https://hb.jixie.io/v2/hbsvrpost")
 	v.SetDefault("adapters.kayzen.endpoint", "https://bids-{{.ZoneID}}.bidder.kayzen.io/?exchange={{.AccountID}}")
 	v.SetDefault("adapters.krushmedia.endpoint", "http://ads4.krushmedia.com/?c=rtb&m=req&key={{.AccountID}}")
-	v.SetDefault("adapters.invibes.endpoint", "https://{{.Host}}/bid/ServerBidAdContent")
+	v.SetDefault("adapters.invibes.endpoint", "https://{{.ZoneID}}.videostep.com/bid/ServerBidAdContent")
 	v.SetDefault("adapters.iqzone.endpoint", "http://smartssp-us-east.iqzone.com/pserver")
 	v.SetDefault("adapters.kidoz.endpoint", "http://prebid-adapter.kidoz.net/openrtb2/auction?src=prebid-server")
 	v.SetDefault("adapters.kubient.endpoint", "https://kssp.kbntx.ch/prebid")


### PR DESCRIPTION
Invibes Bid Adapter update for prebid-server

Removed {Host} macro and replaced with {ZoneID}
No documentation update necessary since this is internal use only.
Maintainer: system_operations@invibes.com