### PR TITLE
pubmatic adapter: report MakeBids errors

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -2,6 +2,7 @@ package pubmatic
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -430,7 +431,7 @@ func getNativeAdm(adm string) (string, error) {
 	nativeAdm := make(map[string]interface{})
 	err = json.Unmarshal([]byte(adm), &nativeAdm)
 	if err != nil {
-		return adm, err
+		return adm, errors.New("unable to unmarshal native adm")
 	}
 
 	// move bid.adm.native to bid.adm
@@ -438,7 +439,7 @@ func getNativeAdm(adm string) (string, error) {
 		//using jsonparser to avoid marshaling, encode escape, etc.
 		value, _, _, err := jsonparser.Get([]byte(adm), string(openrtb_ext.BidTypeNative))
 		if err != nil {
-			return adm, err
+			return adm, errors.New("unable to get native adm")
 		}
 		adm = string(value)
 	}

--- a/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
@@ -72,7 +72,7 @@
                           "bid": [
                               {
                                 "id": "test-native-invalid-adm-json",
-                                  "impid": "test-native-imp",
+                                  "impid": "test-native-imp-invalid-adm",
                                   "price": 0.500000,
                                   "adid": "some-test-id",
                                   "adm": "{",
@@ -81,18 +81,6 @@
                                       "deal_channel": 1,
                                       "bidtype": 2
                                   }
-                              },
-                              {
-                                "id": "test-native-invalid-adm-native-json",
-                                "impid": "test-native-imp",
-                                "price": 0.500000,
-                                "adid": "some-test-id",
-                                "adm": "{\"native\":\"assets\":[{\"id\":2,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":4},{\"id\":3,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"id\":1,\"title\":{\"text\":\"Native Test Title\"}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":5}],\"imptrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"jstracker\":\"<script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'><script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'>\",\"link\":{\"clicktrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"fallback\":\"http://www.pubmatic.com\",\"url\":\"//www.pubmatic.com\"}}}",
-                                "crid": "29681110",
-                                "ext": {
-                                    "deal_channel": 1,
-                                    "bidtype": 2
-                                }
                               }
                           ]
                       }
@@ -108,27 +96,12 @@
           "currency": "USD",
           "bids": [
               {
-                  "bid": {
-                      "id": "test-native-invalid-adm-json",
-                      "impid": "test-native-imp",
-                      "price": 0.5,
-                      "adid": "some-test-id",
-                      "adm": "{",
-                      "crid": "29681110",
-                      "ext": {
-                          "deal_channel": 1,
-                          "bidtype": 2
-                      }
-                  },
-                  "type": "native"
-              },
-              {
                 "bid": {
-                    "id": "test-native-invalid-adm-native-json",
-                    "impid": "test-native-imp",
+                    "id": "test-native-invalid-adm-json",
+                    "impid": "test-native-imp-invalid-adm",
                     "price": 0.5,
                     "adid": "some-test-id",
-                    "adm": "{\"native\":\"assets\":[{\"id\":2,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":4},{\"id\":3,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"id\":1,\"title\":{\"text\":\"Native Test Title\"}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":5}],\"imptrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"jstracker\":\"<script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'><script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'>\",\"link\":{\"clicktrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"fallback\":\"http://www.pubmatic.com\",\"url\":\"//www.pubmatic.com\"}}}",
+                    "adm": "{",
                     "crid": "29681110",
                     "ext": {
                         "deal_channel": 1,
@@ -142,11 +115,7 @@
   ],
   "expectedMakeBidsErrors": [
     {
-      "value": "unexpected end of JSON input",
-      "comparison": "literal"
-    },
-    {
-      "value": "invalid character ':' after object key:value pair",
+      "value": "unable to unmarshal native adm",
       "comparison": "literal"
     }
   ]

--- a/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
@@ -1,0 +1,153 @@
+{
+  "mockBidRequest": {
+      "id": "test-native-request",
+      "imp": [
+          {
+              "id": "test-native-imp",
+              "native": {
+                  "request": "{\"assets\":[{\"id\":1,\"img\":{\"ext\":{\"image1\":\"image2\"},\"h\": 250,\"mimes\":[\"image\/gif\",\"image\/png\"],\"type\":3,\"w\":300},\"required\":1}]}"
+              },
+              "ext": {
+                  "bidder": {
+                      "publisherId": "999",
+                      "wrapper": {
+                          "version": 1,
+                          "profile": 5123
+                      }
+                  }
+              }
+          }
+      ],
+      "ext": {
+        "prebid": {}
+      },
+      "device": {
+          "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
+      },
+      "site": {
+          "id": "siteID",
+          "publisher": {
+              "id": "1234"
+          }
+      }
+  },
+  "httpCalls": [
+      {
+          "expectedRequest": {
+              "uri": "https://hbopenbid.pubmatic.com/translator?source=prebid-server",
+              "body": {
+                  "id": "test-native-request",
+                  "imp": [
+                      {
+                          "id": "test-native-imp",
+                          "native": {
+                              "request": "{\"assets\":[{\"id\":1,\"img\":{\"ext\":{\"image1\":\"image2\"},\"h\": 250,\"mimes\":[\"image\/gif\",\"image\/png\"],\"type\":3,\"w\":300},\"required\":1}]}"
+                          }
+                      }
+                  ],
+                  "device": {
+                      "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
+                  },
+                  "site": {
+                      "id": "siteID",
+                      "publisher": {
+                          "id": "999"
+                      }
+                  },
+                  "ext": {
+                      "wrapper": {
+                          "profile": 5123,
+                          "version": 1
+                      }
+                  }
+              }
+          },
+          "mockResponse": {
+              "status": 200,
+              "body": {
+                  "id": "test-native-request",
+                  "seatbid": [
+                      {
+                          "seat": "958",
+                          "bid": [
+                              {
+                                "id": "test-native-invalid-adm-json",
+                                  "impid": "test-native-imp",
+                                  "price": 0.500000,
+                                  "adid": "some-test-id",
+                                  "adm": "{",
+                                  "crid": "29681110",
+                                  "ext": {
+                                      "deal_channel": 1,
+                                      "bidtype": 2
+                                  }
+                              },
+                              {
+                                "id": "test-native-invalid-adm-native-json",
+                                "impid": "test-native-imp",
+                                "price": 0.500000,
+                                "adid": "some-test-id",
+                                "adm": "{\"native\":\"assets\":[{\"id\":2,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":4},{\"id\":3,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"id\":1,\"title\":{\"text\":\"Native Test Title\"}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":5}],\"imptrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"jstracker\":\"<script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'><script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'>\",\"link\":{\"clicktrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"fallback\":\"http://www.pubmatic.com\",\"url\":\"//www.pubmatic.com\"}}}",
+                                "crid": "29681110",
+                                "ext": {
+                                    "deal_channel": 1,
+                                    "bidtype": 2
+                                }
+                              }
+                          ]
+                      }
+                  ],
+                  "bidid": "5778926625248726496",
+                  "cur": "USD"
+              }
+          }
+      }
+  ],
+  "expectedBidResponses": [
+      {
+          "currency": "USD",
+          "bids": [
+              {
+                  "bid": {
+                      "id": "test-native-invalid-adm-json",
+                      "impid": "test-native-imp",
+                      "price": 0.5,
+                      "adid": "some-test-id",
+                      "adm": "{",
+                      "crid": "29681110",
+                      "ext": {
+                          "deal_channel": 1,
+                          "bidtype": 2
+                      }
+                  },
+                  "type": "native"
+              },
+              {
+                "bid": {
+                    "id": "test-native-invalid-adm-native-json",
+                    "impid": "test-native-imp",
+                    "price": 0.5,
+                    "adid": "some-test-id",
+                    "adm": "{\"native\":\"assets\":[{\"id\":2,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":4},{\"id\":3,\"img\":{\"h\":90,\"url\":\"//ads.pubmatic.com/AdTag/native/728x90.png\",\"w\":728}},{\"id\":1,\"title\":{\"text\":\"Native Test Title\"}},{\"data\":{\"value\":\"Sponsored By PubMatic\"},\"id\":5}],\"imptrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"jstracker\":\"<script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'><script src='\\\/\\\/ads.pubmatic.com\\\/AdTag\\\/native\\\/tempReseponse.js'>\",\"link\":{\"clicktrackers\":[\"http://clicktracker.com/AdTag/9bde02d0-6017-11e4-9df7-005056967c35\"],\"fallback\":\"http://www.pubmatic.com\",\"url\":\"//www.pubmatic.com\"}}}",
+                    "crid": "29681110",
+                    "ext": {
+                        "deal_channel": 1,
+                        "bidtype": 2
+                    }
+                },
+                "type": "native"
+              }
+          ]
+      }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unexpected end of JSON input",
+      "comparison": "literal"
+    },
+    {
+      "value": "invalid character ':' after object key:value pair",
+      "comparison": "literal"
+    }
+  ]
+}


### PR DESCRIPTION
In followup to the PR comments received on https://github.com/prebid/prebid-server/pull/2334, this PR changes will report native ads related errors back to PBS core.