### PR TITLE
GDPR: Refactor AuctionActivitiesAllowed to return struct

### DIFF
--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1652,9 +1652,13 @@ func (m *MockGDPRPerms) BidderSyncAllowed(ctx context.Context, bidder openrtb_ex
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockGDPRPerms) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidReq bool, passGeo bool, passID bool, err error) {
+func (m *MockGDPRPerms) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (permissions gdpr.AuctionPermissions, err error) {
 	args := m.Called(ctx, bidderCoreName, bidder, PublisherID, gdprSignal, consent, aliasGVLIDs)
-	return args.Bool(0), args.Bool(1), args.Bool(2), args.Error(3)
+	return gdpr.AuctionPermissions{
+		AllowBidRequest: args.Bool(0),
+		PassGeo:         args.Bool(1),
+		PassID:          args.Bool(2),
+	}, args.Error(3)
 }
 
 type FakeAccountsFetcher struct {

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1654,11 +1654,7 @@ func (m *MockGDPRPerms) BidderSyncAllowed(ctx context.Context, bidder openrtb_ex
 
 func (m *MockGDPRPerms) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (permissions gdpr.AuctionPermissions, err error) {
 	args := m.Called(ctx, bidderCoreName, bidder, PublisherID, gdprSignal, consent, aliasGVLIDs)
-	return gdpr.AuctionPermissions{
-		AllowBidRequest: args.Bool(0),
-		PassGeo:         args.Bool(1),
-		PassID:          args.Bool(2),
-	}, args.Error(3)
+	return args.Get(0).(gdpr.AuctionPermissions), args.Error(1)
 }
 
 type FakeAccountsFetcher struct {

--- a/endpoints/setuid_test.go
+++ b/endpoints/setuid_test.go
@@ -573,8 +573,12 @@ func (g *mockPermsSetUID) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return false, nil
 }
 
-func (g *mockPermsSetUID) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidReq bool, passGeo bool, passID bool, err error) {
-	return g.personalInfoAllowed, g.personalInfoAllowed, g.personalInfoAllowed, nil
+func (g *mockPermsSetUID) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (permissions gdpr.AuctionPermissions, err error) {
+	return gdpr.AuctionPermissions{
+		AllowBidRequest: g.personalInfoAllowed,
+		PassGeo:         g.personalInfoAllowed,
+		PassID:          g.personalInfoAllowed,
+	}, nil
 }
 
 type fakeSyncer struct {

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -127,12 +127,12 @@ func cleanOpenRTBRequests(ctx context.Context,
 		// GDPR
 		if gdprEnforced {
 			var publisherID = auctionReq.LegacyLabels.PubID
-			bidReq, geo, id, err := gdprPerms.AuctionActivitiesAllowed(ctx, bidderRequest.BidderCoreName, bidderRequest.BidderName, publisherID, gdprSignal, consent, aliasesGVLIDs)
-			bidRequestAllowed = bidReq
+			auctionPermissions, err := gdprPerms.AuctionActivitiesAllowed(ctx, bidderRequest.BidderCoreName, bidderRequest.BidderName, publisherID, gdprSignal, consent, aliasesGVLIDs)
+			bidRequestAllowed = auctionPermissions.AllowBidRequest
 
 			if err == nil {
-				privacyEnforcement.GDPRGeo = !geo
-				privacyEnforcement.GDPRID = !id
+				privacyEnforcement.GDPRGeo = !auctionPermissions.PassGeo
+				privacyEnforcement.GDPRID = !auctionPermissions.PassID
 			} else {
 				privacyEnforcement.GDPRGeo = true
 				privacyEnforcement.GDPRID = true

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -35,18 +35,24 @@ func (p *permissionsMock) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return true, nil
 }
 
-func (p *permissionsMock) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdpr gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidRequest bool, passGeo bool, passID bool, err error) {
+func (p *permissionsMock) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal gdpr.Signal, consent string, aliasGVLIDs map[string]uint16) (permissions gdpr.AuctionPermissions, err error) {
+	permissions = gdpr.AuctionPermissions{
+		PassGeo: p.passGeo,
+		PassID:  p.passID,
+	}
+
 	if p.allowAllBidders {
-		return true, p.passGeo, p.passID, p.activitiesError
+		permissions.AllowBidRequest = true
+		return permissions, p.activitiesError
 	}
 
 	for _, allowedBidder := range p.allowedBidders {
 		if bidder == allowedBidder {
-			allowBidRequest = true
+			permissions.AllowBidRequest = true
 		}
 	}
 
-	return allowBidRequest, p.passGeo, p.passID, p.activitiesError
+	return permissions, p.activitiesError
 }
 
 func assertReq(t *testing.T, bidderRequests []BidderRequest,

--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -21,7 +21,7 @@ type Permissions interface {
 	// Determines whether or not to send PI information to a bidder, or mask it out.
 	//
 	// If the consent string was nonsensical, the returned error will be an ErrorMalformedConsent.
-	AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidReq bool, passGeo bool, passID bool, err error)
+	AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (permissions AuctionPermissions, err error)
 }
 
 type PermissionsBuilder func(config.GDPR, TCF2ConfigReader, map[openrtb_ext.BidderName]uint16, VendorListFetcher) Permissions

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -119,7 +119,7 @@ func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, consen
 	return p.checkPurpose(consentMeta, vendor, vendorID, tcf2ConsentConstants.InfoStorageAccess, enforceVendors, vendorException, false), nil
 }
 
-func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, bidder openrtb_ext.BidderName, consent string, weakVendorEnforcement bool) (permissions AuctionPermissions, err error) {
+func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, bidder openrtb_ext.BidderName, consent string, weakVendorEnforcement bool) (AuctionPermissions, error) {
 	parsedConsent, vendor, err := p.parseVendor(ctx, vendorID, consent)
 	if err != nil {
 		return DenyAll, err
@@ -141,10 +141,10 @@ func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, 
 	consentMeta, ok := parsedConsent.(tcf2.ConsentMetadata)
 	if !ok {
 		err = fmt.Errorf("Unable to access TCF2 parsed consent")
-		return
+		return DenyAll, err
 	}
 
-	permissions = AuctionPermissions{}
+	permissions := AuctionPermissions{}
 	if p.cfg.FeatureOneEnforced() {
 		vendorException := p.cfg.FeatureOneVendorException(bidder)
 		permissions.PassGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement))
@@ -167,7 +167,7 @@ func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, 
 		}
 	}
 
-	return
+	return permissions, nil
 }
 
 const pubRestrictNotAllowed = 0

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -48,19 +48,19 @@ func (p *permissionsImpl) BidderSyncAllowed(ctx context.Context, bidder openrtb_
 	return false, nil
 }
 
-func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidReq bool, passGeo bool, passID bool, err error) {
+func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (permissions AuctionPermissions, err error) {
 	if _, ok := p.nonStandardPublishers[PublisherID]; ok {
-		return true, true, true, nil
+		return AllowAll, nil
 	}
 
 	gdprSignal = SignalNormalize(gdprSignal, p.gdprDefaultValue)
 
 	if gdprSignal == SignalNo {
-		return true, true, true, nil
+		return AllowAll, nil
 	}
 
 	if consent == "" && gdprSignal == SignalYes {
-		return false, false, false, nil
+		return DenyAll, nil
 	}
 
 	weakVendorEnforcement := p.cfg.BasicEnforcementVendor(bidder)
@@ -74,8 +74,8 @@ func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCo
 	return p.defaultVendorPermissions()
 }
 
-func (p *permissionsImpl) defaultVendorPermissions() (allowBidRequest bool, passGeo bool, passID bool, err error) {
-	return false, false, false, nil
+func (p *permissionsImpl) defaultVendorPermissions() (permissions AuctionPermissions, err error) {
+	return DenyAll, nil
 }
 
 func (p *permissionsImpl) resolveVendorId(bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, aliasGVLIDs map[string]uint16) (id uint16, ok bool) {
@@ -119,10 +119,10 @@ func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, consen
 	return p.checkPurpose(consentMeta, vendor, vendorID, tcf2ConsentConstants.InfoStorageAccess, enforceVendors, vendorException, false), nil
 }
 
-func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, bidder openrtb_ext.BidderName, consent string, weakVendorEnforcement bool) (allowBidRequest bool, passGeo bool, passID bool, err error) {
+func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, bidder openrtb_ext.BidderName, consent string, weakVendorEnforcement bool) (permissions AuctionPermissions, err error) {
 	parsedConsent, vendor, err := p.parseVendor(ctx, vendorID, consent)
 	if err != nil {
-		return false, false, false, err
+		return DenyAll, err
 	}
 
 	// vendor will be nil if not a valid TCF2 consent string
@@ -130,12 +130,12 @@ func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, 
 		if weakVendorEnforcement && parsedConsent.Version() == 2 {
 			vendor = vendorTrue{}
 		} else {
-			return false, false, false, nil
+			return DenyAll, nil
 		}
 	}
 
 	if !p.cfg.IsEnabled() {
-		return true, false, false, nil
+		return AllowBidRequestOnly, nil
 	}
 
 	consentMeta, ok := parsedConsent.(tcf2.ConsentMetadata)
@@ -144,24 +144,25 @@ func (p *permissionsImpl) allowActivities(ctx context.Context, vendorID uint16, 
 		return
 	}
 
+	permissions = AuctionPermissions{}
 	if p.cfg.FeatureOneEnforced() {
 		vendorException := p.cfg.FeatureOneVendorException(bidder)
-		passGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement))
+		permissions.PassGeo = vendorException || (consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement))
 	} else {
-		passGeo = true
+		permissions.PassGeo = true
 	}
 	if p.cfg.PurposeEnforced(consentconstants.Purpose(2)) {
 		enforceVendors := p.cfg.PurposeEnforcingVendors(consentconstants.Purpose(2))
 		vendorException := p.cfg.PurposeVendorException(consentconstants.Purpose(2), bidder)
-		allowBidRequest = p.checkPurpose(consentMeta, vendor, vendorID, consentconstants.Purpose(2), enforceVendors, vendorException, weakVendorEnforcement)
+		permissions.AllowBidRequest = p.checkPurpose(consentMeta, vendor, vendorID, consentconstants.Purpose(2), enforceVendors, vendorException, weakVendorEnforcement)
 	} else {
-		allowBidRequest = true
+		permissions.AllowBidRequest = true
 	}
 	for i := 2; i <= 10; i++ {
 		enforceVendors := p.cfg.PurposeEnforcingVendors(consentconstants.Purpose(i))
 		vendorException := p.cfg.PurposeVendorException(consentconstants.Purpose(i), bidder)
 		if p.checkPurpose(consentMeta, vendor, vendorID, consentconstants.Purpose(i), enforceVendors, vendorException, weakVendorEnforcement) {
-			passID = true
+			permissions.PassID = true
 			break
 		}
 	}
@@ -273,8 +274,8 @@ func (a AlwaysAllow) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.B
 	return true, nil
 }
 
-func (a AlwaysAllow) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (allowBidReq bool, passGeo bool, passID bool, err error) {
-	return true, true, true, nil
+func (a AlwaysAllow) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName, PublisherID string, gdprSignal Signal, consent string, aliasGVLIDs map[string]uint16) (permissions AuctionPermissions, err error) {
+	return AllowAll, nil
 }
 
 // vendorTrue claims everything.

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -334,10 +334,10 @@ func TestAllowActivities(t *testing.T) {
 	for _, tt := range tests {
 		perms.gdprDefaultValue = tt.gdprDefaultValue
 
-		_, _, passID, err := perms.AuctionActivitiesAllowed(context.Background(), tt.bidderCoreName, tt.bidderName, tt.publisherID, tt.gdpr, tt.consent, tt.aliasGVLIDs)
+		permissions, err := perms.AuctionActivitiesAllowed(context.Background(), tt.bidderCoreName, tt.bidderName, tt.publisherID, tt.gdpr, tt.consent, tt.aliasGVLIDs)
 
 		assert.Nil(t, err, tt.description)
-		assert.Equal(t, tt.passID, passID, tt.description)
+		assert.Equal(t, tt.passID, permissions.PassID, tt.description)
 	}
 }
 
@@ -430,7 +430,7 @@ type testDef struct {
 	description           string
 	bidder                openrtb_ext.BidderName
 	consent               string
-	allowBid              bool
+	allowBidRequest       bool
 	passGeo               bool
 	passID                bool
 	weakVendorEnforcement bool
@@ -460,30 +460,30 @@ func TestAllowActivitiesGeoAndID(t *testing.T) {
 	// COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA : full consents to purposes and vendors 2, 6, 8 and special feature 1 opt-in
 	testDefs := []testDef{
 		{
-			description:    "Appnexus vendor test, insufficient purposes claimed",
-			bidder:         openrtb_ext.BidderAppnexus,
-			bidderCoreName: openrtb_ext.BidderAppnexus,
-			consent:        "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:       false,
-			passGeo:        false,
-			passID:         false,
+			description:     "Appnexus vendor test, insufficient purposes claimed",
+			bidder:          openrtb_ext.BidderAppnexus,
+			bidderCoreName:  openrtb_ext.BidderAppnexus,
+			consent:         "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
+			allowBidRequest: false,
+			passGeo:         false,
+			passID:          false,
 		},
 		{
-			description:    "Pubmatic Alias vendor test, insufficient purposes claimed",
-			bidder:         "pubmatic1",
-			bidderCoreName: openrtb_ext.BidderPubmatic,
-			consent:        "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:       false,
-			passGeo:        false,
-			passID:         false,
-			aliasGVLIDs:    map[string]uint16{"pubmatic1": 1},
+			description:     "Pubmatic Alias vendor test, insufficient purposes claimed",
+			bidder:          "pubmatic1",
+			bidderCoreName:  openrtb_ext.BidderPubmatic,
+			consent:         "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
+			allowBidRequest: false,
+			passGeo:         false,
+			passID:          false,
+			aliasGVLIDs:     map[string]uint16{"pubmatic1": 1},
 		},
 		{
 			description:           "Appnexus vendor test, insufficient purposes claimed, basic enforcement",
 			bidder:                openrtb_ext.BidderAppnexus,
 			bidderCoreName:        openrtb_ext.BidderAppnexus,
 			consent:               "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:              true,
+			allowBidRequest:       true,
 			passGeo:               true,
 			passID:                true,
 			weakVendorEnforcement: true,
@@ -493,50 +493,50 @@ func TestAllowActivitiesGeoAndID(t *testing.T) {
 			bidder:                openrtb_ext.BidderAudienceNetwork,
 			bidderCoreName:        openrtb_ext.BidderAudienceNetwork,
 			consent:               "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:              true,
+			allowBidRequest:       true,
 			passGeo:               true,
 			passID:                true,
 			weakVendorEnforcement: true,
 		},
 		{
-			description:    "Pubmatic vendor test, flex purposes claimed",
-			bidder:         openrtb_ext.BidderPubmatic,
-			bidderCoreName: openrtb_ext.BidderPubmatic,
-			consent:        "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:       true,
-			passGeo:        true,
-			passID:         true,
+			description:     "Pubmatic vendor test, flex purposes claimed",
+			bidder:          openrtb_ext.BidderPubmatic,
+			bidderCoreName:  openrtb_ext.BidderPubmatic,
+			consent:         "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
+			allowBidRequest: true,
+			passGeo:         true,
+			passID:          true,
 		},
 		{
-			description:    "Pubmatic Alias vendor test, flex purposes claimed",
-			bidder:         "pubmatic1",
-			bidderCoreName: openrtb_ext.BidderPubmatic,
-			consent:        "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:       true,
-			passGeo:        true,
-			passID:         true,
-			aliasGVLIDs:    map[string]uint16{"pubmatic1": 6},
+			description:     "Pubmatic Alias vendor test, flex purposes claimed",
+			bidder:          "pubmatic1",
+			bidderCoreName:  openrtb_ext.BidderPubmatic,
+			consent:         "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
+			allowBidRequest: true,
+			passGeo:         true,
+			passID:          true,
+			aliasGVLIDs:     map[string]uint16{"pubmatic1": 6},
 		},
 		{
-			description:    "Rubicon vendor test, Specific purposes/LIs claimed, no geo claimed",
-			bidder:         openrtb_ext.BidderRubicon,
-			bidderCoreName: openrtb_ext.BidderRubicon,
-			consent:        "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
-			allowBid:       true,
-			passGeo:        false,
-			passID:         true,
+			description:     "Rubicon vendor test, Specific purposes/LIs claimed, no geo claimed",
+			bidder:          openrtb_ext.BidderRubicon,
+			bidderCoreName:  openrtb_ext.BidderRubicon,
+			consent:         "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA",
+			allowBidRequest: true,
+			passGeo:         false,
+			passID:          true,
 		},
 		{
 			// This requires publisher restrictions on any claimed purposes, 2-10. Vendor must declare all claimed purposes
 			// as flex with legit interest as primary.
 			// Using vendor 20 for this.
-			description:    "OpenX vendor test, Specific purposes/LIs claimed, no geo claimed, Publisher restrictions apply",
-			bidder:         openrtb_ext.BidderOpenx,
-			bidderCoreName: openrtb_ext.BidderOpenx,
-			consent:        "CPAavcCPAavcCAGABCFRBKCsAP_AAH_AAAqIHFNf_X_fb3_j-_59_9t0eY1f9_7_v-0zjgeds-8Nyd_X_L8X5mM7vB36pq4KuR4Eu3LBAQdlHOHcTUmw6IkVqTPsbk2Mr7NKJ7PEinMbe2dYGH9_n9XT_ZKY79_____7__-_____7_f__-__3_vp9V---wOJAIMBAUAgAEMAAQIFCIQAAQhiQAAAABBCIBQJIAEqgAWVwEdoIEACAxAQgQAgBBQgwCAAQAAJKAgBACwQCAAiAQAAgAEAIAAEIAILACQEAAAEAJCAAiACECAgiAAg5DAgIgCCAFABAAAuJDACAMooASBAPGQGAAKAAqACGAEwALgAjgBlgDUAHZAPsA_ACMAFLAK2AbwBMQCbAFogLYAYEAw8BkQDOQGeAM-EQHwAVABWAC4AIYAZAAywBqADZAHYAPwAgABGAClgFPANYAdUA-QCGwEOgIvASIAmwBOwCkQFyAMCAYSAw8Bk4DOQGfCQAYADgBzgN_CQTgAEAALgAoACoAGQAOAAeABAACIAFQAMIAaABqADyAIYAigBMgCqAKwAWAAuABvADmAHoAQ0AiACJgEsAS4AmgBSgC3AGGAMgAZcA1ADVAGyAO8AewA-IB9gH6AQAAjABQQClgFPAL8AYoA1gBtADcAG8AOIAegA-QCGwEOgIqAReAkQBMQCZQE2AJ2AUOApEBYoC2AFyALvAYEAwYBhIDDQGHgMiAZIAycBlwDOQGfANIAadA1gDWQoAEAYQaBIACoAKwAXABDADIAGWANQAbIA7AB-AEAAIKARgApYBT4C0ALSAawA3gB1QD5AIbAQ6Ai8BIgCbAE7AKRAXIAwIBhIDDwGMAMnAZyAzwBnwcAEAA4Bv4qA2ABQAFQAQwAmABcAEcAMsAagA7AB-AEYAKXAWgBaQDeAJBATEAmwBTYC2AFyAMCAYeAyIBnIDPAGfANyHQWQAFwAUABUADIAHAAQAAiABdADAAMYAaABqADwAH0AQwBFACZAFUAVgAsABcADEAGYAN4AcwA9ACGAERAJYAmABNACjAFKALEAW4AwwBkADKAGiANQAbIA3wB3gD2gH2AfoBGACVAFBAKeAWKAtAC0gFzALyAX4AxQBuADiQHTAdQA9ACGwEOgIiAReAkEBIgCbAE7AKHAU0AqwBYsC2ALZAXAAuQBdoC7wGEgMNAYeAxIBjADHgGSAMnAZUAywBlwDOQGfANEgaQBpIDSwGnANYAbGPABAIqAb-QgZgALAAoABkAEQALgAYgBDACYAFUALgAYgAzABvAD0AI4AWIAygBqADfAHfAPsA_ACMAFBAKGAU-AtAC0gF-AMUAdQA9ACQQEiAJsAU0AsUBaMC2ALaAXAAuQBdoDDwGJAMiAZOAzkBngDPgGiANJAaWA4AlAyAAQAAsACgAGQAOAAigBgAGIAPAAiABMACqAFwAMQAZgA2gCGgEQARIAowBSgC3AGEAMoAaoA2QB3gD8AIwAU-AtAC0gGKANwAcQA6gCHQEXgJEATYAsUBbAC7QGHgMiAZOAywBnIDPAGfANIAawA4AmACARUA38pBBAAXABQAFQAMgAcABAACKAGAAYwA0ADUAHkAQwBFACYAFIAKoAWAAuABiADMAHMAQwAiABRgClAFiALcAZQA0QBqgDZAHfAPsA_ACMAFBAKGAVsAuYBeQDaAG4APQAh0BF4CRAE2AJ2AUOApoBWwCxQFsALgAXIAu0BhoDDwGMAMiAZIAycBlwDOQGeAM-gaQBpMDWANZAbGVABAA-Ab-A.YAAAAAAAAAAA",
-			allowBid:       true,
-			passGeo:        false,
-			passID:         true,
+			description:     "OpenX vendor test, Specific purposes/LIs claimed, no geo claimed, Publisher restrictions apply",
+			bidder:          openrtb_ext.BidderOpenx,
+			bidderCoreName:  openrtb_ext.BidderOpenx,
+			consent:         "CPAavcCPAavcCAGABCFRBKCsAP_AAH_AAAqIHFNf_X_fb3_j-_59_9t0eY1f9_7_v-0zjgeds-8Nyd_X_L8X5mM7vB36pq4KuR4Eu3LBAQdlHOHcTUmw6IkVqTPsbk2Mr7NKJ7PEinMbe2dYGH9_n9XT_ZKY79_____7__-_____7_f__-__3_vp9V---wOJAIMBAUAgAEMAAQIFCIQAAQhiQAAAABBCIBQJIAEqgAWVwEdoIEACAxAQgQAgBBQgwCAAQAAJKAgBACwQCAAiAQAAgAEAIAAEIAILACQEAAAEAJCAAiACECAgiAAg5DAgIgCCAFABAAAuJDACAMooASBAPGQGAAKAAqACGAEwALgAjgBlgDUAHZAPsA_ACMAFLAK2AbwBMQCbAFogLYAYEAw8BkQDOQGeAM-EQHwAVABWAC4AIYAZAAywBqADZAHYAPwAgABGAClgFPANYAdUA-QCGwEOgIvASIAmwBOwCkQFyAMCAYSAw8Bk4DOQGfCQAYADgBzgN_CQTgAEAALgAoACoAGQAOAAeABAACIAFQAMIAaABqADyAIYAigBMgCqAKwAWAAuABvADmAHoAQ0AiACJgEsAS4AmgBSgC3AGGAMgAZcA1ADVAGyAO8AewA-IB9gH6AQAAjABQQClgFPAL8AYoA1gBtADcAG8AOIAegA-QCGwEOgIqAReAkQBMQCZQE2AJ2AUOApEBYoC2AFyALvAYEAwYBhIDDQGHgMiAZIAycBlwDOQGfANIAadA1gDWQoAEAYQaBIACoAKwAXABDADIAGWANQAbIA7AB-AEAAIKARgApYBT4C0ALSAawA3gB1QD5AIbAQ6Ai8BIgCbAE7AKRAXIAwIBhIDDwGMAMnAZyAzwBnwcAEAA4Bv4qA2ABQAFQAQwAmABcAEcAMsAagA7AB-AEYAKXAWgBaQDeAJBATEAmwBTYC2AFyAMCAYeAyIBnIDPAGfANyHQWQAFwAUABUADIAHAAQAAiABdADAAMYAaABqADwAH0AQwBFACZAFUAVgAsABcADEAGYAN4AcwA9ACGAERAJYAmABNACjAFKALEAW4AwwBkADKAGiANQAbIA3wB3gD2gH2AfoBGACVAFBAKeAWKAtAC0gFzALyAX4AxQBuADiQHTAdQA9ACGwEOgIiAReAkEBIgCbAE7AKHAU0AqwBYsC2ALZAXAAuQBdoC7wGEgMNAYeAxIBjADHgGSAMnAZUAywBlwDOQGfANEgaQBpIDSwGnANYAbGPABAIqAb-QgZgALAAoABkAEQALgAYgBDACYAFUALgAYgAzABvAD0AI4AWIAygBqADfAHfAPsA_ACMAFBAKGAU-AtAC0gF-AMUAdQA9ACQQEiAJsAU0AsUBaMC2ALaAXAAuQBdoDDwGJAMiAZOAzkBngDPgGiANJAaWA4AlAyAAQAAsACgAGQAOAAigBgAGIAPAAiABMACqAFwAMQAZgA2gCGgEQARIAowBSgC3AGEAMoAaoA2QB3gD8AIwAU-AtAC0gGKANwAcQA6gCHQEXgJEATYAsUBbAC7QGHgMiAZOAywBnIDPAGfANIAawA4AmACARUA38pBBAAXABQAFQAMgAcABAACKAGAAYwA0ADUAHkAQwBFACYAFIAKoAWAAuABiADMAHMAQwAiABRgClAFiALcAZQA0QBqgDZAHfAPsA_ACMAFBAKGAVsAuYBeQDaAG4APQAh0BF4CRAE2AJ2AUOApoBWwCxQFsALgAXIAu0BhoDDwGMAMiAZIAycBlwDOQGeAM-gaQBpMDWANZAbGVABAA-Ab-A.YAAAAAAAAAAA",
+			allowBidRequest: true,
+			passGeo:         false,
+			passID:          true,
 		},
 	}
 
@@ -548,11 +548,11 @@ func TestAllowActivitiesGeoAndID(t *testing.T) {
 		}
 		perms.cfg = &tcf2AggConfig
 
-		allowBid, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
+		permissions, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
 		assert.NoErrorf(t, err, "Error processing AuctionActivitiesAllowed for %s", td.description)
-		assert.EqualValuesf(t, td.allowBid, allowBid, "AllowBid failure on %s", td.description)
-		assert.EqualValuesf(t, td.passGeo, passGeo, "PassGeo failure on %s", td.description)
-		assert.EqualValuesf(t, td.passID, passID, "PassID failure on %s", td.description)
+		assert.EqualValuesf(t, td.allowBidRequest, permissions.AllowBidRequest, "AllowBid failure on %s", td.description)
+		assert.EqualValuesf(t, td.passGeo, permissions.PassGeo, "PassGeo failure on %s", td.description)
+		assert.EqualValuesf(t, td.passID, permissions.PassID, "PassID failure on %s", td.description)
 	}
 }
 
@@ -575,10 +575,10 @@ func TestAllowActivitiesWhitelist(t *testing.T) {
 	}
 
 	// Assert that an item that otherwise would not be allowed PI access, gets approved because it is found in the GDPR.NonStandardPublishers array
-	_, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, "appNexusAppID", SignalYes, "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA", map[string]uint16{})
+	permissions, err := perms.AuctionActivitiesAllowed(context.Background(), openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, "appNexusAppID", SignalYes, "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA", map[string]uint16{})
 	assert.NoErrorf(t, err, "Error processing AuctionActivitiesAllowed")
-	assert.EqualValuesf(t, true, passGeo, "PassGeo failure")
-	assert.EqualValuesf(t, true, passID, "PassID failure")
+	assert.EqualValuesf(t, true, permissions.PassGeo, "PassGeo failure")
+	assert.EqualValuesf(t, true, permissions.PassID, "PassID failure")
 }
 
 func TestAllowActivitiesPubRestrict(t *testing.T) {
@@ -640,10 +640,10 @@ func TestAllowActivitiesPubRestrict(t *testing.T) {
 	}
 
 	for _, td := range testDefs {
-		_, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
+		permissions, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
 		assert.NoErrorf(t, err, "Error processing AuctionActivitiesAllowed for %s", td.description)
-		assert.EqualValuesf(t, td.passGeo, passGeo, "PassGeo failure on %s", td.description)
-		assert.EqualValuesf(t, td.passID, passID, "PassID failure on %s", td.description)
+		assert.EqualValuesf(t, td.passGeo, permissions.PassGeo, "PassGeo failure on %s", td.description)
+		assert.EqualValuesf(t, td.passID, permissions.PassID, "PassID failure on %s", td.description)
 	}
 }
 
@@ -795,7 +795,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 		bidder                 openrtb_ext.BidderName
 		bidderCoreName         openrtb_ext.BidderName
 		consent                string
-		allowBid               bool
+		allowBidRequest        bool
 		passGeo                bool
 		passID                 bool
 		aliasGVLIDs            map[string]uint16
@@ -807,7 +807,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderPubmatic,
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2ConsentWithoutVendorConsent,
-			allowBid:               false,
+			allowBidRequest:        false,
 			passGeo:                false,
 			passID:                 false,
 		},
@@ -818,7 +818,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 "pubmatic1",
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2AndVendorConsent,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 true,
 			aliasGVLIDs:            map[string]uint16{"pubmatic1": 6},
@@ -830,7 +830,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 "pubmatic1",
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2AndVendorConsent,
-			allowBid:               false,
+			allowBidRequest:        false,
 			passGeo:                false,
 			passID:                 false,
 			aliasGVLIDs:            map[string]uint16{"pubmatic1": 1},
@@ -842,7 +842,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderPubmatic,
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2ConsentWithoutVendorConsent,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 true,
 		},
@@ -853,7 +853,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderPubmatic,
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2ConsentWithoutVendorConsent,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 false,
 		},
@@ -864,7 +864,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderPubmatic,
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2AndVendorConsent,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 true,
 		},
@@ -875,7 +875,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderRubicon,
 			bidderCoreName:         openrtb_ext.BidderRubicon,
 			consent:                purpose2LIWithoutVendorLI,
-			allowBid:               false,
+			allowBidRequest:        false,
 			passGeo:                false,
 			passID:                 false,
 		},
@@ -886,7 +886,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderRubicon,
 			bidderCoreName:         openrtb_ext.BidderRubicon,
 			consent:                purpose2AndVendorLI,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 true,
 		},
@@ -897,7 +897,7 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 			bidder:                 openrtb_ext.BidderPubmatic,
 			bidderCoreName:         openrtb_ext.BidderPubmatic,
 			consent:                purpose2AndVendorLI,
-			allowBid:               true,
+			allowBidRequest:        true,
 			passGeo:                false,
 			passID:                 true,
 		},
@@ -927,11 +927,11 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 		tcf2AggConfig.HostConfig.PurposeConfigs[consentconstants.Purpose(2)] = &tcf2AggConfig.HostConfig.Purpose2
 		perms.cfg = &tcf2AggConfig
 
-		allowBid, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
+		permissions, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, td.aliasGVLIDs)
 		assert.NoErrorf(t, err, "Error processing AuctionActivitiesAllowed for %s", td.description)
-		assert.EqualValuesf(t, td.allowBid, allowBid, "AllowBid failure on %s", td.description)
-		assert.EqualValuesf(t, td.passGeo, passGeo, "PassGeo failure on %s", td.description)
-		assert.EqualValuesf(t, td.passID, passID, "PassID failure on %s", td.description)
+		assert.EqualValuesf(t, td.allowBidRequest, permissions.AllowBidRequest, "AllowBid failure on %s", td.description)
+		assert.EqualValuesf(t, td.passGeo, permissions.PassGeo, "PassGeo failure on %s", td.description)
+		assert.EqualValuesf(t, td.passID, permissions.PassID, "PassID failure on %s", td.description)
 	}
 }
 
@@ -946,12 +946,12 @@ func TestTCF1Consent(t *testing.T) {
 		},
 	}
 
-	bidReq, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), bidderAllowedByConsent, bidderAllowedByConsent, "", SignalYes, tcf1Consent, map[string]uint16{})
+	permissions, err := perms.AuctionActivitiesAllowed(context.Background(), bidderAllowedByConsent, bidderAllowedByConsent, "", SignalYes, tcf1Consent, map[string]uint16{})
 
 	assert.Nil(t, err, "TCF1 consent - no error returned")
-	assert.Equal(t, false, bidReq, "TCF1 consent - bid request not allowed")
-	assert.Equal(t, false, passGeo, "TCF1 consent - passing geo not allowed")
-	assert.Equal(t, false, passID, "TCF1 consent - passing id not allowed")
+	assert.Equal(t, false, permissions.AllowBidRequest, "TCF1 consent - bid request not allowed")
+	assert.Equal(t, false, permissions.PassGeo, "TCF1 consent - passing geo not allowed")
+	assert.Equal(t, false, permissions.PassID, "TCF1 consent - passing id not allowed")
 }
 
 func TestAllowActivitiesVendorException(t *testing.T) {
@@ -964,7 +964,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 		sf1VendorExceptionMap map[openrtb_ext.BidderName]struct{}
 		bidder                openrtb_ext.BidderName
 		consent               string
-		allowBid              bool
+		allowBidRequest       bool
 		passGeo               bool
 		passID                bool
 		bidderCoreName        openrtb_ext.BidderName
@@ -975,7 +975,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			bidder:               openrtb_ext.BidderAppnexus,
 			bidderCoreName:       openrtb_ext.BidderAppnexus,
 			consent:              noPurposeOrVendorConsentAndPubRestrictsP2,
-			allowBid:             false,
+			allowBidRequest:      false,
 			passGeo:              false,
 			passID:               false,
 		},
@@ -986,7 +986,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			bidder:                openrtb_ext.BidderAppnexus,
 			bidderCoreName:        openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
-			allowBid:              true,
+			allowBidRequest:       true,
 			passGeo:               false,
 			passID:                true,
 		},
@@ -997,7 +997,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			bidder:                openrtb_ext.BidderAppnexus,
 			bidderCoreName:        openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
-			allowBid:              false,
+			allowBidRequest:       false,
 			passGeo:               false,
 			passID:                false,
 		},
@@ -1008,7 +1008,7 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 			bidder:                openrtb_ext.BidderAppnexus,
 			bidderCoreName:        openrtb_ext.BidderAppnexus,
 			consent:               noPurposeOrVendorConsentAndPubRestrictsNone,
-			allowBid:              false,
+			allowBidRequest:       false,
 			passGeo:               true,
 			passID:                false,
 		},
@@ -1034,11 +1034,11 @@ func TestAllowActivitiesVendorException(t *testing.T) {
 		tcf2AggConfig.HostConfig.PurposeConfigs[consentconstants.Purpose(3)] = &tcf2AggConfig.HostConfig.Purpose3
 		perms.cfg = &tcf2AggConfig
 
-		allowBid, passGeo, passID, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, map[string]uint16{})
+		permissions, err := perms.AuctionActivitiesAllowed(context.Background(), td.bidderCoreName, td.bidder, "", SignalYes, td.consent, map[string]uint16{})
 		assert.NoErrorf(t, err, "Error processing AuctionActivitiesAllowed for %s", td.description)
-		assert.EqualValuesf(t, td.allowBid, allowBid, "AllowBid failure on %s", td.description)
-		assert.EqualValuesf(t, td.passGeo, passGeo, "PassGeo failure on %s", td.description)
-		assert.EqualValuesf(t, td.passID, passID, "PassID failure on %s", td.description)
+		assert.EqualValuesf(t, td.allowBidRequest, permissions.AllowBidRequest, "AllowBid failure on %s", td.description)
+		assert.EqualValuesf(t, td.passGeo, permissions.PassGeo, "PassGeo failure on %s", td.description)
+		assert.EqualValuesf(t, td.passID, permissions.PassID, "PassID failure on %s", td.description)
 	}
 }
 

--- a/gdpr/permissions.go
+++ b/gdpr/permissions.go
@@ -1,0 +1,25 @@
+package gdpr
+
+type AuctionPermissions struct {
+	AllowBidRequest bool
+	PassGeo         bool
+	PassID          bool
+}
+
+var AllowAll = AuctionPermissions{
+	AllowBidRequest: true,
+	PassGeo:         true,
+	PassID:          true,
+}
+
+var DenyAll = AuctionPermissions{
+	AllowBidRequest: false,
+	PassGeo:         false,
+	PassID:          false,
+}
+
+var AllowBidRequestOnly = AuctionPermissions{
+	AllowBidRequest: true,
+	PassGeo:         false,
+	PassID:          false,
+}


### PR DESCRIPTION
This is the first of a several refactor PRs that will eventually lead to the incorporation of the basic enforcement algorithm that can be used instead of the full algorithm for specific purposes. No additional logic has been introduced here. This simply alters the `AuctionActivitiesAllowed` GDPR function signature to return a permissions struct instead of three bool values.