### PR TITLE
Stored responses: return nil if no stored reponses was found for ids

### DIFF
--- a/stored_responses/stored_responses.go
+++ b/stored_responses/stored_responses.go
@@ -141,7 +141,7 @@ func ProcessStoredResponses(ctx context.Context, requestJson []byte, storedRespF
 
 	if len(storedResponsesIds) > 0 {
 		storedResponses, errs := storedRespFetcher.FetchResponses(ctx, storedResponsesIds)
-		if len(errs) > 0 {
+		if len(storedResponses) == 0 || len(errs) > 0 {
 			return nil, nil, nil, errs
 		}
 		bidderImpIdReplaceImp := flipMap(impBidderReplaceImp)

--- a/stored_responses/stored_responses_test.go
+++ b/stored_responses/stored_responses_test.go
@@ -350,6 +350,27 @@ func TestProcessStoredAuctionAndBidResponses(t *testing.T) {
 			expectedBidderImpReplaceImpID: BidderImpReplaceImpID{},
 		},
 		{
+			description: "Stored auction response one imp with no stored response",
+			requestJson: []byte(`{"imp": [
+				{
+					"id": "imp-id1",
+					"ext": {
+						"appnexus": {
+							"placementId": 123
+						},
+						"prebid": {
+							"storedauctionresponse": {
+								"id": "4"
+							}
+						}
+					}
+				}
+			]}`),
+			expectedStoredAuctionResponses: nil,
+			expectedStoredBidResponses:     nil,
+			expectedBidderImpReplaceImpID:  nil,
+		},
+		{
 			description: "Stored bid response one imp",
 			requestJson: []byte(`{"imp": [
     			  {
@@ -654,5 +675,11 @@ func (cf *mockStoredBidResponseFetcher) FetchRequests(ctx context.Context, reque
 }
 
 func (cf *mockStoredBidResponseFetcher) FetchResponses(ctx context.Context, ids []string) (data map[string]json.RawMessage, errs []error) {
-	return cf.data, nil
+	resMap := make(map[string]json.RawMessage, len(ids))
+	for _, k := range ids {
+		if v, ok := cf.data[k]; ok {
+			resMap[k] = v
+		}
+	}
+	return resMap, nil
 }


### PR DESCRIPTION
If `storedbidresponse` id(s) was provided in the `imp` request, but no stored response(s) was found, return nil instead of error out on unmarshalling empty string into ExtImpPrebid.

Additionally, the mocked fetcher returns all mocked stored responses, which I believe is incorrect. It should return the responses requested, if any.

Closes #2470
