### PR TITLE
Update yaml files for gzip supported bidders

### DIFF
--- a/static/bidder-info/adkernel.yaml
+++ b/static/bidder-info/adkernel.yaml
@@ -13,3 +13,4 @@ userSync:
   redirect:
     url: "https://sync.adkernel.com/user-sync?t=image&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
     userMacro: "{UID}"
+endpointCompression: "GZIP"

--- a/static/bidder-info/improvedigital.yaml
+++ b/static/bidder-info/improvedigital.yaml
@@ -16,3 +16,4 @@ userSync:
   redirect:
     url: "https://ad.360yield.com/server_match?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
     userMacro: "{PUB_USER_ID}"
+endpointCompression: "GZIP"

--- a/static/bidder-info/invibes.yaml
+++ b/static/bidder-info/invibes.yaml
@@ -10,3 +10,4 @@ userSync:
   # bidder directly at the email address in this file to ask about enabling user sync.
   supports:
     - iframe
+endpointCompression: "GZIP"

--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -12,3 +12,4 @@ userSync:
   redirect:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
     userMacro: "$UID"
+endpointCompression: "GZIP"

--- a/static/bidder-info/mobilefuse.yaml
+++ b/static/bidder-info/mobilefuse.yaml
@@ -6,3 +6,4 @@ capabilities:
     mediaTypes:
       - banner
       - video
+endpointCompression: "GZIP"

--- a/static/bidder-info/onetag.yaml
+++ b/static/bidder-info/onetag.yaml
@@ -16,3 +16,4 @@ userSync:
   iframe:
     url: "https://onetag-sys.com/usync/?redir={{.RedirectURL}}"
     userMacro: "${USER_TOKEN}"
+endpointCompression: "GZIP"

--- a/static/bidder-info/triplelift.yaml
+++ b/static/bidder-info/triplelift.yaml
@@ -20,3 +20,4 @@ userSync:
   redirect:
     url: "https://eb2.3lift.com/getuid?gdpr={{.GDPR}}&cmp_cs={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
     userMacro: "$UID"
+endpointCompression: "GZIP"


### PR DESCRIPTION
Now that GZIP Compression support has been added/merged https://github.com/prebid/prebid-server/pull/2347, this PR merely updates the yaml files of the bidders who support GZIP compression (supported bidders taken from who supports it from PBS Java)