### PR TITLE
IX Adapter: Pass version information in Request.Ext field

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -337,14 +337,12 @@ func BuildIxDiag(request *openrtb2.BidRequest) error {
 	ixdiag := &IxDiag{}
 
 	if extRequest.Prebid != nil {
-		ixdiag = &IxDiag{
-			PbjsV: extRequest.Prebid.Channel.Version,
-		}
+		ixdiag.PbjsV = extRequest.Prebid.Channel.Version
 	}
 
 	// Slice commit hash out of version
 	if strings.Contains(version.Ver, "-") {
-		ixdiag.PbsV = version.Ver[:strings.LastIndex(version.Ver, "-")]
+		ixdiag.PbsV = version.Ver[:strings.Index(version.Ver, "-")]
 	} else if version.Ver != "" {
 		ixdiag.PbsV = version.Ver
 	}
@@ -352,7 +350,10 @@ func BuildIxDiag(request *openrtb2.BidRequest) error {
 	// Only set request.ext if ixDiag is not empty
 	if *ixdiag != (IxDiag{}) {
 		extRequest.IxDiag = ixdiag
-		requestExtJson, _ := json.Marshal(extRequest)
+		requestExtJson, err := json.Marshal(extRequest)
+		if err != nil {
+			return err
+		}
 		request.Ext = requestExtJson
 	}
 	return nil

--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/version"
 
 	"github.com/prebid/openrtb/v17/native1"
 	native1response "github.com/prebid/openrtb/v17/native1/response"
@@ -22,11 +23,28 @@ type IxAdapter struct {
 	maxRequests int
 }
 
+type ExtRequest struct {
+	Prebid *openrtb_ext.ExtRequestPrebid `json:"prebid"`
+	SChain *openrtb2.SupplyChain         `json:"schain,omitempty"`
+	IxDiag *IxDiag                       `json:"ixdiag,omitempty"`
+}
+
+type IxDiag struct {
+	PbsV  string `json:"pbsv,omitempty"`
+	PbjsV string `json:"pbjsv,omitempty"`
+}
+
 func (a *IxAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
 	nImp := len(request.Imp)
 	if nImp > a.maxRequests {
 		request.Imp = request.Imp[:a.maxRequests]
 		nImp = a.maxRequests
+	}
+
+	errs := make([]error, 0)
+
+	if err := BuildIxDiag(request); err != nil {
+		errs = append(errs, err)
 	}
 
 	// Multi-size banner imps are split into single-size requests.
@@ -35,7 +53,6 @@ func (a *IxAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters
 	// Preallocate the max possible size to avoid reallocating arrays.
 	requests := make([]*adapters.RequestData, 0, a.maxRequests)
 	multiSizeRequests := make([]*adapters.RequestData, 0, a.maxRequests-nImp)
-	errs := make([]error, 0, 1)
 
 	headers := http.Header{
 		"Content-Type": {"application/json;charset=utf-8"},
@@ -308,4 +325,35 @@ func marshalJsonWithoutUnicode(v interface{}) (string, error) {
 	// json.Encode also writes a newline, need to remove
 	// https://pkg.go.dev/encoding/json#Encoder.Encode
 	return strings.TrimSuffix(sb.String(), "\n"), nil
+}
+
+func BuildIxDiag(request *openrtb2.BidRequest) error {
+	extRequest := &ExtRequest{}
+	if request.Ext != nil {
+		if err := json.Unmarshal(request.Ext, &extRequest); err != nil {
+			return err
+		}
+	}
+	ixdiag := &IxDiag{}
+
+	if extRequest.Prebid != nil {
+		ixdiag = &IxDiag{
+			PbjsV: extRequest.Prebid.Channel.Version,
+		}
+	}
+
+	// Slice commit hash out of version
+	if strings.Contains(version.Ver, "-") {
+		ixdiag.PbsV = version.Ver[:strings.LastIndex(version.Ver, "-")]
+	} else if version.Ver != "" {
+		ixdiag.PbsV = version.Ver
+	}
+
+	// Only set request.ext if ixDiag is not empty
+	if *ixdiag != (IxDiag{}) {
+		extRequest.IxDiag = ixdiag
+		requestExtJson, _ := json.Marshal(extRequest)
+		request.Ext = requestExtJson
+	}
+	return nil
 }

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -138,6 +138,18 @@ func TestBuildIxDiag(t *testing.T) {
 			pbsVersion:  "1.880-abcdef",
 		},
 		{
+			description: "PBS Version Two Hypens",
+			request: &openrtb2.BidRequest{
+				ID: "1",
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":null,"ixdiag":{"pbsv":"0.23.1"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "0.23.1-3-g4ee257d8",
+		},
+		{
 			description: "PBS Version no Hyphen",
 			request: &openrtb2.BidRequest{
 				ID:  "1",
@@ -187,6 +199,7 @@ func TestBuildIxDiag(t *testing.T) {
 			assert.Equal(t, test.request, test.expectedRequest)
 			assert.Nil(t, err)
 		}
+		version.Ver = ""
 	}
 }
 

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/prebid/prebid-server/adapters/adapterstest"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/version"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/openrtb/v17/adcom1"
 	"github.com/prebid/openrtb/v17/openrtb2"
@@ -100,4 +102,100 @@ func TestIxMakeBidsWithCategoryDuration(t *testing.T) {
 	if len(errors) != expectedErrorCount {
 		t.Errorf("should not have any errors, errors=%v", errors)
 	}
+}
+
+func TestBuildIxDiag(t *testing.T) {
+	testCases := []struct {
+		description     string
+		request         *openrtb2.BidRequest
+		expectedRequest *openrtb2.BidRequest
+		expectError     bool
+		pbsVersion      string
+	}{
+		{
+			description: "Base Test",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbsv":"1.880","pbjsv":"7.20"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "1.880-abcdef",
+		},
+		{
+			description: "No Ext",
+			request: &openrtb2.BidRequest{
+				ID: "1",
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":null,"ixdiag":{"pbsv":"1.880"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "1.880-abcdef",
+		},
+		{
+			description: "PBS Version no Hyphen",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbsv":"1.880","pbjsv":"7.20"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "1.880",
+		},
+		{
+			description: "PBS Version empty string",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbjsv":"7.20"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "",
+		},
+		{
+			description: "Error Test",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":"channel":{"name":"web","version":"7.20"}}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: nil,
+			},
+			expectError: true,
+			pbsVersion:  "1.880-abcdef",
+		},
+	}
+
+	for _, test := range testCases {
+		version.Ver = test.pbsVersion
+		err := BuildIxDiag(test.request)
+		if test.expectError {
+			assert.NotNil(t, err)
+		} else {
+			assert.Equal(t, test.request, test.expectedRequest)
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func TestMakeRequestsErrIxDiag(t *testing.T) {
+	bidder := &IxAdapter{}
+	req := &openrtb2.BidRequest{
+		ID:  "1",
+		Ext: json.RawMessage(`{"prebid":"channel":{"name":"web","version":"7.20"}}}`),
+	}
+	_, errs := bidder.MakeRequests(req, nil)
+	assert.Len(t, errs, 1)
 }


### PR DESCRIPTION
This update to the IX Adapter is to pass Prebid Server Version information and PBJS version information as part of a new "IXDiag" field. This field will be used to pass any diagnostic information as needed.

Changes include changese to ix.go and ix_test.go.