### PR TITLE
Rename adapters to bidders in alternate bidder codes config

### DIFF
--- a/config/accounts.go
+++ b/config/accounts.go
@@ -227,8 +227,8 @@ func (a *AccountIntegration) GetByIntegrationType(integrationType IntegrationTyp
 }
 
 type AlternateBidderCodes struct {
-	Enabled  bool                                   `mapstructure:"enabled" json:"enabled"`
-	Adapters map[string]AdapterAlternateBidderCodes `mapstructure:"adapters" json:"adapters"`
+	Enabled bool                                   `mapstructure:"enabled" json:"enabled"`
+	Bidders map[string]AdapterAlternateBidderCodes `mapstructure:"bidders" json:"bidders"`
 }
 
 type AdapterAlternateBidderCodes struct {
@@ -246,11 +246,11 @@ func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidd
 		return false, nil
 	}
 
-	if bidderCodes.Adapters == nil {
+	if bidderCodes.Bidders == nil {
 		return false, fmt.Errorf(ErrAlternateBidderNotDefined, bidder, alternateBidder)
 	}
 
-	adapterCfg, ok := bidderCodes.Adapters[bidder]
+	adapterCfg, ok := bidderCodes.Bidders[bidder]
 	if !ok {
 		return false, fmt.Errorf(ErrAlternateBidderNotDefined, bidder, alternateBidder)
 	}

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -711,8 +711,8 @@ func TestBasicEnforcementVendor(t *testing.T) {
 
 func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 	type fields struct {
-		Enabled  bool
-		Adapters map[string]AdapterAlternateBidderCodes
+		Enabled bool
+		Bidders map[string]AdapterAlternateBidderCodes
 	}
 	type args struct {
 		bidder          string
@@ -763,7 +763,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			},
 			fields: fields{
 				Enabled: true,
-				Adapters: map[string]AdapterAlternateBidderCodes{
+				Bidders: map[string]AdapterAlternateBidderCodes{
 					"appnexus": {},
 				},
 			},
@@ -778,7 +778,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			},
 			fields: fields{
 				Enabled: true,
-				Adapters: map[string]AdapterAlternateBidderCodes{
+				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {},
 				},
 			},
@@ -793,7 +793,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			},
 			fields: fields{
 				Enabled: true,
-				Adapters: map[string]AdapterAlternateBidderCodes{
+				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
 						AllowedBidderCodes: []string{"*"},
 					},
@@ -809,7 +809,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			},
 			fields: fields{
 				Enabled: true,
-				Adapters: map[string]AdapterAlternateBidderCodes{
+				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
 						AllowedBidderCodes: []string{"groupm"},
 					},
@@ -825,7 +825,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			},
 			fields: fields{
 				Enabled: true,
-				Adapters: map[string]AdapterAlternateBidderCodes{
+				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
 						AllowedBidderCodes: []string{"xyz"},
 					},
@@ -838,8 +838,8 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &AlternateBidderCodes{
-				Enabled:  tt.fields.Enabled,
-				Adapters: tt.fields.Adapters,
+				Enabled: tt.fields.Enabled,
+				Bidders: tt.fields.Bidders,
 			}
 			gotIsValid, gotErr := a.IsValidBidderCode(tt.args.bidder, tt.args.alternateBidder)
 			assert.Equal(t, tt.wantIsValid, gotIsValid)

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2079,7 +2079,7 @@ func TestExtraBid(t *testing.T) {
 	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, map[string]float64{}, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
 		config.AlternateBidderCodes{
 			Enabled: true,
-			Adapters: map[string]config.AdapterAlternateBidderCodes{
+			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
 					AllowedBidderCodes: []string{"groupm"},
 				},
@@ -2182,7 +2182,7 @@ func TestExtraBidWithAlternateBidderCodeDisabled(t *testing.T) {
 	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, map[string]float64{}, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
 		config.AlternateBidderCodes{
 			Enabled: true,
-			Adapters: map[string]config.AdapterAlternateBidderCodes{
+			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
 					AllowedBidderCodes: []string{"groupm-allowed"},
 				},
@@ -2282,7 +2282,7 @@ func TestExtraBidWithBidAdjustments(t *testing.T) {
 	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
 		config.AlternateBidderCodes{
 			Enabled: true,
-			Adapters: map[string]config.AdapterAlternateBidderCodes{
+			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
 					AllowedBidderCodes: []string{"groupm"},
 				},
@@ -2384,7 +2384,7 @@ func TestExtraBidWithBidAdjustmentsUsingAdapterCode(t *testing.T) {
 	seatBids, errs := bidder.requestBid(context.Background(), bidderReq, bidAdjustments, currencyConverter.Rates(), &adapters.ExtraRequestInfo{}, false, false,
 		config.AlternateBidderCodes{
 			Enabled: true,
-			Adapters: map[string]config.AdapterAlternateBidderCodes{
+			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
 					AllowedBidderCodes: []string{"groupm"},
 				},


### PR DESCRIPTION
Rename `adapters` to `bidders` in alternate bidder codes config w.r.t https://github.com/prebid/prebid-server/issues/2174

Old pbs.yaml example:
```
account_defaults:
  alternatebiddercodes:
    enabled: true
    adapters:
      pubmatic:
        allowedbiddercodes: [groupm]
      appnexus:
        allowedbiddercodes: [*]
```

New pbs.yaml example:
```
account_defaults:
  alternatebiddercodes:
    enabled: true
    bidders:
      pubmatic:
        allowedbiddercodes: [groupm]
      appnexus:
        allowedbiddercodes: [*]
```