### PR TITLE
Perform full path host db config lookups in migration to detect presence

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1279,7 +1279,7 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 
 	for _, migration := range migrations {
 		driverField := migration.new + ".connection.driver"
-		if !configDatabaseConnectionPresent(v, migration.new, migration.fields) && configDatabaseConnectionPresent(v, migration.old, migration.fields) {
+		if !isConfigInfoPresent(v, migration.new, migration.fields) && isConfigInfoPresent(v, migration.old, migration.fields) {
 			glog.Warning(fmt.Sprintf("%s is deprecated and should be changed to %s", migration.old, migration.new))
 			glog.Warning(fmt.Sprintf("%s is not set, using default (postgres)", driverField))
 			v.Set(driverField, "postgres")
@@ -1319,7 +1319,7 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 	}
 }
 
-func configDatabaseConnectionPresent(v *viper.Viper, keyPrefix string, fields []string) bool {
+func isConfigInfoPresent(v *viper.Viper, keyPrefix string, fields []string) bool {
 	for _, field := range fields {
 		fieldName := keyPrefix + "." + field
 		if v.IsSet(fieldName) {

--- a/config/config.go
+++ b/config/config.go
@@ -1281,7 +1281,10 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 
 	for _, migration := range migrations {
 		driverField := migration.new + ".connection.driver"
-		if !isConfigInfoPresent(v, migration.new, migration.fields) && isConfigInfoPresent(v, migration.old, migration.fields) {
+		newConfigInfoPresent := isConfigInfoPresent(v, migration.new, migration.fields)
+		oldConfigInfoPresent := isConfigInfoPresent(v, migration.old, migration.fields)
+
+		if !newConfigInfoPresent && oldConfigInfoPresent {
 			glog.Warning(fmt.Sprintf("%s is deprecated and should be changed to %s", migration.old, migration.new))
 			glog.Warning(fmt.Sprintf("%s is not set, using default (postgres)", driverField))
 			v.Set(driverField, "postgres")
@@ -1307,7 +1310,7 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 					}
 				}
 			}
-		} else if v.IsSet(migration.new) && v.IsSet(migration.old) {
+		} else if newConfigInfoPresent && oldConfigInfoPresent {
 			glog.Warning(fmt.Sprintf("using %s and ignoring deprecated %s", migration.new, migration.old))
 
 			for _, field := range migration.fields {

--- a/config/config.go
+++ b/config/config.go
@@ -1279,7 +1279,7 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 
 	for _, migration := range migrations {
 		driverField := migration.new + ".connection.driver"
-		if !v.IsSet(migration.new) && v.IsSet(migration.old) {
+		if !configDatabaseConnectionPresent(v, migration.new, migration.fields) && configDatabaseConnectionPresent(v, migration.old, migration.fields) {
 			glog.Warning(fmt.Sprintf("%s is deprecated and should be changed to %s", migration.old, migration.new))
 			glog.Warning(fmt.Sprintf("%s is not set, using default (postgres)", driverField))
 			v.Set(driverField, "postgres")
@@ -1317,6 +1317,18 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 			}
 		}
 	}
+}
+
+func configDatabaseConnectionPresent(v *viper.Viper, keyPrefix string, fields []string) bool {
+	present := false
+	for _, field := range fields {
+		fieldName := keyPrefix + "." + field
+		if v.IsSet(fieldName) {
+			present = true
+			break
+		}
+	}
+	return present
 }
 
 func setBidderDefaults(v *viper.Viper, bidder string) {

--- a/config/config.go
+++ b/config/config.go
@@ -1319,9 +1319,10 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 	}
 }
 
-func isConfigInfoPresent(v *viper.Viper, keyPrefix string, fields []string) bool {
+func isConfigInfoPresent(v *viper.Viper, prefix string, fields []string) bool {
+	prefix = prefix + "."
 	for _, field := range fields {
-		fieldName := keyPrefix + "." + field
+		fieldName := prefix + field
 		if v.IsSet(fieldName) {
 			return true
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1320,15 +1320,13 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 }
 
 func configDatabaseConnectionPresent(v *viper.Viper, keyPrefix string, fields []string) bool {
-	present := false
 	for _, field := range fields {
 		fieldName := keyPrefix + "." + field
 		if v.IsSet(fieldName) {
-			present = true
-			break
+			return true
 		}
 	}
-	return present
+	return false
 }
 
 func setBidderDefaults(v *viper.Viper, bidder string) {

--- a/config/config.go
+++ b/config/config.go
@@ -991,6 +991,8 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("request_validation.ipv4_private_networks", []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "127.0.0.0/8"})
 	v.SetDefault("request_validation.ipv6_private_networks", []string{"::1/128", "fc00::/7", "fe80::/10", "ff00::/8", "2001:db8::/32"})
 
+	bindDatabaseEnvVars(v)
+
 	// Set environment variable support:
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.SetTypeByDefaultValue(true)
@@ -1328,6 +1330,48 @@ func isConfigInfoPresent(v *viper.Viper, prefix string, fields []string) bool {
 		}
 	}
 	return false
+}
+
+func bindDatabaseEnvVars(v *viper.Viper) {
+	v.BindEnv("stored_requests.database.connection.driver")
+	v.BindEnv("stored_requests.database.connection.dbname")
+	v.BindEnv("stored_requests.database.connection.host")
+	v.BindEnv("stored_requests.database.connection.port")
+	v.BindEnv("stored_requests.database.connection.user")
+	v.BindEnv("stored_requests.database.connection.password")
+	v.BindEnv("stored_requests.database.fetcher.query")
+	v.BindEnv("stored_requests.database.fetcher.amp_query")
+	v.BindEnv("stored_requests.database.initialize_caches.timeout_ms")
+	v.BindEnv("stored_requests.database.initialize_caches.query")
+	v.BindEnv("stored_requests.database.initialize_caches.amp_query")
+	v.BindEnv("stored_requests.database.poll_for_updates.refresh_rate_seconds")
+	v.BindEnv("stored_requests.database.poll_for_updates.timeout_ms")
+	v.BindEnv("stored_requests.database.poll_for_updates.query")
+	v.BindEnv("stored_requests.database.poll_for_updates.amp_query")
+	v.BindEnv("stored_video_req.database.connection.driver")
+	v.BindEnv("stored_video_req.database.connection.dbname")
+	v.BindEnv("stored_video_req.database.connection.host")
+	v.BindEnv("stored_video_req.database.connection.port")
+	v.BindEnv("stored_video_req.database.connection.user")
+	v.BindEnv("stored_video_req.database.connection.password")
+	v.BindEnv("stored_video_req.database.fetcher.query")
+	v.BindEnv("stored_video_req.database.initialize_caches.timeout_ms")
+	v.BindEnv("stored_video_req.database.initialize_caches.query")
+	v.BindEnv("stored_video_req.database.poll_for_updates.refresh_rate_seconds")
+	v.BindEnv("stored_video_req.database.poll_for_updates.timeout_ms")
+	v.BindEnv("stored_video_req.database.poll_for_updates.query")
+	v.BindEnv("stored_responses.database.connection.driver")
+	v.BindEnv("stored_responses.database.connection.dbname")
+	v.BindEnv("stored_responses.database.connection.host")
+	v.BindEnv("stored_responses.database.connection.port")
+	v.BindEnv("stored_responses.database.connection.user")
+	v.BindEnv("stored_responses.database.connection.password")
+	v.BindEnv("stored_responses.database.fetcher.query")
+	v.BindEnv("stored_responses.database.initialize_caches.timeout_ms")
+	v.BindEnv("stored_responses.database.initialize_caches.query")
+	v.BindEnv("stored_responses.database.poll_for_updates.refresh_rate_seconds")
+	v.BindEnv("stored_responses.database.poll_for_updates.timeout_ms")
+	v.BindEnv("stored_responses.database.poll_for_updates.query")
 }
 
 func setBidderDefaults(v *viper.Viper, bidder string) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2369,7 +2369,7 @@ func TestMigrateConfigDatabaseQueryParams(t *testing.T) {
 	assert.Equal(t, want_queries.poll_for_updates_amp_query, v.GetString("stored_responses.database.poll_for_updates.amp_query"))
 }
 
-func TestConfigDatabaseConnectionPresent(t *testing.T) {
+func TestIsConfigInfoPresent(t *testing.T) {
 	configPrefix1Field2Only := []byte(`
       prefix1:
         field2: "value2"
@@ -2454,7 +2454,7 @@ func TestConfigDatabaseConnectionPresent(t *testing.T) {
 		v.SetConfigType("yaml")
 		v.ReadConfig(bytes.NewBuffer(tt.config))
 
-		result := configDatabaseConnectionPresent(v, tt.keyPrefix, tt.fields)
+		result := isConfigInfoPresent(v, tt.keyPrefix, tt.fields)
 		assert.Equal(t, tt.wantResult, result, tt.description)
 	}
 }


### PR DESCRIPTION
This PR fixes an issue introduced in v0.234.0. In that release we added support for MySQL which resulted in deprecating the `postgres` config and adding a generic `database` config for stored requests, stored video requests and stored responses. In order to avoid a breaking change, PBS was made backwards compatible. If hosts are still using the `postgres` config, the values are mapped to `database` at start-up. The migration works correctly if the `postgres` config is specified in a config file but if it is specified via environment variables the migration does not run. This issue can be traced back to our attempt to detect presence of the `postgres` and `database` configurations by performing partial path lookups of `{stored_responses/requests/video_reqs}.postgres` and `{stored_responses/requests/video_reqs}.database` instead of looking for the full names (e.g. `stored_requests.postgres.connection.dbname`) which doesn't work due to how viper works under the hood.
A second issue was also identified once we got the migration to run. If the new field `database` was used and the that config was expressed using environment variables, the configuration was not registering. viper `BindEnv` statements were added to resolve this problem which registers the fields with viper so that the values are successfully mapped to the config structs. In this scenario the migration does not run since the new fields are used. When the migration runs, `BindEnv` is not necessary since the migration contains viper `Set` calls that handle the registration.