### PR TITLE
consumable adapter: add schain and coppa support

### DIFF
--- a/adapters/consumable/consumable.go
+++ b/adapters/consumable/consumable.go
@@ -22,21 +22,23 @@ type ConsumableAdapter struct {
 }
 
 type bidRequest struct {
-	Placements         []placement `json:"placements"`
-	Time               int64       `json:"time"`
-	NetworkId          int         `json:"networkId,omitempty"`
-	SiteId             int         `json:"siteId"`
-	UnitId             int         `json:"unitId"`
-	UnitName           string      `json:"unitName,omitempty"`
-	IncludePricingData bool        `json:"includePricingData"`
-	User               user        `json:"user,omitempty"`
-	Referrer           string      `json:"referrer,omitempty"`
-	Ip                 string      `json:"ip,omitempty"`
-	Url                string      `json:"url,omitempty"`
-	EnableBotFiltering bool        `json:"enableBotFiltering,omitempty"`
-	Parallel           bool        `json:"parallel"`
-	CCPA               string      `json:"ccpa,omitempty"`
-	GDPR               *bidGdpr    `json:"gdpr,omitempty"`
+	Placements         []placement          `json:"placements"`
+	Time               int64                `json:"time"`
+	NetworkId          int                  `json:"networkId,omitempty"`
+	SiteId             int                  `json:"siteId"`
+	UnitId             int                  `json:"unitId"`
+	UnitName           string               `json:"unitName,omitempty"`
+	IncludePricingData bool                 `json:"includePricingData"`
+	User               user                 `json:"user,omitempty"`
+	Referrer           string               `json:"referrer,omitempty"`
+	Ip                 string               `json:"ip,omitempty"`
+	Url                string               `json:"url,omitempty"`
+	EnableBotFiltering bool                 `json:"enableBotFiltering,omitempty"`
+	Parallel           bool                 `json:"parallel"`
+	CCPA               string               `json:"ccpa,omitempty"`
+	GDPR               *bidGdpr             `json:"gdpr,omitempty"`
+	Coppa              bool                 `json:"coppa,omitempty"`
+	SChain             openrtb2.SupplyChain `json:"schain,omitempty"`
 }
 
 type placement struct {
@@ -163,6 +165,15 @@ func (a *ConsumableAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *
 			body.GDPR = &gdpr
 		}
 	}
+
+	if request.Source != nil && request.Source.Ext != nil {
+		var extSChain openrtb_ext.ExtRequestPrebidSChain
+		if err := json.Unmarshal(request.Source.Ext, &extSChain); err == nil {
+			body.SChain = extSChain.SChain
+		}
+	}
+
+	body.Coppa = request.Regs != nil && request.Regs.COPPA > 0
 
 	for i, impression := range request.Imp {
 

--- a/adapters/consumable/consumable/supplemental/simple-banner-coppa.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-coppa.json
@@ -23,6 +23,9 @@
     "site": {
       "domain": "www.some.com",
       "page": "http://www.some.com/page-where-ad-will-be-shown"
+    },
+    "regs": {
+      "coppa": 1
     }
   },
   "httpCalls": [
@@ -75,7 +78,8 @@
           "includePricingData": true,
           "user":{},
           "enableBotFiltering": true,
-          "parallel": true
+          "parallel": true,
+          "coppa": true
         }
       },
       "mockResponse": {

--- a/adapters/consumable/consumable/supplemental/simple-banner-gdpr-2.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-gdpr-2.json
@@ -67,6 +67,11 @@
               "unitId": 42
             }
           ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,

--- a/adapters/consumable/consumable/supplemental/simple-banner-gdpr-3.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-gdpr-3.json
@@ -67,6 +67,11 @@
               "unitId": 42
             }
           ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,

--- a/adapters/consumable/consumable/supplemental/simple-banner-gdpr.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-gdpr.json
@@ -72,6 +72,11 @@
               "unitId": 42
             }
           ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,

--- a/adapters/consumable/consumable/supplemental/simple-banner-no-impressionUrl.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-no-impressionUrl.json
@@ -72,6 +72,11 @@
               "unitName": "the-answer"
             }
           ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,

--- a/adapters/consumable/consumable/supplemental/simple-banner-schain.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-schain.json
@@ -23,6 +23,21 @@
     "site": {
       "domain": "www.some.com",
       "page": "http://www.some.com/page-where-ad-will-be-shown"
+    },
+    "source": {
+      "ext": {
+        "schain": {
+          "ver": "1.0",
+          "complete": 1,
+          "nodes": [
+            {
+              "asi": "indirectseller.com",
+              "sid": "00001",
+              "hp": 1
+            }
+          ]
+        }
+      }
     }
   },
   "httpCalls": [
@@ -62,11 +77,6 @@
               "unitId": 42
             }
           ],
-          "schain": {
-            "complete": 0,
-            "nodes": null,
-            "ver": ""
-          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,
@@ -75,7 +85,18 @@
           "includePricingData": true,
           "user":{},
           "enableBotFiltering": true,
-          "parallel": true
+          "parallel": true,
+          "schain": {
+            "complete": 1,
+            "nodes": [
+              {
+                "asi": "indirectseller.com",
+                "hp": 1,
+                "sid": "00001"
+              }
+            ],
+            "ver": "1.0"
+          }
         }
       },
       "mockResponse": {

--- a/adapters/consumable/consumable/supplemental/simple-banner-us-privacy.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-us-privacy.json
@@ -67,6 +67,11 @@
               "unitId": 42
             }
           ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
           "networkId": 11,
           "siteId": 32,
           "unitId": 42,

--- a/static/bidder-info/consumable.yaml
+++ b/static/bidder-info/consumable.yaml
@@ -1,5 +1,5 @@
 maintainer:
-  email: "naffis@consumable.com"
+  email: "prebid@consumable.com"
 gvlVendorID: 591
 capabilities:
   app:


### PR DESCRIPTION
This PR adds support for schain and coppa in the Consumable Adapter, as well as updating the maintainer email for Consumable.