### PR TITLE
The http.ProxyFromEnvironment as Proxy func in custom http.Transport

### DIFF
--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -32,6 +32,7 @@ type googleResponse struct {
 
 func (deps *UserSyncDeps) VerifyRecaptcha(response string) error {
 	ts := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{RootCAs: ssl.GetRootCAPool()},
 	}
 

--- a/router/router.go
+++ b/router/router.go
@@ -130,6 +130,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 
 	generalHttpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxConnsPerHost:     cfg.Client.MaxConnsPerHost,
 			MaxIdleConns:        cfg.Client.MaxIdleConns,
 			MaxIdleConnsPerHost: cfg.Client.MaxIdleConnsPerHost,
@@ -140,6 +141,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 
 	cacheHttpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxConnsPerHost:     cfg.CacheClient.MaxConnsPerHost,
 			MaxIdleConns:        cfg.CacheClient.MaxIdleConns,
 			MaxIdleConnsPerHost: cfg.CacheClient.MaxIdleConnsPerHost,


### PR DESCRIPTION
This PR addresses this issue: #2245  

This change sets the http.ProxyFromEnvironment as Proxy function in all custom http.Transport used in the prebid-server as the http.DefaultTransport does.
https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/transport.go;l=43
![obraz](https://user-images.githubusercontent.com/104571800/169279277-dee868eb-918c-490c-b95a-7c45b1745e9b.png)

With this change it is possible using prebid-server with an external proxy.