### PR TITLE
Fix alt bidder code test broken by imp wrapper commit

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -4331,7 +4331,7 @@ func TestOverrideConfigAlternateBidderCodesWithRequestValues(t *testing.T) {
 		Imp: []openrtb2.Imp{{
 			ID:     "some-impression-id",
 			Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}, {W: 300, H: 600}}},
-			Ext:    json.RawMessage(`{"pubmatic": {"publisherId": 1}}`),
+			Ext:    json.RawMessage(`{"prebid":{"bidder":{"pubmatic": {"publisherId": 1}}}}`),
 		}},
 		Site: &openrtb2.Site{Page: "prebid.org", Ext: json.RawMessage(`{"amp":0}`)},
 	}


### PR DESCRIPTION
The imp wrapper commit updated the bidder param logic so that all bidder params defined at `imp.ext.BIDDER` are now mapped to the official location `imp.ext.prebid.bidder.BIDDER` further upstream. The alternate bidder code exchange test needed to be updated to define the bidder params in the official location.