### PR TITLE
ExtRequestPrebidCache: Unnecessary UnmarshalJSON

### DIFF
--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -1643,7 +1643,7 @@ func TestValidateRequestExt(t *testing.T) {
 		{
 			description:     "prebid cache - bids - wrong type",
 			givenRequestExt: json.RawMessage(`{"prebid": {"cache": {"bids": true}}}`),
-			expectedError:   `json: cannot unmarshal bool into Go struct field ExtRequestPrebid.cache of type openrtb_ext.ExtRequestPrebidCacheBids`,
+			expectedError:   `json: cannot unmarshal bool into Go struct field ExtRequestPrebidCache.cache.bids of type openrtb_ext.ExtRequestPrebidCacheBids`,
 		},
 		{
 			description:     "prebid cache - bids - provided",
@@ -1657,7 +1657,7 @@ func TestValidateRequestExt(t *testing.T) {
 		{
 			description:     "prebid cache - vastxml - wrong type",
 			givenRequestExt: json.RawMessage(`{"prebid": {"cache": {"vastxml": true}}}`),
-			expectedError:   `json: cannot unmarshal bool into Go struct field ExtRequestPrebid.cache of type openrtb_ext.ExtRequestPrebidCacheVAST`,
+			expectedError:   `json: cannot unmarshal bool into Go struct field ExtRequestPrebidCache.cache.vastxml of type openrtb_ext.ExtRequestPrebidCacheVAST`,
 		},
 		{
 			description:     "prebid cache - vastxml - provided",

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -118,18 +118,6 @@ type ExtRequestPrebidServer struct {
 	DataCenter  string `json:"datacenter"`
 }
 
-// UnmarshalJSON prevents nil bids arguments.
-func (ert *ExtRequestPrebidCache) UnmarshalJSON(b []byte) error {
-	type typesAlias ExtRequestPrebidCache // Prevents infinite UnmarshalJSON loops
-	var proxy typesAlias
-	if err := json.Unmarshal(b, &proxy); err != nil {
-		return err
-	}
-
-	*ert = ExtRequestPrebidCache(proxy)
-	return nil
-}
-
 // ExtRequestPrebidCacheBids defines the contract for bidrequest.ext.prebid.cache.bids
 type ExtRequestPrebidCacheBids struct {
 	ReturnCreative *bool `json:"returnCreative"`


### PR DESCRIPTION
I moved the logic in this method to validation code in the ImpWrapper PR, but left the unmarshal code because I wasn't sure of the bit about infinite loops. I understand now. This code does nothing and can be removed. 