### PR TITLE
Set Currency to bidResponse

### DIFF
--- a/adapters/aja/aja.go
+++ b/adapters/aja/aja.go
@@ -124,6 +124,9 @@ func (a *AJAAdapter) MakeBids(bidReq *openrtb2.BidRequest, adapterReq *adapters.
 			}
 		}
 	}
+	if bidResp.Cur != "" {
+		bidderResp.Currency = bidResp.Cur
+	}
 	return bidderResp, errors
 }
 

--- a/adapters/logicad/logicad.go
+++ b/adapters/logicad/logicad.go
@@ -146,6 +146,9 @@ func (adapter *LogicadAdapter) MakeBids(internalRequest *openrtb2.BidRequest, ex
 			BidType: openrtb_ext.BidTypeBanner,
 		})
 	}
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
 	return bidResponse, nil
 }
 

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -424,6 +424,9 @@ func (a *PubmaticAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 			bidResponse.Bids = append(bidResponse.Bids, typedBid)
 		}
 	}
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
 	return bidResponse, errs
 }
 

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -1096,6 +1096,9 @@ func (a *RubiconAdapter) MakeBids(internalRequest *openrtb2.BidRequest, external
 			}
 		}
 	}
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
 
 	return bidResponse, nil
 }

--- a/adapters/yieldone/yieldone.go
+++ b/adapters/yieldone/yieldone.go
@@ -86,6 +86,9 @@ func (a *YieldoneAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 			})
 		}
 	}
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
 	return bidResponse, nil
 
 }

--- a/adapters/yieldone/yieldone.go
+++ b/adapters/yieldone/yieldone.go
@@ -86,9 +86,6 @@ func (a *YieldoneAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 			})
 		}
 	}
-	if bidResp.Cur != "" {
-		bidResponse.Currency = bidResp.Cur
-	}
 	return bidResponse, nil
 
 }


### PR DESCRIPTION
Some Adapters in use do not have their currency set, resulting in unnecessary currency conversions.

Adapters with no currency set have been changed so that the currency is set.