### PR TITLE
Request Wrapper: Only Create Elements If Needed

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1317,7 +1317,7 @@ func (deps *endpointDeps) validateSite(req *openrtb_ext.RequestWrapper) error {
 		return err
 	}
 	siteAmp := siteExt.GetAmp()
-	if siteAmp < 0 || siteAmp > 1 {
+	if siteAmp != nil && (*siteAmp < 0 || *siteAmp > 1) {
 		return errors.New(`request.site.ext.amp must be either 1, 0, or undefined`)
 	}
 

--- a/openrtb_ext/app.go
+++ b/openrtb_ext/app.go
@@ -6,10 +6,7 @@ type ExtApp struct {
 }
 
 // ExtAppPrebid further defines the contract for bidrequest.app.ext.prebid.
-// We are only enforcing that these two properties be strings if they are provided.
-// They are optional with no current constraints on value, so we don't need a custom
-// UnmarshalJSON() method at this time.
 type ExtAppPrebid struct {
-	Source  string `json:"source"`
-	Version string `json:"version"`
+	Source  string `json:"source,omitempty"`
+	Version string `json:"version,omitempty"`
 }

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -203,16 +203,21 @@ func (rw *RequestWrapper) rebuildAppExt() error {
 }
 
 func (rw *RequestWrapper) rebuildRegExt() error {
-	if rw.Regs == nil && rw.regExt != nil && rw.regExt.Dirty() {
-		rw.Regs = &openrtb2.Regs{}
+	if rw.regExt == nil || !rw.regExt.Dirty() {
+		return nil
 	}
-	if rw.regExt != nil && rw.regExt.Dirty() {
-		regsJson, err := rw.regExt.marshal()
-		if err != nil {
-			return err
-		}
+
+	regsJson, err := rw.regExt.marshal()
+	if err != nil {
+		return err
+	}
+
+	if regsJson != nil && rw.Regs == nil {
+		rw.Regs = &openrtb2.Regs{Ext: regsJson}
+	} else if rw.Regs != nil {
 		rw.Regs.Ext = regsJson
 	}
+
 	return nil
 }
 

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -41,6 +41,8 @@ type RequestWrapper struct {
 	sourceExt  *SourceExt
 }
 
+const jsonEmptyObjectLength = 2
+
 func (rw *RequestWrapper) GetUserExt() (*UserExt, error) {
 	if rw.userExt != nil {
 		return rw.userExt, nil
@@ -188,13 +190,17 @@ func (rw *RequestWrapper) rebuildDeviceExt() error {
 }
 
 func (rw *RequestWrapper) rebuildRequestExt() error {
-	if rw.requestExt != nil && rw.requestExt.Dirty() {
-		requestJson, err := rw.requestExt.marshal()
-		if err != nil {
-			return err
-		}
-		rw.Ext = requestJson
+	if rw.requestExt == nil || !rw.requestExt.Dirty() {
+		return nil
 	}
+
+	requestJson, err := rw.requestExt.marshal()
+	if err != nil {
+		return err
+	}
+
+	rw.Ext = requestJson
+
 	return nil
 }
 
@@ -333,7 +339,7 @@ func (ue *UserExt) marshal() (json.RawMessage, error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(prebidJson) > 2 {
+			if len(prebidJson) > jsonEmptyObjectLength {
 				ue.ext["prebid"] = json.RawMessage(prebidJson)
 			} else {
 				delete(ue.ext, "prebid")
@@ -461,12 +467,16 @@ func (re *RequestExt) unmarshal(extJson json.RawMessage) error {
 
 func (re *RequestExt) marshal() (json.RawMessage, error) {
 	if re.prebidDirty {
-		prebidJson, err := json.Marshal(re.prebid)
-		if err != nil {
-			return nil, err
-		}
-		if len(prebidJson) > 2 {
-			re.ext["prebid"] = json.RawMessage(prebidJson)
+		if re.prebid != nil {
+			prebidJson, err := json.Marshal(re.prebid)
+			if err != nil {
+				return nil, err
+			}
+			if len(prebidJson) > jsonEmptyObjectLength {
+				re.ext["prebid"] = json.RawMessage(prebidJson)
+			} else {
+				delete(re.ext, "prebid")
+			}
 		} else {
 			delete(re.ext, "prebid")
 		}
@@ -474,15 +484,16 @@ func (re *RequestExt) marshal() (json.RawMessage, error) {
 	}
 
 	if re.schainDirty {
-		if re.schain == nil {
-		}
-
-		schainJson, err := json.Marshal(re.schain)
-		if err != nil {
-			return nil, err
-		}
-		if len(schainJson) > 2 && re.schain != nil {
-			re.ext["schain"] = json.RawMessage(schainJson)
+		if re.schain != nil {
+			schainJson, err := json.Marshal(re.schain)
+			if err != nil {
+				return nil, err
+			}
+			if len(schainJson) > jsonEmptyObjectLength {
+				re.ext["schain"] = json.RawMessage(schainJson)
+			} else {
+				delete(re.ext, "schain")
+			}
 		} else {
 			delete(re.ext, "schain")
 		}
@@ -585,7 +596,7 @@ func (de *DeviceExt) marshal() (json.RawMessage, error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(prebidJson) > 2 {
+			if len(prebidJson) > jsonEmptyObjectLength {
 				de.ext["prebid"] = json.RawMessage(prebidJson)
 			} else {
 				delete(de.ext, "prebid")
@@ -671,7 +682,7 @@ func (ae *AppExt) marshal() (json.RawMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(prebidJson) > 2 {
+		if len(prebidJson) > jsonEmptyObjectLength {
 			ae.ext["prebid"] = json.RawMessage(prebidJson)
 		} else {
 			delete(ae.ext, "prebid")
@@ -835,7 +846,7 @@ func (se *SiteExt) marshal() (json.RawMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(ampJson) > 2 {
+		if len(ampJson) > jsonEmptyObjectLength {
 			se.ext["amp"] = json.RawMessage(ampJson)
 		} else {
 			delete(se.ext, "amp")
@@ -913,7 +924,7 @@ func (se *SourceExt) marshal() (json.RawMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(schainJson) > 2 {
+		if len(schainJson) > jsonEmptyObjectLength {
 			se.ext["schain"] = json.RawMessage(schainJson)
 		} else {
 			delete(se.ext, "schain")

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -63,8 +63,8 @@ func TestRebuildUserExt(t *testing.T) {
 		{
 			description:           "Nil - Dirty",
 			request:               openrtb2.BidRequest{},
-			requestUserExtWrapper: UserExt{consent: &strB, consentDirty: true},
-			expectedRequest:       openrtb2.BidRequest{User: &openrtb2.User{Ext: json.RawMessage(`{"consent":"b"}`)}},
+			requestUserExtWrapper: UserExt{consent: &strA, consentDirty: true},
+			expectedRequest:       openrtb2.BidRequest{User: &openrtb2.User{Ext: json.RawMessage(`{"consent":"a"}`)}},
 		},
 		{
 			description:           "Nil - Dirty - No Change",
@@ -267,6 +267,88 @@ func TestRebuildRequestExt(t *testing.T) {
 		test.requestRequestExtWrapper.ext = make(map[string]json.RawMessage)
 
 		w := RequestWrapper{BidRequest: &test.request, requestExt: &test.requestRequestExtWrapper}
+		w.RebuildRequest()
+		assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
+	}
+}
+
+func TestRebuildAppExt(t *testing.T) {
+	prebidContent1 := ExtAppPrebid{Source: "1"}
+	prebidContent2 := ExtAppPrebid{Source: "2"}
+
+	testCases := []struct {
+		description          string
+		request              openrtb2.BidRequest
+		requestAppExtWrapper AppExt
+		expectedRequest      openrtb2.BidRequest
+	}{
+		{
+			description:          "Nil - Not Dirty",
+			request:              openrtb2.BidRequest{},
+			requestAppExtWrapper: AppExt{},
+			expectedRequest:      openrtb2.BidRequest{},
+		},
+		{
+			description:          "Nil - Dirty",
+			request:              openrtb2.BidRequest{},
+			requestAppExtWrapper: AppExt{prebid: &prebidContent1, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+		},
+		{
+			description:          "Nil - Dirty - No Change",
+			request:              openrtb2.BidRequest{},
+			requestAppExtWrapper: AppExt{prebid: nil, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{},
+		},
+		{
+			description:          "Empty - Not Dirty",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{}},
+			requestAppExtWrapper: AppExt{},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{}},
+		},
+		{
+			description:          "Empty - Dirty",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{}},
+			requestAppExtWrapper: AppExt{prebid: &prebidContent1, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+		},
+		{
+			description:          "Empty - Dirty - No Change",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{}},
+			requestAppExtWrapper: AppExt{prebid: nil, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{}},
+		},
+		{
+			description:          "Populated - Not Dirty",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+			requestAppExtWrapper: AppExt{},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+		},
+		{
+			description:          "Populated - Dirty",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+			requestAppExtWrapper: AppExt{prebid: &prebidContent2, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"2"}}`)}},
+		},
+		{
+			description:          "Populated - Dirty - No Change",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+			requestAppExtWrapper: AppExt{prebid: &prebidContent1, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+		},
+		{
+			description:          "Populated - Dirty - Cleared",
+			request:              openrtb2.BidRequest{App: &openrtb2.App{Ext: json.RawMessage(`{"prebid":{"source":"1"}}`)}},
+			requestAppExtWrapper: AppExt{prebid: nil, prebidDirty: true},
+			expectedRequest:      openrtb2.BidRequest{App: &openrtb2.App{}},
+		},
+	}
+
+	for _, test := range testCases {
+		// create required filed in the test loop to keep test declaration easier to read
+		test.requestAppExtWrapper.ext = make(map[string]json.RawMessage)
+
+		w := RequestWrapper{BidRequest: &test.request, appExt: &test.requestAppExtWrapper}
 		w.RebuildRequest()
 		assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
 	}

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -208,80 +208,65 @@ func TestRebuildDeviceExt(t *testing.T) {
 	}
 }
 
-func TestRebuildRegExt(t *testing.T) {
+func TestRebuildRequestExt(t *testing.T) {
+	prebidContent1 := ExtRequestPrebid{Integration: "1"}
+	prebidContent2 := ExtRequestPrebid{Integration: "2"}
+
 	testCases := []struct {
-		description          string
-		request              openrtb2.BidRequest
-		requestRegExtWrapper RegExt
-		expectedRequest      openrtb2.BidRequest
+		description              string
+		request                  openrtb2.BidRequest
+		requestRequestExtWrapper RequestExt
+		expectedRequest          openrtb2.BidRequest
 	}{
 		{
-			description:          "Nil - Not Dirty",
-			request:              openrtb2.BidRequest{},
-			requestRegExtWrapper: RegExt{},
-			expectedRequest:      openrtb2.BidRequest{},
+			description:              "Empty - Not Dirty",
+			request:                  openrtb2.BidRequest{},
+			requestRequestExtWrapper: RequestExt{},
+			expectedRequest:          openrtb2.BidRequest{},
 		},
 		{
-			description:          "Nil - Dirty",
-			request:              openrtb2.BidRequest{},
-			requestRegExtWrapper: RegExt{usPrivacy: "b", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"b"}`)}},
+			description:              "Empty - Dirty",
+			request:                  openrtb2.BidRequest{},
+			requestRequestExtWrapper: RequestExt{prebid: &prebidContent1, prebidDirty: true},
+			expectedRequest:          openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
 		},
 		{
-			description:          "Nil - Dirty - No Change",
-			request:              openrtb2.BidRequest{},
-			requestRegExtWrapper: RegExt{usPrivacy: "", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{},
+			description:              "Empty - Dirty - No Change",
+			request:                  openrtb2.BidRequest{},
+			requestRequestExtWrapper: RequestExt{prebid: nil, prebidDirty: true},
+			expectedRequest:          openrtb2.BidRequest{},
 		},
 		{
-			description:          "Empty - Not Dirty",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
-			requestRegExtWrapper: RegExt{},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
+			description:              "Populated - Not Dirty",
+			request:                  openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
+			requestRequestExtWrapper: RequestExt{},
+			expectedRequest:          openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
 		},
 		{
-			description:          "Empty - Dirty",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
-			requestRegExtWrapper: RegExt{usPrivacy: "b", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"b"}`)}},
+			description:              "Populated - Dirty",
+			request:                  openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
+			requestRequestExtWrapper: RequestExt{prebid: &prebidContent2, prebidDirty: true},
+			expectedRequest:          openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"2"}}`)},
 		},
 		{
-			description:          "Empty - Dirty - No Change",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
-			requestRegExtWrapper: RegExt{usPrivacy: "", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
+			description:              "Populated - Dirty - No Change",
+			request:                  openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
+			requestRequestExtWrapper: RequestExt{prebid: &prebidContent1, prebidDirty: true},
+			expectedRequest:          openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
 		},
 		{
-			description:          "Populated - Not Dirty",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-			requestRegExtWrapper: RegExt{},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-		},
-		{
-			description:          "Populated - Dirty",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-			requestRegExtWrapper: RegExt{usPrivacy: "b", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"b"}`)}},
-		},
-		{
-			description:          "Populated - Dirty - No Change",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-			requestRegExtWrapper: RegExt{usPrivacy: "a", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-		},
-		{
-			description:          "Populated - Dirty - Cleared",
-			request:              openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"a"}`)}},
-			requestRegExtWrapper: RegExt{usPrivacy: "", usPrivacyDirty: true},
-			expectedRequest:      openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
+			description:              "Populated - Dirty - Cleared",
+			request:                  openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"integration":"1"}}`)},
+			requestRequestExtWrapper: RequestExt{prebid: nil, prebidDirty: true},
+			expectedRequest:          openrtb2.BidRequest{},
 		},
 	}
 
 	for _, test := range testCases {
 		// create required filed in the test loop to keep test declaration easier to read
-		test.requestRegExtWrapper.ext = make(map[string]json.RawMessage)
+		test.requestRequestExtWrapper.ext = make(map[string]json.RawMessage)
 
-		w := RequestWrapper{BidRequest: &test.request, regExt: &test.requestRegExtWrapper}
+		w := RequestWrapper{BidRequest: &test.request, requestExt: &test.requestRequestExtWrapper}
 		w.RebuildRequest()
 		assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
 	}

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -353,3 +353,85 @@ func TestRebuildAppExt(t *testing.T) {
 		assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
 	}
 }
+
+func TestRebuildSiteExt(t *testing.T) {
+	int1 := int8(1)
+	int2 := int8(2)
+
+	testCases := []struct {
+		description           string
+		request               openrtb2.BidRequest
+		requestSiteExtWrapper SiteExt
+		expectedRequest       openrtb2.BidRequest
+	}{
+		{
+			description:           "Nil - Not Dirty",
+			request:               openrtb2.BidRequest{},
+			requestSiteExtWrapper: SiteExt{},
+			expectedRequest:       openrtb2.BidRequest{},
+		},
+		{
+			description:           "Nil - Dirty",
+			request:               openrtb2.BidRequest{},
+			requestSiteExtWrapper: SiteExt{amp: &int1, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+		},
+		{
+			description:           "Nil - Dirty - No Change",
+			request:               openrtb2.BidRequest{},
+			requestSiteExtWrapper: SiteExt{amp: nil, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{},
+		},
+		{
+			description:           "Empty - Not Dirty",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{}},
+			requestSiteExtWrapper: SiteExt{},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{}},
+		},
+		{
+			description:           "Empty - Dirty",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{}},
+			requestSiteExtWrapper: SiteExt{amp: &int1, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+		},
+		{
+			description:           "Empty - Dirty - No Change",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{}},
+			requestSiteExtWrapper: SiteExt{amp: nil, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{}},
+		},
+		{
+			description:           "Populated - Not Dirty",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+			requestSiteExtWrapper: SiteExt{},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+		},
+		{
+			description:           "Populated - Dirty",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+			requestSiteExtWrapper: SiteExt{amp: &int2, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":2}`)}},
+		},
+		{
+			description:           "Populated - Dirty - No Change",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+			requestSiteExtWrapper: SiteExt{amp: &int1, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+		},
+		{
+			description:           "Populated - Dirty - Cleared",
+			request:               openrtb2.BidRequest{Site: &openrtb2.Site{Ext: json.RawMessage(`{"amp":1}`)}},
+			requestSiteExtWrapper: SiteExt{amp: nil, ampDirty: true},
+			expectedRequest:       openrtb2.BidRequest{Site: &openrtb2.Site{}},
+		},
+	}
+
+	for _, test := range testCases {
+		// create required filed in the test loop to keep test declaration easier to read
+		test.requestSiteExtWrapper.ext = make(map[string]json.RawMessage)
+
+		w := RequestWrapper{BidRequest: &test.request, siteExt: &test.requestSiteExtWrapper}
+		w.RebuildRequest()
+		assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
+	}
+}

--- a/privacy/ccpa/policy_test.go
+++ b/privacy/ccpa/policy_test.go
@@ -298,7 +298,7 @@ func TestBuildRegsClear(t *testing.T) {
 		{
 			description: "Nil Regs",
 			regs:        nil,
-			expected:    &openrtb2.Regs{Ext: nil},
+			expected:    nil,
 		},
 		{
 			description: "Nil Regs.Ext",


### PR DESCRIPTION
This PR change the behavior of the RequestWrapper to only create new objects if there a non-empty extension object. I also fixed some misc marhsal issues that I discovered through the rebuild ext methods. 