### PR TITLE
Add account-specific error metrics to setuid endpoint

### DIFF
--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -61,6 +61,7 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			metricsEngine.RecordSetUid(metrics.SetUidSyncerUnknown)
+			so.Errors = []error{err}
 			so.Status = http.StatusBadRequest
 			return
 		}
@@ -71,6 +72,7 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			metricsEngine.RecordSetUid(metrics.SetUidBadRequest)
+			so.Errors = []error{err}
 			so.Status = http.StatusBadRequest
 			return
 		}
@@ -82,8 +84,17 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 		account, fetchErrs := accountService.GetAccount(context.Background(), cfg, accountsFetcher, accountID)
 		if len(fetchErrs) > 0 {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(combineErrors(fetchErrs).Error()))
-			metricsEngine.RecordSetUid(metrics.SetUidBadRequest)
+			err := combineErrors(fetchErrs)
+			w.Write([]byte(err.Error()))
+			switch err {
+			case errCookieSyncAccountBlocked:
+				metricsEngine.RecordSetUid(metrics.SetUidAccountBlocked)
+			case errCookieSyncAccountInvalid:
+				metricsEngine.RecordSetUid(metrics.SetUidAccountInvalid)
+			default:
+				metricsEngine.RecordSetUid(metrics.SetUidBadRequest)
+			}
+			so.Errors = []error{err}
 			so.Status = http.StatusBadRequest
 			return
 		}

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -110,6 +110,7 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			case http.StatusUnavailableForLegalReasons:
 				metricsEngine.RecordSetUid(metrics.SetUidGDPRHostCookieBlocked)
 			}
+			so.Errors = []error{errors.New(body)}
 			so.Status = status
 			return
 		}

--- a/endpoints/setuid_test.go
+++ b/endpoints/setuid_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/metrics"
@@ -255,9 +256,11 @@ func TestSetUIDEndpoint(t *testing.T) {
 		},
 	}
 
+	analytics := analyticsConf.NewPBSAnalytics(&config.Analytics{})
 	metrics := &metricsConf.NilMetricsEngine{}
+
 	for _, test := range testCases {
-		response := doRequest(makeRequest(test.uri, test.existingSyncs), metrics,
+		response := doRequest(makeRequest(test.uri, test.existingSyncs), analytics, metrics,
 			test.syncersBidderNameToKey, test.gdprAllowsHostCookies, test.gdprReturnsError, test.gdprMalformed, false)
 		assert.Equal(t, test.expectedStatusCode, response.Code, "Test Case: %s. /setuid returned unexpected error code", test.description)
 
@@ -298,6 +301,7 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 		cfgAccountRequired     bool
 		expectedResponseCode   int
 		expectedMetrics        func(*metrics.MetricsEngineMock)
+		expectedAnalytics      func(*MockAnalytics)
 	}{
 		{
 			description:            "Success - Sync",
@@ -309,6 +313,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidOK).Once()
 				m.On("RecordSyncerSet", "pubmatic", metrics.SyncerSetUidOK).Once()
+			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  200,
+					Bidder:  "pubmatic",
+					UID:     "123",
+					Errors:  []error{},
+					Success: true,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
 			},
 		},
 		{
@@ -322,6 +336,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 				m.On("RecordSetUid", metrics.SetUidOK).Once()
 				m.On("RecordSyncerSet", "pubmatic", metrics.SyncerSetUidCleared).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  200,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{},
+					Success: true,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 		{
 			description:            "Cookie Opted Out",
@@ -332,6 +356,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedResponseCode:   401,
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidOptOut).Once()
+			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  401,
+					Bidder:  "",
+					UID:     "",
+					Errors:  []error{},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
 			},
 		},
 		{
@@ -344,6 +378,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidSyncerUnknown).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "",
+					UID:     "",
+					Errors:  []error{errors.New("The bidder name provided is not supported by Prebid Server")},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 		{
 			description:            "Unknown Format",
@@ -354,6 +398,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedResponseCode:   400,
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidBadRequest).Once()
+			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errors.New(`"f" query param is invalid. must be "b" or "i"`)},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
 			},
 		},
 		{
@@ -366,6 +420,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidBadRequest).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errors.New("gdpr_consent is required when gdpr=1")},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 		{
 			description:            "Prevented By GDPR - Permission Denied By Consent String",
@@ -377,6 +441,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidGDPRHostCookieBlocked).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  451,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errors.New("The gdpr_consent string prevents cookies from being saved")},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 		{
 			description:            "Blocked account",
@@ -387,6 +461,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedResponseCode:   400,
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidAccountBlocked).Once()
+			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errCookieSyncAccountBlocked},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
 			},
 		},
 		{
@@ -400,6 +484,16 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidAccountInvalid).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errCookieSyncAccountInvalid},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 		{
 			description:            "Malformed account",
@@ -412,10 +506,23 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 			expectedMetrics: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordSetUid", metrics.SetUidBadRequest).Once()
 			},
+			expectedAnalytics: func(a *MockAnalytics) {
+				expected := analytics.SetUIDObject{
+					Status:  400,
+					Bidder:  "pubmatic",
+					UID:     "",
+					Errors:  []error{errors.New("json: cannot unmarshal string into Go struct field Account.disabled of type bool")},
+					Success: false,
+				}
+				a.On("LogSetUIDObject", &expected).Once()
+			},
 		},
 	}
 
 	for _, test := range testCases {
+		analyticsEngine := &MockAnalytics{}
+		test.expectedAnalytics(analyticsEngine)
+
 		metricsEngine := &metrics.MetricsEngineMock{}
 		test.expectedMetrics(metricsEngine)
 
@@ -423,9 +530,10 @@ func TestSetUIDEndpointMetrics(t *testing.T) {
 		for _, v := range test.cookies {
 			addCookie(req, v)
 		}
-		response := doRequest(req, metricsEngine, test.syncersBidderNameToKey, test.gdprAllowsHostCookies, false, false, test.cfgAccountRequired)
+		response := doRequest(req, analyticsEngine, metricsEngine, test.syncersBidderNameToKey, test.gdprAllowsHostCookies, false, false, test.cfgAccountRequired)
 
 		assert.Equal(t, test.expectedResponseCode, response.Code, test.description)
+		analyticsEngine.AssertExpectations(t)
 		metricsEngine.AssertExpectations(t)
 	}
 }
@@ -436,8 +544,9 @@ func TestOptedOut(t *testing.T) {
 	cookie.SetOptOut(true)
 	addCookie(request, cookie)
 	syncersBidderNameToKey := map[string]string{"pubmatic": "pubmatic"}
+	analytics := analyticsConf.NewPBSAnalytics(&config.Analytics{})
 	metrics := &metricsConf.NilMetricsEngine{}
-	response := doRequest(request, metrics, syncersBidderNameToKey, true, false, false, false)
+	response := doRequest(request, analytics, metrics, syncersBidderNameToKey, true, false, false, false)
 
 	assert.Equal(t, http.StatusUnauthorized, response.Code)
 }
@@ -573,7 +682,7 @@ func makeRequest(uri string, existingSyncs map[string]string) *http.Request {
 	return request
 }
 
-func doRequest(req *http.Request, metrics metrics.MetricsEngine, syncersBidderNameToKey map[string]string, gdprAllowsHostCookies, gdprReturnsError, gdprReturnsMalformedError, cfgAccountRequired bool) *httptest.ResponseRecorder {
+func doRequest(req *http.Request, analytics analytics.PBSAnalyticsModule, metrics metrics.MetricsEngine, syncersBidderNameToKey map[string]string, gdprAllowsHostCookies, gdprReturnsError, gdprReturnsMalformedError, cfgAccountRequired bool) *httptest.ResponseRecorder {
 	cfg := config.Configuration{
 		AccountRequired: cfgAccountRequired,
 		BlacklistedAcctMap: map[string]bool{
@@ -598,7 +707,6 @@ func doRequest(req *http.Request, metrics metrics.MetricsEngine, syncersBidderNa
 		cfg: gdpr.NewTCF2Config(config.TCF2{}, config.AccountGDPR{}),
 	}.Builder
 
-	analytics := analyticsConf.NewPBSAnalytics(&cfg.Analytics)
 	syncersByBidder := make(map[string]usersync.Syncer)
 	for bidderName, syncerKey := range syncersBidderNameToKey {
 		syncersByBidder[bidderName] = fakeSyncer{key: syncerKey, defaultSyncType: usersync.SyncTypeIFrame}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -315,6 +315,8 @@ func CookieSyncStatuses() []CookieSyncStatus {
 		CookieSyncBadRequest,
 		CookieSyncOptOut,
 		CookieSyncGDPRHostCookieBlocked,
+		CookieSyncAccountBlocked,
+		CookieSyncAccountInvalid,
 	}
 }
 
@@ -347,6 +349,8 @@ const (
 	SetUidBadRequest            SetUidStatus = "bad_request"
 	SetUidOptOut                SetUidStatus = "opt_out"
 	SetUidGDPRHostCookieBlocked SetUidStatus = "gdpr_blocked_host_cookie"
+	SetUidAccountBlocked        SetUidStatus = "acct_blocked"
+	SetUidAccountInvalid        SetUidStatus = "acct_invalid"
 	SetUidSyncerUnknown         SetUidStatus = "syncer_unknown"
 )
 
@@ -357,6 +361,8 @@ func SetUidStatuses() []SetUidStatus {
 		SetUidBadRequest,
 		SetUidOptOut,
 		SetUidGDPRHostCookieBlocked,
+		SetUidAccountBlocked,
+		SetUidAccountInvalid,
 		SetUidSyncerUnknown,
 	}
 }


### PR DESCRIPTION
This PR makes the setuid endpoint consistent with the cookie sync endpoint in how it reports account-related error metrics. Instead of always reporting "bad request" when there is an account error, we now indicate whether the account was blocked, or invalid before defaulting to "bad request".
Also a few changes were made to ensure any errors encountered by the setuid endpoint are appropriately logged when calling the analytic adapter `LogSetUIDObject` function.