### PR TITLE
Downgrade errors to warnings when adapter doesn't support imp format

### DIFF
--- a/adapters/infoawarebidder.go
+++ b/adapters/infoawarebidder.go
@@ -13,12 +13,12 @@ import (
 // media types defined in the static/bidder-info/{bidder}.yaml file.
 //
 // It adjusts incoming requests in the following ways:
-//   1. If App or Site traffic is not supported by the info file, then requests from
-//      those sources will be rejected before the delegate is called.
-//   2. If a given MediaType is not supported for the platform, then it will be set
-//      to nil before the request is forwarded to the delegate.
-//   3. Any Imps which have no MediaTypes left will be removed.
-//   4. If there are no valid Imps left, the delegate won't be called at all.
+//  1. If App or Site traffic is not supported by the info file, then requests from
+//     those sources will be rejected before the delegate is called.
+//  2. If a given MediaType is not supported for the platform, then it will be set
+//     to nil before the request is forwarded to the delegate.
+//  3. Any Imps which have no MediaTypes left will be removed.
+//  4. If there are no valid Imps left, the delegate won't be called at all.
 type InfoAwareBidder struct {
 	Bidder
 	info parsedBidderInfo
@@ -37,13 +37,13 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb2.BidRequest, reqInfo *Ex
 
 	if request.Site != nil {
 		if !i.info.site.enabled {
-			return nil, []error{&errortypes.BadInput{Message: "this bidder does not support site requests"}}
+			return nil, []error{&errortypes.Warning{Message: "this bidder does not support site requests"}}
 		}
 		allowedMediaTypes = i.info.site
 	}
 	if request.App != nil {
 		if !i.info.app.enabled {
-			return nil, []error{&errortypes.BadInput{Message: "this bidder does not support app requests"}}
+			return nil, []error{&errortypes.Warning{Message: "this bidder does not support app requests"}}
 		}
 		allowedMediaTypes = i.info.app
 	}
@@ -57,7 +57,7 @@ func (i *InfoAwareBidder) MakeRequests(request *openrtb2.BidRequest, reqInfo *Ex
 
 	// If all imps in bid request come with unsupported media types, exit
 	if numToFilter == len(request.Imp) {
-		return nil, append(errs, &errortypes.BadInput{Message: "Bid request didn't contain media types supported by the bidder"})
+		return nil, append(errs, &errortypes.Warning{Message: "Bid request didn't contain media types supported by the bidder"})
 	}
 
 	if numToFilter != 0 {
@@ -78,19 +78,19 @@ func pruneImps(imps []openrtb2.Imp, allowedTypes parsedSupports) (int, []error) 
 	for i := 0; i < len(imps); i++ {
 		if !allowedTypes.banner && imps[i].Banner != nil {
 			imps[i].Banner = nil
-			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i)})
+			errs = append(errs, &errortypes.Warning{Message: fmt.Sprintf("request.imp[%d] uses banner, but this bidder doesn't support it", i)})
 		}
 		if !allowedTypes.video && imps[i].Video != nil {
 			imps[i].Video = nil
-			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i)})
+			errs = append(errs, &errortypes.Warning{Message: fmt.Sprintf("request.imp[%d] uses video, but this bidder doesn't support it", i)})
 		}
 		if !allowedTypes.audio && imps[i].Audio != nil {
 			imps[i].Audio = nil
-			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i)})
+			errs = append(errs, &errortypes.Warning{Message: fmt.Sprintf("request.imp[%d] uses audio, but this bidder doesn't support it", i)})
 		}
 		if !allowedTypes.native && imps[i].Native != nil {
 			imps[i].Native = nil
-			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i)})
+			errs = append(errs, &errortypes.Warning{Message: fmt.Sprintf("request.imp[%d] uses native, but this bidder doesn't support it", i)})
 		}
 		if !hasAnyTypes(&imps[i]) {
 			numToFilter = numToFilter + 1

--- a/adapters/infoawarebidder_test.go
+++ b/adapters/infoawarebidder_test.go
@@ -30,7 +30,7 @@ func TestAppNotSupported(t *testing.T) {
 		return
 	}
 	assert.EqualError(t, errs[0], "this bidder does not support app requests")
-	assert.IsType(t, &errortypes.BadInput{}, errs[0])
+	assert.IsType(t, &errortypes.Warning{}, errs[0])
 	assert.Len(t, bids, 0)
 }
 
@@ -52,7 +52,7 @@ func TestSiteNotSupported(t *testing.T) {
 		return
 	}
 	assert.EqualError(t, errs[0], "this bidder does not support site requests")
-	assert.IsType(t, &errortypes.BadInput{}, errs[0])
+	assert.IsType(t, &errortypes.Warning{}, errs[0])
 	assert.Len(t, bids, 0)
 }
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/prebid/prebid-server/issues/2178

The goal of this PR is: In the situation when an adapter doesn't support the format indicated from the request imp, an error is thrown that we want downgraded to a warning since this error is unnecessary to be written to analytics

This error is thrown from the bidder wrapper `InfoAwareBidder`'s call too `MakeRequests()`. So for all the error checks that check  if an adapter doesn't support the imp format (i.e. `{&errortypes.BadInput{Message: "this bidder does not support site requests"}`), we downgrade those to a warning (i.e. `{&errortypes.Warning{Message: "this bidder does not support site requests"}`)

Tests were updated with this change.