### PR TITLE
New GitHub Action: Trivy Security Scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Trivy
-    runs-on: "ubuntu-18.04"
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -22,8 +22,7 @@ jobs:
         with:
           scan-type: 'fs'
           ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,33 @@
+name: Security Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Trivy
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Resolves to empty string for push events and falls back to HEAD.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          
+      - name: Upload Results To GitHub Security Tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Checkout Branch
+    - name: Checkout Code
       uses: actions/checkout@v2
       with:
         # Resolves to empty string for push events and falls back to HEAD.


### PR DESCRIPTION
The default Dependabot is not comprehensive. Adding Trivy to the build pipeline as a stronger defense against CVE security issues throughout the entire dependency hierarchy.