### PR TITLE
VISX: Add string support to UID

### DIFF
--- a/adapters/visx/params_test.go
+++ b/adapters/visx/params_test.go
@@ -2,8 +2,9 @@ package visx
 
 import (
 	"encoding/json"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"testing"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
 func TestValidParams(t *testing.T) {
@@ -34,6 +35,7 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"uid":13245}`,
+	`{"uid":"13245"}`,
 	`{"uid":13245, "size": [10,5]}`,
 	`{"uid":13245, "other_optional": true}`,
 }

--- a/adapters/visx/params_test.go
+++ b/adapters/visx/params_test.go
@@ -47,7 +47,10 @@ var invalidParams = []string{
 	`2`,
 	`{"size":12345678}`,
 	`{"size":""}`,
-	`{"uid": "1"}`,
+	`{"uid": "-1"}`,
+	`{"uid": "232af"}`,
+	`{"uid": "af213"}`,
+	`{"uid": "af"}`,
 	`{"size": true}`,
 	`{"uid": true, "size":"1234567"}`,
 }

--- a/static/bidder-params/visx.json
+++ b/static/bidder-params/visx.json
@@ -5,7 +5,8 @@
   "type": "object",
   "properties": {
     "uid": {
-      "type": "integer",
+      "type": ["integer", "string"],
+      "pattern": "^\\d+$",
       "description": "An ID which identifies this placement of the impression"
     },
     "size": {


### PR DESCRIPTION
Updating UID to support both integer and string.

- Updated schema to support string and integer types
- Added regex to schema for UID format validation
- Added new test params