### PR TITLE
PubMatic: add "acat" parameter

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -307,7 +307,7 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 	return wrapExt, pubID, nil
 }
 
-// extractPubmaticExtFromRequest parse the imp to get it ready to send to pubmatic
+// extractPubmaticExtFromRequest parse the req.ext to fetch wrapper and acat params
 func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapperExt, []string, error) {
 	var acat []string
 	var wrpExt *pubmaticWrapperExt

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -66,7 +66,7 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 	extractWrapperExtFromImp := true
 	extractPubIDFromImp := true
 
-	wrapperExt, err := extractPubmaticWrapperExtFromRequest(request)
+	wrapperExt, acat, err := extractPubmaticExtFromRequest(request)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -114,9 +114,14 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 		return nil, errs
 	}
 
+	reqExt := make(map[string]interface{})
+	if len(acat) > 0 {
+		reqExt["acat"] = acat
+	}
 	if wrapperExt != nil {
-		reqExt := make(map[string]interface{})
 		reqExt["wrapper"] = wrapperExt
+	}
+	if len(reqExt) > 0 {
 		rawExt, err := json.Marshal(reqExt)
 		if err != nil {
 			return nil, []error{err}
@@ -302,23 +307,29 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 	return wrapExt, pubID, nil
 }
 
-// extractPubmaticWrapperExtFromRequest parse the imp to get it ready to send to pubmatic
-func extractPubmaticWrapperExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapperExt, error) {
-	var wrpExt pubmaticWrapperExt
+// extractPubmaticExtFromRequest parse the imp to get it ready to send to pubmatic
+func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapperExt, []string, error) {
+	var acat []string
+	var wrpExt *pubmaticWrapperExt
 	reqExtBidderParams, err := adapters.ExtractReqExtBidderParamsMap(request)
 	if err != nil {
-		return nil, err
+		return wrpExt, acat, err
 	}
 
 	//get request ext bidder params
 	if wrapperObj, present := reqExtBidderParams["wrapper"]; present && len(wrapperObj) != 0 {
-		err = json.Unmarshal(wrapperObj, &wrpExt)
+		wrpExt = &pubmaticWrapperExt{}
+		err = json.Unmarshal(wrapperObj, wrpExt)
 		if err != nil {
-			return nil, err
+			return nil, acat, err
 		}
-		return &wrpExt, nil
 	}
-	return nil, nil
+
+	if _acat, ok := reqExtBidderParams["acat"]; ok {
+		err = json.Unmarshal(_acat, &acat)
+	}
+
+	return wrpExt, acat, err
 }
 
 func addKeywordsToExt(keywords []*openrtb_ext.ExtImpPubmaticKeyVal, extMap map[string]interface{}) {

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -1,11 +1,14 @@
 package pubmatic
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonSamples(t *testing.T) {
@@ -65,5 +68,81 @@ func TestGetBidTypeForUnsupportedCode(t *testing.T) {
 	actualBidTypeValue := getBidType(pubmaticExt)
 	if actualBidTypeValue != openrtb_ext.BidTypeBanner {
 		t.Errorf("Expected Bid Type value was: %v, actual value is: %v", openrtb_ext.BidTypeBanner, actualBidTypeValue)
+	}
+}
+
+func TestExtractPubmaticExtFromRequest(t *testing.T) {
+	type args struct {
+		request *openrtb2.BidRequest
+	}
+	tests := []struct {
+		name               string
+		args               args
+		expectedWrapperExt *pubmaticWrapperExt
+		expectedAcat       []string
+		wantErr            bool
+	}{
+		{
+			name:    "Empty bidder param",
+			wantErr: true,
+		},
+		{
+			name: "Pubmatic wrapper ext missing/empty",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{}}}`),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Only Pubmatic wrapper ext present",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			wantErr:            false,
+		},
+		{
+			name: "Invalid Pubmatic wrapper ext",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"wrapper":{"profile":"123","version":456}}}}`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid Pubmatic acat ext",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":["drg”,”dlu”,”ssr"],"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			expectedAcat:       []string{"drg”,”dlu”,”ssr"},
+			wantErr:            false,
+		},
+		{
+			name: "Invalid Pubmatic acat ext. We are ok with acat being non nil in this case as we are returning unmarshal error",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":[1,3,4],"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			expectedAcat:       []string{"", "", ""},
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWrapperExt, gotAcat, err := extractPubmaticExtFromRequest(tt.args.request)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.expectedWrapperExt, gotWrapperExt)
+			assert.Equal(t, tt.expectedAcat, gotAcat)
+		})
 	}
 }

--- a/adapters/pubmatic/pubmatictest/exemplary/banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/banner.json
@@ -32,6 +32,13 @@
         "device":{
             "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
         },
+        "ext": {
+          "prebid": {
+            "bidderparams": {
+              "acat": ["drg”,”dlu”,”ssr"]
+            }
+          }
+        },
         "site": {
 		      	"id": "siteID",
 		    	  "publisher": {
@@ -79,7 +86,8 @@
                 "wrapper": {
                     "profile": 5123,
                     "version":1
-                }
+                },
+                "acat": ["drg”,”dlu”,”ssr"]
             }
           }
         },

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -43,7 +43,14 @@
 		    	"publisher": {
 			    	"id": "1234"
 		  	}
-	  	}
+	  	},
+      "ext": {
+        "prebid": {
+          "bidderparams": {
+            "acat": ["drg”,”dlu”,”ssr"]
+          }
+        }
+      }
     },
   
     "httpCalls": [
@@ -90,7 +97,8 @@
                 "wrapper": {
                     "profile": 5123,
                     "version":1
-                }
+                },
+                "acat": ["drg”,”dlu”,”ssr"]
             }
           }
         },


### PR DESCRIPTION
Add support to 'act' request ext param in PubMatic adapter.

Documentation https://docs.prebid.org/dev-docs/pbs-bidders.html#pubmatic (https://github.com/prebid/prebid.github.io/pull/3657)

Prebid JS changes are WIP.