### PR TITLE
MediaFuse Prebid-server adapter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -994,7 +994,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("adapters.sa_lunamedia.endpoint", "http://balancer.lmgssp.com/pserver")
 	v.SetDefault("adapters.madvertise.endpoint", "https://mobile.mng-ads.com/bidrequest{{.ZoneID}}")
 	v.SetDefault("adapters.marsmedia.endpoint", "https://bid306.rtbsrv.com/bidder/?bid=f3xtet")
-	v.SetDefault("adapters.mediafuse.endpoint", "http://ghb.hbmp.mediafuse.com/pbs/ortb")
+	v.SetDefault("adapters.mediafuse.endpoint", "http://ghb.hbmp.mediafuse.com/pbs/ortb") 
 	v.SetDefault("adapters.medianet.endpoint", "https://prebid-adapter.media.net/rtb/pb/prebids2s")
 	v.SetDefault("adapters.medianet.extra_info", "https://medianet.golang.pbs.com")
 	v.SetDefault("adapters.mgid.endpoint", "https://prebid.mgid.com/prebid/")


### PR DESCRIPTION
I have created a similar [PR](https://github.com/prebid/prebid-server/pull/2258) to bring live MediaFuse Prebid-server adapter.

As per @AlexBVolcy's comment, I have gone through the [PR](https://github.com/prebid/prebid-server/pull/2198/files), and it seems that all the changes mentioned in the PR are already in place with the current repo.

In addition to this, what else is required from our side to enable the MediaFuse Prebid-server adapter to LIVE?