### PR TITLE
Support adapters to set seat for a bid

### DIFF
--- a/adapters/adapterstest/test_json.go
+++ b/adapters/adapterstest/test_json.go
@@ -207,6 +207,7 @@ type expectedBidResponse struct {
 type expectedBid struct {
 	Bid  json.RawMessage `json:"bid"`
 	Type string          `json:"type"`
+	Seat string          `json:"seat"`
 }
 
 // ---------------------------------------
@@ -314,6 +315,7 @@ func diffBids(t *testing.T, description string, actual *adapters.TypedBid, expec
 		return
 	}
 
+	assert.Equal(t, string(expected.Seat), string(actual.Seat), fmt.Sprintf(`%s.seat "%s" does not match expected "%s."`, description, string(actual.Seat), string(expected.Seat)))
 	assert.Equal(t, string(expected.Type), string(actual.BidType), fmt.Sprintf(`%s.type "%s" does not match expected "%s."`, description, string(actual.BidType), string(expected.Type)))
 	assert.NoError(t, diffOrtbBids(fmt.Sprintf("%s.bid", description), actual.Bid, expected.Bid))
 }

--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -93,12 +93,14 @@ func NewBidderResponse() *BidderResponse {
 // TypedBid.BidType will become "response.seatbid[i].bid.ext.prebid.type" in the final OpenRTB response.
 // TypedBid.BidVideo will become "response.seatbid[i].bid.ext.prebid.video" in the final OpenRTB response.
 // TypedBid.DealPriority is optionally provided by adapters and used internally by the exchange to support deal targeted campaigns.
+// TypedBid.Seat new seat under which the bid should pe placed. Default is adapter name
 type TypedBid struct {
 	Bid          *openrtb2.Bid
 	BidMeta      *openrtb_ext.ExtBidPrebidMeta
 	BidType      openrtb_ext.BidType
 	BidVideo     *openrtb_ext.ExtBidPrebidVideo
 	DealPriority int
+	Seat         openrtb_ext.BidderName
 }
 
 // RequestData and ResponseData exist so that prebid-server core code can implement its "debug" functionality

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -24,6 +24,7 @@ type PubmaticAdapter struct {
 type pubmaticBidExt struct {
 	BidType           *int                 `json:"BidType,omitempty"`
 	VideoCreativeInfo *pubmaticBidExtVideo `json:"video,omitempty"`
+	Marketplace       string               `json:"marketplace,omitempty"`
 }
 
 type pubmaticWrapperExt struct {
@@ -390,9 +391,11 @@ func (a *PubmaticAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 				bid.Cat = bid.Cat[0:1]
 			}
 
+			seat := ""
 			var bidExt *pubmaticBidExt
 			bidType := openrtb_ext.BidTypeBanner
 			if err := json.Unmarshal(bid.Ext, &bidExt); err == nil && bidExt != nil {
+				seat = bidExt.Marketplace
 				if bidExt.VideoCreativeInfo != nil && bidExt.VideoCreativeInfo.Duration != nil {
 					impVideo.Duration = *bidExt.VideoCreativeInfo.Duration
 				}
@@ -402,6 +405,7 @@ func (a *PubmaticAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 				Bid:      &bid,
 				BidType:  bidType,
 				BidVideo: impVideo,
+				Seat:     openrtb_ext.BidderName(seat),
 			})
 
 		}

--- a/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
@@ -1,0 +1,195 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "imp": [{
+            "id": "test-imp-id",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {
+                    "adSlot": "AdTag_Div1@300x250",
+                    "publisherId": "999",
+                    "keywords": [{
+                        "key": "pmZoneID",
+                        "value": ["Zone1", "Zone2"]
+                      },
+                      {
+                         "key": "preference",
+                         "value": ["sports", "movies"]
+                      }
+                    ],
+                    "kadfloor": "0.12",
+                    "wrapper": {
+                        "version": 1,
+                        "profile": 5123
+                    }
+                }
+            }
+        }],
+        "device":{
+            "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
+        },
+        "ext": {
+          "prebid": {
+            "bidderparams": {
+              "acat": ["drg","dlu","ssr"]
+            }
+          }
+        },
+        "site": {
+          "id": "siteID",
+            "publisher": {
+              "id": "1234"
+            }
+          }
+     },
+
+     "httpCalls": [
+      {
+        "expectedRequest": {
+          "uri": "https://hbopenbid.pubmatic.com/translator?source=prebid-server",
+          "body": {
+            "id": "test-request-id",
+            "imp": [
+              {
+                "id": "test-imp-id",
+                "tagid":"AdTag_Div1",
+                 "banner": {
+                  "format": [
+                    {
+                      "w": 300,
+                      "h": 250
+                    }
+                  ],
+                  "h": 250,
+                  "w": 300
+                },
+                "bidfloor": 0.12,
+                "ext": {
+                    "pmZoneId": "Zone1,Zone2",
+                    "preference": "sports,movies"
+                }
+              }
+            ], 
+            "device":{
+                "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
+            },
+            "site": {
+                "id": "siteID",
+                "publisher": {
+                    "id": "999"
+                }
+            },
+            "ext": {
+                "wrapper": {
+                    "profile": 5123,
+                    "version":1
+                },
+                "acat": ["drg","dlu","ssr"]
+            }
+          }
+        },
+        "mockResponse": {
+          "status": 200,
+          "body": {
+            "id": "test-request-id",
+            "seatbid": [
+              {
+                "seat": "958",
+                "bid": [{
+                  "id": "7706636740145184841",
+                  "impid": "test-imp-id",
+                  "price": 0.500000,
+                  "adid": "29681110",
+                  "adm": "some-test-ad",
+                  "adomain": ["pubmatic.com"],
+                  "crid": "29681110",
+                  "h": 250,
+                  "w": 300,
+                  "dealid":"test deal",
+                  "ext": {
+                    "dspid": 6,
+                    "deal_channel": 1
+                  }
+                }]
+              },
+              {
+                "seat": "123",
+                "bid": [{
+                  "id": "1814876ae93d31",
+                  "impid": "test-imp-id",
+                  "price": 0.500000,
+                  "adid": "29681110",
+                  "adm": "some-test-ad",
+                  "adomain": ["mystartab.com"],
+                  "crid": "29681110",
+                  "h": 250,
+                  "w": 300,
+                  "dealid":"test deal",
+                  "ext": {
+                    "dspid": 6,
+                    "deal_channel": 1,
+                    "marketplace": "groupm"
+                  }
+                }]
+              }
+            ],
+            "bidid": "5778926625248726496",
+            "cur": "USD"
+          }
+        }
+      }
+    ],
+
+    "expectedBidResponses": [
+      {
+        "currency": "USD",
+        "bids": [
+          {
+            "bid": {
+              "id": "7706636740145184841",
+              "impid": "test-imp-id",
+              "price": 0.5,
+              "adid": "29681110",
+              "adm": "some-test-ad",
+              "adomain": ["pubmatic.com"],
+              "crid": "29681110",
+              "w": 300,
+              "h": 250,
+              "dealid":"test deal",
+              "ext": {
+                "dspid": 6,
+                "deal_channel": 1
+              }
+            },
+            "type": "banner"
+          },
+          {
+            "bid": {
+              "id": "1814876ae93d31",
+              "impid": "test-imp-id",
+              "price": 0.5,
+              "adid": "29681110",
+              "adm": "some-test-ad",
+              "adomain": ["mystartab.com"],
+              "crid": "29681110",
+              "w": 300,
+              "h": 250,
+              "dealid":"test deal",
+              "ext": {
+                "dspid": 6,
+                "deal_channel": 1,
+                "marketplace": "groupm"
+              }
+            },
+            "type": "banner",
+            "seat": "groupm"
+          }
+        ]
+      }
+    ]
+  }

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/prebid/go-gdpr/consentconstants"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
@@ -18,17 +20,18 @@ const (
 
 // Account represents a publisher account configuration
 type Account struct {
-	ID                      string      `mapstructure:"id" json:"id"`
-	Disabled                bool        `mapstructure:"disabled" json:"disabled"`
-	CacheTTL                DefaultTTLs `mapstructure:"cache_ttl" json:"cache_ttl"`
-	EventsEnabled           bool        `mapstructure:"events_enabled" json:"events_enabled"`
-	CCPA                    AccountCCPA `mapstructure:"ccpa" json:"ccpa"`
-	GDPR                    AccountGDPR `mapstructure:"gdpr" json:"gdpr"`
-	DebugAllow              bool        `mapstructure:"debug_allow" json:"debug_allow"`
-	DefaultIntegration      string      `mapstructure:"default_integration" json:"default_integration"`
-	CookieSync              CookieSync  `mapstructure:"cookie_sync" json:"cookie_sync"`
-	Events                  Events      `mapstructure:"events" json:"events"` // Don't enable this feature. It is still under developmment - https://github.com/prebid/prebid-server/issues/1725
-	TruncateTargetAttribute *int        `mapstructure:"truncate_target_attr" json:"truncate_target_attr"`
+	ID                      string               `mapstructure:"id" json:"id"`
+	Disabled                bool                 `mapstructure:"disabled" json:"disabled"`
+	CacheTTL                DefaultTTLs          `mapstructure:"cache_ttl" json:"cache_ttl"`
+	EventsEnabled           bool                 `mapstructure:"events_enabled" json:"events_enabled"`
+	CCPA                    AccountCCPA          `mapstructure:"ccpa" json:"ccpa"`
+	GDPR                    AccountGDPR          `mapstructure:"gdpr" json:"gdpr"`
+	DebugAllow              bool                 `mapstructure:"debug_allow" json:"debug_allow"`
+	DefaultIntegration      string               `mapstructure:"default_integration" json:"default_integration"`
+	CookieSync              CookieSync           `mapstructure:"cookie_sync" json:"cookie_sync"`
+	Events                  Events               `mapstructure:"events" json:"events"` // Don't enable this feature. It is still under developmment - https://github.com/prebid/prebid-server/issues/1725
+	TruncateTargetAttribute *int                 `mapstructure:"truncate_target_attr" json:"truncate_target_attr"`
+	AlternateBidderCodes    AlternateBidderCodes `mapstructure:"alternatebiddercodes" json:"alternatebiddercodes"`
 }
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.
@@ -221,4 +224,51 @@ func (a *AccountIntegration) GetByIntegrationType(integrationType IntegrationTyp
 	}
 
 	return integrationEnabled
+}
+
+type AlternateBidderCodes struct {
+	Enabled  bool                                   `mapstructure:"enabled" json:"enabled"`
+	Adapters map[string]AdapterAlternateBidderCodes `mapstructure:"adapters" json:"adapters"`
+}
+
+type AdapterAlternateBidderCodes struct {
+	Enabled            bool     `mapstructure:"enabled" json:"enabled"`
+	AllowedBidderCodes []string `mapstructure:"allowedbiddercodes" json:"allowedbiddercodes"`
+}
+
+func (account *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidder string) (bool, error) {
+	const ErrAlternateBidderNotDefined = "alternateBidderCodes not defined for adapter %q, rejecting bids for %q"
+
+	if alternateBidder == "" || bidder == alternateBidder {
+		return true, nil
+	}
+
+	if !account.Enabled {
+		return false, nil
+	}
+
+	if account.Adapters == nil {
+		return false, fmt.Errorf(ErrAlternateBidderNotDefined, bidder, alternateBidder)
+	}
+
+	adapterCfg, ok := account.Adapters[bidder]
+	if !ok {
+		return false, fmt.Errorf(ErrAlternateBidderNotDefined, bidder, alternateBidder)
+	}
+
+	if !adapterCfg.Enabled || len(adapterCfg.AllowedBidderCodes) == 0 {
+		return false, fmt.Errorf("alternateBidderCodes disabled for %q, rejecting bids for %q", bidder, alternateBidder)
+	}
+
+	if adapterCfg.AllowedBidderCodes[0] == "*" {
+		return true, nil
+	}
+
+	for _, code := range adapterCfg.AllowedBidderCodes {
+		if alternateBidder == code {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("invalid biddercode %q sent by adapter %q", alternateBidder, bidder)
 }

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/prebid/go-gdpr/consentconstants"
@@ -705,5 +706,147 @@ func TestBasicEnforcementVendor(t *testing.T) {
 
 		assert.Equal(t, tt.wantIsBasicVendor, value, tt.description)
 		assert.Equal(t, tt.wantBasicVendorSet, present, tt.description)
+	}
+}
+
+func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
+	type fields struct {
+		Enabled  bool
+		Adapters map[string]AdapterAlternateBidderCodes
+	}
+	type args struct {
+		bidder          string
+		alternateBidder string
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		wantIsValid bool
+		wantErr     error
+	}{
+		{
+			name:        "Default alternateBidder is not set/blank",
+			wantIsValid: true,
+		},
+		{
+			name: "alternateBidder, bidder are same",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "pubmatic",
+			},
+			wantIsValid: true,
+		},
+		{
+			name: "alternateBidder disabled at account level or alternateBidder config is not available",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			wantIsValid: false,
+		},
+		{
+			name: "alternateBidder enabled at account level, adapter config is not available",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields:      fields{Enabled: true},
+			wantIsValid: false,
+			wantErr:     errors.New(`alternateBidderCodes not defined for adapter "pubmatic", rejecting bids for "groupm"`),
+		},
+		{
+			name: "alternateBidder enabled at account level, adapter config present, has alternateBidder disabled, or len(allowedBidderCodes)=0",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Adapters: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {Enabled: false},
+				},
+			},
+			wantIsValid: false,
+			wantErr:     errors.New(`alternateBidderCodes disabled for "pubmatic", rejecting bids for "groupm"`),
+		},
+		{
+			name: "alternateBidder enabled at account level, adapter config present, has alternateBidder enabled, allowedBidderCodes empty or not available",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Adapters: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {Enabled: true},
+				},
+			},
+			wantIsValid: false,
+			wantErr:     errors.New(`alternateBidderCodes disabled for "pubmatic", rejecting bids for "groupm"`),
+		},
+		{
+			name: "allowedBidderCodes is *",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Adapters: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {
+						Enabled:            true,
+						AllowedBidderCodes: []string{"*"},
+					},
+				},
+			},
+			wantIsValid: true,
+		},
+		{
+			name: "allowedBidderCodes is in the list",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Adapters: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {
+						Enabled:            true,
+						AllowedBidderCodes: []string{"groupm"},
+					},
+				},
+			},
+			wantIsValid: true,
+		},
+		{
+			name: "allowedBidderCodes is not in the list",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Adapters: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {
+						Enabled:            true,
+						AllowedBidderCodes: []string{"xyz"},
+					},
+				},
+			},
+			wantIsValid: false,
+			wantErr:     errors.New(`invalid biddercode "groupm" sent by adapter "pubmatic"`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AlternateBidderCodes{
+				Enabled:  tt.fields.Enabled,
+				Adapters: tt.fields.Adapters,
+			}
+			gotIsValid, gotErr := a.IsValidBidderCode(tt.args.bidder, tt.args.alternateBidder)
+			assert.Equal(t, tt.wantIsValid, gotIsValid)
+			assert.Equal(t, tt.wantErr, gotErr)
+		})
 	}
 }

--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -12,6 +12,7 @@ const (
 	BlacklistedAcctErrorCode
 	AcctRequiredErrorCode
 	NoConversionRateErrorCode
+	AlternateBidderCodeErrorCode
 )
 
 // Defines numeric codes for well-known warnings.
@@ -21,6 +22,7 @@ const (
 	AccountLevelDebugDisabledWarningCode
 	BidderLevelDebugDisabledWarningCode
 	DisabledCurrencyConversionWarningCode
+	AlternateBidderCodeWarningCode
 )
 
 // Coder provides an error or warning code with severity.

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -51,7 +51,7 @@ type AdaptedBidder interface {
 	//
 	// Any errors will be user-facing in the API.
 	// Error messages should help publishers understand what might account for "bad" bids.
-	requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustment float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool) (*pbsOrtbSeatBid, []error)
+	requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustments map[string]float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool, alternateBidderCodes config.AlternateBidderCodes) ([]*pbsOrtbSeatBid, []error)
 }
 
 const ImpIdReqBody = "Stored bid response for impression id: "
@@ -93,6 +93,8 @@ type pbsOrtbSeatBid struct {
 	// httpCalls is the list of debugging info. It should only be populated if the request.test == 1.
 	// This will become response.ext.debug.httpcalls.{bidder} on the final Response.
 	httpCalls []*openrtb_ext.ExtHttpCall
+	// seat defines whom these extra bids belong to.
+	seat string
 }
 
 // AdaptBidder converts an adapters.Bidder into an exchange.AdaptedBidder.
@@ -134,7 +136,7 @@ type bidderAdapterConfig struct {
 	DebugInfo          config.DebugInfo
 }
 
-func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustment float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool) (*pbsOrtbSeatBid, []error) {
+func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustments map[string]float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool, alternateBidderCodes config.AlternateBidderCodes) ([]*pbsOrtbSeatBid, []error) {
 
 	var reqData []*adapters.RequestData
 	var errs []error
@@ -193,10 +195,13 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 	}
 
 	defaultCurrency := "USD"
-	seatBid := &pbsOrtbSeatBid{
-		bids:      make([]*pbsOrtbBid, 0, dataLen),
-		currency:  defaultCurrency,
-		httpCalls: make([]*openrtb_ext.ExtHttpCall, 0, dataLen),
+	seatBidMap := map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+		bidderRequest.BidderName: {
+			bids:      make([]*pbsOrtbBid, 0, dataLen),
+			currency:  defaultCurrency,
+			httpCalls: make([]*openrtb_ext.ExtHttpCall, 0, dataLen),
+			seat:      string(bidderRequest.BidderName),
+		},
 	}
 
 	// If the bidder made multiple requests, we still want them to enter as many bids as possible...
@@ -209,11 +214,11 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 		// - account debug is allowed
 		// - bidder debug is allowed
 		if headerDebugAllowed {
-			seatBid.httpCalls = append(seatBid.httpCalls, makeExt(httpInfo))
+			seatBidMap[bidderRequest.BidderName].httpCalls = append(seatBidMap[bidderRequest.BidderName].httpCalls, makeExt(httpInfo))
 		} else {
 			if accountDebugAllowed {
 				if bidder.config.DebugInfo.Allow {
-					seatBid.httpCalls = append(seatBid.httpCalls, makeExt(httpInfo))
+					seatBidMap[bidderRequest.BidderName].httpCalls = append(seatBidMap[bidderRequest.BidderName].httpCalls, makeExt(httpInfo))
 				} else {
 					debugDisabledWarning := errortypes.Warning{
 						WarningCode: errortypes.BidderLevelDebugDisabledWarningCode,
@@ -244,7 +249,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 				var err error
 				for _, bidReqCur := range bidderRequest.BidRequest.Cur {
 					if conversionRate, err = conversions.GetRate(bidResponse.Currency, bidReqCur); err == nil {
-						seatBid.currency = bidReqCur
+						seatBidMap[bidderRequest.BidderName].currency = bidReqCur
 						break
 					}
 				}
@@ -283,12 +288,53 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 				if err == nil {
 					// Conversion rate found, using it for conversion
 					for i := 0; i < len(bidResponse.Bids); i++ {
+						if bidResponse.Bids[i].BidMeta == nil {
+							bidResponse.Bids[i].BidMeta = &openrtb_ext.ExtBidPrebidMeta{}
+						}
+						bidResponse.Bids[i].BidMeta.AdapterCode = bidderRequest.BidderName.String()
+
+						bidderName := bidderRequest.BidderName
+						if bidResponse.Bids[i].Seat != "" {
+							bidderName = bidResponse.Bids[i].Seat
+						}
+
+						if valid, err := alternateBidderCodes.IsValidBidderCode(bidderRequest.BidderName.String(), bidderName.String()); !valid {
+							if err != nil {
+								err = &errortypes.Warning{
+									WarningCode: errortypes.AlternateBidderCodeWarningCode,
+									Message:     err.Error(),
+								}
+								errs = append(errs, err)
+							}
+							continue
+						}
+
+						adjustmentFactor := 1.0
+						if givenAdjustment, ok := bidAdjustments[bidderName.String()]; ok {
+							adjustmentFactor = givenAdjustment
+						} else if givenAdjustment, ok := bidAdjustments[bidderRequest.BidderName.String()]; ok {
+							adjustmentFactor = givenAdjustment
+						}
+
 						originalBidCpm := 0.0
 						if bidResponse.Bids[i].Bid != nil {
 							originalBidCpm = bidResponse.Bids[i].Bid.Price
-							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * bidAdjustment * conversionRate
+							bidResponse.Bids[i].Bid.Price = bidResponse.Bids[i].Bid.Price * adjustmentFactor * conversionRate
 						}
-						seatBid.bids = append(seatBid.bids, &pbsOrtbBid{
+
+						if _, ok := seatBidMap[bidderName]; !ok {
+							// Initalize seatBidMap entry as this is first extra bid with seat bidderName
+							// seatBidMap[bidderName] =
+							seatBidMap[bidderName] = &pbsOrtbSeatBid{
+								bids:     make([]*pbsOrtbBid, 0, dataLen),
+								currency: defaultCurrency,
+								// Do we need to fill httpCalls for this?. Can we refer one from adaptercode for debugging?
+								httpCalls: seatBidMap[bidderRequest.BidderName].httpCalls,
+								seat:      bidderName.String(),
+							}
+						}
+
+						seatBidMap[bidderName].bids = append(seatBidMap[bidderName].bids, &pbsOrtbBid{
 							bid:            bidResponse.Bids[i].Bid,
 							bidMeta:        bidResponse.Bids[i].BidMeta,
 							bidType:        bidResponse.Bids[i].BidType,
@@ -307,7 +353,13 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 			errs = append(errs, httpInfo.err)
 		}
 	}
-	return seatBid, errs
+
+	seatBids := make([]*pbsOrtbSeatBid, 0, len(seatBidMap))
+	for _, seatBid := range seatBidMap {
+		seatBids = append(seatBids, seatBid)
+	}
+
+	return seatBids, errs
 }
 
 func addNativeTypes(bid *openrtb2.Bid, request *openrtb2.BidRequest) (*nativeResponse.Response, []error) {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +55,7 @@ func TestSingleBidder(t *testing.T) {
 	requestHeaders := http.Header{}
 	requestHeaders.Add("Content-Type", "application/json")
 
-	bidAdjustment := 2.0
+	bidAdjustments := map[string]float64{"test": 2.0}
 	firstInitialPrice := 3.0
 	secondInitialPrice := 4.0
 
@@ -98,7 +99,9 @@ func TestSingleBidder(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: "test",
 		}
-		seatBid, errs := bidder.requestBid(ctx, bidderReq, bidAdjustment, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false)
+		seatBids, errs := bidder.requestBid(ctx, bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
+		assert.Len(t, seatBids, 1)
+		seatBid := seatBids[0]
 
 		// Make sure the goodSingleBidder was called with the expected arguments.
 		if bidderImpl.httpResponse == nil {
@@ -133,6 +136,7 @@ func TestSingleBidder(t *testing.T) {
 				t.Errorf("Bid %d did not have the right deal priority. Expected %s, got %s", index, typedBid.BidType, seatBid.bids[index].bidType)
 			}
 		}
+		bidAdjustment := bidAdjustments["test"]
 		if mockBidderResponse.Bids[0].Bid.Price != bidAdjustment*firstInitialPrice {
 			t.Errorf("Bid[0].Price was not adjusted properly. Expected %f, got %f", bidAdjustment*firstInitialPrice, mockBidderResponse.Bids[0].Bid.Price)
 		}
@@ -184,7 +188,8 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: "test",
 	}
-	seatBid, errs := bidder.requestBid(ctx, bidderReq, 1, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false)
+	bidAdjustments := map[string]float64{"test": 1}
+	seatBids, errs := bidder.requestBid(ctx, bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
 
 	expectedHttpCalls := []*openrtb_ext.ExtHttpCall{
 		{
@@ -197,7 +202,8 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.ElementsMatch(t, seatBid.httpCalls, expectedHttpCalls)
+	assert.Len(t, seatBids, 1)
+	assert.ElementsMatch(t, seatBids[0].httpCalls, expectedHttpCalls)
 }
 
 func TestSetGPCHeader(t *testing.T) {
@@ -228,7 +234,8 @@ func TestSetGPCHeader(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: "test",
 	}
-	seatBid, errs := bidder.requestBid(ctx, bidderReq, 1, currencyConverter.Rates(), &adapters.ExtraRequestInfo{GlobalPrivacyControlHeader: "1"}, true, false)
+	bidAdjustments := map[string]float64{"test": 1}
+	seatBids, errs := bidder.requestBid(ctx, bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{GlobalPrivacyControlHeader: "1"}, true, false, config.AlternateBidderCodes{})
 
 	expectedHttpCall := []*openrtb_ext.ExtHttpCall{
 		{
@@ -241,7 +248,8 @@ func TestSetGPCHeader(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.ElementsMatch(t, seatBid.httpCalls, expectedHttpCall)
+	assert.Len(t, seatBids, 1)
+	assert.ElementsMatch(t, seatBids[0].httpCalls, expectedHttpCall)
 }
 
 func TestSetGPCHeaderNil(t *testing.T) {
@@ -270,7 +278,8 @@ func TestSetGPCHeaderNil(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: "test",
 	}
-	seatBid, errs := bidder.requestBid(ctx, bidderReq, 1, currencyConverter.Rates(), &adapters.ExtraRequestInfo{GlobalPrivacyControlHeader: "1"}, true, false)
+	bidAdjustments := map[string]float64{"test": 1}
+	seatBids, errs := bidder.requestBid(ctx, bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{GlobalPrivacyControlHeader: "1"}, true, false, config.AlternateBidderCodes{})
 
 	expectedHttpCall := []*openrtb_ext.ExtHttpCall{
 		{
@@ -283,7 +292,8 @@ func TestSetGPCHeaderNil(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.ElementsMatch(t, seatBid.httpCalls, expectedHttpCall)
+	assert.Len(t, seatBids, 1)
+	assert.ElementsMatch(t, seatBids[0].httpCalls, expectedHttpCall)
 }
 
 // TestMultiBidder makes sure all the requests get sent, and the responses processed.
@@ -332,17 +342,18 @@ func TestMultiBidder(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: "test",
 	}
-	seatBid, errs := bidder.requestBid(context.Background(), bidderReq, 1.0, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, true)
+	bidAdjustments := map[string]float64{"test": 1.0}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, true, config.AlternateBidderCodes{})
 
-	if seatBid == nil {
+	if len(seatBids) != 1 {
 		t.Fatalf("SeatBid should exist, because bids exist.")
 	}
 
 	if len(errs) != 1+len(bidderImpl.httpRequests) {
 		t.Errorf("Expected %d errors. Got %d", 1+len(bidderImpl.httpRequests), len(errs))
 	}
-	if len(seatBid.bids) != len(bidderImpl.httpResponses)*len(mockBidderResponse.Bids) {
-		t.Errorf("Expected %d bids. Got %d", len(bidderImpl.httpResponses)*len(mockBidderResponse.Bids), len(seatBid.bids))
+	if len(seatBids[0].bids) != len(bidderImpl.httpResponses)*len(mockBidderResponse.Bids) {
+		t.Errorf("Expected %d bids. Got %d", len(bidderImpl.httpResponses)*len(mockBidderResponse.Bids), len(seatBids[0].bids))
 	}
 
 }
@@ -698,15 +709,19 @@ func TestMultiCurrencies(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: openrtb_ext.BidderAppnexus,
 		}
-		seatBid, errs := bidder.requestBid(
+		bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1}
+		seatBids, errs := bidder.requestBid(
 			context.Background(),
 			bidderReq,
-			1,
+			bidAdjustments,
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			true,
 			true,
+			config.AlternateBidderCodes{},
 		)
+		assert.Len(t, seatBids, 1)
+		seatBid := seatBids[0]
 
 		// Verify:
 		resultLightBids := make([]bid, len(seatBid.bids))
@@ -848,15 +863,19 @@ func TestMultiCurrencies_RateConverterNotSet(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: "test",
 		}
-		seatBid, errs := bidder.requestBid(
+		bidAdjustments := map[string]float64{"test": 1}
+		seatBids, errs := bidder.requestBid(
 			context.Background(),
 			bidderReq,
-			1,
+			bidAdjustments,
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			true,
 			true,
+			config.AlternateBidderCodes{},
 		)
+		assert.Len(t, seatBids, 1)
+		seatBid := seatBids[0]
 
 		// Verify:
 		assert.Equal(t, false, (seatBid == nil && tc.expectedBidsCount != 0), tc.description)
@@ -1017,15 +1036,19 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Cur: tc.bidRequestCurrencies, Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: "test",
 		}
-		seatBid, errs := bidder.requestBid(
+		bidAdjustments := map[string]float64{"test": 1}
+		seatBids, errs := bidder.requestBid(
 			context.Background(),
 			bidderReq,
-			1,
+			bidAdjustments,
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			true,
 			false,
+			config.AlternateBidderCodes{},
 		)
+		assert.Len(t, seatBids, 1)
+		seatBid := seatBids[0]
 
 		// Verify:
 		if tc.expectedError {
@@ -1325,18 +1348,21 @@ func TestMobileNativeTypes(t *testing.T) {
 			BidRequest: tc.mockBidderRequest,
 			BidderName: "test",
 		}
+		bidAdjustments := map[string]float64{"test": 1.0}
 		seatBids, _ := bidder.requestBid(
 			context.Background(),
 			bidderReq,
-			1.0,
+			bidAdjustments,
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			true,
 			true,
+			config.AlternateBidderCodes{},
 		)
+		assert.Len(t, seatBids, 1)
 
 		var actualValue string
-		for _, bid := range seatBids.bids {
+		for _, bid := range seatBids[0].bids {
 			actualValue = bid.bid.AdM
 			assert.JSONEq(t, tc.expectedValue, actualValue, tc.description)
 		}
@@ -1396,18 +1422,21 @@ func TestRequestBidsStoredBidResponses(t *testing.T) {
 			BidderName:            openrtb_ext.BidderAppnexus,
 			BidderStoredResponses: tc.bidderStoredResponses,
 		}
+		bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
 		seatBids, _ := bidder.requestBid(
 			context.Background(),
 			bidderReq,
-			1.0,
+			bidAdjustments,
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			true,
 			true,
+			config.AlternateBidderCodes{},
 		)
+		assert.Len(t, seatBids, 1)
 
-		assert.Len(t, seatBids.bids, len(tc.expectedBidIds), "Incorrect bids number for test case ", tc.description)
-		for index, bid := range seatBids.bids {
+		assert.Len(t, seatBids[0].bids, len(tc.expectedBidIds), "Incorrect bids number for test case ", tc.description)
+		for index, bid := range seatBids[0].bids {
 			assert.Equal(t, tc.expectedBidIds[index], bid.bid.ID, tc.description)
 			assert.Equal(t, tc.expectedImpIds[index], bid.bid.ImpID, tc.description)
 		}
@@ -1422,7 +1451,8 @@ func TestErrorReporting(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: "test",
 	}
-	bids, errs := bidder.requestBid(context.Background(), bidderReq, 1.0, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false)
+	bidAdjustments := map[string]float64{"test": 1.0}
+	bids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
 	if bids != nil {
 		t.Errorf("There should be no seatbid if no http requests are returned.")
 	}
@@ -1621,7 +1651,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 	defer server.Close()
 
 	// declare requestBid parameters
-	bidAdjustment := 2.0
+	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 2.0}
 
 	bidderImpl := &goodSingleBidder{
 		httpRequest: &adapters.RequestData{
@@ -1648,7 +1678,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
-	_, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustment, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, true)
+	_, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, true, true, config.AlternateBidderCodes{})
 
 	// Assert no errors
 	assert.Equal(t, 0, len(errs), "bidder.requestBid returned errors %v \n", errs)
@@ -1972,4 +2002,402 @@ func (bidder *notifyingBidder) MakeBids(internalRequest *openrtb2.BidRequest, ex
 
 func (bidder *notifyingBidder) MakeTimeoutNotification(req *adapters.RequestData) (*adapters.RequestData, []error) {
 	return &bidder.notifyRequest, nil
+}
+
+func TestExtraBid(t *testing.T) {
+	respStatus := 200
+	respBody := "{\"bid\":false}"
+	server := httptest.NewServer(mockHandler(respStatus, "getBody", respBody))
+	defer server.Close()
+
+	requestHeaders := http.Header{}
+	requestHeaders.Add("Content-Type", "application/json")
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{
+			Bids: []*adapters.TypedBid{
+				{
+					Bid: &openrtb2.Bid{
+						ID: "pubmaticImp1",
+					},
+					BidType:      openrtb_ext.BidTypeBanner,
+					DealPriority: 4,
+					Seat:         "pubmatic",
+				},
+				{
+					Bid: &openrtb2.Bid{
+						ID: "groupmImp1",
+					},
+					BidType:      openrtb_ext.BidTypeVideo,
+					DealPriority: 5,
+					Seat:         "groupm",
+				},
+			},
+		},
+	}
+
+	wantSeatBids := []*pbsOrtbSeatBid{
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid:            &openrtb2.Bid{ID: "groupmImp1"},
+				dealPriority:   5,
+				bidType:        openrtb_ext.BidTypeVideo,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     "groupm",
+			currency: "USD",
+		},
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid:            &openrtb2.Bid{ID: "pubmaticImp1"},
+				dealPriority:   4,
+				bidType:        openrtb_ext.BidTypeBanner,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     string(openrtb_ext.BidderPubmatic),
+			currency: "USD",
+		},
+	}
+
+	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderAppnexus, &config.DebugInfo{})
+	currencyConverter := currency.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	bidderReq := BidderRequest{
+		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
+		BidderName: openrtb_ext.BidderPubmatic,
+	}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, map[string]float64{}, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
+		config.AlternateBidderCodes{
+			Enabled: true,
+			Adapters: map[string]config.AdapterAlternateBidderCodes{
+				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
+					AllowedBidderCodes: []string{"groupm"},
+				},
+			},
+		})
+	assert.Nil(t, errs)
+	assert.Len(t, seatBids, 2)
+	sort.Slice(seatBids, func(i, j int) bool {
+		return len(seatBids[i].seat) < len(seatBids[j].seat)
+	})
+	assert.Equal(t, wantSeatBids, seatBids)
+}
+
+func TestExtraBidWithAlternateBidderCodeDisabled(t *testing.T) {
+	respStatus := 200
+	respBody := "{\"bid\":false}"
+	server := httptest.NewServer(mockHandler(respStatus, "getBody", respBody))
+	defer server.Close()
+
+	requestHeaders := http.Header{}
+	requestHeaders.Add("Content-Type", "application/json")
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{
+			Bids: []*adapters.TypedBid{
+				{
+					Bid: &openrtb2.Bid{
+						ID: "pubmaticImp1",
+					},
+					BidType:      openrtb_ext.BidTypeBanner,
+					DealPriority: 4,
+					Seat:         "pubmatic",
+				},
+				{
+					Bid: &openrtb2.Bid{
+						ID: "groupmImp1",
+					},
+					BidType:      openrtb_ext.BidTypeVideo,
+					DealPriority: 5,
+					Seat:         "groupm-rejected",
+				},
+				{
+					Bid: &openrtb2.Bid{
+						ID: "groupmImp2",
+					},
+					BidType:      openrtb_ext.BidTypeVideo,
+					DealPriority: 5,
+					Seat:         "groupm-allowed",
+				},
+			},
+		},
+	}
+
+	wantSeatBids := []*pbsOrtbSeatBid{
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid:            &openrtb2.Bid{ID: "groupmImp2"},
+				dealPriority:   5,
+				bidType:        openrtb_ext.BidTypeVideo,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     "groupm-allowed",
+			currency: "USD",
+		},
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid:            &openrtb2.Bid{ID: "pubmaticImp1"},
+				dealPriority:   4,
+				bidType:        openrtb_ext.BidTypeBanner,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     string(openrtb_ext.BidderPubmatic),
+			currency: "USD",
+		},
+	}
+	wantErrs := []error{
+		&errortypes.Warning{
+			WarningCode: errortypes.AlternateBidderCodeWarningCode,
+			Message:     `invalid biddercode "groupm-rejected" sent by adapter "pubmatic"`,
+		},
+	}
+
+	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderAppnexus, &config.DebugInfo{})
+	currencyConverter := currency.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	bidderReq := BidderRequest{
+		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
+		BidderName: openrtb_ext.BidderPubmatic,
+	}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, map[string]float64{}, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
+		config.AlternateBidderCodes{
+			Enabled: true,
+			Adapters: map[string]config.AdapterAlternateBidderCodes{
+				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
+					AllowedBidderCodes: []string{"groupm-allowed"},
+				},
+			},
+		})
+	assert.Equal(t, wantErrs, errs)
+	assert.Len(t, seatBids, 2)
+	assert.ElementsMatch(t, wantSeatBids, seatBids)
+}
+
+func TestExtraBidWithBidAdjustments(t *testing.T) {
+	respStatus := 200
+	respBody := "{\"bid\":false}"
+	server := httptest.NewServer(mockHandler(respStatus, "getBody", respBody))
+	defer server.Close()
+
+	requestHeaders := http.Header{}
+	requestHeaders.Add("Content-Type", "application/json")
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{
+			Bids: []*adapters.TypedBid{
+				{
+					Bid: &openrtb2.Bid{
+						ID:    "pubmaticImp1",
+						Price: 3,
+					},
+					BidType:      openrtb_ext.BidTypeBanner,
+					DealPriority: 4,
+					Seat:         "pubmatic",
+				},
+				{
+					Bid: &openrtb2.Bid{
+						ID:    "groupmImp1",
+						Price: 7,
+					},
+					BidType:      openrtb_ext.BidTypeVideo,
+					DealPriority: 5,
+					Seat:         "groupm",
+				},
+			},
+		},
+	}
+
+	wantSeatBids := []*pbsOrtbSeatBid{
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid: &openrtb2.Bid{
+					ID:    "groupmImp1",
+					Price: 21,
+				},
+				dealPriority:   5,
+				bidType:        openrtb_ext.BidTypeVideo,
+				originalBidCPM: 7,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     "groupm",
+			currency: "USD",
+		},
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid: &openrtb2.Bid{
+					ID:    "pubmaticImp1",
+					Price: 6,
+				},
+				dealPriority:   4,
+				bidType:        openrtb_ext.BidTypeBanner,
+				originalBidCur: "USD",
+				originalBidCPM: 3,
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     string(openrtb_ext.BidderPubmatic),
+			currency: "USD",
+		},
+	}
+
+	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderAppnexus, &config.DebugInfo{})
+	currencyConverter := currency.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	bidderReq := BidderRequest{
+		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
+		BidderName: openrtb_ext.BidderPubmatic,
+	}
+	bidAdjustments := map[string]float64{
+		string(openrtb_ext.BidderPubmatic): 2,
+		string(openrtb_ext.BidderGroupm):   3,
+	}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
+		config.AlternateBidderCodes{
+			Enabled: true,
+			Adapters: map[string]config.AdapterAlternateBidderCodes{
+				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
+					AllowedBidderCodes: []string{"groupm"},
+				},
+			},
+		})
+	assert.Nil(t, errs)
+	assert.Len(t, seatBids, 2)
+	sort.Slice(seatBids, func(i, j int) bool {
+		return len(seatBids[i].seat) < len(seatBids[j].seat)
+	})
+	assert.Equal(t, wantSeatBids, seatBids)
+}
+
+func TestExtraBidWithBidAdjustmentsUsingAdapterCode(t *testing.T) {
+	respStatus := 200
+	respBody := "{\"bid\":false}"
+	server := httptest.NewServer(mockHandler(respStatus, "getBody", respBody))
+	defer server.Close()
+
+	requestHeaders := http.Header{}
+	requestHeaders.Add("Content-Type", "application/json")
+
+	bidderImpl := &goodSingleBidder{
+		httpRequest: &adapters.RequestData{
+			Method:  "POST",
+			Uri:     server.URL,
+			Body:    []byte("{\"key\":\"val\"}"),
+			Headers: http.Header{},
+		},
+		bidResponse: &adapters.BidderResponse{
+			Bids: []*adapters.TypedBid{
+				{
+					Bid: &openrtb2.Bid{
+						ID:    "pubmaticImp1",
+						Price: 3,
+					},
+					BidType:      openrtb_ext.BidTypeBanner,
+					DealPriority: 4,
+					Seat:         "pubmatic",
+				},
+				{
+					Bid: &openrtb2.Bid{
+						ID:    "groupmImp1",
+						Price: 7,
+					},
+					BidType:      openrtb_ext.BidTypeVideo,
+					DealPriority: 5,
+					Seat:         "groupm",
+				},
+			},
+		},
+	}
+
+	wantSeatBids := []*pbsOrtbSeatBid{
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid: &openrtb2.Bid{
+					ID:    "groupmImp1",
+					Price: 14,
+				},
+				dealPriority:   5,
+				bidType:        openrtb_ext.BidTypeVideo,
+				originalBidCPM: 7,
+				originalBidCur: "USD",
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     "groupm",
+			currency: "USD",
+		},
+		{
+			httpCalls: []*openrtb_ext.ExtHttpCall{},
+			bids: []*pbsOrtbBid{{
+				bid: &openrtb2.Bid{
+					ID:    "pubmaticImp1",
+					Price: 6,
+				},
+				dealPriority:   4,
+				bidType:        openrtb_ext.BidTypeBanner,
+				originalBidCur: "USD",
+				originalBidCPM: 3,
+				bidMeta:        &openrtb_ext.ExtBidPrebidMeta{AdapterCode: string(openrtb_ext.BidderPubmatic)},
+			}},
+			seat:     string(openrtb_ext.BidderPubmatic),
+			currency: "USD",
+		},
+	}
+
+	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderAppnexus, &config.DebugInfo{})
+	currencyConverter := currency.NewRateConverter(&http.Client{}, "", time.Duration(0))
+
+	bidderReq := BidderRequest{
+		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
+		BidderName: openrtb_ext.BidderPubmatic,
+	}
+	bidAdjustments := map[string]float64{
+		string(openrtb_ext.BidderPubmatic): 2,
+	}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
+		config.AlternateBidderCodes{
+			Enabled: true,
+			Adapters: map[string]config.AdapterAlternateBidderCodes{
+				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
+					AllowedBidderCodes: []string{"groupm"},
+				},
+			},
+		})
+	assert.Nil(t, errs)
+	assert.Len(t, seatBids, 2)
+	sort.Slice(seatBids, func(i, j int) bool {
+		return len(seatBids[i].seat) < len(seatBids[j].seat)
+	})
+	assert.Equal(t, wantSeatBids, seatBids)
 }

--- a/exchange/bidder_validate_bids_test.go
+++ b/exchange/bidder_validate_bids_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/currency"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ import (
 
 func TestAllValidBids(t *testing.T) {
 	var bidder AdaptedBidder = addValidatedBidderMiddleware(&mockAdaptedBidder{
-		bidResponse: &pbsOrtbSeatBid{
+		bidResponse: []*pbsOrtbSeatBid{{
 			bids: []*pbsOrtbBid{
 				{
 					bid: &openrtb2.Bid{
@@ -50,19 +51,21 @@ func TestAllValidBids(t *testing.T) {
 				},
 			},
 		},
-	})
+		}})
 	bidderReq := BidderRequest{
 		BidRequest: &openrtb2.BidRequest{},
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
-	seatBid, errs := bidder.requestBid(context.Background(), bidderReq, 1.0, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false)
-	assert.Len(t, seatBid.bids, 4)
+	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
+	assert.Len(t, seatBids, 1)
+	assert.Len(t, seatBids[0].bids, 4)
 	assert.Len(t, errs, 0)
 }
 
 func TestAllBadBids(t *testing.T) {
 	bidder := addValidatedBidderMiddleware(&mockAdaptedBidder{
-		bidResponse: &pbsOrtbSeatBid{
+		bidResponse: []*pbsOrtbSeatBid{{
 			bids: []*pbsOrtbBid{
 				{
 					bid: &openrtb2.Bid{
@@ -112,19 +115,21 @@ func TestAllBadBids(t *testing.T) {
 				{},
 			},
 		},
-	})
+		}})
 	bidderReq := BidderRequest{
 		BidRequest: &openrtb2.BidRequest{},
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
-	seatBid, errs := bidder.requestBid(context.Background(), bidderReq, 1.0, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false)
-	assert.Len(t, seatBid.bids, 0)
+	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
+	assert.Len(t, seatBids, 1)
+	assert.Len(t, seatBids[0].bids, 0)
 	assert.Len(t, errs, 7)
 }
 
 func TestMixedBids(t *testing.T) {
 	bidder := addValidatedBidderMiddleware(&mockAdaptedBidder{
-		bidResponse: &pbsOrtbSeatBid{
+		bidResponse: []*pbsOrtbSeatBid{{
 			bids: []*pbsOrtbBid{
 				{
 					bid: &openrtb2.Bid{
@@ -185,13 +190,15 @@ func TestMixedBids(t *testing.T) {
 				{},
 			},
 		},
-	})
+		}})
 	bidderReq := BidderRequest{
 		BidRequest: &openrtb2.BidRequest{},
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
-	seatBid, errs := bidder.requestBid(context.Background(), bidderReq, 1.0, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false)
-	assert.Len(t, seatBid.bids, 3)
+	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
+	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
+	assert.Len(t, seatBids, 1)
+	assert.Len(t, seatBids[0].bids, 3)
 	assert.Len(t, errs, 5)
 }
 
@@ -291,11 +298,11 @@ func TestCurrencyBids(t *testing.T) {
 			},
 		}
 		bidder := addValidatedBidderMiddleware(&mockAdaptedBidder{
-			bidResponse: &pbsOrtbSeatBid{
+			bidResponse: []*pbsOrtbSeatBid{{
 				currency: tc.brpCur,
 				bids:     bids,
 			},
-		})
+			}})
 
 		expectedValidBids := len(bids)
 		expectedErrs := 0
@@ -310,18 +317,19 @@ func TestCurrencyBids(t *testing.T) {
 			Cur: tc.brqCur,
 		}
 		bidderRequest := BidderRequest{BidRequest: request, BidderName: openrtb_ext.BidderAppnexus}
-
-		seatBid, errs := bidder.requestBid(context.Background(), bidderRequest, 1.0, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false)
-		assert.Len(t, seatBid.bids, expectedValidBids)
+		bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
+		seatBids, errs := bidder.requestBid(context.Background(), bidderRequest, bidAdjustments, currency.NewConstantRates(), &adapters.ExtraRequestInfo{}, true, false, config.AlternateBidderCodes{})
+		assert.Len(t, seatBids, 1)
+		assert.Len(t, seatBids[0].bids, expectedValidBids)
 		assert.Len(t, errs, expectedErrs)
 	}
 }
 
 type mockAdaptedBidder struct {
-	bidResponse   *pbsOrtbSeatBid
+	bidResponse   []*pbsOrtbSeatBid
 	errorResponse []error
 }
 
-func (b *mockAdaptedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustment float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool) (*pbsOrtbSeatBid, []error) {
+func (b *mockAdaptedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, bidAdjustments map[string]float64, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, accountDebugAllowed, headerDebugAllowed bool, alternateBidderCodes config.AlternateBidderCodes) ([]*pbsOrtbSeatBid, []error) {
 	return b.bidResponse, b.errorResponse
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -78,9 +78,9 @@ type seatResponseExtra struct {
 }
 
 type bidResponseWrapper struct {
-	adapterBids  *pbsOrtbSeatBid
-	adapterExtra *seatResponseExtra
-	bidder       openrtb_ext.BidderName
+	adapterSeatBids []*pbsOrtbSeatBid
+	adapterExtra    *seatResponseExtra
+	bidder          openrtb_ext.BidderName
 }
 
 type BidIDGenerator interface {
@@ -273,7 +273,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r AuctionRequest, debugLog *
 	} else {
 		// List of bidders we have requests for.
 		liveAdapters = listBiddersWithRequests(bidderRequests)
-		adapterBids, adapterExtra, anyBidsReturned = e.getAllBids(auctionCtx, bidderRequests, bidAdjustmentFactors, conversions, accountDebugAllow, r.GlobalPrivacyControlHeader, debugLog.DebugOverride)
+		adapterBids, adapterExtra, anyBidsReturned = e.getAllBids(auctionCtx, bidderRequests, bidAdjustmentFactors, conversions, accountDebugAllow, r.GlobalPrivacyControlHeader, debugLog.DebugOverride, r.Account.AlternateBidderCodes)
 	}
 
 	var auc *auction
@@ -480,7 +480,8 @@ func (e *exchange) getAllBids(
 	conversions currency.Conversions,
 	accountDebugAllowed bool,
 	globalPrivacyControlHeader string,
-	headerDebugAllowed bool) (
+	headerDebugAllowed bool,
+	alternateBidderCodes config.AlternateBidderCodes) (
 	map[openrtb_ext.BidderName]*pbsOrtbSeatBid,
 	map[openrtb_ext.BidderName]*seatResponseExtra, bool) {
 	// Set up pointers to the bid results
@@ -505,39 +506,37 @@ func (e *exchange) getAllBids(
 			}()
 			start := time.Now()
 
-			adjustmentFactor := 1.0
-			if givenAdjustment, ok := bidAdjustments[string(bidderRequest.BidderName)]; ok {
-				adjustmentFactor = givenAdjustment
-			}
 			reqInfo := adapters.NewExtraRequestInfo(conversions)
 			reqInfo.PbsEntryPoint = bidderRequest.BidderLabels.RType
 			reqInfo.GlobalPrivacyControlHeader = globalPrivacyControlHeader
 
-			bids, err := e.adapterMap[bidderRequest.BidderCoreName].requestBid(ctx, bidderRequest, adjustmentFactor, conversions, &reqInfo, accountDebugAllowed, headerDebugAllowed)
+			seatBids, err := e.adapterMap[bidderRequest.BidderCoreName].requestBid(ctx, bidderRequest, bidAdjustments, conversions, &reqInfo, accountDebugAllowed, headerDebugAllowed, alternateBidderCodes)
 
 			// Add in time reporting
 			elapsed := time.Since(start)
-			brw.adapterBids = bids
+			brw.adapterSeatBids = seatBids
 			// Structure to record extra tracking data generated during bidding
 			ae := new(seatResponseExtra)
 			ae.ResponseTimeMillis = int(elapsed / time.Millisecond)
-			if bids != nil {
-				ae.HttpCalls = bids.httpCalls
+			if len(seatBids) != 0 {
+				ae.HttpCalls = seatBids[0].httpCalls
 			}
 
 			// Timing statistics
 			e.me.RecordAdapterTime(bidderRequest.BidderLabels, time.Since(start))
-			bidderRequest.BidderLabels.AdapterBids = bidsToMetric(brw.adapterBids)
+			bidderRequest.BidderLabels.AdapterBids = bidsToMetric(brw.adapterSeatBids)
 			bidderRequest.BidderLabels.AdapterErrors = errorsToMetric(err)
 			// Append any bid validation errors to the error list
 			ae.Errors = errsToBidderErrors(err)
 			ae.Warnings = errsToBidderWarnings(err)
 			brw.adapterExtra = ae
-			if bids != nil {
-				for _, bid := range bids.bids {
-					var cpm = float64(bid.bid.Price * 1000)
-					e.me.RecordAdapterPrice(bidderRequest.BidderLabels, cpm)
-					e.me.RecordAdapterBidReceived(bidderRequest.BidderLabels, bid.bidType, bid.bid.AdM != "")
+			for _, seatBid := range seatBids {
+				if seatBid != nil {
+					for _, bid := range seatBid.bids {
+						var cpm = float64(bid.bid.Price * 1000)
+						e.me.RecordAdapterPrice(bidderRequest.BidderLabels, cpm)
+						e.me.RecordAdapterBidReceived(bidderRequest.BidderLabels, bid.bidType, bid.bid.AdM != "")
+					}
 				}
 			}
 			chBids <- brw
@@ -549,8 +548,14 @@ func (e *exchange) getAllBids(
 		brw := <-chBids
 
 		//if bidder returned no bids back - remove bidder from further processing
-		if brw.adapterBids != nil && len(brw.adapterBids.bids) != 0 {
-			adapterBids[brw.bidder] = brw.adapterBids
+		for _, seatBid := range brw.adapterSeatBids {
+			if seatBid != nil && len(seatBid.bids) != 0 {
+				if _, ok := adapterBids[openrtb_ext.BidderName(seatBid.seat)]; ok {
+					adapterBids[openrtb_ext.BidderName(seatBid.seat)].bids = append(adapterBids[openrtb_ext.BidderName(seatBid.seat)].bids, seatBid.bids...)
+				} else {
+					adapterBids[openrtb_ext.BidderName(seatBid.seat)] = seatBid
+				}
+			}
 		}
 		//but we need to add all bidders data to adapterExtra to have metrics and other metadata
 		adapterExtra[brw.bidder] = brw.adapterExtra
@@ -594,11 +599,13 @@ func (e *exchange) recoverSafely(bidderRequests []BidderRequest,
 	}
 }
 
-func bidsToMetric(bids *pbsOrtbSeatBid) metrics.AdapterBid {
-	if bids == nil || len(bids.bids) == 0 {
-		return metrics.AdapterBidNone
+func bidsToMetric(seatBids []*pbsOrtbSeatBid) metrics.AdapterBid {
+	for _, seatBid := range seatBids {
+		if seatBid != nil && len(seatBid.bids) != 0 {
+			return metrics.AdapterBidPresent
+		}
 	}
-	return metrics.AdapterBidPresent
+	return metrics.AdapterBidNone
 }
 
 func errorsToMetric(errs []error) map[metrics.AdapterError]struct{} {
@@ -617,6 +624,8 @@ func errorsToMetric(errs []error) map[metrics.AdapterError]struct{} {
 			ret[metrics.AdapterErrorBadServerResponse] = s
 		case errortypes.FailedToRequestBidsErrorCode:
 			ret[metrics.AdapterErrorFailedToRequestBids] = s
+		case errortypes.AlternateBidderCodeWarningCode:
+			ret[metrics.AdapterErrorValidation] = s
 		default:
 			ret[metrics.AdapterErrorUnknown] = s
 		}
@@ -650,7 +659,7 @@ func errsToBidderWarnings(errs []error) []openrtb_ext.ExtBidderMessage {
 }
 
 // This piece takes all the bids supplied by the adapters and crafts an openRTB response to send back to the requester
-func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, bidRequest *openrtb2.BidRequest, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, errList []error) (*openrtb2.BidResponse, error) {
+func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterSeatBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, bidRequest *openrtb2.BidRequest, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, errList []error) (*openrtb2.BidResponse, error) {
 	bidResponse := new(openrtb2.BidResponse)
 	var err error
 
@@ -663,12 +672,12 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 	// Create the SeatBids. We use a zero sized slice so that we can append non-zero seat bids, and not include seatBid
 	// objects for seatBids without any bids. Preallocate the max possible size to avoid reallocating the array as we go.
 	seatBids := make([]openrtb2.SeatBid, 0, len(liveAdapters))
-	for _, a := range liveAdapters {
+	for a, adapterSeatBids := range adapterSeatBids {
 		//while processing every single bib, do we need to handle categories here?
-		if adapterBids[a] != nil && len(adapterBids[a].bids) > 0 {
-			sb := e.makeSeatBid(adapterBids[a], a, adapterExtra, auc, returnCreative, impExtInfoMap)
+		if adapterSeatBids != nil && len(adapterSeatBids.bids) > 0 {
+			sb := e.makeSeatBid(adapterSeatBids, a, adapterExtra, auc, returnCreative, impExtInfoMap)
 			seatBids = append(seatBids, *sb)
-			bidResponse.Cur = adapterBids[a].currency
+			bidResponse.Cur = adapterSeatBids.currency
 		}
 	}
 
@@ -1176,7 +1185,7 @@ func buildStoredAuctionResponse(storedAuctionResponses map[string]json.RawMessag
 			} else {
 				//create new seat bid and add it to live adapters
 				liveAdapters = append(liveAdapters, bidderName)
-				newSeatBid := pbsOrtbSeatBid{bidsToAdd, "", nil}
+				newSeatBid := pbsOrtbSeatBid{bidsToAdd, "", nil, ""}
 				adapterBids[bidderName] = &newSeatBid
 
 			}

--- a/exchange/exchangetest/aliases.json
+++ b/exchange/exchangetest/aliases.json
@@ -64,8 +64,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]
@@ -101,8 +100,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["districtm-error"]

--- a/exchange/exchangetest/append-bidder-names.json
+++ b/exchange/exchangetest/append-bidder-names.json
@@ -54,7 +54,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -88,8 +88,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/bid-consolidation-test.json
+++ b/exchange/exchangetest/bid-consolidation-test.json
@@ -48,7 +48,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -72,13 +72,14 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "rubicon": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -91,8 +92,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "rubicon"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/bid-ext-prebid-collision.json
+++ b/exchange/exchangetest/bid-ext-prebid-collision.json
@@ -39,11 +39,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -61,8 +60,9 @@
                             }
                         },
                         "bidType": "video"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/bid-ext.json
+++ b/exchange/exchangetest/bid-ext.json
@@ -39,11 +39,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -58,8 +57,9 @@
                             }
                         },
                         "bidType": "video"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/bid-id-invalid.json
+++ b/exchange/exchangetest/bid-id-invalid.json
@@ -45,7 +45,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -65,8 +65,9 @@
                 "PrimaryCategory": ""
               }
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/bid-id-valid.json
+++ b/exchange/exchangetest/bid-id-valid.json
@@ -45,7 +45,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -65,8 +65,9 @@
                 "PrimaryCategory": ""
               }
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/bidadjustmentfactors.json
+++ b/exchange/exchangetest/bidadjustmentfactors.json
@@ -67,7 +67,10 @@
             }
           }
         },
-        "bidAdjustment": 2.5
+        "bidAdjustments": {
+          "appnexus": 2.5,
+          "districtm": 0.3
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]
@@ -105,7 +108,10 @@
             }
           }
         },
-        "bidAdjustment": 0.3
+        "bidAdjustments": {
+          "appnexus": 2.5,
+          "districtm": 0.3
+        }
       },
       "mockResponse": {
         "errors": ["districtm-error"]

--- a/exchange/exchangetest/ccpa-featureflag-off.json
+++ b/exchange/exchangetest/ccpa-featureflag-off.json
@@ -54,8 +54,7 @@
                     "user": {
                         "buyeruid": "some-buyer-id"
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/ccpa-featureflag-on.json
+++ b/exchange/exchangetest/ccpa-featureflag-on.json
@@ -53,8 +53,7 @@
                     },
                     "user": {
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/ccpa-nosale-any-bidder.json
+++ b/exchange/exchangetest/ccpa-nosale-any-bidder.json
@@ -64,8 +64,7 @@
                     "user": {
                         "buyeruid": "some-buyer-id"
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/ccpa-nosale-specific-bidder.json
+++ b/exchange/exchangetest/ccpa-nosale-specific-bidder.json
@@ -64,8 +64,7 @@
                     "user": {
                         "buyeruid": "some-buyer-id"
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/debuglog_disabled.json
+++ b/exchange/exchangetest/debuglog_disabled.json
@@ -63,7 +63,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -97,8 +97,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/debuglog_enabled.json
+++ b/exchange/exchangetest/debuglog_enabled.json
@@ -65,7 +65,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -99,8 +99,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/debuglog_enabled_no_bids.json
+++ b/exchange/exchangetest/debuglog_enabled_no_bids.json
@@ -64,7 +64,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {}
+        "pbsSeatBids": [{}]
       }
     }
   },

--- a/exchange/exchangetest/eidpermissions-allowed-alias.json
+++ b/exchange/exchangetest/eidpermissions-allowed-alias.json
@@ -79,11 +79,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -94,8 +93,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "video"
-                    }]
-                }
+                    }],
+                    "seat": "foo"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/eidpermissions-allowed.json
+++ b/exchange/exchangetest/eidpermissions-allowed.json
@@ -73,11 +73,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -88,8 +87,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "video"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/eidpermissions-denied.json
+++ b/exchange/exchangetest/eidpermissions-denied.json
@@ -67,11 +67,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -82,8 +81,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "video"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/events-bid-account-off-request-off.json
+++ b/exchange/exchangetest/events-bid-account-off-request-off.json
@@ -27,7 +27,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -51,8 +51,9 @@
               },
               "bidType": "banner"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/events-bid-account-off-request-on.json
+++ b/exchange/exchangetest/events-bid-account-off-request-on.json
@@ -29,7 +29,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -53,8 +53,9 @@
               },
               "bidType": "banner"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/events-bid-account-on-request-off.json
+++ b/exchange/exchangetest/events-bid-account-on-request-off.json
@@ -28,7 +28,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -52,8 +52,9 @@
               },
               "bidType": "banner"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/events-vast-account-off-request-off.json
+++ b/exchange/exchangetest/events-vast-account-off-request-off.json
@@ -35,7 +35,7 @@
     "appnexus": {
       "modifyingVastXmlAllowed": true,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -61,14 +61,15 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "modifyingVastXmlAllowed": false,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -82,8 +83,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/events-vast-account-off-request-on.json
+++ b/exchange/exchangetest/events-vast-account-off-request-on.json
@@ -41,7 +41,7 @@
     "appnexus": {
       "modifyingVastXmlAllowed": true,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -67,14 +67,15 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "modifyingVastXmlAllowed": false,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -88,8 +89,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/events-vast-account-on-request-off.json
+++ b/exchange/exchangetest/events-vast-account-on-request-off.json
@@ -36,7 +36,7 @@
     "appnexus": {
       "modifyingVastXmlAllowed": true,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -62,14 +62,15 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "modifyingVastXmlAllowed": false,
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -83,8 +84,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/explicit-buyeruid.json
+++ b/exchange/exchangetest/explicit-buyeruid.json
@@ -57,8 +57,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
+++ b/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
@@ -2,8 +2,8 @@
   "incomingRequest": {
     "ortbRequest": {
       "id": "some-request-id",
-      "app": {
-        "id": "some-app"
+      "site": {
+        "page": "test.somepage.com"
       },
       "imp": [
         {
@@ -12,11 +12,8 @@
             "mimes": ["video/mp4"]
           },
           "ext": {
-            "appnexus": {
-              "placementId": 1
-            },
-            "audienceNetwork": {
-              "placementId": "some-placement"
+            "pmbidder": {
+              "publisherId": 5890
             }
           }
         },
@@ -26,24 +23,27 @@
             "mimes": ["video/mp4"]
           },
           "ext": {
-            "appnexus": {
-              "placementId": 2
-            },
-            "audienceNetwork": {
-              "placementId": "some-other-placement"
+            "pmbidder": {
+              "publisherId": 5890
             }
           }
         }
       ],
       "ext": {
         "prebid": {
-          "targeting": {}
+          "targeting": {
+            "includewinners": true,
+            "includebidderkeys": true
+          },
+          "aliases": {
+            "pmbidder": "pubmatic"
+          }
         }
       }
     }
   },
   "outgoingRequests": {
-    "appnexus": {
+    "pmbidder": {
       "mockResponse": {
         "pbsSeatBids": [{
           "pbsBids": [
@@ -56,7 +56,10 @@
                 "h": 250,
                 "crid": "creative-1"
               },
-              "bidType": "video"
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pmbidder"
+              }
             },
             {
               "ortbBid": {
@@ -67,7 +70,10 @@
                 "h": 250,
                 "crid": "creative-2"
               },
-              "bidType": "video"
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pmbidder"
+              }
             },
             {
               "ortbBid": {
@@ -78,16 +84,15 @@
                 "h": 500,
                 "crid": "creative-3"
               },
-              "bidType": "video"
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pmbidder"
+              }
             }
           ],
-          "seat": "appnexus"
-        }]
-      }
-    },
-    "audienceNetwork": {
-      "mockResponse": {
-        "pbsSeatBids": [{
+          "seat": "groupm"
+        },
+        {
           "pbsBids": [
             {
               "ortbBid": {
@@ -98,10 +103,13 @@
                 "h": 250,
                 "crid": "creative-4"
               },
-              "bidType": "video"
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pmbidder"
+              }
             }
           ],
-          "seat": "audienceNetwork"
+          "seat": "pmbidder"
         }]
       }
     }
@@ -111,7 +119,7 @@
       "id": "some-request-id",
       "seatbid": [
         {
-          "seat": "audienceNetwork",
+          "seat": "pmbidder",
           "bid": [{
             "id": "contending-bid",
             "impid": "my-imp-id",
@@ -122,21 +130,23 @@
             "ext": {
               "origbidcpm": 0.51,
               "prebid": {
+                "meta": {
+                  "adaptercode": "pmbidder"
+                },
                 "type": "video",
                 "targeting": {
-                  "hb_bidder_audienceNe": "audienceNetwork",
-                  "hb_cache_host_audien": "www.pbcserver.com",
-                  "hb_cache_path_audien": "/pbcache/endpoint",
-                  "hb_pb_audienceNetwor": "0.50",
-                  "hb_size_audienceNetw": "200x250",
-                  "hb_env_audienceNetwo": "mobile-app"
+                  "hb_bidder_pmbidder": "pmbidder",
+                  "hb_cache_host_pmbidd": "www.pbcserver.com",
+                  "hb_cache_path_pmbidd": "/pbcache/endpoint",
+                  "hb_pb_pmbidder": "0.50",
+                  "hb_size_pmbidder": "200x250"
                 }
               }
             }
           }]
         },
         {
-          "seat": "appnexus",
+          "seat": "groupm",
           "bid": [{
             "id": "winning-bid",
             "impid": "my-imp-id",
@@ -147,20 +157,21 @@
             "ext": {
               "origbidcpm": 0.71,
               "prebid": {
+                "meta": {
+                  "adaptercode": "pmbidder"
+                },
                 "type": "video",
                 "targeting": {
-                  "hb_bidder": "appnexus",
+                  "hb_bidder": "groupm",
+                  "hb_bidder_groupm": "groupm",
                   "hb_cache_host": "www.pbcserver.com",
-                  "hb_cache_host_appnex": "www.pbcserver.com",
+                  "hb_cache_host_groupm": "www.pbcserver.com",
                   "hb_cache_path": "/pbcache/endpoint",
-                  "hb_cache_path_appnex": "/pbcache/endpoint",
-                  "hb_bidder_appnexus": "appnexus",
+                  "hb_cache_path_groupm": "/pbcache/endpoint",
                   "hb_pb": "0.70",
-                  "hb_pb_appnexus": "0.70",
+                  "hb_pb_groupm": "0.70",
                   "hb_size": "200x250",
-                  "hb_size_appnexus": "200x250",
-                  "hb_env": "mobile-app",
-                  "hb_env_appnexus": "mobile-app"
+                  "hb_size_groupm": "200x250"
                 }
               }
             }
@@ -175,6 +186,9 @@
             "ext": {
               "origbidcpm": 0.21,
               "prebid": {
+                "meta": {
+                  "adaptercode": "pmbidder"
+                },
                 "type": "video"
               }
             }
@@ -189,20 +203,21 @@
             "ext": {
               "origbidcpm": 0.61,
               "prebid": {
+                "meta": {
+                  "adaptercode": "pmbidder"
+                },
                 "type": "video",
                 "targeting": {
-                  "hb_bidder": "appnexus",
+                  "hb_bidder": "groupm",
+                  "hb_bidder_groupm": "groupm",
                   "hb_cache_host": "www.pbcserver.com",
-                  "hb_cache_host_appnex": "www.pbcserver.com",
+                  "hb_cache_host_groupm": "www.pbcserver.com",
                   "hb_cache_path": "/pbcache/endpoint",
-                  "hb_cache_path_appnex": "/pbcache/endpoint",
-                  "hb_bidder_appnexus": "appnexus",
+                  "hb_cache_path_groupm": "/pbcache/endpoint",
                   "hb_pb": "0.60",
-                  "hb_pb_appnexus": "0.60",
+                  "hb_pb_groupm": "0.60",
                   "hb_size": "300x500",
-                  "hb_size_appnexus": "300x500",
-                  "hb_env": "mobile-app",
-                  "hb_env_appnexus": "mobile-app"
+                  "hb_size_groupm": "300x500"
                 }
               }
             }

--- a/exchange/exchangetest/extra-bids.json
+++ b/exchange/exchangetest/extra-bids.json
@@ -1,0 +1,318 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "pubmatic": {
+              "publisherId": 5890
+            },
+            "appnexus": {
+              "placementId": 1
+            }
+          }
+        },
+        {
+          "id": "imp-id-2",
+          "video": {
+            "mimes": ["video/mp4"]
+          },
+          "ext": {
+            "pubmatic": {
+              "publisherId": 5890
+            },
+            "appnexus": {
+              "placementId": 1
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "targeting": {
+            "includewinners": true,
+            "includebidderkeys": true
+          }
+        }
+      }
+    }
+  },
+  "outgoingRequests": {
+    "pubmatic": {
+      "mockResponse": {
+        "pbsSeatBids": [{
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "winning-bid",
+                "impid": "my-imp-id",
+                "price": 0.71,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-1"
+              },
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pubmatic"
+              }
+            },
+            {
+              "ortbBid": {
+                "id": "losing-bid",
+                "impid": "my-imp-id",
+                "price": 0.21,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-2"
+              },
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pubmatic"
+              }
+            },
+            {
+              "ortbBid": {
+                "id": "other-bid",
+                "impid": "imp-id-2",
+                "price": 0.61,
+                "w": 300,
+                "h": 500,
+                "crid": "creative-3"
+              },
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pubmatic"
+              }
+            }
+          ],
+          "seat": "pubmatic"
+        },
+        {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "contending-bid",
+                "impid": "my-imp-id",
+                "price": 0.51,
+                "w": 200,
+                "h": 250,
+                "crid": "creative-4"
+              },
+              "bidType": "video",
+              "bidMeta": {
+                "adaptercode": "pubmatic"
+              }
+            }
+          ],
+          "seat": "groupm"
+        }]
+      }
+    },
+    "appnexus": {
+      "mockResponse": {
+        "pbsSeatBids": [{
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "apn-bid",
+                "impid": "my-imp-id",
+                "price": 0.3,
+                "w": 200,
+                "h": 500,
+                "crid": "creative-a-1"
+              },
+              "bidType": "banner",
+              "bidMeta": {
+                "adaptercode": "appnexus"
+              }
+            }
+          ],
+          "seat": "appnexus"
+        },
+        {
+          "pbsBids": [
+            {
+              "ortbBid": {
+                "id": "apn-bid-2",
+                "impid": "my-imp-id",
+                "price": 0.3,
+                "w": 200,
+                "h": 500,
+                "crid": "creative-a-2"
+              },
+              "bidType": "banner",
+              "bidMeta": {
+                "adaptercode": "appnexus"
+              }
+            }
+          ],
+          "seat": "groupm"
+        }]
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "seatbid": [
+        {
+          "seat": "groupm",
+          "bid": [{
+            "id": "contending-bid",
+            "impid": "my-imp-id",
+            "price": 0.51,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-4",
+            "ext": {
+              "origbidcpm": 0.51,
+              "prebid": {
+                "meta": {
+                  "adaptercode": "pubmatic"
+                },
+                "type": "video",
+                "targeting": {
+                  "hb_bidder_groupm": "groupm",
+                  "hb_cache_host_groupm": "www.pbcserver.com",
+                  "hb_cache_path_groupm": "/pbcache/endpoint",
+                  "hb_pb_groupm": "0.50",
+                  "hb_size_groupm": "200x250"
+                }
+              }
+            }
+          },
+          {
+            "id": "apn-bid-2",
+            "impid": "my-imp-id",
+            "price": 0.3,
+            "w": 200,
+            "h": 500,
+            "crid": "creative-a-2",
+            "ext": {
+              "origbidcpm": 0.3,
+              "prebid": {
+                "meta": {
+                  "adaptercode": "appnexus"
+                },
+                "type": "banner"
+              }
+            }
+          }]
+        },
+        {
+          "seat": "pubmatic",
+          "bid": [{
+            "id": "winning-bid",
+            "impid": "my-imp-id",
+            "price": 0.71,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-1",
+            "ext": {
+              "origbidcpm": 0.71,
+              "prebid": {
+                "meta": {
+                  "adaptercode": "pubmatic"
+                },
+                "type": "video",
+                "targeting": {
+                  "hb_bidder": "pubmatic",
+                  "hb_bidder_pubmatic": "pubmatic",
+                  "hb_cache_host": "www.pbcserver.com",
+                  "hb_cache_host_pubmat": "www.pbcserver.com",
+                  "hb_cache_path": "/pbcache/endpoint",
+                  "hb_cache_path_pubmat": "/pbcache/endpoint",
+                  "hb_pb": "0.70",
+                  "hb_pb_pubmatic": "0.70",
+                  "hb_size": "200x250",
+                  "hb_size_pubmatic": "200x250"
+                }
+              }
+            }
+          },
+          {
+            "id": "losing-bid",
+            "impid": "my-imp-id",
+            "price": 0.21,
+            "w": 200,
+            "h": 250,
+            "crid": "creative-2",
+            "ext": {
+              "origbidcpm": 0.21,
+              "prebid": {
+                "meta": {
+                  "adaptercode": "pubmatic"
+                },
+                "type": "video"
+              }
+            }
+          },
+          {
+            "id": "other-bid",
+            "impid": "imp-id-2",
+            "price": 0.61,
+            "w": 300,
+            "h": 500,
+            "crid": "creative-3",
+            "ext": {
+              "origbidcpm": 0.61,
+              "prebid": {
+                "meta": {
+                  "adaptercode": "pubmatic"
+                },
+                "type": "video",
+                "targeting": {
+                  "hb_bidder": "pubmatic",
+                  "hb_bidder_pubmatic": "pubmatic",
+                  "hb_cache_host": "www.pbcserver.com",
+                  "hb_cache_host_pubmat": "www.pbcserver.com",
+                  "hb_cache_path": "/pbcache/endpoint",
+                  "hb_cache_path_pubmat": "/pbcache/endpoint",
+                  "hb_pb": "0.60",
+                  "hb_pb_pubmatic": "0.60",
+                  "hb_size": "300x500",
+                  "hb_size_pubmatic": "300x500"
+                }
+              }
+            }
+          }]
+        },
+        {
+          "seat": "appnexus",
+          "bid": [{
+            "id": "apn-bid",
+            "impid": "my-imp-id",
+            "price": 0.3,
+            "w": 200,
+            "h": 500,
+            "crid": "creative-a-1",
+            "ext": {
+                "origbidcpm": 0.3,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "banner",
+                  "targeting": {
+                    "hb_bidder_appnexus":"appnexus",
+                    "hb_cache_host_appnex":"www.pbcserver.com",
+                    "hb_cache_path_appnex":"/pbcache/endpoint",
+                    "hb_pb_appnexus":"0.20",
+                    "hb_size_appnexus":"200x500"
+                  }
+                }
+            }
+          }]
+        }
+      ]
+    }
+  }
+}

--- a/exchange/exchangetest/firstpartydata-imp-ext-multiple-bidders.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-multiple-bidders.json
@@ -71,11 +71,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -86,8 +85,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         },
         "rubicon": {
@@ -124,11 +124,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "rubi-bid",
@@ -139,8 +138,9 @@
                             "crid": "creative-2"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "rubicon"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json
@@ -75,11 +75,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -90,8 +89,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         },
         "rubicon": {
@@ -128,11 +128,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "rubi-bid",
@@ -143,8 +142,9 @@
                             "crid": "creative-2"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "rubicon"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/firstpartydata-imp-ext-one-bidder.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-one-bidder.json
@@ -66,11 +66,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -81,8 +80,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
@@ -70,11 +70,10 @@
                             }
                         }
                     }]
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
-                "pbsSeatBid": {
+                "pbsSeatBids": [{
                     "pbsBids": [{
                         "ortbBid": {
                             "id": "apn-bid",
@@ -85,8 +84,9 @@
                             "crid": "creative-1"
                         },
                         "bidType": "banner"
-                    }]
-                }
+                    }],
+                    "seat": "appnexus"
+                }]
             }
         }
     },

--- a/exchange/exchangetest/firstpartydata-multibidder-config-valid.json
+++ b/exchange/exchangetest/firstpartydata-multibidder-config-valid.json
@@ -111,8 +111,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       }
     },
     "rubicon": {
@@ -154,8 +153,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       }
     }
   }

--- a/exchange/exchangetest/gdpr-geo-eu-off-device.json
+++ b/exchange/exchangetest/gdpr-geo-eu-off-device.json
@@ -54,8 +54,7 @@
                             "country": "FRA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/gdpr-geo-eu-off.json
+++ b/exchange/exchangetest/gdpr-geo-eu-off.json
@@ -50,8 +50,7 @@
                             "country": "FRA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/gdpr-geo-eu-on-featureflag-off.json
+++ b/exchange/exchangetest/gdpr-geo-eu-on-featureflag-off.json
@@ -51,8 +51,7 @@
                             "country": "FRA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/gdpr-geo-eu-on.json
+++ b/exchange/exchangetest/gdpr-geo-eu-on.json
@@ -50,8 +50,7 @@
                             "country": "FRA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/gdpr-geo-usa-off.json
+++ b/exchange/exchangetest/gdpr-geo-usa-off.json
@@ -50,8 +50,7 @@
                             "country": "USA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/gdpr-geo-usa-on.json
+++ b/exchange/exchangetest/gdpr-geo-usa-on.json
@@ -50,8 +50,7 @@
                             "country": "USA"
                         }
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/include-brand-category.json
+++ b/exchange/exchangetest/include-brand-category.json
@@ -48,7 +48,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -78,8 +78,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/lmt-featureflag-off.json
+++ b/exchange/exchangetest/lmt-featureflag-off.json
@@ -52,8 +52,7 @@
                         "id": "some-id",
                         "buyeruid": "some-buyer-id"
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/lmt-featureflag-on.json
+++ b/exchange/exchangetest/lmt-featureflag-on.json
@@ -50,8 +50,7 @@
                     },
                     "user": {
                     }
-                },
-                "bidAdjustment": 1.0
+                }
             },
             "mockResponse": {
                 "errors": ["appnexus-error"]

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -70,7 +70,7 @@
             "status": 200
           }
         ],
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -85,8 +85,9 @@
                 ]
               }
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {

--- a/exchange/exchangetest/request-multi-bidders-one-no-resp.json
+++ b/exchange/exchangetest/request-multi-bidders-one-no-resp.json
@@ -53,7 +53,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -68,8 +68,9 @@
                 ]
               }
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {

--- a/exchange/exchangetest/request-no-user.json
+++ b/exchange/exchangetest/request-no-user.json
@@ -47,8 +47,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/request-other-user-ext.json
+++ b/exchange/exchangetest/request-other-user-ext.json
@@ -58,8 +58,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/request-other-user.json
+++ b/exchange/exchangetest/request-other-user.json
@@ -51,8 +51,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/request-user-no-prebid.json
+++ b/exchange/exchangetest/request-user-no-prebid.json
@@ -55,8 +55,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/targeting-cache-vast-banner.json
+++ b/exchange/exchangetest/targeting-cache-vast-banner.json
@@ -32,7 +32,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -45,8 +45,9 @@
               },
               "bidType": "banner"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/targeting-cache-vast.json
+++ b/exchange/exchangetest/targeting-cache-vast.json
@@ -31,7 +31,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -44,8 +44,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/targeting-cache-zero.json
+++ b/exchange/exchangetest/targeting-cache-zero.json
@@ -34,7 +34,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -47,8 +47,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/targeting-no-winners.json
+++ b/exchange/exchangetest/targeting-no-winners.json
@@ -47,7 +47,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -82,13 +82,14 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -101,8 +102,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/targeting-only-winners.json
+++ b/exchange/exchangetest/targeting-only-winners.json
@@ -47,7 +47,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -82,13 +82,14 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -101,8 +102,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/targeting-with-winners.json
+++ b/exchange/exchangetest/targeting-with-winners.json
@@ -45,7 +45,7 @@
   "outgoingRequests": {
     "appnexus": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -80,13 +80,14 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "appnexus"
+        }]
       }
     },
     "audienceNetwork": {
       "mockResponse": {
-        "pbsSeatBid": {
+        "pbsSeatBids": [{
           "pbsBids": [
             {
               "ortbBid": {
@@ -99,8 +100,9 @@
               },
               "bidType": "video"
             }
-          ]
-        }
+          ],
+          "seat": "audienceNetwork"
+        }]
       }
     }
   },

--- a/exchange/exchangetest/tmax.json
+++ b/exchange/exchangetest/tmax.json
@@ -49,8 +49,7 @@
               }
             }
           ]
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]

--- a/exchange/exchangetest/tricky-userids.json
+++ b/exchange/exchangetest/tricky-userids.json
@@ -79,8 +79,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]
@@ -118,8 +117,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["appnexus-error"]
@@ -155,8 +153,7 @@
               }
             }
           }
-        },
-        "bidAdjustment": 1.0
+        }
       },
       "mockResponse": {
         "errors": ["districtm-error"]

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -238,6 +238,7 @@ const (
 	AdapterErrorBadServerResponse   AdapterError = "badserverresponse"
 	AdapterErrorTimeout             AdapterError = "timeout"
 	AdapterErrorFailedToRequestBids AdapterError = "failedtorequestbid"
+	AdapterErrorValidation          AdapterError = "validation"
 	AdapterErrorUnknown             AdapterError = "unknown_error"
 )
 
@@ -247,6 +248,7 @@ func AdapterErrors() []AdapterError {
 		AdapterErrorBadServerResponse,
 		AdapterErrorTimeout,
 		AdapterErrorFailedToRequestBids,
+		AdapterErrorValidation,
 		AdapterErrorUnknown,
 	}
 }

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -53,6 +53,7 @@ type ExtBidPrebidMeta struct {
 	NetworkName          string          `json:"networkName,omitempty"`
 	PrimaryCategoryID    string          `json:"primaryCatId,omitempty"`
 	SecondaryCategoryIDs []string        `json:"secondaryCatIds,omitempty"`
+	AdapterCode          string          `json:"adaptercode,omitempty"`
 }
 
 // ExtBidPrebidVideo defines the contract for bidresponse.seatbid.bid[i].ext.prebid.video


### PR DESCRIPTION
Implements https://github.com/prebid/prebid-server/issues/2174: **Conventions and controls for adapters responding with multiple biddercodes** 

- Populate new field `seatbid.bid.ext.prebid.meta.adaptercode` with the adapter code.
- Allow adapters to set `seat` of bid(s).
- PubMatic sets `seat` for bids with value from `bid.ext.marketplace`.
- update existing tests
  - assert bid `seat` for all adapters.
  - update requestBid() mock to include `seat` and `adaptercode`.
- add new tests
  - add exchange test to validate extra bids under new `seat`.
  - add exchange test to validate extra bids and their `adaptercode` under new `seat` of an alias bidder.
  - add test to assert `requestBid()` changes.
  - Add `pubmatic` adapter test to assert extra-bid and a new response ext field `marketplace`.
- Validate extra-bidders as per phase-2 description.
- Do bid adjustment for extra-bid as per phase-2 description.

Creating this new pull request as the original https://github.com/prebid/prebid-server/pull/2257 one was from wrong account.

@hhhjort Could you please approve this PR. There are no changes. Apologies for the inconvenience.