### PR TITLE
Add bidder level toggle for alternatebiddercodes config

### DIFF
--- a/config/accounts.go
+++ b/config/accounts.go
@@ -232,11 +232,13 @@ type AlternateBidderCodes struct {
 }
 
 type AdapterAlternateBidderCodes struct {
+	Enabled            bool     `mapstructure:"enabled" json:"enabled"`
 	AllowedBidderCodes []string `mapstructure:"allowedbiddercodes" json:"allowedbiddercodes"`
 }
 
 func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidder string) (bool, error) {
 	const ErrAlternateBidderNotDefined = "alternateBidderCodes not defined for adapter %q, rejecting bids for %q"
+	const ErrAlternateBidderNotEnabled = "alternateBidderCodes not enabled for adapter %q, rejecting bids for %q"
 
 	if alternateBidder == "" || bidder == alternateBidder {
 		return true, nil
@@ -255,11 +257,12 @@ func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidd
 		return false, fmt.Errorf(ErrAlternateBidderNotDefined, bidder, alternateBidder)
 	}
 
-	if len(adapterCfg.AllowedBidderCodes) == 0 {
-		return false, fmt.Errorf("alternateBidderCodes disabled for %q, rejecting bids for %q", bidder, alternateBidder)
+	if !adapterCfg.Enabled {
+		// config has bidder entry but is not enabled, report it
+		return false, fmt.Errorf(ErrAlternateBidderNotEnabled, bidder, alternateBidder)
 	}
 
-	if adapterCfg.AllowedBidderCodes[0] == "*" {
+	if len(adapterCfg.AllowedBidderCodes) == 0 || adapterCfg.AllowedBidderCodes[0] == "*" {
 		return true, nil
 	}
 

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -261,7 +261,7 @@ func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidd
 		return false, fmt.Errorf("alternateBidderCodes disabled for %q, rejecting bids for %q", bidder, alternateBidder)
 	}
 
-	if len(adapterCfg.AllowedBidderCodes) == 0 || adapterCfg.AllowedBidderCodes[0] == "*" {
+	if adapterCfg.AllowedBidderCodes == nil || (len(adapterCfg.AllowedBidderCodes) == 1 && adapterCfg.AllowedBidderCodes[0] == "*") {
 		return true, nil
 	}
 

--- a/config/accounts.go
+++ b/config/accounts.go
@@ -238,7 +238,6 @@ type AdapterAlternateBidderCodes struct {
 
 func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidder string) (bool, error) {
 	const ErrAlternateBidderNotDefined = "alternateBidderCodes not defined for adapter %q, rejecting bids for %q"
-	const ErrAlternateBidderNotEnabled = "alternateBidderCodes not enabled for adapter %q, rejecting bids for %q"
 
 	if alternateBidder == "" || bidder == alternateBidder {
 		return true, nil
@@ -259,7 +258,7 @@ func (bidderCodes *AlternateBidderCodes) IsValidBidderCode(bidder, alternateBidd
 
 	if !adapterCfg.Enabled {
 		// config has bidder entry but is not enabled, report it
-		return false, fmt.Errorf(ErrAlternateBidderNotEnabled, bidder, alternateBidder)
+		return false, fmt.Errorf("alternateBidderCodes disabled for %q, rejecting bids for %q", bidder, alternateBidder)
 	}
 
 	if len(adapterCfg.AllowedBidderCodes) == 0 || adapterCfg.AllowedBidderCodes[0] == "*" {

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -771,7 +771,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			wantErr:     errors.New(`alternateBidderCodes not defined for adapter "pubmatic", rejecting bids for "groupm"`),
 		},
 		{
-			name: "account.alternatebiddercodes config enabled but adapter config has allowedBidderCodes list empty or not defined",
+			name: "account.alternatebiddercodes config enabled but adapter config is disabled",
 			args: args{
 				bidder:          "pubmatic",
 				alternateBidder: "groupm",
@@ -779,11 +779,25 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			fields: fields{
 				Enabled: true,
 				Bidders: map[string]AdapterAlternateBidderCodes{
-					"pubmatic": {},
+					"pubmatic": {Enabled: false},
 				},
 			},
 			wantIsValid: false,
-			wantErr:     errors.New(`alternateBidderCodes disabled for "pubmatic", rejecting bids for "groupm"`),
+			wantErr:     errors.New(`alternateBidderCodes not enabled for adapter "pubmatic", rejecting bids for "groupm"`),
+		},
+		{
+			name: "account.alternatebiddercodes and adapter config enabled but adapter config has allowedBidderCodes list empty or not defined",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Bidders: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {Enabled: true},
+				},
+			},
+			wantIsValid: true,
 		},
 		{
 			name: "allowedBidderCodes is *",
@@ -795,6 +809,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 				Enabled: true,
 				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
+						Enabled:            true,
 						AllowedBidderCodes: []string{"*"},
 					},
 				},
@@ -811,6 +826,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 				Enabled: true,
 				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
+						Enabled:            true,
 						AllowedBidderCodes: []string{"groupm"},
 					},
 				},
@@ -827,6 +843,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 				Enabled: true,
 				Bidders: map[string]AdapterAlternateBidderCodes{
 					"pubmatic": {
+						Enabled:            true,
 						AllowedBidderCodes: []string{"xyz"},
 					},
 				},

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -851,6 +851,21 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			wantIsValid: false,
 			wantErr:     errors.New(`invalid biddercode "groupm" sent by adapter "pubmatic"`),
 		},
+		{
+			name: "account.alternatebiddercodes and adapter config enabled but adapter config has allowedBidderCodes list empty",
+			args: args{
+				bidder:          "pubmatic",
+				alternateBidder: "groupm",
+			},
+			fields: fields{
+				Enabled: true,
+				Bidders: map[string]AdapterAlternateBidderCodes{
+					"pubmatic": {Enabled: true, AllowedBidderCodes: []string{}},
+				},
+			},
+			wantIsValid: false,
+			wantErr:     errors.New(`invalid biddercode "groupm" sent by adapter "pubmatic"`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -786,7 +786,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 			wantErr:     errors.New(`alternateBidderCodes disabled for "pubmatic", rejecting bids for "groupm"`),
 		},
 		{
-			name: "account.alternatebiddercodes and adapter config enabled but adapter config has allowedBidderCodes list empty or not defined",
+			name: "account.alternatebiddercodes and adapter config enabled but adapter config does not have allowedBidderCodes defined",
 			args: args{
 				bidder:          "pubmatic",
 				alternateBidder: "groupm",

--- a/config/accounts_test.go
+++ b/config/accounts_test.go
@@ -783,7 +783,7 @@ func TestAlternateBidderCodes_IsValidBidderCode(t *testing.T) {
 				},
 			},
 			wantIsValid: false,
-			wantErr:     errors.New(`alternateBidderCodes not enabled for adapter "pubmatic", rejecting bids for "groupm"`),
+			wantErr:     errors.New(`alternateBidderCodes disabled for "pubmatic", rejecting bids for "groupm"`),
 		},
 		{
 			name: "account.alternatebiddercodes and adapter config enabled but adapter config has allowedBidderCodes list empty or not defined",

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2081,6 +2081,7 @@ func TestExtraBid(t *testing.T) {
 			Enabled: true,
 			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
 					AllowedBidderCodes: []string{"groupm"},
 				},
 			},
@@ -2184,6 +2185,7 @@ func TestExtraBidWithAlternateBidderCodeDisabled(t *testing.T) {
 			Enabled: true,
 			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
 					AllowedBidderCodes: []string{"groupm-allowed"},
 				},
 			},
@@ -2284,6 +2286,7 @@ func TestExtraBidWithBidAdjustments(t *testing.T) {
 			Enabled: true,
 			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
 					AllowedBidderCodes: []string{"groupm"},
 				},
 			},
@@ -2386,6 +2389,7 @@ func TestExtraBidWithBidAdjustmentsUsingAdapterCode(t *testing.T) {
 			Enabled: true,
 			Bidders: map[string]config.AdapterAlternateBidderCodes{
 				string(openrtb_ext.BidderPubmatic): {
+					Enabled:            true,
 					AllowedBidderCodes: []string{"groupm"},
 				},
 			},


### PR DESCRIPTION
This change introduces bidder level toggle in alternatebiddercodes config https://github.com/prebid/prebid-server/issues/2174 (similar to that in PBJS).  
The bidder level toggle needs to be explicitly enabled with below config combinations (pfa).

<img width="1659" alt="pbs alternatebiddercodes config 2" src="https://user-images.githubusercontent.com/97721111/180967506-0b33f7a0-0a1f-4f29-8dee-3439312a83b2.png">

Old pbs.yaml example:
```
 account_defaults:
   alternatebiddercodes:
     enabled: true
     bidders:
       pubmatic:
         allowedbiddercodes: [groupm]
       appnexus:
         allowedbiddercodes: [*]
```

New pbs.yaml example:
```
 account_defaults:
   alternatebiddercodes:
     enabled: true
     bidders:
       pubmatic:
         enabled: true
         allowedbiddercodes: [groupm]
       appnexus:
         enabled: true
         allowedbiddercodes: [*]
```