### PR TITLE
fix extra-bid's multicurrency scenario

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -362,7 +362,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 							// Initalize seatBidMap entry as this is first extra bid with seat bidderName
 							seatBidMap[bidderName] = &pbsOrtbSeatBid{
 								bids:     make([]*pbsOrtbBid, 0, dataLen),
-								currency: defaultCurrency,
+								currency: seatBidMap[bidderRequest.BidderName].currency,
 								// Do we need to fill httpCalls for this?. Can we refer one from adaptercode for debugging?
 								httpCalls: seatBidMap[bidderRequest.BidderName].httpCalls,
 								seat:      bidderName.String(),


### PR DESCRIPTION
Fixed below scenario:

In alternatebiddercodes feature, if the request currency is non-USD, the extra-bids are being omitted from the response with below error 
```
"errors": {
            "pubmatic": [
                {
                    "code": 999,
                    "message": "Bid currency is not allowed. Was 'USD', wants: ['INR']"
                }
            ]
        },
```

This is because the response currency for the extra-bids is wrongly set to default USD.