### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/adapters/adapterstest/test_json.go
+++ b/adapters/adapterstest/test_json.go
@@ -3,7 +3,8 @@ package adapterstest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"net/http"
+	"os"
 	"regexp"
 	"testing"
 
@@ -15,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
-
-	"net/http"
 )
 
 // RunJSONBidderTest is a helper method intended to unit test Bidders' adapters.
@@ -64,7 +63,7 @@ func RunJSONBidderTest(t *testing.T, rootDir string, bidder adapters.Bidder) {
 // runTests runs all the *.json files in a directory. If allowErrors is false, and one of the test files
 // expects errors from the bidder, then the test will fail.
 func runTests(t *testing.T, directory string, bidder adapters.Bidder, allowErrors, isAmpTest, isVideoTest bool) {
-	if specFiles, err := ioutil.ReadDir(directory); err == nil {
+	if specFiles, err := os.ReadDir(directory); err == nil {
 		for _, specFile := range specFiles {
 			fileName := fmt.Sprintf("%s/%s", directory, specFile.Name())
 			specData, err := loadFile(fileName)
@@ -82,7 +81,7 @@ func runTests(t *testing.T, directory string, bidder adapters.Bidder, allowError
 
 // LoadFile reads and parses a file as a test case. If something goes wrong, it returns an error.
 func loadFile(filename string) (*testSpec, error) {
-	specData, err := ioutil.ReadFile(filename)
+	specData, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read file %s: %v", filename, err)
 	}

--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -474,7 +474,7 @@ func resolvePlatformID(platformID string) int {
 
 func loadCategoryMapFromFileSystem() map[string]string {
 	// Load custom options for our adapter (currently just a lookup table to convert appnexus => iab categories)
-	opts, err := ioutil.ReadFile("./static/adapter/appnexus/opts.json")
+	opts, err := os.ReadFile("./static/adapter/appnexus/opts.json")
 	if err == nil {
 		var adapterOptions appnexusAdapterOptions
 

--- a/analytics/pubstack/eventchannel/eventchannel_test.go
+++ b/analytics/pubstack/eventchannel/eventchannel_test.go
@@ -3,7 +3,7 @@ package eventchannel
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"math"
 	"sync"
 	"testing"
@@ -21,7 +21,7 @@ func readGz(encoded []byte) string {
 	gr, _ := gzip.NewReader(bytes.NewReader(encoded))
 	defer gr.Close()
 
-	decoded, _ := ioutil.ReadAll(gr)
+	decoded, _ := io.ReadAll(gr)
 	return string(decoded)
 }
 

--- a/analytics/pubstack/eventchannel/sender_test.go
+++ b/analytics/pubstack/eventchannel/sender_test.go
@@ -1,7 +1,7 @@
 package eventchannel
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +13,7 @@ func TestBuildEndpointSender(t *testing.T) {
 	requestBody := make([]byte, 10)
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
-		requestBody, _ = ioutil.ReadAll(req.Body)
+		requestBody, _ = io.ReadAll(req.Body)
 		res.WriteHeader(200)
 	}))
 

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -3,17 +3,18 @@ package config
 import (
 	"errors"
 	"fmt"
-	validator "github.com/asaskevich/govalidator"
-	"github.com/golang/glog"
-	"github.com/prebid/prebid-server/macros"
-	"github.com/prebid/prebid-server/util/sliceutil"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	"github.com/golang/glog"
+	"github.com/prebid/prebid-server/macros"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/util/sliceutil"
+
+	validator "github.com/asaskevich/govalidator"
 	"gopkg.in/yaml.v3"
 )
 
@@ -180,7 +181,7 @@ type InfoReaderFromDisk struct {
 }
 
 func (r InfoReaderFromDisk) Read() (map[string][]byte, error) {
-	bidderConfigs, err := ioutil.ReadDir(r.Path)
+	bidderConfigs, err := os.ReadDir(r.Path)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -192,7 +193,7 @@ func (r InfoReaderFromDisk) Read() (map[string][]byte, error) {
 		}
 		fileName := bidderConfig.Name()
 		filePath := filepath.Join(r.Path, fileName)
-		data, err := ioutil.ReadFile(filePath)
+		data, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/currency/rate_converter.go
+++ b/currency/rate_converter.go
@@ -3,7 +3,7 @@ package currency
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -60,7 +60,7 @@ func (rc *RateConverter) fetch() (*Rates, error) {
 
 	defer response.Body.Close()
 
-	bytesJSON, err := ioutil.ReadAll(response.Body)
+	bytesJSON, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/currency/rate_converter_test.go
+++ b/currency/rate_converter_test.go
@@ -1,7 +1,7 @@
 package currency
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -374,6 +374,6 @@ func (m *mockHttpClient) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(m.responseBody)),
+		Body:       io.NopCloser(strings.NewReader(m.responseBody)),
 	}, nil
 }

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -106,7 +106,7 @@ func (c *cookieSyncEndpoint) Handle(w http.ResponseWriter, r *http.Request, _ ht
 
 func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, privacy.Policies, error) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return usersync.Request{}, privacy.Policies{}, errCookieSyncBody
 	}

--- a/endpoints/events/account_test.go
+++ b/endpoints/events/account_test.go
@@ -3,7 +3,7 @@ package events
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -135,7 +135,7 @@ func TestHandleAccountServiceErrors(t *testing.T) {
 
 				// execute
 				handler.h(recorder, handler.r, nil)
-				d, err := ioutil.ReadAll(recorder.Result().Body)
+				d, err := io.ReadAll(recorder.Result().Body)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/endpoints/events/event_test.go
+++ b/endpoints/events/event_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -132,7 +132,7 @@ func TestShouldReturnBadRequestWhenTypeIsMissing(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestShouldReturnBadRequestWhenTypeIsInvalid(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestShouldReturnBadRequestWhenBidIdIsMissing(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestShouldReturnBadRequestWhenTimestampIsInvalid(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestShouldReturnUnauthorizedWhenAccountIsMissing(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +312,7 @@ func TestShouldReturnBadRequestWhenFormatValueIsInvalid(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func TestShouldReturnBadRequestWhenAnalyticsValueIsInvalid(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func TestShouldNotPassEventToAnalyticsReporterWhenAccountNotFound(t *testing.T) 
 
 	// execute
 	e(recorder, req, nil)
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func TestShouldReturnBadRequestWhenIntegrationValueIsInvalid(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestShouldNotPassEventToAnalyticsReporterWhenAccountEventNotEnabled(t *test
 
 	// execute
 	e(recorder, req, nil)
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,7 +566,7 @@ func TestShouldRespondWithPixelAndContentTypeWhenRequestFormatIsImage(t *testing
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -607,7 +607,7 @@ func TestShouldRespondWithNoContentWhenRequestFormatIsNotDefined(t *testing.T) {
 	// execute
 	e(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -809,7 +809,7 @@ func TestShouldReturnBadRequestWhenVTypeIsInvalid(t *testing.T) {
 		e := NewEventEndpoint(cfg, mockAccountsFetcher, mockAnalyticsModule)
 		e(recorder, test.req, nil)
 
-		d, err := ioutil.ReadAll(recorder.Result().Body)
+		d, err := io.ReadAll(recorder.Result().Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -164,7 +163,7 @@ func ParseVTrackRequest(httpRequest *http.Request, maxRequestSize int64) (req *B
 	}
 
 	defer httpRequest.Body.Close()
-	requestJson, err := ioutil.ReadAll(lr)
+	requestJson, err := io.ReadAll(lr)
 	if err != nil {
 		return req, err
 	}

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -73,7 +73,7 @@ func TestShouldRespondWithBadRequestWhenAccountParameterIsMissing(t *testing.T) 
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestShouldRespondWithBadRequestWhenRequestBodyIsEmpty(t *testing.T) {
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestShouldRespondWithBadRequestWhenBidIdIsMissing(t *testing.T) {
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestShouldRespondWithBadRequestWhenBidderIsMissing(t *testing.T) {
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +300,7 @@ func TestShouldRespondWithInternalServerErrorWhenPbsCacheClientFails(t *testing.
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastNotAllowe
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +469,7 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastAllowed(t
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -524,7 +524,7 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableUnknownBiddersWhenUnknownBidde
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -580,7 +580,7 @@ func TestShouldReturnBadRequestWhenRequestExceedsMaxRequestSize(t *testing.T) {
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,7 +624,7 @@ func TestShouldRespondWithInternalErrorPbsCacheIsNotConfigured(t *testing.T) {
 	// execute
 	e.Handle(recorder, req, nil)
 
-	d, err := ioutil.ReadAll(recorder.Result().Body)
+	d, err := io.ReadAll(recorder.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/endpoints/info/bidders_detail_test.go
+++ b/endpoints/info/bidders_detail_test.go
@@ -2,7 +2,7 @@ package info
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -440,7 +440,7 @@ func TestBiddersDetailHandler(t *testing.T) {
 		result := responseRecorder.Result()
 		assert.Equal(t, result.StatusCode, test.expectedStatus, test.description+":statuscode")
 
-		resultBody, _ := ioutil.ReadAll(result.Body)
+		resultBody, _ := io.ReadAll(result.Body)
 		assert.Equal(t, test.expectedResponse, resultBody, test.description+":body")
 
 		resultHeaders := result.Header

--- a/endpoints/info/bidders_test.go
+++ b/endpoints/info/bidders_test.go
@@ -1,7 +1,7 @@
 package info
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -240,7 +240,7 @@ func TestBiddersHandler(t *testing.T) {
 		result := responseRecorder.Result()
 		assert.Equal(t, result.StatusCode, test.expectedStatus)
 
-		resultBody, _ := ioutil.ReadAll(result.Body)
+		resultBody, _ := io.ReadAll(result.Body)
 		assert.Equal(t, []byte(test.expectedBody), resultBody)
 
 		resultHeaders := result.Header

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -61,7 +61,7 @@ func TestGoodAmpRequests(t *testing.T) {
 	for _, tgroup := range testGroups {
 		for _, filename := range tgroup.testFiles {
 			// Read test case and unmarshal
-			fileJsonData, err := ioutil.ReadFile(tgroup.dir + filename)
+			fileJsonData, err := os.ReadFile(tgroup.dir + filename)
 			if !assert.NoError(t, err, "Failed to fetch a valid request: %v. Test file: %s", err, filename) {
 				continue
 			}
@@ -152,7 +152,7 @@ func TestAccountErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fileJsonData, err := ioutil.ReadFile("sample-requests/" + tt.filename)
+		fileJsonData, err := os.ReadFile("sample-requests/" + tt.filename)
 		if !assert.NoError(t, err, "Failed to fetch a valid request: %v. Test file: %s", err, tt.filename) {
 			continue
 		}
@@ -986,7 +986,7 @@ func TestAMPSiteExt(t *testing.T) {
 // TestBadRequests makes sure we return 400's on bad requests.
 func TestAmpBadRequests(t *testing.T) {
 	dir := "sample-requests/invalid-whole"
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	assert.NoError(t, err, "Failed to read folder: %s", dir)
 
 	badRequests := make(map[string]json.RawMessage, len(files))

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -272,14 +271,14 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request) (req *openrtb_
 		R: httpRequest.Body,
 		N: deps.cfg.MaxRequestSize,
 	}
-	requestJson, err := ioutil.ReadAll(lr)
+	requestJson, err := io.ReadAll(lr)
 	if err != nil {
 		errs = []error{err}
 		return
 	}
 	// If the request size was too large, read through the rest of the request body so that the connection can be reused.
 	if lr.N <= 0 {
-		if written, err := io.Copy(ioutil.Discard, httpRequest.Body); written > 0 || err != nil {
+		if written, err := io.Copy(io.Discard, httpRequest.Body); written > 0 || err != nil {
 			errs = []error{fmt.Errorf("Request size exceeded max size of %d bytes.", deps.cfg.MaxRequestSize)}
 			return
 		}

--- a/endpoints/openrtb2/auction_benchmark_test.go
+++ b/endpoints/openrtb2/auction_benchmark_test.go
@@ -3,9 +3,9 @@ package openrtb2
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -138,7 +138,7 @@ func BenchmarkValidWholeExemplary(b *testing.B) {
 		b.Run(fmt.Sprintf("input_file_%s", testFile), func(b *testing.B) {
 			b.StopTimer()
 			// Set up
-			fileData, err := ioutil.ReadFile(testFile)
+			fileData, err := os.ReadFile(testFile)
 			if err != nil {
 				b.Fatalf("unable to read file %s", testFile)
 			}

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -110,7 +110,7 @@ func TestJsonSampleRequests(t *testing.T) {
 		testCaseFiles, err := getTestFiles(filepath.Join("sample-requests", tc.sampleRequestsSubDir))
 		if assert.NoError(t, err, "Test case %s. Error reading files from directory %s \n", tc.description, tc.sampleRequestsSubDir) {
 			for _, testFile := range testCaseFiles {
-				fileData, err := ioutil.ReadFile(testFile)
+				fileData, err := os.ReadFile(testFile)
 				if assert.NoError(t, err, "Test case %s. Error reading file %s \n", tc.description, testFile) {
 					// Retrieve test case input and expected output from JSON file
 					test, err := parseTestFile(fileData, testFile)
@@ -2396,7 +2396,7 @@ func TestValidateImpExt(t *testing.T) {
 }
 
 func validRequest(t *testing.T, filename string) string {
-	requestData, err := ioutil.ReadFile("sample-requests/valid-whole/supplementary/" + filename)
+	requestData, err := os.ReadFile("sample-requests/valid-whole/supplementary/" + filename)
 	if err != nil {
 		t.Fatalf("Failed to fetch a valid request: %v", err)
 	}
@@ -4663,7 +4663,7 @@ func (cf *mockStoredResponseFetcher) FetchResponses(ctx context.Context, ids []s
 }
 
 func getObject(t *testing.T, filename, key string) json.RawMessage {
-	requestData, err := ioutil.ReadFile("sample-requests/valid-whole/supplementary/" + filename)
+	requestData, err := os.ReadFile("sample-requests/valid-whole/supplementary/" + filename)
 	if err != nil {
 		t.Fatalf("Failed to fetch a valid request: %v", err)
 	}

--- a/endpoints/openrtb2/test_utils.go
+++ b/endpoints/openrtb2/test_utils.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -1091,7 +1091,7 @@ func newBidderInfo(isDisabled bool) config.BidderInfo {
 func getTestFiles(dir string) ([]string, error) {
 	var filesToAssert []string
 
-	fileList, err := ioutil.ReadDir(dir)
+	fileList, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -1389,7 +1389,7 @@ func (c *wellBehavedCache) PutJson(ctx context.Context, values []pbc.Cacheable) 
 }
 
 func readFile(t *testing.T, filename string) []byte {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("Failed to read file %s: %v", filename, err)
 	}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -162,7 +161,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		R: r.Body,
 		N: deps.cfg.MaxRequestSize,
 	}
-	requestJson, err := ioutil.ReadAll(lr)
+	requestJson, err := io.ReadAll(lr)
 	if err != nil {
 		handleError(&labels, w, []error{err}, &vo, &debugLog)
 		return

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -1463,7 +1463,7 @@ var testVideoStoredRequestData = map[string]json.RawMessage{
 }
 
 func readVideoTestFile(t *testing.T, filename string) string {
-	requestData, err := ioutil.ReadFile(filename)
+	requestData, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("Failed to fetch a valid request: %v", err)
 	}

--- a/endpoints/version_test.go
+++ b/endpoints/version_test.go
@@ -1,7 +1,7 @@
 package endpoints
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestVersion(t *testing.T) {
 
 		handler(w, nil)
 
-		response, err := ioutil.ReadAll(w.Result().Body)
+		response, err := io.ReadAll(w.Result().Body)
 		if assert.NoError(t, err, test.description+":read") {
 			assert.JSONEq(t, test.expected, string(response), test.description+":response")
 		}

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -101,7 +101,7 @@ func TestBuildCacheString(t *testing.T) {
 // customcachekey.json test here verifies custom cache key not used for non-vast video
 func TestCacheJSON(t *testing.T) {
 	for _, dir := range []string{"cachetest", "customcachekeytest", "impcustomcachekeytest", "eventscachetest"} {
-		if specFiles, err := ioutil.ReadDir(dir); err == nil {
+		if specFiles, err := os.ReadDir(dir); err == nil {
 			for _, specFile := range specFiles {
 				fileName := filepath.Join(dir, specFile.Name())
 				fileDisplayName := "exchange/" + fileName
@@ -170,7 +170,7 @@ func TestIsDebugOverrideEnabled(t *testing.T) {
 
 // LoadCacheSpec reads and parses a file as a test case. If something goes wrong, it returns an error.
 func loadCacheSpec(filename string) (*cacheSpec, error) {
-	specData, err := ioutil.ReadFile(filename)
+	specData, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read file %s: %v", filename, err)
 	}

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptrace"
 	"regexp"
@@ -561,7 +561,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 		}
 	}
 
-	respBody, err := ioutil.ReadAll(httpResp.Body)
+	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return &httpCallInfo{
 			request: req,

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -1926,7 +1926,7 @@ func (DNSDoneTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(strings.NewReader("postBody")),
+		Body:       io.NopCloser(strings.NewReader("postBody")),
 	}
 
 	return resp, nil
@@ -1942,7 +1942,7 @@ func (TLSHandshakeTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(strings.NewReader("postBody")),
+		Body:       io.NopCloser(strings.NewReader("postBody")),
 	}
 
 	return resp, nil

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -2098,7 +2099,7 @@ func TestTimeoutComputation(t *testing.T) {
 
 // TestExchangeJSON executes tests for all the *.json files in exchangetest.
 func TestExchangeJSON(t *testing.T) {
-	if specFiles, err := ioutil.ReadDir("./exchangetest"); err == nil {
+	if specFiles, err := os.ReadDir("./exchangetest"); err == nil {
 		for _, specFile := range specFiles {
 			fileName := "./exchangetest/" + specFile.Name()
 			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
@@ -2114,7 +2115,7 @@ func TestExchangeJSON(t *testing.T) {
 
 // LoadFile reads and parses a file as a test case. If something goes wrong, it returns an error.
 func loadFile(filename string) (*exchangeSpec, error) {
-	specData, err := ioutil.ReadFile(filename)
+	specData, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read file %s: %v", filename, err)
 	}
@@ -4659,7 +4660,7 @@ func (m *fakeCurrencyRatesHttpClient) Do(req *http.Request) (*http.Response, err
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(m.responseBody)),
+		Body:       io.NopCloser(strings.NewReader(m.responseBody)),
 	}, nil
 }
 

--- a/firstpartydata/first_party_data_test.go
+++ b/firstpartydata/first_party_data_test.go
@@ -2,7 +2,7 @@ package firstpartydata
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/prebid/openrtb/v17/openrtb2"
@@ -468,7 +468,7 @@ func TestExtractOpenRtbGlobalFPD(t *testing.T) {
 
 func TestExtractBidderConfigFPD(t *testing.T) {
 
-	if specFiles, err := ioutil.ReadDir("./tests/extractbidderconfigfpd"); err == nil {
+	if specFiles, err := os.ReadDir("./tests/extractbidderconfigfpd"); err == nil {
 		for _, specFile := range specFiles {
 			fileName := "./tests/extractbidderconfigfpd/" + specFile.Name()
 
@@ -533,7 +533,7 @@ func TestExtractBidderConfigFPD(t *testing.T) {
 
 func TestResolveFPD(t *testing.T) {
 
-	if specFiles, err := ioutil.ReadDir("./tests/resolvefpd"); err == nil {
+	if specFiles, err := os.ReadDir("./tests/resolvefpd"); err == nil {
 		for _, specFile := range specFiles {
 			fileName := "./tests/resolvefpd/" + specFile.Name()
 
@@ -645,7 +645,7 @@ func TestResolveFPD(t *testing.T) {
 
 func TestExtractFPDForBidders(t *testing.T) {
 
-	if specFiles, err := ioutil.ReadDir("./tests/extractfpdforbidders"); err == nil {
+	if specFiles, err := os.ReadDir("./tests/extractfpdforbidders"); err == nil {
 		for _, specFile := range specFiles {
 			fileName := "./tests/extractfpdforbidders/" + specFile.Name()
 
@@ -736,7 +736,7 @@ func TestExtractFPDForBidders(t *testing.T) {
 
 func loadFpdFile(filename string) (fpdFile, error) {
 	var fileData fpdFile
-	fileContents, err := ioutil.ReadFile(filename)
+	fileContents, err := os.ReadFile(filename)
 	if err != nil {
 		return fileData, err
 	}

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -3,7 +3,7 @@ package gdpr
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -117,7 +117,7 @@ func saveOne(ctx context.Context, client *http.Client, url string, saver saveVen
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		glog.Errorf("Error reading response body from GET %s. Cookie syncs may be affected: %v", url, err)
 		return 0

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -473,7 +473,7 @@ type BidderParamValidator interface {
 // NewBidderParamsValidator makes a BidderParamValidator, assuming all the necessary files exist in the filesystem.
 // This will error if, for example, a Bidder gets added but no JSON schema is written for them.
 func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, error) {
-	fileInfos, err := ioutil.ReadDir(schemaDirectory)
+	fileInfos, err := os.ReadDir(schemaDirectory)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read JSON schemas from directory %s. %v", schemaDirectory, err)
 	}
@@ -497,7 +497,7 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 			return nil, fmt.Errorf("Failed to load json schema at %s: %v", toOpen, err)
 		}
 
-		fileBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", schemaDirectory, fileInfo.Name()))
+		fileBytes, err := os.ReadFile(fmt.Sprintf("%s/%s", schemaDirectory, fileInfo.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read file %s/%s: %v", schemaDirectory, fileInfo.Name(), err)
 		}

--- a/prebid_cache_client/client.go
+++ b/prebid_cache_client/client.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -118,7 +118,7 @@ func (c *clientImpl) PutJson(ctx context.Context, values []Cacheable) (uuids []s
 	defer anResp.Body.Close()
 	c.metrics.RecordPrebidCacheRequestTime(true, elapsedTime)
 
-	responseBody, err := ioutil.ReadAll(anResp.Body)
+	responseBody, err := io.ReadAll(anResp.Body)
 	if anResp.StatusCode != 200 {
 		logError(&errs, "Prebid Cache call to %s returned %d: %s", c.putUrl, anResp.StatusCode, responseBody)
 		return uuidsToReturn, errs

--- a/router/router.go
+++ b/router/router.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -54,7 +54,7 @@ import (
 // If the root directory, or any of the files in it, cannot be read, then the program will exit.
 func NewJsonDirectoryServer(schemaDirectory string, validator openrtb_ext.BidderParamValidator, aliases map[string]string) httprouter.Handle {
 	// Slurp the files into memory first, since they're small and it minimizes request latency.
-	files, err := ioutil.ReadDir(schemaDirectory)
+	files, err := os.ReadDir(schemaDirectory)
 	if err != nil {
 		glog.Fatalf("Failed to read directory %s: %v", schemaDirectory, err)
 	}
@@ -337,7 +337,7 @@ func readDefaultRequest(defReqConfig config.DefReqConfig) (map[string]string, []
 		if len(defReqConfig.FileSystem.FileName) == 0 {
 			return aliases, []byte{}
 		}
-		defReqJSON, err := ioutil.ReadFile(defReqConfig.FileSystem.FileName)
+		defReqJSON, err := os.ReadFile(defReqConfig.FileSystem.FileName)
 		if err != nil {
 			glog.Fatalf("error reading aliases from file %s: %v", defReqConfig.FileSystem.FileName, err)
 			return aliases, []byte{}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -2,9 +2,9 @@ package router
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
@@ -47,7 +47,7 @@ func TestNewJsonDirectoryServer(t *testing.T) {
 	json.Unmarshal(recorder.Body.Bytes(), &data)
 
 	// Make sure that every adapter has a json schema by the same name associated with it.
-	adapterFiles, err := ioutil.ReadDir(adapterDirectory)
+	adapterFiles, err := os.ReadDir(adapterDirectory)
 	if err != nil {
 		t.Fatalf("Failed to open the adapters directory: %v", err)
 	}

--- a/server/ssl/ssl.go
+++ b/server/ssl/ssl.go
@@ -3,7 +3,7 @@ package ssl
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // from https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
@@ -27,7 +27,7 @@ func AppendPEMFileToRootCAPool(certPool *x509.CertPool, pemFileName string) (*x5
 	}
 	if pemFileName != "" {
 		//read file and place it's contents in `pemCerts`
-		pemCerts, err := ioutil.ReadFile(pemFileName)
+		pemCerts, err := os.ReadFile(pemFileName)
 		if err != nil {
 			return certPool, fmt.Errorf("Failed to read file %s: %v", pemFileName, err)
 		}

--- a/stored_requests/backends/file_fetcher/fetcher.go
+++ b/stored_requests/backends/file_fetcher/fetcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/prebid/prebid-server/stored_requests"
@@ -104,7 +104,7 @@ func collectStoredData(directory string, fileSystem FileSystem, err error) (File
 	if err != nil {
 		return FileSystem{nil, nil}, err
 	}
-	fileInfos, err := ioutil.ReadDir(directory)
+	fileInfos, err := os.ReadDir(directory)
 	if err != nil {
 		return FileSystem{nil, nil}, err
 	}
@@ -122,7 +122,7 @@ func collectStoredData(directory string, fileSystem FileSystem, err error) (File
 
 		} else {
 			if strings.HasSuffix(fileInfo.Name(), ".json") { // Skip the .gitignore
-				fileData, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", directory, fileInfo.Name()))
+				fileData, err := os.ReadFile(fmt.Sprintf("%s/%s", directory, fileInfo.Name()))
 				if err != nil {
 					return FileSystem{nil, nil}, err
 				}

--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -129,7 +129,7 @@ func (fetcher *HttpFetcher) FetchAccounts(ctx context.Context, accountIDs []stri
 		}
 	}
 	defer httpResp.Body.Close()
-	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	respBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, []error{
 			fmt.Errorf(`Error fetching accounts %v via http: error reading response: %v`, accountIDs, err),
@@ -201,7 +201,7 @@ func (fetcher *HttpFetcher) FetchCategories(ctx context.Context, primaryAdServer
 	}
 	defer httpResp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	respBytes, err := io.ReadAll(httpResp.Body)
 	tmp := make(map[string]stored_requests.Category)
 
 	if err := json.Unmarshal(respBytes, &tmp); err != nil {
@@ -227,7 +227,7 @@ func buildRequest(endpoint string, requestIDs []string, impIDs []string) (*http.
 }
 
 func unpackResponse(resp *http.Response) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		errs = append(errs, err)
 		return

--- a/stored_requests/events/api/api.go
+++ b/stored_requests/events/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -35,7 +35,7 @@ func NewEventsAPI() (events.EventProducer, httprouter.Handle) {
 
 func (api *eventsAPI) HandleEvent(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	if r.Method == "POST" {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Missing update data.\n"))
@@ -51,7 +51,7 @@ func (api *eventsAPI) HandleEvent(w http.ResponseWriter, r *http.Request, _ http
 
 		api.saves <- save
 	} else if r.Method == "DELETE" {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Missing invalidation data.\n"))

--- a/stored_requests/events/http/http.go
+++ b/stored_requests/events/http/http.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	httpCore "net/http"
 	"net/url"
 	"time"
@@ -172,7 +172,7 @@ func (e *HTTPEvents) parse(endpoint string, resp *httpCore.Response, err error) 
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		glog.Errorf("Failed to read body of GET %s for Stored Requests: %v", endpoint, err)
 		return nil, false


### PR DESCRIPTION
Recently we have upgraded to Go 1.19 in #2428. The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir