### PR TITLE
IX Adapter - Add iframe usersync support

### DIFF
--- a/static/bidder-info/ix.yaml
+++ b/static/bidder-info/ix.yaml
@@ -18,4 +18,6 @@ userSync:
   redirect:
     url: "https://ssum.casalemedia.com/usermatchredir?s=194962&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
     userMacro: ""
+  iframe:
+    url: "https://ssum-sec.casalemedia.com/usermatch?s=184674&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
     # ix appends the user id to end of the redirect url and does not utilize a macro


### PR DESCRIPTION
This PR is to add iframe usersync support for ix bid adapter.

This has been confirmed using the cookie_sync endpoint locally.