### PR TITLE
UOE-7905: Do not allow publishers to bypass GDPR

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -31,6 +31,7 @@ var (
 	errCookieSyncBody                              = errors.New("Failed to read request body")
 	errCookieSyncGDPRConsentMissing                = errors.New("gdpr_consent is required if gdpr=1")
 	errCookieSyncGDPRConsentMissingSignalAmbiguous = errors.New("gdpr_consent is required. gdpr is not specified and is assumed to be 1 by the server. set gdpr=0 to exempt this request")
+	errCookieSyncGDPRMandatoryByHost               = errors.New("gdpr_consent is required. gdpr exemption disabled")
 	errCookieSyncInvalidBiddersType                = errors.New("invalid bidders type. must either be a string '*' or a string array of bidders")
 	errCookieSyncAccountBlocked                    = errors.New("account is disabled, please reach out to the prebid server host")
 	errCookieSyncAccountInvalid                    = errors.New("account must be valid if provided, please reach out to the prebid server host")
@@ -130,6 +131,12 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 	gdprSignal, err := gdpr.SignalParse(gdprString)
 	if err != nil {
 		return usersync.Request{}, privacy.Policies{}, err
+	}
+
+	//OpenWrap: do not allow publishers to bypass GDPR
+	if c.privacyConfig.gdprConfig.DefaultValue == "1" && gdprSignal == gdpr.SignalNo {
+		// gdprString = c.privacyConfig.gdprConfig.DefaultValue
+		return usersync.Request{}, privacy.Policies{}, errCookieSyncGDPRMandatoryByHost
 	}
 
 	if request.GDPRConsent == "" {


### PR DESCRIPTION
PBS config needed to test this:
```
gdpr:
  enabled: true
  default_value: true
  host_vendor_id: 76
  timeouts_ms:
    init_vendorlist_fetches: 100000
    active_vendorlist_fetch: 100000
```