### PR TITLE
Adding Support for EventType=Vast in Analytics Endpoint

### DIFF
--- a/analytics/event.go
+++ b/analytics/event.go
@@ -5,8 +5,9 @@ type EventType string
 
 // Possible values of events Prebid Server can receive for an ad.
 const (
-	Win EventType = "win"
-	Imp EventType = "imp"
+	Win  EventType = "win"
+	Imp  EventType = "imp"
+	Vast EventType = "vast"
 )
 
 // ResponseFormat enumerates the values of a Prebid Server event.
@@ -17,6 +18,18 @@ const (
 	Blank ResponseFormat = "b"
 	// Image describes an event which returns an HTTP 200 with a PNG body.
 	Image ResponseFormat = "i"
+)
+
+// VastType enumerates the values of vast type events Prebid Server can receive
+type VastType string
+
+// Possible value of VastType event prebid server can receive.
+const (
+	Start         VastType = "start"
+	FirstQuartile VastType = "firstQuartile"
+	MidPoint      VastType = "midPoint"
+	ThirdQuartile VastType = "thirdQuartile"
+	Complete      VastType = "complete"
 )
 
 // Analytics indicates if the notification event should be handled or not
@@ -36,4 +49,5 @@ type EventRequest struct {
 	Bidder      string         `json:"bidder,omitempty"`
 	Timestamp   int64          `json:"timestamp,omitempty"`
 	Integration string         `json:"integration,omitempty"`
+	VType       VastType       `json:"vtype,omitempty"`
 }

--- a/endpoints/events/event.go
+++ b/endpoints/events/event.go
@@ -25,6 +25,7 @@ const (
 	TypeParameter      = "t"
 	BidIdParameter     = "b"
 	AccountIdParameter = "a"
+	VTypeParameter     = "vtype"
 
 	// Optional
 	BidderParameter          = "bidder"
@@ -144,6 +145,16 @@ func ParseEventRequest(r *http.Request) (*analytics.EventRequest, []error) {
 		errs = append(errs, err)
 	}
 
+	if event.Type == analytics.Vast {
+		if err := readVType(event, r); err != nil {
+			errs = append(errs, err)
+		}
+	} else {
+		if t := r.URL.Query().Get(VTypeParameter); t != "" {
+			errs = append(errs, &errortypes.BadInput{Message: "parameter 'vtype' is only required for t=vast"})
+		}
+	}
+
 	// validate bidid
 	if bidid, err := checkRequiredParameter(r, BidIdParameter); err != nil {
 		errs = append(errs, err)
@@ -261,9 +272,38 @@ func readType(er *analytics.EventRequest, httpRequest *http.Request) error {
 	case string(analytics.Win):
 		er.Type = analytics.Win
 		return nil
+	case string(analytics.Vast):
+		er.Type = analytics.Vast
+		return nil
 	default:
 		return &errortypes.BadInput{Message: fmt.Sprintf("unknown type: '%s'", t)}
 	}
+}
+
+// readVType validates analytics.EventRequest vtype
+func readVType(er *analytics.EventRequest, httpRequest *http.Request) error {
+	vtype, err := checkRequiredParameter(httpRequest, VTypeParameter)
+
+	if err != nil {
+		return err
+	}
+
+	switch vtype {
+	case string(analytics.Start):
+		er.VType = analytics.Start
+	case string(analytics.FirstQuartile):
+		er.VType = analytics.FirstQuartile
+	case string(analytics.MidPoint):
+		er.VType = analytics.MidPoint
+	case string(analytics.ThirdQuartile):
+		er.VType = analytics.ThirdQuartile
+	case string(analytics.Complete):
+		er.VType = analytics.Complete
+	default:
+		return &errortypes.BadInput{Message: fmt.Sprintf("unknown vtype: '%s'", vtype)}
+	}
+
+	return nil
 }
 
 // readFormat validates analytics.EventRequest format attribute

--- a/endpoints/events/event_test.go
+++ b/endpoints/events/event_test.go
@@ -645,6 +645,16 @@ func TestShouldParseEventCorrectly(t *testing.T) {
 				Analytics: analytics.Enabled,
 			},
 		},
+		"three": {
+			req: httptest.NewRequest("GET", "/event?t=vast&vtype=start&b=bidId&ts=0&a=accountId", strings.NewReader("")),
+			expected: &analytics.EventRequest{
+				Type:      analytics.Vast,
+				VType:     analytics.Start,
+				BidID:     "bidId",
+				Timestamp: 0,
+				Analytics: analytics.Enabled,
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -748,5 +758,58 @@ func TestReadIntegrationType(t *testing.T) {
 			assert.Empty(t, err, test.description)
 			assert.Equalf(t, test.expectedIntegrationType, testEventRequest.Integration, test.description)
 		}
+	}
+}
+
+func TestShouldReturnBadRequestWhenVTypeIsInvalid(t *testing.T) {
+
+	// prepare
+	reqData := ""
+
+	tests := map[string]struct {
+		req                *http.Request
+		expectedStatusCode int
+		expectedStatus     string
+	}{
+		"vtype parameter is missing": {
+			httptest.NewRequest("GET", "/event?t=vast&b=bidID", strings.NewReader(reqData)),
+			400,
+			"invalid request: parameter 'vtype' is required\n",
+		},
+		"invalid vtype parameter": {
+			httptest.NewRequest("GET", "/event?t=vast&vtype=abc&b=bidID", strings.NewReader(reqData)),
+			400,
+			"invalid request: unknown vtype: 'abc'\n",
+		},
+	}
+
+	for _, test := range tests {
+		// mock AccountsFetcher
+		mockAccountsFetcher := &mockAccountsFetcher{}
+
+		// mock PBS Analytics Module
+		mockAnalyticsModule := &eventsMockAnalyticsModule{
+			Fail: false,
+		}
+
+		// mock config
+		cfg := &config.Configuration{
+			AccountDefaults: config.Account{},
+		}
+
+		recorder := httptest.NewRecorder()
+
+		e := NewEventEndpoint(cfg, mockAccountsFetcher, mockAnalyticsModule)
+		// execute
+		e(recorder, test.req, nil)
+
+		d, err := ioutil.ReadAll(recorder.Result().Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// validate
+		assert.Equal(t, test.expectedStatusCode, recorder.Result().StatusCode, "Expected 400 on request with invalid vtype parameter")
+		assert.Equal(t, test.expectedStatus, string(d))
 	}
 }


### PR DESCRIPTION
Please review this PR. This PR is addressing the changes for Supporting EventType = Vast in Analytics Endpoint for VAST Events

Prebid Server Video Events - Phase I -https://docs.google.com/document/d/1zzi06jWpYsvhuiQ_3KCpes0DpmpO2teatmo4V5kIhi0/edit?usp=sharing
Review Document - https://docs.google.com/document/d/1tH6I9Vho-_KaUIGNCMum9JwbxHDc0FyG2wD8T-h3wkY/edit?usp=sharing
PRD - https://docs.google.com/document/d/1a-U1DytiCTtacM27qH3OZwhPa7bDwQzfpVRHDhyikWw/edit#heading=h.x6fobe7fnos0