### PR TITLE
consumable adapter: add content metadata support

### DIFF
--- a/adapters/consumable/consumable.go
+++ b/adapters/consumable/consumable.go
@@ -39,6 +39,7 @@ type bidRequest struct {
 	GDPR               *bidGdpr             `json:"gdpr,omitempty"`
 	Coppa              bool                 `json:"coppa,omitempty"`
 	SChain             openrtb2.SupplyChain `json:"schain"`
+	Content            *openrtb2.Content    `json:"content,omitempty"`
 }
 
 type placement struct {
@@ -188,6 +189,12 @@ func (a *ConsumableAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *
 	}
 
 	body.Coppa = request.Regs != nil && request.Regs.COPPA > 0
+
+	if request.Site != nil && request.Site.Content != nil {
+		body.Content = request.Site.Content
+	} else if request.App != nil && request.App.Content != nil {
+		body.Content = request.App.Content
+	}
 
 	for i, impression := range request.Imp {
 

--- a/adapters/consumable/consumable/supplemental/simple-banner-content-meta.json
+++ b/adapters/consumable/consumable/supplemental/simple-banner-content-meta.json
@@ -1,0 +1,128 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [{ "w": 728, "h": 250 }]
+        },
+        "ext": {
+          "bidder": {
+            "networkId": 11,
+            "siteId": 32,
+            "unitId": 42
+          }
+        }
+      }
+    ],
+    "device": {
+      "ua": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.91 Safari/537.36",
+      "ip": "123.123.123.123"
+    },
+    "site": {
+      "domain": "www.some.com",
+      "page": "http://www.some.com/page-where-ad-will-be-shown",
+      "content": {
+        "id": "1009680902",
+        "title": "What You Know Bout Love",
+        "context": 3,
+        "url": "https://www.deezer.com/track/1009680902",
+        "artist": "Pop Smoke",
+        "album": "Shoot For The Stars Aim For The Moon"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://e.serverbid.com/api/v2",
+        "headers": {
+          "Accept": ["application/json"],
+          "Content-Type": ["application/json"],
+          "User-Agent": [
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.91 Safari/537.36"
+          ],
+          "X-Forwarded-For": ["123.123.123.123"],
+          "Forwarded": ["for=123.123.123.123"],
+          "Origin": ["http://www.some.com"],
+          "Referer": ["http://www.some.com/page-where-ad-will-be-shown"]
+        },
+        "body": {
+          "content": {
+            "id": "1009680902",
+            "title": "What You Know Bout Love",
+            "context": 3,
+            "url": "https://www.deezer.com/track/1009680902",
+            "artist": "Pop Smoke",
+            "album": "Shoot For The Stars Aim For The Moon"
+          },
+          "placements": [
+            {
+              "adTypes": [2730],
+              "divName": "test-imp-id",
+              "networkId": 11,
+              "siteId": 32,
+              "unitId": 42
+            }
+          ],
+          "schain": {
+            "complete": 0,
+            "nodes": null,
+            "ver": ""
+          },
+          "networkId": 11,
+          "siteId": 32,
+          "unitId": 42,
+          "time": 1451651415,
+          "url": "http://www.some.com/page-where-ad-will-be-shown",
+          "includePricingData": true,
+          "user": {},
+          "enableBotFiltering": true,
+          "parallel": true
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "decisions": {
+            "test-imp-id": {
+              "adId": 1234567890,
+              "pricing": {
+                "clearPrice": 0.5
+              },
+              "width": 728,
+              "height": 250,
+              "impressionUrl": "http://localhost:8080/shown",
+              "contents": [
+                {
+                  "body": "<blink>Remember this: https://www.google.com/search?q=blink+tag ?</blink>"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-request-id",
+            "impid": "test-imp-id",
+            "price": 0.5,
+            "adm": "<blink>Remember this: https://www.google.com/search?q=blink+tag ?</blink>",
+            "crid": "1234567890",
+            "exp": 30,
+            "w": 728,
+            "h": 250
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for content metadata in the bid request