### PR TITLE
Fix interstitial.minwidtheperc typo

### DIFF
--- a/openrtb_ext/device.go
+++ b/openrtb_ext/device.go
@@ -70,7 +70,7 @@ type ExtDevicePrebid struct {
 
 // ExtDeviceInt defines the contract for bidrequest.device.ext.prebid.interstitial
 type ExtDeviceInt struct {
-	MinWidthPerc  int64 `json:"minwidtheperc"`
+	MinWidthPerc  int64 `json:"minwidthperc"`
 	MinHeightPerc int64 `json:"minheightperc"`
 }
 


### PR DESCRIPTION
I was sending an request to the auction endpoint to test interstitial functionality for a separate issue, and noticed there was a typo in the definition of the json field at `device.ext.prebid.interstitial.minwidtheperc.` When you send a request utilizing that naming, it would cause this error `Invalid request: request.device.ext.prebid.interstitial.minwidthperc must be a number between 0 and 100`. 

In short: `minwidtheperc` needs to just be `minwidthperc`, so this PR provides that typo fix.

I'm leaving this in draft mode, because the team spoke about adding json tests in relation to this typo, but I need to ask a few clarifying questions regarding this on Monday before I add them. 