### PR TITLE
AdkernelAdn: static endpoint host

### DIFF
--- a/adapters/adkernelAdn/adkernelAdn.go
+++ b/adapters/adkernelAdn/adkernelAdn.go
@@ -15,8 +15,6 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-const defaultDomain string = "tag.adkernel.com"
-
 type adkernelAdnAdapter struct {
 	EndpointTemplate *template.Template
 }
@@ -103,7 +101,6 @@ func dispatchImpressions(imps []openrtb2.Imp, impsExt []openrtb_ext.ExtImpAdkern
 			res[impExt] = make([]openrtb2.Imp, 0)
 		}
 		res[impExt] = append(res[impExt], imp)
-
 	}
 	return res, errors
 }
@@ -212,12 +209,8 @@ func createBidRequest(prebidBidRequest *openrtb2.BidRequest, params *openrtb_ext
 
 // Builds enpoint url based on adapter-specific pub settings from imp.ext
 func (adapter *adkernelAdnAdapter) buildEndpointURL(params *openrtb_ext.ExtImpAdkernelAdn) (string, error) {
-	reqHost := defaultDomain
-	if params.Host != "" {
-		reqHost = params.Host
-	}
 	pubIDStr := strconv.Itoa(params.PublisherID)
-	endpointParams := macros.EndpointTemplateParams{Host: reqHost, PublisherID: pubIDStr}
+	endpointParams := macros.EndpointTemplateParams{PublisherID: pubIDStr}
 	return macros.ResolveMacros(adapter.EndpointTemplate, endpointParams)
 }
 

--- a/adapters/adkernelAdn/adkernelAdn_test.go
+++ b/adapters/adkernelAdn/adkernelAdn_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderAdkernelAdn, config.Adapter{
-		Endpoint: "http://{{.Host}}/rtbpub?account={{.PublisherID}}"})
+		Endpoint: "https://pbs2.adksrv.com/rtbpub?account={{.PublisherID}}"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/adkernelAdn/adkerneladntest/exemplary/multiformat-impression.json
+++ b/adapters/adkernelAdn/adkerneladntest/exemplary/multiformat-impression.json
@@ -36,7 +36,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=102",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=102",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernelAdn/adkerneladntest/exemplary/single-banner-impression.json
+++ b/adapters/adkernelAdn/adkerneladntest/exemplary/single-banner-impression.json
@@ -29,7 +29,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=101",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=101",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernelAdn/adkerneladntest/exemplary/single-video-impression.json
+++ b/adapters/adkernelAdn/adkerneladntest/exemplary/single-video-impression.json
@@ -33,7 +33,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=102",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=102",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/204status.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/204status.json
@@ -26,7 +26,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=101",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=101",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/http-err-status.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/http-err-status.json
@@ -26,7 +26,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=101",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=101",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernelAdn/adkerneladntest/supplemental/two-impressions-two-seatbids.json
+++ b/adapters/adkernelAdn/adkerneladntest/supplemental/two-impressions-two-seatbids.json
@@ -37,7 +37,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://tag.test.com/rtbpub?account=101",
+        "uri": "https://pbs2.adksrv.com/rtbpub?account=101",
         "body": {
             "app": {
             "bundle": "com.rovia.angrybirds",

--- a/config/config.go
+++ b/config/config.go
@@ -819,7 +819,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.adgeneration.endpoint", "https://d.socdm.com/adsv/v1")
 	v.SetDefault("adapters.adhese.endpoint", "https://ads-{{.AccountID}}.adhese.com/json")
 	v.SetDefault("adapters.adkernel.endpoint", "https://pbs.adksrv.com/hb?zone={{.ZoneID}}")
-	v.SetDefault("adapters.adkerneladn.endpoint", "http://{{.Host}}/rtbpub?account={{.PublisherID}}")
+	v.SetDefault("adapters.adkerneladn.endpoint", "https://pbs2.adksrv.com/rtbpub?account={{.PublisherID}}")
 	v.SetDefault("adapters.adman.endpoint", "http://pub.admanmedia.com/?c=o&m=ortb")
 	v.SetDefault("adapters.admixer.endpoint", "http://inv-nets.admixer.net/pbs.aspx")
 	v.SetDefault("adapters.adocean.endpoint", "https://{{.Host}}")

--- a/openrtb_ext/imp_adkernelAdn.go
+++ b/openrtb_ext/imp_adkernelAdn.go
@@ -2,6 +2,5 @@ package openrtb_ext
 
 // ExtImpAdkernelAdn defines the contract for bidrequest.imp[i].ext.adkernelAdn
 type ExtImpAdkernelAdn struct {
-	PublisherID int    `json:"pubId"`
-	Host        string `json:"host,omitempty"`
+	PublisherID int `json:"pubId"`
 }

--- a/static/bidder-params/adkernelAdn.json
+++ b/static/bidder-params/adkernelAdn.json
@@ -9,10 +9,6 @@
         "type": "integer",
         "minimum": 1,
         "description": "Publisher Id to use."
-      },
-      "host": {
-        "type": "string",
-        "description": "Network host to send request"
       }
   },
   "required": ["pubId"]


### PR DESCRIPTION
Switched to static adkernel host instead of publisher-side configured domains to address https://github.com/prebid/prebid-server/issues/2127