### PR TITLE
Stored responses metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -490,6 +490,9 @@ type DisabledMetrics struct {
 	// True if we want to stop collecting account debug request metrics
 	AccountDebug bool `mapstructure:"account_debug"`
 
+	// True if we want to stop collecting account stored respponses metrics
+	AccountStoredResponses bool `mapstructure:"account_stored_responses"`
+
 	// True if we don't want to collect metrics about the connections prebid
 	// server establishes with bidder servers such as the number of connections
 	// that were created or reused.
@@ -784,6 +787,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	// no metrics configured by default (metrics{host|database|username|password})
 	v.SetDefault("metrics.disabled_metrics.account_adapter_details", false)
 	v.SetDefault("metrics.disabled_metrics.account_debug", true)
+	v.SetDefault("metrics.disabled_metrics.account_stored_responses", true)
 	v.SetDefault("metrics.disabled_metrics.adapter_connections_metrics", true)
 	v.SetDefault("metrics.disabled_metrics.adapter_gdpr_request_blocked", false)
 	v.SetDefault("metrics.influxdb.host", "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -138,6 +138,7 @@ func TestDefaults(t *testing.T) {
 	cmpInts(t, "metrics.influxdb.collection_rate_seconds", cfg.Metrics.Influxdb.MetricSendInterval, 20)
 	cmpBools(t, "account_adapter_details", cfg.Metrics.Disabled.AccountAdapterDetails, false)
 	cmpBools(t, "account_debug", cfg.Metrics.Disabled.AccountDebug, true)
+	cmpBools(t, "account_stored_responses", cfg.Metrics.Disabled.AccountStoredResponses, true)
 	cmpBools(t, "adapter_connections_metrics", cfg.Metrics.Disabled.AdapterConnectionMetrics, true)
 	cmpBools(t, "adapter_gdpr_request_blocked", cfg.Metrics.Disabled.AdapterGDPRRequestBlocked, false)
 	cmpStrings(t, "certificates_file", cfg.PemCertsFile, "")
@@ -341,6 +342,7 @@ metrics:
   disabled_metrics:
     account_adapter_details: true
     account_debug: false
+    account_stored_responses: false
     adapter_connections_metrics: true
     adapter_gdpr_request_blocked: true
 adapters:
@@ -614,6 +616,7 @@ func TestFullConfig(t *testing.T) {
 	cmpBools(t, "auto_gen_source_tid", cfg.AutoGenSourceTID, false)
 	cmpBools(t, "account_adapter_details", cfg.Metrics.Disabled.AccountAdapterDetails, true)
 	cmpBools(t, "account_debug", cfg.Metrics.Disabled.AccountDebug, false)
+	cmpBools(t, "account_stored_responses", cfg.Metrics.Disabled.AccountStoredResponses, false)
 	cmpBools(t, "adapter_connections_metrics", cfg.Metrics.Disabled.AdapterConnectionMetrics, true)
 	cmpBools(t, "adapter_gdpr_request_blocked", cfg.Metrics.Disabled.AdapterGDPRRequestBlocked, true)
 	cmpStrings(t, "certificates_file", cfg.PemCertsFile, "/etc/ssl/cert.pem")

--- a/config/stored_requests.go
+++ b/config/stored_requests.go
@@ -19,6 +19,7 @@ const (
 	VideoDataType      DataType = "Video"
 	AMPRequestDataType DataType = "AMP Request"
 	AccountDataType    DataType = "Account"
+	ResponseDataType   DataType = "Response"
 )
 
 // Section returns the config section this type is defined in
@@ -29,6 +30,7 @@ func (dataType DataType) Section() string {
 		VideoDataType:      "stored_video_req",
 		AMPRequestDataType: "stored_amp_req",
 		AccountDataType:    "accounts",
+		ResponseDataType:   "stored_responses",
 	}[dataType]
 }
 
@@ -133,6 +135,7 @@ func resolvedStoredRequestsConfig(cfg *Configuration) {
 	cfg.StoredVideo.dataType = VideoDataType
 	cfg.CategoryMapping.dataType = CategoryDataType
 	cfg.Accounts.dataType = AccountDataType
+	cfg.StoredResponses.dataType = ResponseDataType
 }
 
 func (cfg *StoredRequests) validate(errs []error) []error {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -248,6 +248,10 @@ func (e *exchange) HoldAuction(ctx context.Context, r AuctionRequest, debugLog *
 
 	e.me.RecordRequestPrivacy(privacyLabels)
 
+	if len(r.StoredAuctionResponses) > 0 || len(r.StoredBidResponses) > 0 {
+		e.me.RecordStoredResponse(r.PubID)
+	}
+
 	// If we need to cache bids, then it will take some time to call prebid cache.
 	// We should reduce the amount of time the bidders have, to compensate.
 	auctionCtx, cancel := e.makeAuctionContext(ctx, cacheInstructions.cacheBids)

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -261,6 +261,12 @@ func (me *MultiMetricsEngine) RecordDebugRequest(debugEnabled bool, pubId string
 	}
 }
 
+func (me *MultiMetricsEngine) RecordStoredResponse(pubId string) {
+	for _, thisME := range *me {
+		thisME.RecordStoredResponse(pubId)
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -375,4 +381,7 @@ func (me *NilMetricsEngine) RecordAdapterGDPRRequestBlocked(adapter openrtb_ext.
 
 // RecordDebugRequest as a noop
 func (me *NilMetricsEngine) RecordDebugRequest(debugEnabled bool, pubId string) {
+}
+
+func (me *NilMetricsEngine) RecordStoredResponse(pubId string) {
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -454,7 +454,7 @@ func (me *Metrics) RecordDebugRequest(debugEnabled bool, pubID string) {
 
 func (me *Metrics) RecordStoredResponse(pubId string) {
 	me.StoredResponsesMeter.Mark(1)
-	if pubId != PublisherUnknown {
+	if pubId != PublisherUnknown && !me.MetricsDisabled.AccountStoredResponses {
 		me.getAccountMetrics(pubId).storedResponsesMeter.Mark(1)
 	}
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -32,6 +32,7 @@ type Metrics struct {
 	AccountCacheMeter              map[CacheResult]metrics.Meter
 	DNSLookupTimer                 metrics.Timer
 	TLSHandshakeTimer              metrics.Timer
+	StoredResponsesMeter           metrics.Meter
 
 	// Metrics for OpenRTB requests specifically. So we can track what % of RequestsMeter are OpenRTB
 	// and know when legacy requests have been abandoned.
@@ -99,7 +100,8 @@ type accountMetrics struct {
 	bidsReceivedMeter metrics.Meter
 	priceHistogram    metrics.Histogram
 	// store account by adapter metrics. Type is map[PBSBidder.BidderCode]
-	adapterMetrics map[openrtb_ext.BidderName]*AdapterMetrics
+	adapterMetrics       map[openrtb_ext.BidderName]*AdapterMetrics
+	storedResponsesMeter metrics.Meter
 }
 
 // NewBlankMetrics creates a new Metrics object with all blank metrics object. This may also be useful for
@@ -141,6 +143,7 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderNa
 		SetUidMeter:                    blankMeter,
 		SetUidStatusMeter:              make(map[SetUidStatus]metrics.Meter),
 		SyncerSetsMeter:                make(map[string]map[SyncerSetUidStatus]metrics.Meter),
+		StoredResponsesMeter:           blankMeter,
 
 		ImpsTypeBanner: blankMeter,
 		ImpsTypeVideo:  blankMeter,
@@ -228,6 +231,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.TLSHandshakeTimer = metrics.GetOrRegisterTimer("tls_handshake_time", registry)
 	newMetrics.PrebidCacheRequestTimerSuccess = metrics.GetOrRegisterTimer("prebid_cache_request_time.ok", registry)
 	newMetrics.PrebidCacheRequestTimerError = metrics.GetOrRegisterTimer("prebid_cache_request_time.err", registry)
+	newMetrics.StoredResponsesMeter = metrics.GetOrRegisterMeter("stored_responses", registry)
 
 	for _, dt := range StoredDataTypes() {
 		for _, ft := range StoredDataFetchTypes() {
@@ -402,6 +406,7 @@ func (me *Metrics) getAccountMetrics(id string) *accountMetrics {
 	am.bidsReceivedMeter = metrics.GetOrRegisterMeter(fmt.Sprintf("account.%s.bids_received", id), me.MetricsRegistry)
 	am.priceHistogram = metrics.GetOrRegisterHistogram(fmt.Sprintf("account.%s.prices", id), me.MetricsRegistry, metrics.NewExpDecaySample(1028, 0.015))
 	am.adapterMetrics = make(map[openrtb_ext.BidderName]*AdapterMetrics, len(me.exchanges))
+	am.storedResponsesMeter = metrics.GetOrRegisterMeter(fmt.Sprintf("account.%s.stored_responses", id), me.MetricsRegistry)
 	if !me.MetricsDisabled.AccountAdapterDetails {
 		for _, a := range me.exchanges {
 			am.adapterMetrics[a] = makeBlankAdapterMetrics(me.MetricsDisabled)
@@ -444,6 +449,13 @@ func (me *Metrics) RecordDebugRequest(debugEnabled bool, pubID string) {
 				am.debugRequestMeter.Mark(1)
 			}
 		}
+	}
+}
+
+func (me *Metrics) RecordStoredResponse(pubId string) {
+	me.StoredResponsesMeter.Mark(1)
+	if pubId != PublisherUnknown {
+		me.getAccountMetrics(pubId).storedResponsesMeter.Mark(1)
 	}
 }
 

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -33,6 +33,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "setuid_requests.opt_out", m.SetUidStatusMeter[SetUidOptOut])
 	ensureContains(t, registry, "setuid_requests.gdpr_blocked_host_cookie", m.SetUidStatusMeter[SetUidGDPRHostCookieBlocked])
 	ensureContains(t, registry, "setuid_requests.syncer_unknown", m.SetUidStatusMeter[SetUidSyncerUnknown])
+	ensureContains(t, registry, "stored_responses", m.StoredResponsesMeter)
 
 	ensureContains(t, registry, "prebid_cache_request_time.ok", m.PrebidCacheRequestTimerSuccess)
 	ensureContains(t, registry, "prebid_cache_request_time.err", m.PrebidCacheRequestTimerError)
@@ -737,6 +738,38 @@ func TestRecordSyncerSet(t *testing.T) {
 
 	assert.Equal(t, m.SyncerSetsMeter["foo"][SyncerSetUidOK].Count(), int64(0))
 	assert.Equal(t, m.SyncerSetsMeter["foo"][SyncerSetUidCleared].Count(), int64(1))
+}
+
+func TestStoredResponses(t *testing.T) {
+	testCases := []struct {
+		description                         string
+		givenPubID                          string
+		expectedAccountStoredResponsesCount int64
+		expectedStoredResponsesCount        int64
+	}{
+		{
+			description:                         "Publisher id is given, both metrics should be updated",
+			givenPubID:                          "acct-id",
+			expectedAccountStoredResponsesCount: 1,
+			expectedStoredResponsesCount:        1,
+		},
+		{
+			description:                         "Publisher id is given, both metrics should be updated",
+			givenPubID:                          PublisherUnknown,
+			expectedAccountStoredResponsesCount: 0,
+			expectedStoredResponsesCount:        1,
+		},
+	}
+	for _, test := range testCases {
+		registry := metrics.NewRegistry()
+		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus}, config.DisabledMetrics{}, nil)
+
+		m.RecordStoredResponse(test.givenPubID)
+		am := m.getAccountMetrics(test.givenPubID)
+
+		assert.Equal(t, test.expectedStoredResponsesCount, m.StoredResponsesMeter.Count())
+		assert.Equal(t, test.expectedAccountStoredResponsesCount, am.storedResponsesMeter.Count())
+	}
 }
 
 func ensureContainsBidTypeMetrics(t *testing.T, registry metrics.Registry, prefix string, mdm map[openrtb_ext.BidType]*MarkupDeliveryMetrics) {

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -754,7 +754,7 @@ func TestStoredResponses(t *testing.T) {
 			expectedStoredResponsesCount:        1,
 		},
 		{
-			description:                         "Publisher id is given, both metrics should be updated",
+			description:                         "Publisher id is unknown, only expectedStoredResponsesCount metric should be updated",
 			givenPubID:                          PublisherUnknown,
 			expectedAccountStoredResponsesCount: 0,
 			expectedStoredResponsesCount:        1,

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -742,27 +742,44 @@ func TestRecordSyncerSet(t *testing.T) {
 
 func TestStoredResponses(t *testing.T) {
 	testCases := []struct {
-		description                         string
-		givenPubID                          string
-		expectedAccountStoredResponsesCount int64
-		expectedStoredResponsesCount        int64
+		description                           string
+		givenPubID                            string
+		accountStoredResponsesMetricsDisabled bool
+		expectedAccountStoredResponsesCount   int64
+		expectedStoredResponsesCount          int64
 	}{
 		{
-			description:                         "Publisher id is given, both metrics should be updated",
-			givenPubID:                          "acct-id",
-			expectedAccountStoredResponsesCount: 1,
-			expectedStoredResponsesCount:        1,
+			description:                           "Publisher id is given, account stored responses disabled, both metrics should be updated",
+			givenPubID:                            "acct-id",
+			accountStoredResponsesMetricsDisabled: true,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
 		},
 		{
-			description:                         "Publisher id is unknown, only expectedStoredResponsesCount metric should be updated",
-			givenPubID:                          PublisherUnknown,
-			expectedAccountStoredResponsesCount: 0,
-			expectedStoredResponsesCount:        1,
+			description:                           "Publisher id is given, account stored responses enabled, both metrics should be updated",
+			givenPubID:                            "acct-id",
+			accountStoredResponsesMetricsDisabled: false,
+			expectedAccountStoredResponsesCount:   1,
+			expectedStoredResponsesCount:          1,
+		},
+		{
+			description:                           "Publisher id is unknown, account stored responses enabled, only expectedStoredResponsesCount metric should be updated",
+			givenPubID:                            PublisherUnknown,
+			accountStoredResponsesMetricsDisabled: false,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
+		},
+		{
+			description:                           "Publisher id is unknown, account stored responses disabled, only expectedStoredResponsesCount metric should be updated",
+			givenPubID:                            PublisherUnknown,
+			accountStoredResponsesMetricsDisabled: true,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
 		},
 	}
 	for _, test := range testCases {
 		registry := metrics.NewRegistry()
-		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus}, config.DisabledMetrics{}, nil)
+		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus}, config.DisabledMetrics{AccountStoredResponses: test.accountStoredResponsesMetricsDisabled}, nil)
 
 		m.RecordStoredResponse(test.givenPubID)
 		am := m.getAccountMetrics(test.givenPubID)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -57,6 +57,7 @@ const (
 	CategoryDataType StoredDataType = "category"
 	RequestDataType  StoredDataType = "request"
 	VideoDataType    StoredDataType = "video"
+	ResponseDataType StoredDataType = "response"
 )
 
 func StoredDataTypes() []StoredDataType {
@@ -66,6 +67,7 @@ func StoredDataTypes() []StoredDataType {
 		CategoryDataType,
 		RequestDataType,
 		VideoDataType,
+		ResponseDataType,
 	}
 }
 
@@ -412,4 +414,5 @@ type MetricsEngine interface {
 	RecordRequestPrivacy(privacy PrivacyLabels)
 	RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName)
 	RecordDebugRequest(debugEnabled bool, pubId string)
+	RecordStoredResponse(pubId string)
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -150,3 +150,7 @@ func (me *MetricsEngineMock) RecordAdapterGDPRRequestBlocked(adapterName openrtb
 func (me *MetricsEngineMock) RecordDebugRequest(debugEnabled bool, pubId string) {
 	me.Called(debugEnabled, pubId)
 }
+
+func (me *MetricsEngineMock) RecordStoredResponse(pubId string) {
+	me.Called(pubId)
+}

--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -77,6 +77,10 @@ func preloadLabelValues(m *Metrics, syncerKeys []string) {
 		storedDataFetchTypeLabel: storedDataFetchTypeValues,
 	})
 
+	preloadLabelValuesForHistogram(m.storedResponsesFetchTimer, map[string][]string{
+		storedDataFetchTypeLabel: storedDataFetchTypeValues,
+	})
+
 	preloadLabelValuesForCounter(m.storedAccountErrors, map[string][]string{
 		storedDataErrorLabel: storedDataErrorValues,
 	})
@@ -94,6 +98,10 @@ func preloadLabelValues(m *Metrics, syncerKeys []string) {
 	})
 
 	preloadLabelValuesForCounter(m.storedVideoErrors, map[string][]string{
+		storedDataErrorLabel: storedDataErrorValues,
+	})
+
+	preloadLabelValuesForCounter(m.storedResponsesErrors, map[string][]string{
 		storedDataErrorLabel: storedDataErrorValues,
 	})
 

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -525,7 +525,7 @@ func (m *Metrics) RecordDebugRequest(debugEnabled bool, pubID string) {
 
 func (m *Metrics) RecordStoredResponse(pubId string) {
 	m.storedResponses.Inc()
-	if pubId != metrics.PublisherUnknown {
+	if !m.metricsDisabled.AccountStoredResponses && pubId != metrics.PublisherUnknown {
 		m.accountStoredResponses.With(prometheus.Labels{
 			accountLabel: pubId,
 		}).Inc()

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -51,6 +51,9 @@ type Metrics struct {
 	privacyCOPPA                 *prometheus.CounterVec
 	privacyLMT                   *prometheus.CounterVec
 	privacyTCF                   *prometheus.CounterVec
+	storedResponses              prometheus.Counter
+	storedResponsesFetchTimer    *prometheus.HistogramVec
+	storedResponsesErrors        *prometheus.CounterVec
 
 	// Adapter Metrics
 	adapterBids                *prometheus.CounterVec
@@ -69,8 +72,9 @@ type Metrics struct {
 	syncerSets     *prometheus.CounterVec
 
 	// Account Metrics
-	accountRequests      *prometheus.CounterVec
-	accountDebugRequests *prometheus.CounterVec
+	accountRequests        *prometheus.CounterVec
+	accountDebugRequests   *prometheus.CounterVec
+	accountStoredResponses *prometheus.CounterVec
 
 	metricsDisabled config.DisabledMetrics
 }
@@ -311,6 +315,21 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 			[]string{adapterLabel})
 	}
 
+	metrics.storedResponsesFetchTimer = newHistogramVec(cfg, reg,
+		"stored_response_fetch_time_seconds",
+		"Seconds to fetch stored responses labeled by fetch type",
+		[]string{storedDataFetchTypeLabel},
+		standardTimeBuckets)
+
+	metrics.storedResponsesErrors = newCounter(cfg, reg,
+		"stored_response_errors",
+		"Count of stored video errors by error type",
+		[]string{storedDataErrorLabel})
+
+	metrics.storedResponses = newCounterWithoutLabels(cfg, reg,
+		"stored_responses",
+		"Count of total requests to Prebid Server that have stored responses")
+
 	metrics.adapterBids = newCounter(cfg, reg,
 		"adapter_bids",
 		"Count of bids labeled by adapter and markup delivery type (adm or nurl).",
@@ -386,6 +405,11 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		"Seconds request was waiting in queue",
 		[]string{requestTypeLabel, requestStatusLabel},
 		queuedRequestTimeBuckets)
+
+	metrics.accountStoredResponses = newCounter(cfg, reg,
+		"account_stored_responses",
+		"Count of total requests to Prebid Server that have stored responses labled by account",
+		[]string{accountLabel})
 
 	metrics.Gatherer = reg
 
@@ -499,6 +523,16 @@ func (m *Metrics) RecordDebugRequest(debugEnabled bool, pubID string) {
 	}
 }
 
+func (m *Metrics) RecordStoredResponse(pubId string) {
+	m.storedResponses.Inc()
+	if pubId != metrics.PublisherUnknown {
+		m.accountStoredResponses.With(prometheus.Labels{
+			accountLabel: pubId,
+		}).Inc()
+	}
+
+}
+
 func (m *Metrics) RecordImps(labels metrics.ImpLabels) {
 	m.impressions.With(prometheus.Labels{
 		isBannerLabel: strconv.FormatBool(labels.BannerImps),
@@ -538,6 +572,10 @@ func (m *Metrics) RecordStoredDataFetchTime(labels metrics.StoredDataLabels, len
 		m.storedVideoFetchTimer.With(prometheus.Labels{
 			storedDataFetchTypeLabel: string(labels.DataFetchType),
 		}).Observe(length.Seconds())
+	case metrics.ResponseDataType:
+		m.storedResponsesFetchTimer.With(prometheus.Labels{
+			storedDataFetchTypeLabel: string(labels.DataFetchType),
+		}).Observe(length.Seconds())
 	}
 }
 
@@ -561,6 +599,10 @@ func (m *Metrics) RecordStoredDataError(labels metrics.StoredDataLabels) {
 		}).Inc()
 	case metrics.VideoDataType:
 		m.storedVideoErrors.With(prometheus.Labels{
+			storedDataErrorLabel: string(labels.Error),
+		}).Inc()
+	case metrics.ResponseDataType:
+		m.storedResponsesErrors.With(prometheus.Labels{
 			storedDataErrorLabel: string(labels.Error),
 		}).Inc()
 	}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -530,7 +530,6 @@ func (m *Metrics) RecordStoredResponse(pubId string) {
 			accountLabel: pubId,
 		}).Inc()
 	}
-
 }
 
 func (m *Metrics) RecordImps(labels metrics.ImpLabels) {

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1644,28 +1644,46 @@ func TestRecordAdapterGDPRRequestBlocked(t *testing.T) {
 
 func TestStoredResponsesMetric(t *testing.T) {
 	testCases := []struct {
-		description                         string
-		publisherId                         string
-		expectedAccountStoredResponsesCount float64
-		expectedStoredResponsesCount        float64
+		description                           string
+		publisherId                           string
+		accountStoredResponsesMetricsDisabled bool
+		expectedAccountStoredResponsesCount   float64
+		expectedStoredResponsesCount          float64
 	}{
 
 		{
-			description:                         "Publisher id is given, expected both account stored responses and stored responses counter to have a record",
-			publisherId:                         "acct-id",
-			expectedAccountStoredResponsesCount: 1,
-			expectedStoredResponsesCount:        1,
+			description:                           "Publisher id is given, account stored responses enabled, expected both account stored responses and stored responses counter to have a record",
+			publisherId:                           "acct-id",
+			accountStoredResponsesMetricsDisabled: false,
+			expectedAccountStoredResponsesCount:   1,
+			expectedStoredResponsesCount:          1,
 		},
 		{
-			description:                         "Publisher id is unknown, expected stored responses counter only to have a record",
-			publisherId:                         metrics.PublisherUnknown,
-			expectedAccountStoredResponsesCount: 0,
-			expectedStoredResponsesCount:        1,
+			description:                           "Publisher id is given, account stored responses disabled, expected stored responses counter only to have a record",
+			publisherId:                           "acct-id",
+			accountStoredResponsesMetricsDisabled: true,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
+		},
+		{
+			description:                           "Publisher id is unknown, account stored responses enabled, expected stored responses counter only to have a record",
+			publisherId:                           metrics.PublisherUnknown,
+			accountStoredResponsesMetricsDisabled: true,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
+		},
+		{
+			description:                           "Publisher id is unknown, account stored responses disabled, expected stored responses counter only to have a record",
+			publisherId:                           metrics.PublisherUnknown,
+			accountStoredResponsesMetricsDisabled: false,
+			expectedAccountStoredResponsesCount:   0,
+			expectedStoredResponsesCount:          1,
 		},
 	}
 
 	for _, test := range testCases {
 		m := createMetricsForTesting()
+		m.metricsDisabled.AccountStoredResponses = test.accountStoredResponsesMetricsDisabled
 		m.RecordStoredResponse(test.publisherId)
 
 		assertCounterVecValue(t, "", "account stored responses", m.accountStoredResponses, test.expectedAccountStoredResponsesCount, prometheus.Labels{accountLabel: "acct-id"})

--- a/stored_requests/events/postgres/database.go
+++ b/stored_requests/events/postgres/database.go
@@ -25,6 +25,7 @@ var storedDataTypeMetricMap = map[config.DataType]metrics.StoredDataType{
 	config.VideoDataType:      metrics.VideoDataType,
 	config.AMPRequestDataType: metrics.AMPDataType,
 	config.AccountDataType:    metrics.AccountDataType,
+	config.ResponseDataType:   metrics.ResponseDataType,
 }
 
 type PostgresEventProducerConfig struct {


### PR DESCRIPTION
Implementation for Stored bid responses metrics:
1) Number of requests that have stored bid responses or stored auction responses - new metric
2) Time to fetch stored response and fetching errors. These use new metrics and existing functionality to track it: `RecordStoredDataFetchTime` and `RecordStoredDataError `