### PR TITLE
Apply new Truncate Targeting Config to Key

### DIFF
--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -96,7 +96,7 @@ func (targData *targetData) addKeys(keys map[string]string, key openrtb_ext.Targ
 		keys[key.BidderKey(bidderName, maxLength)] = value
 	}
 	if targData.includeWinners && overallWinner {
-		keys[string(key)] = value
+		keys[key.TruncateKey(maxLength)] = value
 	}
 }
 

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -262,8 +262,9 @@ var bid084 *openrtb2.Bid = &openrtb2.Bid{
 	Price: 0.84,
 }
 
-var truncateTargetAttrValueLess int = 10
-var truncateTargetAttrValueGreater int = 25
+var truncateTargetAttrValue10 int = 10
+var truncateTargetAttrValue5 int = 5
+var truncateTargetAttrValue25 int = 25
 var truncateTargetAttrValueNegative int = -1
 var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
@@ -451,7 +452,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 				},
 			},
 		},
-		TruncateTargetAttr: &truncateTargetAttrValueLess,
+		TruncateTargetAttr: &truncateTargetAttrValue10,
 	},
 	{
 		Description: "Truncate Targeting Attribute value is given and is greater than const MaxKeyLength",
@@ -485,7 +486,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 				},
 			},
 		},
-		TruncateTargetAttr: &truncateTargetAttrValueGreater,
+		TruncateTargetAttr: &truncateTargetAttrValue25,
 	},
 	{
 		Description: "Truncate Targeting Attribute value is given and is negative",
@@ -517,6 +518,99 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 					"hb_bidder_rubicon": "rubicon",
 					"hb_pb_rubicon":     "0.80",
 				},
+			},
+		},
+		TruncateTargetAttr: &truncateTargetAttrValueNegative,
+	},
+	{
+		Description: "Check that key gets truncated properly when value is smaller than key",
+		TargetData: targetData{
+			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			includeWinners:   true,
+		},
+		Auction: auction{
+			winningBidsByBidder: map[string]map[openrtb_ext.BidderName]*pbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {
+						bid:     bid123,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+					openrtb_ext.BidderRubicon: {
+						bid:     bid084,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+				},
+			},
+		},
+		ExpectedBidTargetsByBidder: map[string]map[openrtb_ext.BidderName]map[string]string{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: {
+					"hb_bi": "appnexus",
+					"hb_pb": "1.20",
+				},
+				openrtb_ext.BidderRubicon: {},
+			},
+		},
+		TruncateTargetAttr: &truncateTargetAttrValue5,
+	},
+	{
+		Description: "Check that key gets truncated properly when value is greater than key",
+		TargetData: targetData{
+			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			includeWinners:   true,
+		},
+		Auction: auction{
+			winningBidsByBidder: map[string]map[openrtb_ext.BidderName]*pbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {
+						bid:     bid123,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+					openrtb_ext.BidderRubicon: {
+						bid:     bid084,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+				},
+			},
+		},
+		ExpectedBidTargetsByBidder: map[string]map[openrtb_ext.BidderName]map[string]string{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: {
+					"hb_bidder": "appnexus",
+					"hb_pb":     "1.20",
+				},
+				openrtb_ext.BidderRubicon: {},
+			},
+		},
+		TruncateTargetAttr: &truncateTargetAttrValue25,
+	},
+	{
+		Description: "Check that key gets truncated properly when value is negative",
+		TargetData: targetData{
+			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			includeWinners:   true,
+		},
+		Auction: auction{
+			winningBidsByBidder: map[string]map[openrtb_ext.BidderName]*pbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {
+						bid:     bid123,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+					openrtb_ext.BidderRubicon: {
+						bid:     bid084,
+						bidType: openrtb_ext.BidTypeBanner,
+					},
+				},
+			},
+		},
+		ExpectedBidTargetsByBidder: map[string]map[openrtb_ext.BidderName]map[string]string{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: {
+					"hb_bidder": "appnexus",
+					"hb_pb":     "1.20",
+				},
+				openrtb_ext.BidderRubicon: {},
 			},
 		},
 		TruncateTargetAttr: &truncateTargetAttrValueNegative,

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -161,6 +161,13 @@ func min(x, y int) int {
 	return y
 }
 
+func (key TargetingKey) TruncateKey(maxLength int) string {
+	if maxLength > 0 {
+		return string(key)[:min(len(string(key)), maxLength)]
+	}
+	return string(key)
+}
+
 const (
 	StoredRequestAttributes = "storedrequestattributes"
 )

--- a/openrtb_ext/bid_test.go
+++ b/openrtb_ext/bid_test.go
@@ -1,6 +1,10 @@
 package openrtb_ext
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestBidderKey(t *testing.T) {
 	apnKey := HbpbConstantKey.BidderKey(BidderAppnexus, 50)
@@ -13,6 +17,39 @@ func TestTruncatedKey(t *testing.T) {
 	apnKey := HbpbConstantKey.BidderKey(BidderAppnexus, 8)
 	if apnKey != "hb_pb_ap" {
 		t.Errorf("Bad truncated targeting key. Expected hb_pb_ap, got %s", apnKey)
+	}
+}
+
+func TestTruncateKey(t *testing.T) {
+	testCases := []struct {
+		description          string
+		givenMaxLength       int
+		givenTargetingKey    TargetingKey
+		expectedTargetingKey string
+	}{
+		{
+			description:          "Targeting key is smaller than max length, expect targeting key to stay the same",
+			givenMaxLength:       15,
+			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			expectedTargetingKey: "hb_bidder_key",
+		},
+		{
+			description:          "Targeting key is larger than max length, expect targeting key to be truncated",
+			givenMaxLength:       9,
+			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			expectedTargetingKey: "hb_bidder",
+		},
+		{
+			description:          "Max length isn't greater than zero, expect targeting key to not be truncated",
+			givenMaxLength:       0,
+			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			expectedTargetingKey: "hb_bidder_key",
+		},
+	}
+
+	for _, test := range testCases {
+		truncatedKey := test.givenTargetingKey.TruncateKey(test.givenMaxLength)
+		assert.Equalf(t, test.expectedTargetingKey, truncatedKey, "The Targeting Key is incorrect: %s\n", test.description)
 	}
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/prebid/prebid-server/pull/2181

In this PR, I update the `addKeys` function to also apply the truncation to the Targeting Key itself