### PR TITLE
PubMatic: add "acat" parameter

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -66,7 +66,7 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 	extractWrapperExtFromImp := true
 	extractPubIDFromImp := true
 
-	wrapperExt, err := extractPubmaticWrapperExtFromRequest(request)
+	wrapperExt, acat, err := extractPubmaticExtFromRequest(request)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -114,9 +114,14 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 		return nil, errs
 	}
 
+	reqExt := make(map[string]interface{})
+	if len(acat) > 0 {
+		reqExt["acat"] = acat
+	}
 	if wrapperExt != nil {
-		reqExt := make(map[string]interface{})
 		reqExt["wrapper"] = wrapperExt
+	}
+	if len(reqExt) > 0 {
 		rawExt, err := json.Marshal(reqExt)
 		if err != nil {
 			return nil, []error{err}
@@ -310,23 +315,29 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 	return wrapExt, pubID, nil
 }
 
-// extractPubmaticWrapperExtFromRequest parse the imp to get it ready to send to pubmatic
-func extractPubmaticWrapperExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapperExt, error) {
-	var wrpExt pubmaticWrapperExt
+// extractPubmaticExtFromRequest parse the req.ext to fetch wrapper and acat params
+func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapperExt, []string, error) {
+	var acat []string
+	var wrpExt *pubmaticWrapperExt
 	reqExtBidderParams, err := adapters.ExtractReqExtBidderParamsMap(request)
 	if err != nil {
-		return nil, err
+		return wrpExt, acat, err
 	}
 
 	//get request ext bidder params
 	if wrapperObj, present := reqExtBidderParams["wrapper"]; present && len(wrapperObj) != 0 {
-		err = json.Unmarshal(wrapperObj, &wrpExt)
+		wrpExt = &pubmaticWrapperExt{}
+		err = json.Unmarshal(wrapperObj, wrpExt)
 		if err != nil {
-			return nil, err
+			return nil, acat, err
 		}
-		return &wrpExt, nil
 	}
-	return nil, nil
+
+	if _acat, ok := reqExtBidderParams["acat"]; ok {
+		err = json.Unmarshal(_acat, &acat)
+	}
+
+	return wrpExt, acat, err
 }
 
 func addKeywordsToExt(keywords []*openrtb_ext.ExtImpPubmaticKeyVal, extMap map[string]interface{}) {

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -333,8 +333,8 @@ func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapp
 		}
 	}
 
-	if _acat, ok := reqExtBidderParams["acat"]; ok {
-		err = json.Unmarshal(_acat, &acat)
+	if acatBytes, ok := reqExtBidderParams["acat"]; ok {
+		err = json.Unmarshal(acatBytes, &acat)
 		for i := 0; i < len(acat); i++ {
 			acat[i] = strings.TrimSpace(acat[i])
 		}

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -335,6 +335,9 @@ func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapp
 
 	if _acat, ok := reqExtBidderParams["acat"]; ok {
 		err = json.Unmarshal(_acat, &acat)
+		for i := 0; i < len(acat); i++ {
+			acat[i] = strings.TrimSpace(acat[i])
+		}
 	}
 
 	return wrpExt, acat, err

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -321,7 +321,7 @@ func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (*pubmaticWrapp
 	var wrpExt *pubmaticWrapperExt
 	reqExtBidderParams, err := adapters.ExtractReqExtBidderParamsMap(request)
 	if err != nil {
-		return wrpExt, acat, err
+		return nil, acat, err
 	}
 
 	//get request ext bidder params

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
@@ -223,6 +224,43 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.expectedWrapperExt, gotWrapperExt)
 			assert.Equal(t, tt.expectedAcat, gotAcat)
+		})
+	}
+}
+
+func TestPubmaticAdapter_MakeRequests(t *testing.T) {
+	type fields struct {
+		URI string
+	}
+	type args struct {
+		request *openrtb2.BidRequest
+		reqInfo *adapters.ExtraRequestInfo
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		expectedReqData []*adapters.RequestData
+		wantErr         bool
+	}{
+		// Happy paths covered by TestJsonSamples()
+		// Covering only error scenarios here
+		{
+			name: "invalid bidderparams",
+			args: args{
+				request: &openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"bidderparams":{"wrapper":"123"}}}`)},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &PubmaticAdapter{
+				URI: tt.fields.URI,
+			}
+			gotReqData, gotErr := a.MakeRequests(tt.args.request, tt.args.reqInfo)
+			assert.Equal(t, tt.wantErr, len(gotErr) != 0)
+			assert.Equal(t, tt.expectedReqData, gotReqData)
 		})
 	}
 }

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -150,3 +150,79 @@ func TestParseImpressionObject(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractPubmaticExtFromRequest(t *testing.T) {
+	type args struct {
+		request *openrtb2.BidRequest
+	}
+	tests := []struct {
+		name               string
+		args               args
+		expectedWrapperExt *pubmaticWrapperExt
+		expectedAcat       []string
+		wantErr            bool
+	}{
+		{
+			name:    "Empty bidder param",
+			wantErr: true,
+		},
+		{
+			name: "Pubmatic wrapper ext missing/empty",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{}}}`),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Only Pubmatic wrapper ext present",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			wantErr:            false,
+		},
+		{
+			name: "Invalid Pubmatic wrapper ext",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"wrapper":{"profile":"123","version":456}}}}`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid Pubmatic acat ext",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":["drg”,”dlu”,”ssr"],"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			expectedAcat:       []string{"drg”,”dlu”,”ssr"},
+			wantErr:            false,
+		},
+		{
+			name: "Invalid Pubmatic acat ext. We are ok with acat being non nil in this case as we are returning unmarshal error",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":[1,3,4],"wrapper":{"profile":123,"version":456}}}}`),
+				},
+			},
+			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
+			expectedAcat:       []string{"", "", ""},
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWrapperExt, gotAcat, err := extractPubmaticExtFromRequest(tt.args.request)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.expectedWrapperExt, gotWrapperExt)
+			assert.Equal(t, tt.expectedAcat, gotAcat)
+		})
+	}
+}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -198,11 +198,11 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			name: "Valid Pubmatic acat ext",
 			args: args{
 				request: &openrtb2.BidRequest{
-					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":["drg”,”dlu”,”ssr"],"wrapper":{"profile":123,"version":456}}}}`),
+					Ext: json.RawMessage(`{"prebid":{"bidderparams":{"acat":[" drg \t","dlu","ssr"],"wrapper":{"profile":123,"version":456}}}}`),
 				},
 			},
 			expectedWrapperExt: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
-			expectedAcat:       []string{"drg”,”dlu”,”ssr"},
+			expectedAcat:       []string{"drg", "dlu", "ssr"},
 			wantErr:            false,
 		},
 		{

--- a/adapters/pubmatic/pubmatictest/exemplary/banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/banner.json
@@ -33,6 +33,13 @@
         "device":{
             "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
         },
+        "ext": {
+          "prebid": {
+            "bidderparams": {
+              "acat": ["drg”,”dlu”,”ssr"]
+            }
+          }
+        },
         "site": {
 		      	"id": "siteID",
 		    	  "publisher": {
@@ -81,7 +88,8 @@
                 "wrapper": {
                     "profile": 5123,
                     "version":1
-                }
+                },
+                "acat": ["drg”,”dlu”,”ssr"]
             }
           }
         },

--- a/adapters/pubmatic/pubmatictest/exemplary/banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/banner.json
@@ -36,7 +36,7 @@
         "ext": {
           "prebid": {
             "bidderparams": {
-              "acat": ["drg”,”dlu”,”ssr"]
+              "acat": ["drg","dlu","ssr"]
             }
           }
         },
@@ -89,7 +89,7 @@
                     "profile": 5123,
                     "version":1
                 },
-                "acat": ["drg”,”dlu”,”ssr"]
+                "acat": ["drg","dlu","ssr"]
             }
           }
         },

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -48,7 +48,7 @@
       "ext": {
         "prebid": {
           "bidderparams": {
-            "acat": ["drg”,”dlu”,”ssr"]
+            "acat": ["drg","dlu","ssr"]
           }
         }
       }
@@ -100,7 +100,7 @@
                     "profile": 5123,
                     "version":1
                 },
-                "acat": ["drg”,”dlu”,”ssr"]
+                "acat": ["drg","dlu","ssr"]
             }
           }
         },

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -44,7 +44,14 @@
 		    	"publisher": {
 			    	"id": "1234"
 		  	}
-	  	}
+	  	},
+      "ext": {
+        "prebid": {
+          "bidderparams": {
+            "acat": ["drg”,”dlu”,”ssr"]
+          }
+        }
+      }
     },
   
     "httpCalls": [
@@ -92,7 +99,8 @@
                 "wrapper": {
                     "profile": 5123,
                     "version":1
-                }
+                },
+                "acat": ["drg”,”dlu”,”ssr"]
             }
           }
         },

--- a/static/bidder-params/pubmatic.json
+++ b/static/bidder-params/pubmatic.json
@@ -25,11 +25,11 @@
 			"description": "Deals Custom Targeting, pipe separated key-value pairs e.g key1=V1,V2,V3|key2=v1|key3=v3,v5"
 		},
 		"acat": {
-            "type": "array",
-            "description": "List of allowed categories for a given auction to be sent in request.ext",
-            "items": {
-                "type": "string"
-            }
+			"type": "array",
+			"description": "List of allowed categories for a given auction to be sent in request.ext",
+			"items": {
+				"type": "string"
+			}
         },
 		"wrapper": {
 			"type": "object",

--- a/static/bidder-params/pubmatic.json
+++ b/static/bidder-params/pubmatic.json
@@ -24,6 +24,13 @@
 			"type": "string",
 			"description": "Deals Custom Targeting, pipe separated key-value pairs e.g key1=V1,V2,V3|key2=v1|key3=v3,v5"
 		},
+		"acat": {
+            "type": "array",
+            "description": "List of allowed categories for a given auction to be sent in request.ext",
+            "items": {
+                "type": "string"
+            }
+        },
 		"wrapper": {
 			"type": "object",
 			"description": "Specifies pubmatic openwrap configuration for a publisher",

--- a/static/bidder-params/pubmatic.json
+++ b/static/bidder-params/pubmatic.json
@@ -30,7 +30,7 @@
 			"items": {
 				"type": "string"
 			}
-        },
+		},
 		"wrapper": {
 			"type": "object",
 			"description": "Specifies pubmatic openwrap configuration for a publisher",


### PR DESCRIPTION
Add support to 'act' request ext param in PubMatic adapter.

Documentation https://docs.prebid.org/dev-docs/pbs-bidders.html#pubmatic (https://github.com/prebid/prebid.github.io/pull/3657)

PBJS: https://github.com/prebid/Prebid.js/pull/8246