### PR TITLE
IX Adapter: Fix panic when ext.prebid.channel is nil

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -336,7 +336,7 @@ func BuildIxDiag(request *openrtb2.BidRequest) error {
 	}
 	ixdiag := &IxDiag{}
 
-	if extRequest.Prebid != nil {
+	if extRequest.Prebid != nil && extRequest.Prebid.Channel != nil {
 		ixdiag.PbjsV = extRequest.Prebid.Channel.Version
 	}
 
@@ -350,11 +350,11 @@ func BuildIxDiag(request *openrtb2.BidRequest) error {
 	// Only set request.ext if ixDiag is not empty
 	if *ixdiag != (IxDiag{}) {
 		extRequest.IxDiag = ixdiag
-		requestExtJson, err := json.Marshal(extRequest)
+		extRequestJson, err := json.Marshal(extRequest)
 		if err != nil {
 			return err
 		}
-		request.Ext = requestExtJson
+		request.Ext = extRequestJson
 	}
 	return nil
 }

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -126,6 +126,19 @@ func TestBuildIxDiag(t *testing.T) {
 			pbsVersion:  "1.880-abcdef",
 		},
 		{
+			description: "Base test for nil channel but non-empty ext prebid payload",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"server":{"externalurl":"http://localhost:8000"}}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"server":{"externalurl":"http://localhost:8000","gvlid":0,"datacenter":""}},"ixdiag":{"pbsv":"1.880"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "1.880-abcdef",
+		},
+		{
 			description: "No Ext",
 			request: &openrtb2.BidRequest{
 				ID: "1",
@@ -191,15 +204,16 @@ func TestBuildIxDiag(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		version.Ver = test.pbsVersion
-		err := BuildIxDiag(test.request)
-		if test.expectError {
-			assert.NotNil(t, err)
-		} else {
-			assert.Equal(t, test.request, test.expectedRequest)
-			assert.Nil(t, err)
-		}
-		version.Ver = ""
+		t.Run(test.description, func(t *testing.T) {
+			version.Ver = test.pbsVersion
+			err := BuildIxDiag(test.request)
+			if test.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedRequest, test.request)
+				assert.Nil(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Recent changes at https://github.com/prebid/prebid-server/pull/2449 cause panic when ext.prebid.channel is nil.
Fixing this with nil check and added test case to cover.