### PR TITLE
Per Impression TID Generation and Source TID Logic Updated

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -398,7 +398,7 @@ func (deps *endpointDeps) parseAmpRequest(httpRequest *http.Request) (req *openr
 	// At this point, we should have a valid request that definitely has Targeting and Cache turned on
 	hasStoredResponses := len(storedAuctionResponses) > 0
 
-	e = deps.validateRequest(req, true, hasStoredResponses, storedBidResponses)
+	e = deps.validateRequest(req, true, hasStoredResponses, storedBidResponses, false)
 	errs = append(errs, e...)
 	return
 }

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -792,12 +792,17 @@ func validateAndFillSourceTID(req *openrtb_ext.RequestWrapper, generateRequestID
 		req.Source = &openrtb2.Source{}
 	}
 
-	if (generateRequestID && (isAmp || hasStoredBidRequest)) || req.Source.TID == "{{UUID}}" {
-		if rawUUID, err := uuid.NewV4(); err == nil {
-			req.Source.TID = rawUUID.String()
-		} else {
-			return errors.New("req.Source.TID missing in the req and error creating a random UID")
-		}
+	rawUUID, err := uuid.NewV4()
+	if err != nil {
+		return errors.New("error creating a random UUID for source.tid")
+	}
+
+	if req.Source.TID == "" || req.Source.TID == "{{UUID}}" {
+		req.Source.TID = rawUUID.String()
+	}
+
+	if generateRequestID && (isAmp || hasStoredBidRequest) {
+		req.Source.TID = rawUUID.String()
 	}
 
 	for _, impWrapper := range req.GetImp() {
@@ -810,7 +815,7 @@ func validateAndFillSourceTID(req *openrtb_ext.RequestWrapper, generateRequestID
 			ie.SetTid(rawUUID.String())
 			impWrapper.RebuildImp()
 		}
-		if generateRequestID && ie.GetTid() != "" && (isAmp || hasStoredBidRequest) {
+		if generateRequestID && (isAmp || hasStoredBidRequest) {
 			ie.SetTid(rawUUID.String())
 			impWrapper.RebuildImp()
 		}

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1112,7 +1112,6 @@ func TestStoredRequests(t *testing.T) {
 		}
 		expectJson := json.RawMessage(testFinalRequests[i])
 		assert.JSONEq(t, string(expectJson), string(newRequest), "Incorrect result request %d", i)
-
 		expectedImp := testStoredImpIds[i]
 		expectedStoredImp := json.RawMessage(testStoredImps[i])
 		if len(impExtInfoMap[expectedImp].StoredImp) > 0 {
@@ -1631,7 +1630,7 @@ func TestValidateRequest(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		errorList := deps.validateRequest(test.givenRequestWrapper, test.givenIsAmp, false, nil)
+		errorList := deps.validateRequest(test.givenRequestWrapper, test.givenIsAmp, false, nil, false)
 		assert.Equalf(t, test.expectedErrorList, errorList, "Error doesn't match: %s\n", test.description)
 
 		if len(errorList) == 0 {
@@ -2453,7 +2452,7 @@ func TestCurrencyTrunc(t *testing.T) {
 		Cur: []string{"USD", "EUR"},
 	}
 
-	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 
 	expectedError := errortypes.Warning{Message: "A prebid request can only process one currency. Taking the first currency in the list, USD, as the active currency"}
 	assert.ElementsMatch(t, errL, []error{&expectedError})
@@ -2502,7 +2501,7 @@ func TestCCPAInvalid(t *testing.T) {
 		},
 	}
 
-	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 
 	expectedWarning := errortypes.Warning{
 		Message:     "CCPA consent is invalid and will be ignored. (request.regs.ext.us_privacy must contain 4 characters)",
@@ -2554,7 +2553,7 @@ func TestNoSaleInvalid(t *testing.T) {
 		Ext: json.RawMessage(`{"prebid": {"nosale": ["*", "appnexus"]} }`),
 	}
 
-	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 
 	expectedError := errors.New("request.ext.prebid.nosale is invalid: can only specify all bidders if no other bidders are provided")
 	assert.ElementsMatch(t, errL, []error{expectedError})
@@ -2604,7 +2603,7 @@ func TestValidateSourceTID(t *testing.T) {
 		},
 	}
 
-	deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 	assert.NotEmpty(t, req.Source.TID, "Expected req.Source.TID to be filled with a randomly generated UID")
 }
 
@@ -2649,7 +2648,7 @@ func TestSChainInvalid(t *testing.T) {
 		Ext: json.RawMessage(`{"prebid":{"schains":[{"bidders":["appnexus"],"schain":{"complete":1,"nodes":[{"asi":"directseller1.com","sid":"00001","rid":"BidRequest1","hp":1}],"ver":"1.0"}}, {"bidders":["appnexus"],"schain":{"complete":1,"nodes":[{"asi":"directseller2.com","sid":"00002","rid":"BidRequest2","hp":1}],"ver":"1.0"}}]}}`),
 	}
 
-	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 
 	expectedError := errors.New("request.ext.prebid.schains contains multiple schains for bidder appnexus; it must contain no more than one per bidder.")
 	assert.ElementsMatch(t, errL, []error{expectedError})
@@ -2920,13 +2919,18 @@ func TestSanitizeRequest(t *testing.T) {
 func TestValidateAndFillSourceTID(t *testing.T) {
 	testTID := "some-tid"
 	testCases := []struct {
-		description     string
-		req             *openrtb_ext.RequestWrapper
-		expectRandTID   bool
-		expectSourceTid string
+		description         string
+		req                 *openrtb_ext.RequestWrapper
+		generateRequestID   bool
+		hasStoredBidRequest bool
+		isAmp               bool
+		expectRandImpTID    bool
+		expectRandSourceTID bool
+		expectSourceTid     *string
+		expectImpTid        *string
 	}{
 		{
-			description: "req source.tid and imp.tid both not present, expect BOTH imp.tid and source.tid populated",
+			description: "req source.tid not set, expect random value",
 			req: &openrtb_ext.RequestWrapper{
 				BidRequest: &openrtb2.BidRequest{
 					ID:     "1",
@@ -2934,22 +2938,59 @@ func TestValidateAndFillSourceTID(t *testing.T) {
 					Source: &openrtb2.Source{},
 				},
 			},
-			expectRandTID:   true,
-			expectSourceTid: "1",
+			generateRequestID:   false,
+			hasStoredBidRequest: false,
+			isAmp:               false,
+			expectRandSourceTID: true,
+			expectRandImpTID:    false,
 		},
 		{
-			description: "req.Source not present, expect BOTH imp.tid and source.tid populated",
+			description: "req source.tid set to {{UUID}}, expect to be replaced by random value",
 			req: &openrtb_ext.RequestWrapper{
 				BidRequest: &openrtb2.BidRequest{
-					ID:  "1",
-					Imp: []openrtb2.Imp{{ID: "1"}},
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1"}},
+					Source: &openrtb2.Source{TID: "{{UUID}}"},
 				},
 			},
-			expectRandTID:   true,
-			expectSourceTid: "1",
+			generateRequestID:   false,
+			hasStoredBidRequest: false,
+			isAmp:               false,
+			expectRandSourceTID: true,
+			expectRandImpTID:    false,
 		},
 		{
-			description: "req.Source.TID present. Expecting no change",
+			description: "req source.tid is set, isAmp = true, generateRequestID = true, expect to be replaced by random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1"}},
+					Source: &openrtb2.Source{TID: "test-tid"},
+				},
+			},
+			generateRequestID:   true,
+			hasStoredBidRequest: false,
+			isAmp:               true,
+			expectRandSourceTID: true,
+			expectRandImpTID:    false,
+		},
+		{
+			description: "req source.tid is set,  hasStoredBidRequest = true, generateRequestID = true, expect to be replaced by random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1"}},
+					Source: &openrtb2.Source{TID: "test-tid"},
+				},
+			},
+			generateRequestID:   true,
+			hasStoredBidRequest: true,
+			isAmp:               false,
+			expectRandSourceTID: true,
+			expectRandImpTID:    false,
+		},
+		{
+			description: "req source.tid is set,  hasStoredBidRequest = true, generateRequestID = false, expect NOT to be replaced by random value",
 			req: &openrtb_ext.RequestWrapper{
 				BidRequest: &openrtb2.BidRequest{
 					ID:     "1",
@@ -2957,11 +2998,75 @@ func TestValidateAndFillSourceTID(t *testing.T) {
 					Source: &openrtb2.Source{TID: testTID},
 				},
 			},
-			expectRandTID:   false,
-			expectSourceTid: testTID,
+			generateRequestID:   false,
+			hasStoredBidRequest: true,
+			isAmp:               false,
+			expectRandSourceTID: false,
+			expectRandImpTID:    false,
+			expectSourceTid:     &testTID,
 		},
 		{
-			description: "req.Source.TID present abd imp.ext.tid present. Expecting no change",
+			description: "req imp.ext.tid not set, expect random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1"}},
+					Source: &openrtb2.Source{},
+				},
+			},
+			generateRequestID:   false,
+			hasStoredBidRequest: false,
+			isAmp:               false,
+			expectRandSourceTID: false,
+			expectRandImpTID:    true,
+		},
+		{
+			description: "req imp.ext.tid set to {{UUID}}, expect random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1", Ext: json.RawMessage(`{"tid": "{{UUID}}"}`)}},
+					Source: &openrtb2.Source{},
+				},
+			},
+			generateRequestID:   false,
+			hasStoredBidRequest: false,
+			isAmp:               false,
+			expectRandSourceTID: false,
+			expectRandImpTID:    true,
+		},
+		{
+			description: "req imp.tid is set,  hasStoredBidRequest = true, generateRequestID = true, expect to be replaced by random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1", Ext: json.RawMessage(`{"tid": "some-tid"}`)}},
+					Source: &openrtb2.Source{TID: "test-tid"},
+				},
+			},
+			generateRequestID:   true,
+			hasStoredBidRequest: true,
+			isAmp:               false,
+			expectRandSourceTID: false,
+			expectRandImpTID:    true,
+		},
+		{
+			description: "req imp.tid is set,  isAmp = true, generateRequestID = true, expect to be replaced by random value",
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					ID:     "1",
+					Imp:    []openrtb2.Imp{{ID: "1", Ext: json.RawMessage(`{"tid": "some-tid"}`)}},
+					Source: &openrtb2.Source{TID: "test-tid"},
+				},
+			},
+			generateRequestID:   true,
+			hasStoredBidRequest: false,
+			isAmp:               true,
+			expectRandSourceTID: false,
+			expectRandImpTID:    true,
+		},
+		{
+			description: "req imp.tid is set,  hasStoredBidRequest = true, generateRequestID = false, expect NOT to be replaced by random value",
 			req: &openrtb_ext.RequestWrapper{
 				BidRequest: &openrtb2.BidRequest{
 					ID:     "1",
@@ -2969,21 +3074,31 @@ func TestValidateAndFillSourceTID(t *testing.T) {
 					Source: &openrtb2.Source{TID: testTID},
 				},
 			},
-			expectRandTID:   false,
-			expectSourceTid: testTID,
+			generateRequestID:   false,
+			hasStoredBidRequest: true,
+			isAmp:               false,
+			expectRandSourceTID: false,
+			expectRandImpTID:    false,
+			expectImpTid:        &testTID,
 		},
 	}
 
 	for _, test := range testCases {
-		_ = validateAndFillSourceTID(test.req)
+		_ = validateAndFillSourceTID(test.req, test.generateRequestID, test.hasStoredBidRequest, test.isAmp)
 		impWrapper := &openrtb_ext.ImpWrapper{}
 		impWrapper.Imp = &test.req.Imp[0]
 		ie, _ := impWrapper.GetImpExt()
 		impTID := ie.GetTid()
-		if test.expectRandTID {
+		if test.expectRandSourceTID {
+			assert.NotEmpty(t, test.req.Source.TID, test.description)
+		} else if test.expectRandImpTID {
+			assert.NotEqual(t, testTID, impTID, test.description)
 			assert.NotEmpty(t, impTID, test.description)
+		} else if test.expectSourceTid != nil {
+			assert.Equal(t, test.req.Source.TID, *test.expectSourceTid, test.description)
+		} else if test.expectImpTid != nil {
+			assert.Equal(t, impTID, *test.expectImpTid, test.description)
 		}
-		assert.Equal(t, test.expectSourceTid, test.req.Source.TID, test.description)
 	}
 }
 
@@ -3028,7 +3143,7 @@ func TestEidPermissionsInvalid(t *testing.T) {
 		Ext: json.RawMessage(`{"prebid": {"data": {"eidpermissions": [{"source":"a", "bidders":[]}]} } }`),
 	}
 
-	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil)
+	errL := deps.validateRequest(&openrtb_ext.RequestWrapper{BidRequest: &req}, false, false, nil, false)
 
 	expectedError := errors.New(`request.ext.prebid.data.eidpermissions[0] missing or empty required field: "bidders"`)
 	assert.ElementsMatch(t, errL, []error{expectedError})
@@ -4678,7 +4793,7 @@ func TestValidateStoredResp(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		errorList := deps.validateRequest(test.givenRequestWrapper, false, test.hasStoredAuctionResponses, test.storedBidResponses)
+		errorList := deps.validateRequest(test.givenRequestWrapper, false, test.hasStoredAuctionResponses, test.storedBidResponses, false)
 		assert.Equalf(t, test.expectedErrorList, errorList, "Error doesn't match: %s\n", test.description)
 	}
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -2917,47 +2917,63 @@ func TestSanitizeRequest(t *testing.T) {
 	}
 }
 
-func TestValidateAndFillSourceTID(t *testing.T) {
-	testTID := "some-tid"
-	testCases := []struct {
-		description   string
-		req           *openrtb2.BidRequest
-		expectRandTID bool
-		expectedTID   string
-	}{
-		{
-			description:   "req.Source not present. Expecting a randomly generated TID value",
-			req:           &openrtb2.BidRequest{},
-			expectRandTID: true,
-		},
-		{
-			description: "req.Source.TID not present. Expecting a randomly generated TID value",
-			req: &openrtb2.BidRequest{
-				Source: &openrtb2.Source{},
-			},
-			expectRandTID: true,
-		},
-		{
-			description: "req.Source.TID present. Expecting no change",
-			req: &openrtb2.BidRequest{
-				Source: &openrtb2.Source{
-					TID: testTID,
-				},
-			},
-			expectRandTID: false,
-			expectedTID:   testTID,
-		},
+func TestValidateAndFillSourceTIDNoSource(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:     "1",
+		Imp:    []openrtb2.Imp{{ID: "1"}},
+		Source: &openrtb2.Source{},
 	}
+	_ = validateAndFillSourceTID(req)
+	impWrapper := &openrtb_ext.ImpWrapper{}
+	impWrapper.Imp = &req.Imp[0]
+	ie, _ := impWrapper.GetImpExt()
+	tid := ie.GetTid()
+	assert.NotEmpty(t, tid, "req.Source present. expect imp.ext.tid set to random TID value")
+	assert.Equal(t, "1", req.Source.TID, "req.Source present. Expecting source.tid set to req.id")
+}
 
-	for _, test := range testCases {
-		_ = validateAndFillSourceTID(test.req)
-		if test.expectRandTID {
-			assert.NotEmpty(t, test.req.Source.TID, test.description)
-			assert.NotEqual(t, test.expectedTID, test.req.Source.TID, test.description)
-		} else {
-			assert.Equal(t, test.expectedTID, test.req.Source.TID, test.description)
-		}
+func TestValidateAndFillSourceTIDNoSourcePresent(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:  "1",
+		Imp: []openrtb2.Imp{{ID: "1"}},
 	}
+	_ = validateAndFillSourceTID(req)
+	impWrapper := &openrtb_ext.ImpWrapper{}
+	impWrapper.Imp = &req.Imp[0]
+	ie, _ := impWrapper.GetImpExt()
+	tid := ie.GetTid()
+	assert.NotEmpty(t, tid, "req.Source not present. expect imp.ext.tid set to random TID value")
+	assert.Equal(t, "1", req.Source.TID, "req.Source not present. Expecting source.tid set to req.id")
+}
+
+func TestValidateAndFillSourceTIDSourceTIDPresent(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:     "1",
+		Imp:    []openrtb2.Imp{{ID: "1"}},
+		Source: &openrtb2.Source{TID: "12345"},
+	}
+	_ = validateAndFillSourceTID(req)
+	impWrapper := &openrtb_ext.ImpWrapper{}
+	impWrapper.Imp = &req.Imp[0]
+	ie, _ := impWrapper.GetImpExt()
+	tid := ie.GetTid()
+	assert.Empty(t, tid, "req.Source.TID present. Expecting no added imp.ext.tid")
+	assert.Equal(t, "12345", req.Source.TID, "req.Source.TID present. Expecting source.tid not to change")
+}
+
+func TestValidateAndFillSourceTIDImpTIDPresent(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:     "1",
+		Imp:    []openrtb2.Imp{{ID: "1", Ext: json.RawMessage(`{"tid": "some-tid"}`)}},
+		Source: &openrtb2.Source{TID: "12345"},
+	}
+	_ = validateAndFillSourceTID(req)
+	impWrapper := &openrtb_ext.ImpWrapper{}
+	impWrapper.Imp = &req.Imp[0]
+	ie, _ := impWrapper.GetImpExt()
+	tid := ie.GetTid()
+	assert.Equal(t, "some-tid", tid, "req.Source.TID and imp.ext.tid present, no change")
+	assert.Equal(t, "12345", req.Source.TID, "req.Source.TID present. Expecting source.tid not to change")
 }
 
 func TestEidPermissionsInvalid(t *testing.T) {

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -253,7 +253,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	// Populate any "missing" OpenRTB fields with info from other sources, (e.g. HTTP request headers).
 	deps.setFieldsImplicitly(r, bidReqWrapper)
 
-	errL = deps.validateRequest(bidReqWrapper, false, false, nil)
+	errL = deps.validateRequest(bidReqWrapper, false, false, nil, false)
 	if errortypes.ContainsFatalError(errL) {
 		handleError(&labels, w, errL, &vo, &debugLog)
 		return

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -1273,6 +1273,8 @@ type ImpExt struct {
 	extDirty    bool
 	prebid      *ExtImpPrebid
 	prebidDirty bool
+	tid         string
+	tidDirty    bool
 }
 
 func (e *ImpExt) unmarshal(extJson json.RawMessage) error {
@@ -1298,6 +1300,13 @@ func (e *ImpExt) unmarshal(extJson json.RawMessage) error {
 		}
 	}
 
+	tidJson, hasTid := e.ext["tid"]
+	if hasTid {
+		if err := json.Unmarshal(tidJson, &e.tid); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -1319,6 +1328,18 @@ func (e *ImpExt) marshal() (json.RawMessage, error) {
 		e.prebidDirty = false
 	}
 
+	if e.tidDirty {
+		if e.tid != "" {
+			tidJson, err := json.Marshal(e.tid)
+			if err != nil {
+				return nil, err
+			}
+			e.ext["tid"] = json.RawMessage(tidJson)
+		} else {
+			delete(e.ext, "tid")
+		}
+	}
+
 	e.extDirty = false
 	if len(e.ext) == 0 {
 		return nil, nil
@@ -1327,7 +1348,7 @@ func (e *ImpExt) marshal() (json.RawMessage, error) {
 }
 
 func (e *ImpExt) Dirty() bool {
-	return e.extDirty || e.prebidDirty
+	return e.extDirty || e.prebidDirty || e.tidDirty
 }
 
 func (e *ImpExt) GetExt() map[string]json.RawMessage {
@@ -1361,6 +1382,16 @@ func (e *ImpExt) GetOrCreatePrebid() *ExtImpPrebid {
 func (e *ImpExt) SetPrebid(prebid *ExtImpPrebid) {
 	e.prebid = prebid
 	e.prebidDirty = true
+}
+
+func (e *ImpExt) GetTid() string {
+	tid := e.tid
+	return tid
+}
+
+func (e *ImpExt) SetTid(tid string) {
+	e.tid = tid
+	e.tidDirty = true
 }
 
 func CreateImpExtForTesting(ext map[string]json.RawMessage, prebid *ExtImpPrebid) ImpExt {

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -1329,15 +1329,16 @@ func (e *ImpExt) marshal() (json.RawMessage, error) {
 	}
 
 	if e.tidDirty {
-		if e.tid != "" {
+		if len(e.tid) > 0 {
 			tidJson, err := json.Marshal(e.tid)
 			if err != nil {
 				return nil, err
 			}
-			e.ext["tid"] = json.RawMessage(tidJson)
+			e.ext["tid"] = tidJson
 		} else {
 			delete(e.ext, "tid")
 		}
+		e.tidDirty = false
 	}
 
 	e.extDirty = false

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -917,6 +917,24 @@ func TestImpWrapperRebuildImp(t *testing.T) {
 			impExtWrapper: ImpExt{prebid: &ExtImpPrebid{IsRewardedInventory: nil}, prebidDirty: true},
 			expectedImp:   openrtb2.Imp{},
 		},
+		{
+			description:   "Populated Tid - Dirty",
+			imp:           openrtb2.Imp{Ext: json.RawMessage(`{"tid": "some-tid"}`)},
+			impExtWrapper: ImpExt{tidDirty: true, tid: "12345"},
+			expectedImp:   openrtb2.Imp{Ext: json.RawMessage(`{"tid":"12345"}`)},
+		},
+		{
+			description:   "Populated Tid - Dirty - No Change",
+			imp:           openrtb2.Imp{Ext: json.RawMessage(`{"tid": "some-tid"}`)},
+			impExtWrapper: ImpExt{tid: "some-tid", tidDirty: true},
+			expectedImp:   openrtb2.Imp{Ext: json.RawMessage(`{"tid":"some-tid"}`)},
+		},
+		{
+			description:   "Populated Tid - Dirty - Cleared",
+			imp:           openrtb2.Imp{Ext: json.RawMessage(`{"tid":"some-tid"}`)},
+			impExtWrapper: ImpExt{tid: "", tidDirty: true},
+			expectedImp:   openrtb2.Imp{},
+		},
 	}
 
 	for _, test := range testCases {
@@ -982,4 +1000,16 @@ func TestImpWrapperGetImpExt(t *testing.T) {
 			assert.Equal(t, test.expectedImpExt, *impExt, test.description)
 		}
 	}
+}
+
+func TestImpExtTid(t *testing.T) {
+	impExt := &ImpExt{}
+
+	impExt.unmarshal(nil)
+	assert.Equal(t, false, impExt.Dirty(), "New impext should not be dirty.")
+	assert.Empty(t, impExt.GetTid(), "Empty ImpExt should have  empty tid")
+
+	newTid := "tid"
+	impExt.SetTid(newTid)
+	assert.Equal(t, "tid", impExt.GetTid(), "ImpExt tid is incorrect")
 }

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -963,12 +963,14 @@ func TestImpWrapperGetImpExt(t *testing.T) {
 		},
 		{
 			description:  "Populated - Ext",
-			givenWrapper: ImpWrapper{Imp: &openrtb2.Imp{Ext: json.RawMessage(`{"prebid":{"is_rewarded_inventory":1},"other":42}`)}},
+			givenWrapper: ImpWrapper{Imp: &openrtb2.Imp{Ext: json.RawMessage(`{"prebid":{"is_rewarded_inventory":1},"other":42, "tid": "test-tid"}`)}},
 			expectedImpExt: ImpExt{
 				ext: map[string]json.RawMessage{
 					"prebid": json.RawMessage(`{"is_rewarded_inventory":1}`),
 					"other":  json.RawMessage(`42`),
+					"tid":    json.RawMessage(`"test-tid"`),
 				},
+				tid:    "test-tid",
 				prebid: &ExtImpPrebid{IsRewardedInventory: &isRewardedInventoryOne},
 			},
 		},

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -1012,4 +1012,5 @@ func TestImpExtTid(t *testing.T) {
 	newTid := "tid"
 	impExt.SetTid(newTid)
 	assert.Equal(t, "tid", impExt.GetTid(), "ImpExt tid is incorrect")
+	assert.Equal(t, true, impExt.Dirty(), "New impext should be dirty.")
 }


### PR DESCRIPTION
This PR is to update the logic SourceTID logic when enabled to fill source tid. This is related to https://github.com/prebid/prebid-server/issues/2381.

Logic is outlined in this issue: https://github.com/prebid/prebid-server/issues/2381#issuecomment-1284533924

Changes in this PR:
- Logic update in validateAndFillSourceTid to support the logic outlined above
- Changes to ImpWrapper to support accessing and setting tid in imp.ext
- Unit tests added to support the above changes