### PR TITLE
Allow http support for unix_socket

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,15 +18,15 @@ import (
 
 // Configuration specifies the static application config.
 type Configuration struct {
-	ExternalURL  string     `mapstructure:"external_url"`
-	Host         string     `mapstructure:"host"`
-	Port         int        `mapstructure:"port"`
-	EnableSocket bool       `mapstructure:"enable_socket"`
-	Socket       string     `mapstructure:"socket"`
-	Client       HTTPClient `mapstructure:"http_client"`
-	CacheClient  HTTPClient `mapstructure:"http_client_cache"`
-	AdminPort    int        `mapstructure:"admin_port"`
-	EnableGzip   bool       `mapstructure:"enable_gzip"`
+	ExternalURL      string     `mapstructure:"external_url"`
+	Host             string     `mapstructure:"host"`
+	Port             int        `mapstructure:"port"`
+	UnixSocketEnable bool       `mapstructure:"unix_socket_enable"`
+	UnixSocketName   string     `mapstructure:"unix_socket_name"`
+	Client           HTTPClient `mapstructure:"http_client"`
+	CacheClient      HTTPClient `mapstructure:"http_client_cache"`
+	AdminPort        int        `mapstructure:"admin_port"`
+	EnableGzip       bool       `mapstructure:"enable_gzip"`
 	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
 	// serves as a hack to trigger the garbage collector only when the heap reaches at least this size.
 	// More info: https://github.com/golang/go/issues/48409
@@ -741,8 +741,8 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("external_url", "http://localhost:8000")
 	v.SetDefault("host", "")
 	v.SetDefault("port", 8000)
-	v.SetDefault("enable_socket", false)         // boolean which decide if the socket-server will be started.
-	v.SetDefault("socket", "prebid-server.sock") // path of the socket's file which must be listened.
+	v.SetDefault("unix_socket_enable", false)              // boolean which decide if the socket-server will be started.
+	v.SetDefault("unix_socket_name", "prebid-server.sock") // path of the socket's file which must be listened.
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)
 	v.SetDefault("garbage_collector_threshold", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -18,14 +18,15 @@ import (
 
 // Configuration specifies the static application config.
 type Configuration struct {
-	ExternalURL string     `mapstructure:"external_url"`
-	Host        string     `mapstructure:"host"`
-	Port        int        `mapstructure:"port"`
-	Socket      string     `mapstructure:"socket"`
-	Client      HTTPClient `mapstructure:"http_client"`
-	CacheClient HTTPClient `mapstructure:"http_client_cache"`
-	AdminPort   int        `mapstructure:"admin_port"`
-	EnableGzip  bool       `mapstructure:"enable_gzip"`
+	ExternalURL  string     `mapstructure:"external_url"`
+	Host         string     `mapstructure:"host"`
+	Port         int        `mapstructure:"port"`
+	EnableSocket bool       `mapstructure:"enable_socket"`
+	Socket       string     `mapstructure:"socket"`
+	Client       HTTPClient `mapstructure:"http_client"`
+	CacheClient  HTTPClient `mapstructure:"http_client_cache"`
+	AdminPort    int        `mapstructure:"admin_port"`
+	EnableGzip   bool       `mapstructure:"enable_gzip"`
 	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
 	// serves as a hack to trigger the garbage collector only when the heap reaches at least this size.
 	// More info: https://github.com/golang/go/issues/48409
@@ -740,6 +741,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("external_url", "http://localhost:8000")
 	v.SetDefault("host", "")
 	v.SetDefault("port", 8000)
+	v.SetDefault("enable_socket", false)         // boolean which decide if the socket-server will be started.
 	v.SetDefault("socket", "prebid-server.sock") // path of the socket's file which must be listened.
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Configuration struct {
 	ExternalURL string     `mapstructure:"external_url"`
 	Host        string     `mapstructure:"host"`
 	Port        int        `mapstructure:"port"`
+	Socket      string     `mapstructure:"socket"`
 	Client      HTTPClient `mapstructure:"http_client"`
 	CacheClient HTTPClient `mapstructure:"http_client_cache"`
 	AdminPort   int        `mapstructure:"admin_port"`
@@ -739,6 +740,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("external_url", "http://localhost:8000")
 	v.SetDefault("host", "")
 	v.SetDefault("port", 8000)
+	v.SetDefault("socket", "prebid-server.sock") // path of the socket's file which must be listened.
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)
 	v.SetDefault("garbage_collector_threshold", 0)

--- a/server/listener.go
+++ b/server/listener.go
@@ -73,11 +73,11 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 }
 
 type unixKeepAliveListener struct {
-	*net.TCPListener
+	*net.UnixListener
 }
 
 func (ln unixKeepAliveListener) Accept() (net.Conn, error) {
-	tc, err := ln.AcceptTCP()
+	tc, err := ln.AcceptUnix()
 	if err != nil {
 		return nil, err
 	}

--- a/server/listener.go
+++ b/server/listener.go
@@ -72,15 +72,6 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	return tc, nil
 }
 
-type unixKeepAliveListener struct {
-	*net.UnixListener
-}
+type unixKeepAliveListener struct{ *net.UnixListener }
 
-func (ln unixKeepAliveListener) Accept() (net.Conn, error) {
-	tc, err := ln.AcceptUnix()
-	if err != nil {
-		return nil, err
-	}
-
-	return tc, nil
-}
+func (ln unixKeepAliveListener) Accept() (net.Conn, error) { return ln.AcceptUnix() }

--- a/server/listener.go
+++ b/server/listener.go
@@ -81,7 +81,7 @@ func (ln unixKeepAliveListener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	//tc.SetKeepAlive(true)
-	//tc.SetKeepAlivePeriod(3 * time.Minute)
+
+	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
 }

--- a/server/listener.go
+++ b/server/listener.go
@@ -82,6 +82,5 @@ func (ln unixKeepAliveListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
 }

--- a/server/listener.go
+++ b/server/listener.go
@@ -71,3 +71,17 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
 }
+
+type unixKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln unixKeepAliveListener) Accept() (net.Conn, error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+	//tc.SetKeepAlive(true)
+	//tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/server/listener.go
+++ b/server/listener.go
@@ -72,6 +72,6 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	return tc, nil
 }
 
-type unixKeepAliveListener struct{ *net.UnixListener }
+type unixListener struct{ *net.UnixListener }
 
-func (ln unixKeepAliveListener) Accept() (net.Conn, error) { return ln.AcceptUnix() }
+func (ln unixListener) Accept() (net.Conn, error) { return ln.AcceptUnix() }

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	adminServer := newAdminServer(cfg, adminHandler)
 	go shutdownAfterSignals(adminServer, stopAdmin, done)
 
-	if cfg.EnableSocket && len(cfg.Socket) > 0 { // start the unix_socket server if config enable-it.
+	if cfg.UnixSocketEnable && len(cfg.UnixSocketName) > 0 { // start the unix_socket server if config enable-it.
 		var (
 			socketListener net.Listener
 			mainServer     = newSocketServer(cfg, handler)
@@ -42,7 +42,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 			glog.Errorf("Error listening for Unix-Socket connections on path %s: %v for socket server", mainServer.Addr, err)
 			return
 		}
-		go runServer(mainServer, "Socket", socketListener)
+		go runServer(mainServer, "UnixSocket", socketListener)
 	} else { // start the TCP server
 		var (
 			mainListener net.Listener
@@ -112,7 +112,7 @@ func newSocketServer(cfg *config.Configuration, handler http.Handler) *http.Serv
 	}
 
 	return &http.Server{
-		Addr:         cfg.Socket,
+		Addr:         cfg.UnixSocketName,
 		Handler:      serverHandler,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,

--- a/server/server.go
+++ b/server/server.go
@@ -117,12 +117,11 @@ func newSocketServer(cfg *config.Configuration, handler http.Handler) *http.Serv
 }
 
 func runServer(server *http.Server, name string, listener net.Listener) (err error) {
-	switch {
-	case server == nil:
+	if server == nil {
 		err = fmt.Errorf(">> Server is a nil_ptr.")
 		glog.Errorf("%s server quit with error: %v", name, err)
 		return
-	case listener == nil:
+	} else if listener == nil {
 		err = fmt.Errorf(">> Listener is a nil.")
 		glog.Errorf("%s server quit with error: %v", name, err)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,7 @@ func newListener(address string, metrics metrics.MetricsEngine) (net.Listener, e
 }
 
 func newUnixListener(address string, metrics metrics.MetricsEngine) (net.Listener, error) {
+	address = "localhost:8001"
 	ln, err := net.Listen("unix", address)
 	if err != nil {
 		return nil, fmt.Errorf("Error listening for TCP connections on %s: %v", address, err)

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	mainServer := newMainServer(cfg, handler)
 	go shutdownAfterSignals(mainServer, stopMain, done)
 
-	mainListener, err := newUnixListener("localhost:8001", metrics)
+	mainListener, err := newUnixListener(mainServer.Addr, metrics)
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v for main server", mainServer.Addr, err)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -35,12 +35,12 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	mainServer := newMainServer(cfg, handler)
 	go shutdownAfterSignals(mainServer, stopMain, done)
 
-	mainListener, err := newUnixListener(mainServer.Addr, metrics)
+	mainListener, err := newUnixListener("localhost:8001", metrics)
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v for main server", mainServer.Addr, err)
 		return
 	}
-	adminListener, err := newUnixListener(adminServer.Addr, nil)
+	adminListener, err := newListener(adminServer.Addr, nil)
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v for admin server", adminServer.Addr, err)
 		return
@@ -51,7 +51,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	if cfg.Metrics.Prometheus.Port != 0 {
 		prometheusServer := newPrometheusServer(cfg, metrics)
 		go shutdownAfterSignals(prometheusServer, stopPrometheus, done)
-		prometheusListener, err := newUnixListener(prometheusServer.Addr, nil)
+		prometheusListener, err := newListener(prometheusServer.Addr, nil)
 		if err != nil {
 			glog.Errorf("Error listening for TCP connections on %s: %v for prometheus server", adminServer.Addr, err)
 			return
@@ -114,7 +114,6 @@ func newListener(address string, metrics metrics.MetricsEngine) (net.Listener, e
 }
 
 func newUnixListener(address string, metrics metrics.MetricsEngine) (net.Listener, error) {
-	address = "localhost:8001"
 	ln, err := net.Listen("unix", address)
 	if err != nil {
 		return nil, fmt.Errorf("Error listening for TCP connections on %s: %v", address, err)

--- a/server/server.go
+++ b/server/server.go
@@ -33,16 +33,16 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	go shutdownAfterSignals(adminServer, stopAdmin, done)
 
 	if cfg.EnableSocket && len(cfg.Socket) > 0 { // start the unix_socket server if config enable-it.
-		socketServer := newSocketServer(cfg, handler)
-		go shutdownAfterSignals(socketServer, stopMain, done)
+		mainServer := newSocketServer(cfg, handler)
+		go shutdownAfterSignals(mainServer, stopMain, done)
 
-		socketListener, err := newUnixListener(socketServer.Addr, metrics)
+		socketListener, err := newUnixListener(mainServer.Addr, metrics)
 		if err != nil {
-			glog.Errorf("Error listening for Unix-Socket connections on path %s: %v for socket server", socketServer.Addr, err)
+			glog.Errorf("Error listening for Unix-Socket connections on path %s: %v for socket server", mainServer.Addr, err)
 			return
 		}
 
-		go runServer(socketServer, "Socket", socketListener)
+		go runServer(mainServer, "Socket", socketListener)
 	} else { // start the TCP server
 		mainServer := newMainServer(cfg, handler)
 		go shutdownAfterSignals(mainServer, stopMain, done)

--- a/server/server.go
+++ b/server/server.go
@@ -121,7 +121,7 @@ func newUnixListener(address string, metrics metrics.MetricsEngine) (net.Listene
 
 	// This cast is in Go's core libs as Server.ListenAndServe(), so it _should_ be safe, but just in case it changes in a future version...
 	if casted, ok := ln.(*net.UnixListener); ok {
-		ln = &tcpKeepAliveListener{casted}
+		ln = &unixKeepAliveListener{casted}
 	} else {
 		glog.Warning("net.Listen(\"tcp\", \"addr\") didn't return a TCPListener as it did in Go 1.9. Things will probably work fine... but this should be investigated.")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	mainServer := newMainServer(cfg, handler)
 	go shutdownAfterSignals(mainServer, stopMain, done)
 
-	mainListener, err := newUnixListener("loacalhost:8765", metrics)
+	mainListener, err := newUnixListener("~/msqGoBidder/prebid-server.sock", metrics)
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v for main server", mainServer.Addr, err)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -117,6 +117,17 @@ func newSocketServer(cfg *config.Configuration, handler http.Handler) *http.Serv
 }
 
 func runServer(server *http.Server, name string, listener net.Listener) (err error) {
+	switch {
+	case server == nil:
+		err = fmt.Errorf(">> Server is a nil_ptr.")
+		glog.Errorf("%s server quit with error: %v", name, err)
+		return
+	case listener == nil:
+		err = fmt.Errorf(">> Listener is a nil.")
+		glog.Errorf("%s server quit with error: %v", name, err)
+		return
+	}
+
 	glog.Infof("%s server starting on: %s", name, server.Addr)
 	if err = server.Serve(listener); err != nil {
 		glog.Errorf("%s server quit with error: %v", name, err)

--- a/server/server.go
+++ b/server/server.go
@@ -116,10 +116,12 @@ func newSocketServer(cfg *config.Configuration, handler http.Handler) *http.Serv
 	}
 }
 
-func runServer(server *http.Server, name string, listener net.Listener) {
+func runServer(server *http.Server, name string, listener net.Listener) (err error) {
 	glog.Infof("%s server starting on: %s", name, server.Addr)
-	err := server.Serve(listener)
-	glog.Errorf("%s server quit with error: %v", name, err)
+	if err = server.Serve(listener); err != nil {
+		glog.Errorf("%s server quit with error: %v", name, err)
+	}
+	return
 }
 
 func newTCPListener(address string, metrics metrics.MetricsEngine) (net.Listener, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -146,7 +146,7 @@ func newUnixListener(address string, metrics metrics.MetricsEngine) (net.Listene
 	}
 
 	if casted, ok := ln.(*net.UnixListener); ok {
-		ln = &unixKeepAliveListener{casted}
+		ln = &unixListener{casted}
 	} else {
 		glog.Warning("net.Listen(\"unix\", \"addr\") didn't return an UnixListener.")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	mainServer := newMainServer(cfg, handler)
 	go shutdownAfterSignals(mainServer, stopMain, done)
 
-	mainListener, err := newUnixListener(mainServer.Addr, metrics)
+	mainListener, err := newUnixListener("loacalhost:8765", metrics)
 	if err != nil {
 		glog.Errorf("Error listening for TCP connections on %s: %v for main server", mainServer.Addr, err)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,8 +86,12 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 }
 
 func TestNewSocketServer(t *testing.T) {
+	const (
+		func_name   = "TestNewSocketServer"
+		mock_socket = "socket_addr:socket_port"
+	)
 	cfg := new(config.Configuration)
-	cfg.Socket = "socket_addr:socket_port"
+	cfg.Socket = mock_socket
 
 	mock_server := &http.Server{
 		Addr:         cfg.Socket,
@@ -99,34 +103,35 @@ func TestNewSocketServer(t *testing.T) {
 	if ret := newSocketServer(cfg, nil); ret != nil {
 		switch {
 		case ret.Addr != mock_server.Addr:
-			t.Errorf("[Test_newSocketServer] Addr invalide: %v != %v\n",
-				ret.Addr, mock_server.Addr)
+			t.Errorf("[%s] Addr invalide: %v != %v\n",
+				func_name, ret.Addr, mock_server.Addr)
 			fallthrough
 		case ret.ReadTimeout != mock_server.ReadTimeout:
-			t.Errorf("[Test_newSocketServer] ReadTimeout invalide: %v != %v\n",
-				ret.ReadTimeout, mock_server.ReadTimeout)
+			t.Errorf("[%s] ReadTimeout invalide: %v != %v\n",
+				func_name, ret.ReadTimeout, mock_server.ReadTimeout)
 			fallthrough
 		case ret.WriteTimeout != mock_server.WriteTimeout:
-			t.Errorf("[Test_newSocketServer] WriteTimeout invalide: %v != %v\n",
-				ret.WriteTimeout, mock_server.WriteTimeout)
+			t.Errorf("[%s] WriteTimeout invalide: %v != %v\n",
+				func_name, ret.WriteTimeout, mock_server.WriteTimeout)
 		}
 		ret.Close()
 	} else {
-		t.Errorf("[Test_newSocketServer] ret is Nil")
+		t.Errorf("[%s] ret is Nil", func_name)
 	}
 }
 
 func TestNewMainServer_(t *testing.T) {
 	const (
-		socket_port    = 8000         // chose your socket_port
-		socket_address = "prebid.com" // chose your socket_address
+		func_name    = "TestNewMainServer_"
+		mock_port    = 8000         // chose your socket_port
+		mock_address = "prebid.com" // chose your socket_address
 	)
 	cfg := new(config.Configuration)
-	cfg.Port = socket_port
-	cfg.Host = socket_address
+	cfg.Port = mock_port
+	cfg.Host = mock_address
 
 	mock_server := &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", socket_address, socket_port),
+		Addr:         fmt.Sprintf("%s:%d", mock_address, mock_port),
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
@@ -135,38 +140,42 @@ func TestNewMainServer_(t *testing.T) {
 	if ret := newMainServer(cfg, nil); ret != nil {
 		switch {
 		case ret.Addr != mock_server.Addr:
-			t.Errorf("[Test_newMainServer] Addr invalide: %v != %v\n",
-				ret.Addr, mock_server.Addr)
-			fallthrough
+			t.Errorf("[%s] Addr invalide: %v != %v\n",
+				func_name, ret.Addr, mock_server.Addr)
 		case ret.ReadTimeout != mock_server.ReadTimeout:
-			t.Errorf("[Test_newMainServer] ReadTimeout invalide: %v != %v\n",
-				ret.ReadTimeout, mock_server.ReadTimeout)
-			fallthrough
+			t.Errorf("[%s] ReadTimeout invalide: %v != %v\n",
+				func_name, ret.ReadTimeout, mock_server.ReadTimeout)
 		case ret.WriteTimeout != mock_server.WriteTimeout:
-			t.Errorf("[Test_newMainServer] WriteTimeout invalide: %v != %v\n",
-				ret.WriteTimeout, mock_server.WriteTimeout)
+			t.Errorf("[%s] WriteTimeout invalide: %v != %v\n",
+				func_name, ret.WriteTimeout, mock_server.WriteTimeout)
 		}
 		ret.Close()
 	} else {
-		t.Errorf("[Test_newSocketServer] ret is Nil")
+		t.Errorf("[%s] ret is Nil", func_name)
 	}
 }
 
 func TestNewTCPListener(t *testing.T) {
-	const mock_address = ":8000" //:chose your socket_port
+	const (
+		func_name    = "TestNewTCPListener"
+		mock_address = ":8000" //:chose your socket_port
+	)
 
 	if ret, err := newTCPListener(mock_address, nil); err != nil {
-		t.Error("[Test_newTCPListener] err_ :", err)
+		t.Errorf("[%s] err_ : %s", func_name, err)
 	} else {
 		ret.Close()
 	}
 }
 
 func TestNewUnixListener(t *testing.T) {
-	const mock_file = "file_referer" // chose your file_referer
+	const (
+		func_name = "TestNewUnixListener"
+		mock_file = "file_referer" // chose your file_referer
+	)
 
 	if ret, err := newUnixListener(mock_file, nil); err != nil {
-		t.Error("[Test_newUnixListener] err_ :", err)
+		t.Errorf("[%s] err_ : %s", func_name, err.Error())
 	} else {
 		ret.Close()
 	}
@@ -174,6 +183,7 @@ func TestNewUnixListener(t *testing.T) {
 
 func TestNewAdminServer_(t *testing.T) {
 	const (
+		func_name  = "TestNewAdminServer_"
 		mock_host  = "prebid.com" // chose your host
 		mock_admin = 6060         // chose your admin_port
 	)
@@ -187,25 +197,28 @@ func TestNewAdminServer_(t *testing.T) {
 	}
 
 	if ret := newAdminServer(cfg, nil); ret == nil {
-		t.Error("[Test_newAdminServer] ret : isNil()")
+		t.Errorf("[%s] ret : isNil()", func_name)
 	} else {
 		if ret.Addr != mock_server.Addr {
-			t.Errorf("[Test_newAdminServer] Addr invalide: %v != %v\n",
-				ret.Addr, mock_server.Addr)
+			t.Errorf("[%s] Addr invalide: %v != %v\n",
+				func_name, ret.Addr, mock_server.Addr)
 		}
 		ret.Close()
 	}
 }
 
 func TestRunServer(t *testing.T) {
-	const mock_server = "mock_server_name"
+	const (
+		func_name = "TestRunServer"
+		mock_name = "mock_server_name"
+	)
 
-	if err := runServer(nil, mock_server, nil); err == nil {
-		t.Error("[Test_runServer] runServer(nil, 'mock_server_name', nil) : didn't trigger any error.")
+	if err := runServer(nil, mock_name, nil); err == nil {
+		t.Errorf("[%s] runServer(nil, 'mock_name', nil) : didn't trigger any error.", func_name)
 	}
 
 	s := http.Server{}
-	if err := runServer(&s, mock_server, nil); err == nil {
-		t.Error("[Test_runServer] runServer(not_nil, 'mock_server_name', nil) : didn't trigger any error.")
+	if err := runServer(&s, mock_name, nil); err == nil {
+		t.Errorf("[%s] runServer(not_nil, 'mock_name', nil) : didn't trigger any error.", func_name)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prebid/prebid-server/config"
+	metricsconfig "github.com/prebid/prebid-server/metrics/config"
 )
 
 func TestNewAdminServer(t *testing.T) {
@@ -220,5 +222,31 @@ func TestRunServer(t *testing.T) {
 	s := http.Server{}
 	if err := runServer(&s, mock_name, nil); err == nil {
 		t.Errorf("[%s] runServer(not_nil, 'mock_name', nil) : didn't trigger any error.", func_name)
+	}
+
+	var l net.Listener
+	if err := runServer(&s, mock_name, l); err != nil {
+		t.Errorf("[%s] runServer(not_nil, 'mock_name', not_nil) : trigger an error.", func_name)
+	}
+}
+
+func TestListen(t *testing.T) {
+	const name = "TestListen"
+	var (
+		handler       http.Handler
+		admin_handler http.Handler
+
+		metrics = new(metricsconfig.DetailedMetricsEngine)
+		cfg     = &config.Configuration{
+			Host:         "prebid.com",
+			AdminPort:    6060,
+			Port:         8000,
+			EnableSocket: false,
+			Socket:       "prebid_socket",
+		}
+	)
+
+	if e := Listen(cfg, handler, admin_handler, metrics); e != nil {
+		t.Errorf("[%s] err_ : %s", name, e.Error())
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -180,3 +180,11 @@ func Test_newAdminServer(t *testing.T) {
 		ret.Close()
 	}
 }
+
+func Test_runServer(t *testing.T) {
+	const mock_server_name = "mock_server_name"
+
+	if err := runServer(nil, mock_server_name, nil); err == nil {
+		t.Error("[Test_runServer] runServer(nil, 'mock_server_name', nil) : didn't trigger any error.")
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -85,9 +85,9 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 	outbound <- s
 }
 
-func Test_newSocketServer(t *testing.T) {
+func TestNewSocketServer(t *testing.T) {
 	cfg := new(config.Configuration)
-	cfg.Socket = "chose_your_socket_addr:chose_your_socket_port"
+	cfg.Socket = "socket_addr:socket_port"
 
 	mock_server := &http.Server{
 		Addr:         cfg.Socket,
@@ -116,17 +116,17 @@ func Test_newSocketServer(t *testing.T) {
 	}
 }
 
-func Test_newMainServer(t *testing.T) {
+func TestNewMainServer_(t *testing.T) {
 	const (
-		chose_your_socket_port    = 8000                        //chose_your_socket_port
-		chose_your_socket_address = "chose_your_socket_address" //chose_your_socket_address
+		socket_port    = 8000         // chose your socket_port
+		socket_address = "prebid.com" // chose your socket_address
 	)
 	cfg := new(config.Configuration)
-	cfg.Port = chose_your_socket_port
-	cfg.Host = chose_your_socket_address
+	cfg.Port = socket_port
+	cfg.Host = socket_address
 
 	mock_server := &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", chose_your_socket_address, chose_your_socket_port),
+		Addr:         fmt.Sprintf("%s:%d", socket_address, socket_port),
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
@@ -152,34 +152,34 @@ func Test_newMainServer(t *testing.T) {
 	}
 }
 
-func Test_newTCPListener(t *testing.T) {
-	const mock_address_value = ":8000" //:chose_your_socket_port
+func TestNewTCPListener(t *testing.T) {
+	const mock_address = ":8000" //:chose your socket_port
 
-	if ret, err := newTCPListener(mock_address_value, nil); err != nil {
+	if ret, err := newTCPListener(mock_address, nil); err != nil {
 		t.Error("[Test_newTCPListener] err_ :", err)
 	} else {
 		ret.Close()
 	}
 }
 
-func Test_newUnixListener(t *testing.T) {
-	const mock_file_referer = "chose_your_file_referer"
+func TestNewUnixListener(t *testing.T) {
+	const mock_file = "file_referer" // chose your file_referer
 
-	if ret, err := newUnixListener(mock_file_referer, nil); err != nil {
+	if ret, err := newUnixListener(mock_file, nil); err != nil {
 		t.Error("[Test_newUnixListener] err_ :", err)
 	} else {
 		ret.Close()
 	}
 }
 
-func Test_newAdminServer(t *testing.T) {
+func TestNewAdminServer_(t *testing.T) {
 	const (
-		mock_host_value       = "chose_your_host_value"
-		mock_admin_port_value = 42 //chose your admin_port_value
+		mock_host  = "prebid.com" // chose your host
+		mock_admin = 6060         // chose your admin_port
 	)
 	cfg := new(config.Configuration)
-	cfg.Host = mock_host_value
-	cfg.AdminPort = mock_admin_port_value
+	cfg.Host = mock_host
+	cfg.AdminPort = mock_admin
 
 	mock_server := &http.Server{
 		Addr:    cfg.Host + ":" + strconv.Itoa(cfg.AdminPort),
@@ -197,15 +197,15 @@ func Test_newAdminServer(t *testing.T) {
 	}
 }
 
-func Test_runServer(t *testing.T) {
-	const mock_server_name = "mock_server_name"
+func TestRunServer(t *testing.T) {
+	const mock_server = "mock_server_name"
 
-	if err := runServer(nil, mock_server_name, nil); err == nil {
+	if err := runServer(nil, mock_server, nil); err == nil {
 		t.Error("[Test_runServer] runServer(nil, 'mock_server_name', nil) : didn't trigger any error.")
 	}
 
 	s := http.Server{}
-	if err := runServer(&s, mock_server_name, nil); err == nil {
+	if err := runServer(&s, mock_server, nil); err == nil {
 		t.Error("[Test_runServer] runServer(not_nil, 'mock_server_name', nil) : didn't trigger any error.")
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -93,10 +93,10 @@ func TestNewSocketServer(t *testing.T) {
 		mock_socket = "socket_addr:socket_port"
 	)
 	cfg := new(config.Configuration)
-	cfg.Socket = mock_socket
+	cfg.UnixSocketName = mock_socket
 
 	mock_server := &http.Server{
-		Addr:         cfg.Socket,
+		Addr:         cfg.UnixSocketName,
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
@@ -239,12 +239,12 @@ func TestListen(t *testing.T) {
 
 		metrics = new(metricsconfig.DetailedMetricsEngine)
 		cfg     = &config.Configuration{
-			Host:         "prebid.com",
-			AdminPort:    6060,
-			Port:         8000,
-			EnableSocket: false,
-			Socket:       "prebid_socket",
-			EnableGzip:   false,
+			Host:             "prebid.com",
+			AdminPort:        6060,
+			Port:             8000,
+			UnixSocketEnable: false,
+			UnixSocketName:   "prebid_socket",
+			EnableGzip:       false,
 		}
 	)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -118,15 +118,15 @@ func Test_newSocketServer(t *testing.T) {
 
 func Test_newMainServer(t *testing.T) {
 	const (
-		chose_your_socket_port    = "8000"                      //chose_your_socket_port
+		chose_your_socket_port    = 8000                        //chose_your_socket_port
 		chose_your_socket_address = "chose_your_socket_address" //chose_your_socket_address
 	)
 	cfg := new(config.Configuration)
-	cfg.Socket = chose_your_socket_port
+	cfg.Port = chose_your_socket_port
 	cfg.Host = chose_your_socket_address
 
 	mock_server := &http.Server{
-		Addr:         fmt.Sprintf("%s:%s", chose_your_socket_address, chose_your_socket_port),
+		Addr:         fmt.Sprintf("%s:%d", chose_your_socket_address, chose_your_socket_port),
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,7 +86,7 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 
 func Test_newSocketServer(t *testing.T) {
 	cfg := new(config.Configuration)
-	cfg.Socket = "mock_socket_addr"
+	cfg.Socket = "chose_your_socket_addr:chose_your_socket_port"
 
 	mock_server := &http.Server{
 		Addr:         cfg.Socket,
@@ -112,7 +112,7 @@ func Test_newSocketServer(t *testing.T) {
 
 func Test_newMainServer(t *testing.T) {
 	cfg := new(config.Configuration)
-	cfg.Socket = "mock_socket_addr"
+	cfg.Socket = "chose_your_socket_addr:chose_your_socket_port"
 
 	mock_server := &http.Server{
 		Addr:         cfg.Socket,
@@ -137,7 +137,7 @@ func Test_newMainServer(t *testing.T) {
 }
 
 func Test_newTCPListener(t *testing.T) {
-	const mock_address_value = "chose_your_value:chose_your_port"
+	const mock_address_value = "chose_your_address:chose_your_port"
 
 	if ret, err := newTCPListener(mock_address_value, nil); err != nil {
 		t.Error("[Test_newTCPListener] err_ :", err)
@@ -147,9 +147,9 @@ func Test_newTCPListener(t *testing.T) {
 }
 
 func Test_newUnixListener(t *testing.T) {
-	const mock_address_value = "chose_your_value"
+	const mock_file_referer = "chose_your_file_referer"
 
-	if ret, err := newUnixListener(mock_address_value, nil); err != nil {
+	if ret, err := newUnixListener(mock_file_referer, nil); err != nil {
 		t.Error("[Test_newUnixListener] err_ :", err)
 	} else {
 		ret.Close()
@@ -158,8 +158,8 @@ func Test_newUnixListener(t *testing.T) {
 
 func Test_newAdminServer(t *testing.T) {
 	const (
-		mock_host_value       = "chose_your_value"
-		mock_admin_port_value = 42
+		mock_host_value       = "chose_your_host_value"
+		mock_admin_port_value = 42 //chose your admin_port_value
 	)
 	cfg := new(config.Configuration)
 	cfg.Host = mock_host_value

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -116,11 +117,12 @@ func Test_newSocketServer(t *testing.T) {
 }
 
 func Test_newMainServer(t *testing.T) {
+	const chose_your_socket = "8000" //:chose_your_socket_port
 	cfg := new(config.Configuration)
-	cfg.Socket = ":8000" //:chose_your_socket_port
+	cfg.Socket = chose_your_socket
 
 	mock_server := &http.Server{
-		Addr:         cfg.Socket,
+		Addr:         fmt.Sprintf(":%s", chose_your_socket),
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -133,7 +133,7 @@ func TestNewUnixListener(t *testing.T) {
 
 	ret, err := newUnixListener(mockFile, nil)
 	assert.NotEqual(t, nil, err, "err_ : isNil()")
-	assert.NotEqual(t, nil, ret, "ret : isNil()")
+	assert.Equal(t, nil, ret, "ret : NOT Nil()")
 
 	if ret != nil {
 		ret.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -225,7 +225,7 @@ func TestRunServer(t *testing.T) {
 	}
 
 	var l net.Listener
-	l, _ = net.Listen("mock_listener", "/")
+	l, _ = net.Listen("mock_listener", ":8000")
 	if err := runServer(&s, mock_name, l); err != nil {
 		t.Errorf("[%s] runServer(not_nil, 'mock_name', not_nil) : trigger an error.", func_name)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,7 +21,7 @@ func TestNewAdminServer(t *testing.T) {
 	}
 	server := newAdminServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != "prebid.com:6060" {
-		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:6060\n", server.Addr)
+		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:6060", server.Addr)
 	}
 }
 
@@ -33,7 +33,7 @@ func TestNewMainServer(t *testing.T) {
 	}
 	server := newMainServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != "prebid.com:8000" {
-		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:8000\n", server.Addr)
+		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:8000", server.Addr)
 	}
 }
 
@@ -82,7 +82,7 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 	var s struct{}
 	sig := <-inbound
 	if sig != os.Interrupt {
-		t.Errorf("Unexpected signal: %s\n", sig.String())
+		t.Errorf("Unexpected signal: %s", sig.String())
 	}
 	outbound <- s
 }
@@ -105,15 +105,15 @@ func TestNewSocketServer(t *testing.T) {
 	if ret := newSocketServer(cfg, nil); ret != nil {
 		switch {
 		case ret.Addr != mock_server.Addr:
-			t.Errorf("[%s] Addr invalide: %v != %v\n",
+			t.Errorf("[%s] Addr invalide: %v != %v",
 				func_name, ret.Addr, mock_server.Addr)
 			fallthrough
 		case ret.ReadTimeout != mock_server.ReadTimeout:
-			t.Errorf("[%s] ReadTimeout invalide: %v != %v\n",
+			t.Errorf("[%s] ReadTimeout invalide: %v != %v",
 				func_name, ret.ReadTimeout, mock_server.ReadTimeout)
 			fallthrough
 		case ret.WriteTimeout != mock_server.WriteTimeout:
-			t.Errorf("[%s] WriteTimeout invalide: %v != %v\n",
+			t.Errorf("[%s] WriteTimeout invalide: %v != %v",
 				func_name, ret.WriteTimeout, mock_server.WriteTimeout)
 		}
 		ret.Close()
@@ -142,13 +142,13 @@ func TestNewMainServer_(t *testing.T) {
 	if ret := newMainServer(cfg, nil); ret != nil {
 		switch {
 		case ret.Addr != mock_server.Addr:
-			t.Errorf("[%s] Addr invalide: %v != %v\n",
+			t.Errorf("[%s] Addr invalide: %v != %v",
 				func_name, ret.Addr, mock_server.Addr)
 		case ret.ReadTimeout != mock_server.ReadTimeout:
-			t.Errorf("[%s] ReadTimeout invalide: %v != %v\n",
+			t.Errorf("[%s] ReadTimeout invalide: %v != %v",
 				func_name, ret.ReadTimeout, mock_server.ReadTimeout)
 		case ret.WriteTimeout != mock_server.WriteTimeout:
-			t.Errorf("[%s] WriteTimeout invalide: %v != %v\n",
+			t.Errorf("[%s] WriteTimeout invalide: %v != %v",
 				func_name, ret.WriteTimeout, mock_server.WriteTimeout)
 		}
 		ret.Close()
@@ -202,7 +202,7 @@ func TestNewAdminServer_(t *testing.T) {
 		t.Errorf("[%s] ret : isNil()", func_name)
 	} else {
 		if ret.Addr != mock_server.Addr {
-			t.Errorf("[%s] Addr invalide: %v != %v\n",
+			t.Errorf("[%s] Addr invalide: %v != %v",
 				func_name, ret.Addr, mock_server.Addr)
 		}
 		ret.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -117,12 +117,16 @@ func Test_newSocketServer(t *testing.T) {
 }
 
 func Test_newMainServer(t *testing.T) {
-	const chose_your_socket = "8000" //:chose_your_socket_port
+	const (
+		chose_your_socket_port    = "8000"                      //chose_your_socket_port
+		chose_your_socket_address = "chose_your_socket_address" //chose_your_socket_address
+	)
 	cfg := new(config.Configuration)
-	cfg.Socket = chose_your_socket
+	cfg.Socket = chose_your_socket_port
+	cfg.Host = chose_your_socket_address
 
 	mock_server := &http.Server{
-		Addr:         fmt.Sprintf(":%s", chose_your_socket),
+		Addr:         fmt.Sprintf("%s:%s", chose_your_socket_address, chose_your_socket_port),
 		Handler:      nil,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,7 +18,7 @@ func TestNewAdminServer(t *testing.T) {
 	}
 	server := newAdminServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != "prebid.com:6060" {
-		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:6060", server.Addr)
+		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:6060\n", server.Addr)
 	}
 }
 
@@ -30,7 +30,7 @@ func TestNewMainServer(t *testing.T) {
 	}
 	server := newMainServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != "prebid.com:8000" {
-		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:8000", server.Addr)
+		t.Errorf("Admin server address should be %s. Got %s", "prebid.com:8000\n", server.Addr)
 	}
 }
 
@@ -79,7 +79,7 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 	var s struct{}
 	sig := <-inbound
 	if sig != os.Interrupt {
-		t.Errorf("Unexpected signal: %s", sig.String())
+		t.Errorf("Unexpected signal: %s\n", sig.String())
 	}
 	outbound <- s
 }
@@ -98,13 +98,13 @@ func Test_newSocketServer(t *testing.T) {
 	ret := newSocketServer(cfg, nil)
 	switch {
 	case ret.Addr != mock_server.Addr:
-		t.Error("[Test_newSocketServer] Addr invalide: %v != %v",
+		t.Errorf("[Test_newSocketServer] Addr invalide: %v != %v\n",
 			ret.Addr, mock_server.Addr)
 	case ret.ReadTimeout != mock_server.ReadTimeout:
-		t.Error("[Test_newSocketServer] ReadTimeout invalide: %v != %v",
+		t.Errorf("[Test_newSocketServer] ReadTimeout invalide: %v != %v\n",
 			ret.ReadTimeout, mock_server.ReadTimeout)
 	case ret.WriteTimeout != mock_server.WriteTimeout:
-		t.Error("[Test_newSocketServer] WriteTimeout invalide: %v != %v",
+		t.Errorf("[Test_newSocketServer] WriteTimeout invalide: %v != %v\n",
 			ret.WriteTimeout, mock_server.WriteTimeout)
 	}
 	ret.Close()
@@ -124,13 +124,13 @@ func Test_newMainServer(t *testing.T) {
 	ret := newMainServer(cfg, nil)
 	switch {
 	case ret.Addr != mock_server.Addr:
-		t.Error("[Test_newMainServer] Addr invalide: %v != %v",
+		t.Errorf("[Test_newMainServer] Addr invalide: %v != %v\n",
 			ret.Addr, mock_server.Addr)
 	case ret.ReadTimeout != mock_server.ReadTimeout:
-		t.Error("[Test_newMainServer] ReadTimeout invalide: %v != %v",
+		t.Errorf("[Test_newMainServer] ReadTimeout invalide: %v != %v\n",
 			ret.ReadTimeout, mock_server.ReadTimeout)
 	case ret.WriteTimeout != mock_server.WriteTimeout:
-		t.Error("[Test_newMainServer] WriteTimeout invalide: %v != %v",
+		t.Errorf("[Test_newMainServer] WriteTimeout invalide: %v != %v\n",
 			ret.WriteTimeout, mock_server.WriteTimeout)
 	}
 	ret.Close()
@@ -174,7 +174,7 @@ func Test_newAdminServer(t *testing.T) {
 		t.Error("[Test_newAdminServer] ret : isNil()")
 	} else {
 		if ret.Addr != mock_server.Addr {
-			t.Error("[Test_newAdminServer] Addr invalide: %v != %v",
+			t.Errorf("[Test_newAdminServer] Addr invalide: %v != %v\n",
 				ret.Addr, mock_server.Addr)
 		}
 		ret.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -120,8 +120,8 @@ func TestNewTCPListener(t *testing.T) {
 	const mockAddress = ":8000" //:chose your socket_port
 
 	ret, err := newTCPListener(mockAddress, nil)
-	assert.NotEqual(t, nil, err, fmt.Sprintf("err_ : %s", err))
-	assert.Equal(t, nil, ret, "ret : NOT Nil()")
+	assert.Equal(t, nil, err, fmt.Sprintf("err_ : %v", err))
+	assert.NotEqual(t, nil, ret, "ret : isNil()")
 
 	if ret != nil {
 		ret.Close()
@@ -132,8 +132,8 @@ func TestNewUnixListener(t *testing.T) {
 	const mockFile = "file_referer" // chose your file_referer
 
 	ret, err := newUnixListener(mockFile, nil)
-	assert.NotEqual(t, nil, err, "err_ : isNil()")
-	assert.Equal(t, nil, ret, "ret : NOT Nil()")
+	assert.Equal(t, nil, err, "err_ : NOT-Nil()")
+	assert.NotEqual(t, nil, ret, "ret : isNil()")
 
 	if ret != nil {
 		ret.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -225,6 +225,7 @@ func TestRunServer(t *testing.T) {
 	}
 
 	var l net.Listener
+	l, _ = net.Listen("mock_listener", "/")
 	if err := runServer(&s, mock_name, l); err != nil {
 		t.Errorf("[%s] runServer(not_nil, 'mock_name', not_nil) : trigger an error.", func_name)
 	}
@@ -243,6 +244,7 @@ func TestListen(t *testing.T) {
 			Port:         8000,
 			EnableSocket: false,
 			Socket:       "prebid_socket",
+			EnableGzip:   false,
 		}
 	)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -225,9 +225,9 @@ func TestRunServer(t *testing.T) {
 	}
 
 	var l net.Listener
-	l, _ = net.Listen("tcp", ":8000")
-	if err := runServer(&s, mock_name, l); err != nil {
-		t.Errorf("[%s] runServer(not_nil, 'mock_name', not_nil) : trigger an error.", func_name)
+	l, _ = net.Listen("error", ":8000")
+	if err := runServer(&s, mock_name, l); err == nil {
+		t.Errorf("[%s] runServer('error', 'mock_name', not_nil) : trigger an error.", func_name)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -227,7 +227,7 @@ func TestRunServer(t *testing.T) {
 	var l net.Listener
 	l, _ = net.Listen("error", ":8000")
 	if err := runServer(&s, mock_name, l); err == nil {
-		t.Errorf("[%s] runServer('error', 'mock_name', not_nil) : trigger an error.", func_name)
+		t.Errorf("[%s] Listen('error', ':8000') : didn't trigger any error.", func_name)
 	}
 }
 
@@ -248,7 +248,13 @@ func TestListen(t *testing.T) {
 		}
 	)
 
-	if e := Listen(cfg, handler, admin_handler, metrics); e != nil {
+	const mock_err = "Error listening for TCP connections on prebid.com:8000: listen tcp 185.53.177.10:8000: bind: cannot assign requested address"
+	if e := Listen(cfg, handler, admin_handler, metrics); e != nil && e.Error() != mock_err {
 		t.Errorf("[%s] err_ : %s", name, e.Error())
+	} else if e != nil {
+		t.Errorf("[%s] e : %s\n", name, e.Error())
+		t.Errorf("mock_err : %s", mock_err)
+	} else {
+		t.Errorf("[%s] e isNil", name)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prebid/prebid-server/config"
 )
@@ -80,4 +82,101 @@ func forwardSignal(t *testing.T, outbound chan<- struct{}, inbound <-chan os.Sig
 		t.Errorf("Unexpected signal: %s", sig.String())
 	}
 	outbound <- s
+}
+
+func Test_newSocketServer(t *testing.T) {
+	cfg := new(config.Configuration)
+	cfg.Socket = "mock_socket_addr"
+
+	mock_server := &http.Server{
+		Addr:         cfg.Socket,
+		Handler:      nil,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+	}
+
+	ret := newSocketServer(cfg, nil)
+	switch {
+	case ret.Addr != mock_server.Addr:
+		t.Error("[Test_newSocketServer] Addr invalide: %v != %v",
+			ret.Addr, mock_server.Addr)
+	case ret.ReadTimeout != mock_server.ReadTimeout:
+		t.Error("[Test_newSocketServer] ReadTimeout invalide: %v != %v",
+			ret.ReadTimeout, mock_server.ReadTimeout)
+	case ret.WriteTimeout != mock_server.WriteTimeout:
+		t.Error("[Test_newSocketServer] WriteTimeout invalide: %v != %v",
+			ret.WriteTimeout, mock_server.WriteTimeout)
+	}
+	ret.Close()
+}
+
+func Test_newMainServer(t *testing.T) {
+	cfg := new(config.Configuration)
+	cfg.Socket = "mock_socket_addr"
+
+	mock_server := &http.Server{
+		Addr:         cfg.Socket,
+		Handler:      nil,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+	}
+
+	ret := newMainServer(cfg, nil)
+	switch {
+	case ret.Addr != mock_server.Addr:
+		t.Error("[Test_newMainServer] Addr invalide: %v != %v",
+			ret.Addr, mock_server.Addr)
+	case ret.ReadTimeout != mock_server.ReadTimeout:
+		t.Error("[Test_newMainServer] ReadTimeout invalide: %v != %v",
+			ret.ReadTimeout, mock_server.ReadTimeout)
+	case ret.WriteTimeout != mock_server.WriteTimeout:
+		t.Error("[Test_newMainServer] WriteTimeout invalide: %v != %v",
+			ret.WriteTimeout, mock_server.WriteTimeout)
+	}
+	ret.Close()
+}
+
+func Test_newTCPListener(t *testing.T) {
+	const mock_address_value = "chose_your_value"
+
+	if ret, err := newTCPListener(mock_address_value, nil); err != nil {
+		t.Error("[Test_newTCPListener] err_ :", err)
+	} else {
+		ret.Close()
+	}
+}
+
+func Test_newUnixListener(t *testing.T) {
+	const mock_address_value = "chose_your_value"
+
+	if ret, err := newUnixListener(mock_address_value, nil); err != nil {
+		t.Error("[Test_newUnixListener] err_ :", err)
+	} else {
+		ret.Close()
+	}
+}
+
+func Test_newAdminServer(t *testing.T) {
+	const (
+		mock_host_value       = "chose_your_value"
+		mock_admin_port_value = 42
+	)
+	cfg := new(config.Configuration)
+	cfg.Host = mock_host_value
+	cfg.AdminPort = mock_admin_port_value
+
+	mock_server := &http.Server{
+		Addr:    cfg.Host + ":" + strconv.Itoa(cfg.AdminPort),
+		Handler: nil,
+	}
+
+	if ret := newAdminServer(cfg, nil); ret == nil {
+		t.Error("[Test_newAdminServer] ret : isNil()")
+	} else {
+		if ret.Addr != mock_server.Addr {
+			t.Error("[Test_newAdminServer] Addr invalide: %v != %v",
+				ret.Addr, mock_server.Addr)
+		}
+		ret.Close()
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -225,7 +225,7 @@ func TestRunServer(t *testing.T) {
 	}
 
 	var l net.Listener
-	l, _ = net.Listen("mock_listener", ":8000")
+	l, _ = net.Listen("tcp", ":8000")
 	if err := runServer(&s, mock_name, l); err != nil {
 		t.Errorf("[%s] runServer(not_nil, 'mock_name', not_nil) : trigger an error.", func_name)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -137,7 +137,7 @@ func Test_newMainServer(t *testing.T) {
 }
 
 func Test_newTCPListener(t *testing.T) {
-	const mock_address_value = "chose_your_value"
+	const mock_address_value = "chose_your_value:chose_your_port"
 
 	if ret, err := newTCPListener(mock_address_value, nil); err != nil {
 		t.Error("[Test_newTCPListener] err_ :", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -121,7 +121,7 @@ func TestNewTCPListener(t *testing.T) {
 
 	ret, err := newTCPListener(mockAddress, nil)
 	assert.NotEqual(t, nil, err, fmt.Sprintf("err_ : %s", err))
-	assert.NotEqual(t, nil, ret, "ret : isNil()")
+	assert.Equal(t, nil, ret, "ret : NOT Nil()")
 
 	if ret != nil {
 		ret.Close()
@@ -132,7 +132,7 @@ func TestNewUnixListener(t *testing.T) {
 	const mockFile = "file_referer" // chose your file_referer
 
 	ret, err := newUnixListener(mockFile, nil)
-	assert.Equal(t, nil, err, fmt.Sprintf("err_ : %s", err.Error()))
+	assert.Equal(t, nil, err, "err_ : NOT Nil")
 	assert.NotEqual(t, nil, ret, "ret : isNil()")
 
 	if ret != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -132,7 +132,7 @@ func TestNewUnixListener(t *testing.T) {
 	const mockFile = "file_referer" // chose your file_referer
 
 	ret, err := newUnixListener(mockFile, nil)
-	assert.Equal(t, nil, err, "err_ : NOT Nil")
+	assert.NotEqual(t, nil, err, "err_ : isNil()")
 	assert.NotEqual(t, nil, ret, "ret : isNil()")
 
 	if ret != nil {
@@ -168,16 +168,16 @@ func TestRunServer(t *testing.T) {
 	const mockName = "mockServer_name"
 
 	err := runServer(nil, mockName, nil)
-	assert.Equal(t, nil, err, "runServer(nil, 'mockName', nil) : didn't trigger any error.")
+	assert.NotEqual(t, nil, err, "runServer(nil, 'mockName', nil) : didn't trigger any error.")
 
 	s := http.Server{}
 	err = runServer(&s, mockName, nil)
-	assert.Equal(t, nil, err, "runServer(not_nil, 'mockName', nil) : didn't trigger any error.")
+	assert.NotEqual(t, nil, err, "runServer(not_nil, 'mockName', nil) : didn't trigger any error.")
 
 	var l net.Listener
 	l, _ = net.Listen("error", ":8000")
 	err = runServer(&s, mockName, l)
-	assert.Equal(t, nil, err, "Listen('error', ':8000') : didn't trigger any error.")
+	assert.NotEqual(t, nil, err, "Listen('error', ':8000') : didn't trigger any error.")
 }
 
 func TestListen(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -248,13 +248,7 @@ func TestListen(t *testing.T) {
 		}
 	)
 
-	const mock_err = "Error listening for TCP connections on prebid.com:8000: listen tcp 185.53.177.10:8000: bind: cannot assign requested address"
-	if e := Listen(cfg, handler, admin_handler, metrics); e != nil && e.Error() != mock_err {
-		t.Errorf("[%s] err_ : %s", name, e.Error())
-	} else if e != nil {
-		t.Errorf("[%s] e : %s\n", name, e.Error())
-		t.Errorf("mock_err : %s", mock_err)
-	} else {
+	if e := Listen(cfg, handler, admin_handler, metrics); e == nil {
 		t.Errorf("[%s] e isNil", name)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -95,24 +95,29 @@ func Test_newSocketServer(t *testing.T) {
 		WriteTimeout: 15 * time.Second,
 	}
 
-	ret := newSocketServer(cfg, nil)
-	switch {
-	case ret.Addr != mock_server.Addr:
-		t.Errorf("[Test_newSocketServer] Addr invalide: %v != %v\n",
-			ret.Addr, mock_server.Addr)
-	case ret.ReadTimeout != mock_server.ReadTimeout:
-		t.Errorf("[Test_newSocketServer] ReadTimeout invalide: %v != %v\n",
-			ret.ReadTimeout, mock_server.ReadTimeout)
-	case ret.WriteTimeout != mock_server.WriteTimeout:
-		t.Errorf("[Test_newSocketServer] WriteTimeout invalide: %v != %v\n",
-			ret.WriteTimeout, mock_server.WriteTimeout)
+	if ret := newSocketServer(cfg, nil); ret != nil {
+		switch {
+		case ret.Addr != mock_server.Addr:
+			t.Errorf("[Test_newSocketServer] Addr invalide: %v != %v\n",
+				ret.Addr, mock_server.Addr)
+			fallthrough
+		case ret.ReadTimeout != mock_server.ReadTimeout:
+			t.Errorf("[Test_newSocketServer] ReadTimeout invalide: %v != %v\n",
+				ret.ReadTimeout, mock_server.ReadTimeout)
+			fallthrough
+		case ret.WriteTimeout != mock_server.WriteTimeout:
+			t.Errorf("[Test_newSocketServer] WriteTimeout invalide: %v != %v\n",
+				ret.WriteTimeout, mock_server.WriteTimeout)
+		}
+		ret.Close()
+	} else {
+		t.Errorf("[Test_newSocketServer] ret is Nil")
 	}
-	ret.Close()
 }
 
 func Test_newMainServer(t *testing.T) {
 	cfg := new(config.Configuration)
-	cfg.Socket = "chose_your_socket_addr:chose_your_socket_port"
+	cfg.Socket = ":8000" //:chose_your_socket_port
 
 	mock_server := &http.Server{
 		Addr:         cfg.Socket,
@@ -121,23 +126,28 @@ func Test_newMainServer(t *testing.T) {
 		WriteTimeout: 15 * time.Second,
 	}
 
-	ret := newMainServer(cfg, nil)
-	switch {
-	case ret.Addr != mock_server.Addr:
-		t.Errorf("[Test_newMainServer] Addr invalide: %v != %v\n",
-			ret.Addr, mock_server.Addr)
-	case ret.ReadTimeout != mock_server.ReadTimeout:
-		t.Errorf("[Test_newMainServer] ReadTimeout invalide: %v != %v\n",
-			ret.ReadTimeout, mock_server.ReadTimeout)
-	case ret.WriteTimeout != mock_server.WriteTimeout:
-		t.Errorf("[Test_newMainServer] WriteTimeout invalide: %v != %v\n",
-			ret.WriteTimeout, mock_server.WriteTimeout)
+	if ret := newMainServer(cfg, nil); ret != nil {
+		switch {
+		case ret.Addr != mock_server.Addr:
+			t.Errorf("[Test_newMainServer] Addr invalide: %v != %v\n",
+				ret.Addr, mock_server.Addr)
+			fallthrough
+		case ret.ReadTimeout != mock_server.ReadTimeout:
+			t.Errorf("[Test_newMainServer] ReadTimeout invalide: %v != %v\n",
+				ret.ReadTimeout, mock_server.ReadTimeout)
+			fallthrough
+		case ret.WriteTimeout != mock_server.WriteTimeout:
+			t.Errorf("[Test_newMainServer] WriteTimeout invalide: %v != %v\n",
+				ret.WriteTimeout, mock_server.WriteTimeout)
+		}
+		ret.Close()
+	} else {
+		t.Errorf("[Test_newSocketServer] ret is Nil")
 	}
-	ret.Close()
 }
 
 func Test_newTCPListener(t *testing.T) {
-	const mock_address_value = "chose_your_address:chose_your_port"
+	const mock_address_value = ":8000" //:chose_your_socket_port
 
 	if ret, err := newTCPListener(mock_address_value, nil); err != nil {
 		t.Error("[Test_newTCPListener] err_ :", err)
@@ -186,5 +196,10 @@ func Test_runServer(t *testing.T) {
 
 	if err := runServer(nil, mock_server_name, nil); err == nil {
 		t.Error("[Test_runServer] runServer(nil, 'mock_server_name', nil) : didn't trigger any error.")
+	}
+
+	s := http.Server{}
+	if err := runServer(&s, mock_server_name, nil); err == nil {
+		t.Error("[Test_runServer] runServer(not_nil, 'mock_server_name', nil) : didn't trigger any error.")
 	}
 }


### PR DESCRIPTION
REF : issue #2147 [feature request]

Allow users to listen unix_socket's file of main_server's handlers.