### PR TITLE
AdsCert signer metrics

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -176,13 +176,16 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 				reqData[i].Headers.Add("Sec-GPC", reqInfo.GlobalPrivacyControlHeader)
 			}
 			if bidRequestOptions.addCallSignHeader {
+				startSignRequestTime := time.Now()
 				signatureMessage, err := adsCertSigner.Sign(reqData[i].Uri, reqData[i].Body)
+				bidder.me.RecordAdsCertSignTime(time.Since(startSignRequestTime))
 				if err != nil {
-					//add metrics here
+					bidder.me.RecordAdsCertReq(false)
 					errs = append(errs, &errortypes.Warning{Message: fmt.Sprintf("AdsCert signer is enabled but cannot sign the request: %s", err.Error())})
 				}
 				if err == nil && len(signatureMessage) > 0 {
 					reqData[i].Headers.Add(adscert.SignHeader, signatureMessage)
+					bidder.me.RecordAdsCertReq(true)
 				}
 			}
 

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -267,6 +267,18 @@ func (me *MultiMetricsEngine) RecordStoredResponse(pubId string) {
 	}
 }
 
+func (me *MultiMetricsEngine) RecordAdsCertReq(success bool) {
+	for _, thisME := range *me {
+		thisME.RecordAdsCertReq(success)
+	}
+}
+
+func (me *MultiMetricsEngine) RecordAdsCertSignTime(adsCertSignTime time.Duration) {
+	for _, thisME := range *me {
+		thisME.RecordAdsCertSignTime(adsCertSignTime)
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -384,4 +396,12 @@ func (me *NilMetricsEngine) RecordDebugRequest(debugEnabled bool, pubId string) 
 }
 
 func (me *NilMetricsEngine) RecordStoredResponse(pubId string) {
+}
+
+func (me *NilMetricsEngine) RecordAdsCertReq(success bool) {
+
+}
+
+func (me *NilMetricsEngine) RecordAdsCertSignTime(adsCertSignTime time.Duration) {
+
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -421,4 +421,6 @@ type MetricsEngine interface {
 	RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName)
 	RecordDebugRequest(debugEnabled bool, pubId string)
 	RecordStoredResponse(pubId string)
+	RecordAdsCertReq(success bool)
+	RecordAdsCertSignTime(adsCertSignTime time.Duration)
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -154,3 +154,11 @@ func (me *MetricsEngineMock) RecordDebugRequest(debugEnabled bool, pubId string)
 func (me *MetricsEngineMock) RecordStoredResponse(pubId string) {
 	me.Called(pubId)
 }
+
+func (me *MetricsEngineMock) RecordAdsCertReq(success bool) {
+	me.Called(success)
+}
+
+func (me *MetricsEngineMock) RecordAdsCertSignTime(adsCertSignTime time.Duration) {
+	me.Called(adsCertSignTime)
+}

--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -145,6 +145,10 @@ func preloadLabelValues(m *Metrics, syncerKeys []string) {
 		hasBidsLabel: boolValues,
 	})
 
+	preloadLabelValuesForCounter(m.adsCertRequests, map[string][]string{
+		successLabel: boolValues,
+	})
+
 	if !m.metricsDisabled.AdapterConnectionMetrics {
 		preloadLabelValuesForCounter(m.adapterCreatedConnections, map[string][]string{
 			adapterLabel: adapterValues,


### PR DESCRIPTION
New metrics are added to track AdsCert signing:
`RecordAdsCertReq` - record requests with AdsCert header, tracks number of successful and failed requests.
`RecordAdsCertSignTime` - time to sign AdsCert request

Local test with Prometheus passed, all metrics are correctly displayed in Prometheus data  