### PR TITLE
Read imp[].ext.tid, fix PBJS 7.3.0 compatibility

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1259,6 +1259,8 @@ func isBidderToValidate(bidder string) bool {
 		return false
 	case openrtb_ext.BidderReservedSKAdN:
 		return false
+	case openrtb_ext.BidderReservedTID:
+		return false
 	default:
 		return true
 	}

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -421,8 +421,8 @@ func createSanitizedImpExt(impExt, impExtPrebid map[string]json.RawMessage) (map
 		sanitizedImpExt[openrtb_ext.GPIDKey] = v
 	}
 
-	if v, exists := impExt[string(openrtb_ext.TID)]; exists {
-		sanitizedImpExt[openrtb_ext.TID] = v
+	if v, exists := impExt[string(openrtb_ext.TIDKey)]; exists {
+		sanitizedImpExt[openrtb_ext.TIDKey] = v
 	}
 
 	return sanitizedImpExt, nil
@@ -455,7 +455,8 @@ func isSpecialField(bidder string) bool {
 		bidder == openrtb_ext.FirstPartyDataExtKey ||
 		bidder == openrtb_ext.SKAdNExtKey ||
 		bidder == openrtb_ext.GPIDKey ||
-		bidder == openrtb_ext.PrebidExtKey || bidder == openrtb_ext.TID
+		bidder == openrtb_ext.PrebidExtKey ||
+		bidder == openrtb_ext.TIDKey
 }
 
 // prepareUser changes req.User so that it's ready for the given bidder.

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -421,6 +421,10 @@ func createSanitizedImpExt(impExt, impExtPrebid map[string]json.RawMessage) (map
 		sanitizedImpExt[openrtb_ext.GPIDKey] = v
 	}
 
+	if v, exists := impExt[string(openrtb_ext.TID)]; exists {
+		sanitizedImpExt[openrtb_ext.TID] = v
+	}
+
 	return sanitizedImpExt, nil
 }
 
@@ -451,7 +455,7 @@ func isSpecialField(bidder string) bool {
 		bidder == openrtb_ext.FirstPartyDataExtKey ||
 		bidder == openrtb_ext.SKAdNExtKey ||
 		bidder == openrtb_ext.GPIDKey ||
-		bidder == openrtb_ext.PrebidExtKey
+		bidder == openrtb_ext.PrebidExtKey || bidder == openrtb_ext.TID
 }
 
 // prepareUser changes req.User so that it's ready for the given bidder.

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -354,6 +354,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 				"context":   json.RawMessage(`"anyContext"`),
 				"skadn":     json.RawMessage(`"anySKAdNetwork"`),
 				"gpid":      json.RawMessage(`"anyGPID"`),
+				"tid":       json.RawMessage(`"anyTID"`),
 			},
 			givenImpExtPrebid: map[string]json.RawMessage{
 				"bidder":    json.RawMessage(`"anyBidder"`),
@@ -365,6 +366,7 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),
 				"gpid":    json.RawMessage(`"anyGPID"`),
+				"tid":     json.RawMessage(`"anyTID"`),
 			},
 			expectedError: "",
 		},
@@ -465,6 +467,12 @@ func TestExtractBidderExts(t *testing.T) {
 		{
 			description:              "Mixed - Overwrites - imp.ext.BIDDER + imp.ext.prebid.bidder.BIDDER",
 			givenImpExt:              map[string]json.RawMessage{"bidderA": json.RawMessage(`{"shouldBe":"Ignored"}}`)},
+			givenImpExtPrebidBidders: map[string]json.RawMessage{"bidderA": bidderAJSON},
+			expected:                 map[string]json.RawMessage{"bidderA": bidderAJSON},
+		},
+		{
+			description:              "imp.ext.tid",
+			givenImpExt:              map[string]json.RawMessage{"bidderA": json.RawMessage(`{"shouldBe":"Ignored"}}`), "tid": json.RawMessage(`{`)},
 			givenImpExtPrebidBidders: map[string]json.RawMessage{"bidderA": bidderAJSON},
 			expected:                 map[string]json.RawMessage{"bidderA": bidderAJSON},
 		},

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -436,7 +436,7 @@ func TestExtractBidderExts(t *testing.T) {
 		},
 		{
 			description:              "Special Names Ignored - imp.ext.BIDDER",
-			givenImpExt:              map[string]json.RawMessage{"prebid": json.RawMessage(`{"prebid":"value1"}}`), "context": json.RawMessage(`{"firstPartyData":"value2"}}`), "skadn": json.RawMessage(`{"skAdNetwork":"value3"}}`), "gpid": json.RawMessage(`{"gpid":"value4"}}`)},
+			givenImpExt:              map[string]json.RawMessage{"prebid": json.RawMessage(`{"prebid":"value1"}}`), "context": json.RawMessage(`{"firstPartyData":"value2"}}`), "skadn": json.RawMessage(`{"skAdNetwork":"value3"}}`), "gpid": json.RawMessage(`{"gpid":"value4"}}`), "tid": json.RawMessage("6e927474-4c83-40ac-8180-16858314b7c5")},
 			givenImpExtPrebidBidders: map[string]json.RawMessage{},
 			expected:                 map[string]json.RawMessage{},
 		},
@@ -467,12 +467,6 @@ func TestExtractBidderExts(t *testing.T) {
 		{
 			description:              "Mixed - Overwrites - imp.ext.BIDDER + imp.ext.prebid.bidder.BIDDER",
 			givenImpExt:              map[string]json.RawMessage{"bidderA": json.RawMessage(`{"shouldBe":"Ignored"}}`)},
-			givenImpExtPrebidBidders: map[string]json.RawMessage{"bidderA": bidderAJSON},
-			expected:                 map[string]json.RawMessage{"bidderA": bidderAJSON},
-		},
-		{
-			description:              "imp.ext.tid",
-			givenImpExt:              map[string]json.RawMessage{"bidderA": json.RawMessage(`{"shouldBe":"Ignored"}}`), "tid": json.RawMessage(`{`)},
 			givenImpExtPrebidBidders: map[string]json.RawMessage{"bidderA": bidderAJSON},
 			expected:                 map[string]json.RawMessage{"bidderA": bidderAJSON},
 		},

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -35,6 +35,7 @@ const (
 	BidderReservedGPID    BidderName = "gpid"    // Reserved for Global Placement ID (GPID).
 	BidderReservedPrebid  BidderName = "prebid"  // Reserved for Prebid Server configuration.
 	BidderReservedSKAdN   BidderName = "skadn"   // Reserved for Apple's SKAdNetwork OpenRTB extension.
+	BidderReservedTID     BidderName = "tid"     // Reserved for Per-Impression Transactions IDs for Multi-Impression Bid Requests.
 )
 
 // IsBidderNameReserved returns true if the specified name is a case insensitive match for a reserved bidder name.
@@ -64,6 +65,10 @@ func IsBidderNameReserved(name string) bool {
 	}
 
 	if strings.EqualFold(name, string(BidderReservedPrebid)) {
+		return true
+	}
+
+	if strings.EqualFold(name, string(BidderReservedTID)) {
 		return true
 	}
 

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -113,8 +113,11 @@ func TestIsBidderNameReserved(t *testing.T) {
 		{"skadn", true},
 		{"skADN", true},
 		{"SKADN", true},
-		{"notreserved", false},
 		{"tid", true},
+		{"TId", true},
+		{"Tid", true},
+		{"TiD", true},
+		{"notreserved", false},
 	}
 
 	for _, test := range testCases {

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -114,6 +114,7 @@ func TestIsBidderNameReserved(t *testing.T) {
 		{"skADN", true},
 		{"SKADN", true},
 		{"notreserved", false},
+		{"tid", true},
 	}
 
 	for _, test := range testCases {

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -20,6 +20,9 @@ const GPIDKey = "gpid"
 // NativeExchangeSpecificLowerBound defines the lower threshold of exchange specific types for native ads. There is no upper bound.
 const NativeExchangeSpecificLowerBound = 500
 
+// TID reserved for Per-Impression Transactions IDs for Multi-Impression Bid Requests.
+const TID = "tid"
+
 const MaxDecimalFigures int = 15
 
 // ExtRequest defines the contract for bidrequest.ext

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -17,11 +17,11 @@ const SKAdNExtKey = "skadn"
 // GPIDKey defines the field name within request.ext reserved for the Global Placement ID (GPID),
 const GPIDKey = "gpid"
 
+// TIDKey reserved for Per-Impression Transactions IDs for Multi-Impression Bid Requests.
+const TIDKey = "tid"
+
 // NativeExchangeSpecificLowerBound defines the lower threshold of exchange specific types for native ads. There is no upper bound.
 const NativeExchangeSpecificLowerBound = 500
-
-// TID reserved for Per-Impression Transactions IDs for Multi-Impression Bid Requests.
-const TID = "tid"
 
 const MaxDecimalFigures int = 15
 


### PR DESCRIPTION
Added changes to read and mark `imp[].ext.tid` as special field and not a bidder code.


With https://github.com/prebid/Prebid.js/pull/8591 (https://github.com/prebid/Prebid.js/issues/8543) PBJS 7.3.0 sends `imp[].ext.tid` to PBS where PBS interprets `tid` as bidder code. Hence, blocking PBS adapter from using with PBJS 7.3.0.
Below is the error response from PBS.
```
Invalid request: request.imp[0].ext contains unknown bidder: tid. Did you forget an alias in request.ext.prebid.aliases?
```