### PR TITLE
Set account id to publisher unknown on cookie sync endpoint

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -113,6 +113,9 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 		return usersync.Request{}, privacy.Policies{}, fmt.Errorf("JSON parsing failed: %s", err.Error())
 	}
 
+	if request.Account == "" {
+		request.Account = metrics.PublisherUnknown
+	}
 	account, fetchErrs := accountService.GetAccount(context.Background(), c.config, c.accountsFetcher, request.Account)
 	if len(fetchErrs) > 0 {
 		return usersync.Request{}, privacy.Policies{}, combineErrors(fetchErrs)


### PR DESCRIPTION
This PR fixes a recently introduced bug in the cookie sync endpoint. A recent change to the endpoint made the account required which is not the desired behavior. This fix makes the account optional by following the approach in the auction flows. Now if the account is not specified on the cookie sync endpoint it will be set to "unknown", which will result in the `GetAccount` function returning an account object consisting only of host config account defaults.

I believe `endpoints/cookie_sync_test.go#TestCookieSyncParseRequest` and `account/account_test.go#TestGetAccount` provide adequate testing for the scenario where the account ID is not provided.

This was also tested manually E2E with the account parameter omitted and the account parameter set to an empty string.