### PR TITLE
Fix the default prefix for Prometheus metrics

### DIFF
--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -425,7 +425,13 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 
 	metrics.Gatherer = reg
 
-	metricsPrefix := fmt.Sprintf("%s_%s_", cfg.Namespace, cfg.Subsystem)
+	metricsPrefix := "";
+	if len(cfg.Namespace) > 0 {
+		metricsPrefix += fmt.Sprintf("%s_", cfg.Namespace);
+	}
+	if len(cfg.Subsystem) > 0 {
+		metricsPrefix += fmt.Sprintf("%s_", cfg.Subsystem);
+	}
 
 	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)
 	metrics.Registerer.MustRegister(promCollector.NewGoCollector())

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -425,12 +425,12 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 
 	metrics.Gatherer = reg
 
-	metricsPrefix := "";
+	metricsPrefix := ""
 	if len(cfg.Namespace) > 0 {
-		metricsPrefix += fmt.Sprintf("%s_", cfg.Namespace);
+		metricsPrefix += fmt.Sprintf("%s_", cfg.Namespace)
 	}
 	if len(cfg.Subsystem) > 0 {
-		metricsPrefix += fmt.Sprintf("%s_", cfg.Subsystem);
+		metricsPrefix += fmt.Sprintf("%s_", cfg.Subsystem)
 	}
 
 	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)


### PR DESCRIPTION
When no _metrics.prometheus.namespace_ and no _metrics.prometheus.subsystem_ are set, it adds "__" as prefix. eg: "__go_goroutines" (Actual behaviour).

But to make it compatible with standard Go dashboards (in Grafana), we expect metrics to be exported without any prefix. eg: "go_goroutines".

This PR adds the namespace or the subsystem only if they are set.
Please, let me know if it's not the right approach.
Thanks