### PR TITLE
Pb 1407 instance level event flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -469,6 +469,7 @@ type VTrack struct {
 
 type Event struct {
 	TimeoutMS int64 `mapstructure:"timeout_ms"`
+	Enabled   bool  `mapstructure:"enabled"`
 }
 
 type HostCookie struct {
@@ -899,6 +900,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("vtrack.enabled", true)
 
 	v.SetDefault("event.timeout_ms", 1000)
+	v.SetDefault("event.enabled", false)
 
 	v.SetDefault("accounts.filesystem.enabled", false)
 	v.SetDefault("accounts.filesystem.directorypath", "./stored_requests/data/by_id")

--- a/endpoints/events/event.go
+++ b/endpoints/events/event.go
@@ -105,7 +105,7 @@ func (e *eventEndpoint) Handle(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 
 	// account does not support events
-	if !(account.EventsEnabled || e.Cfg.Event.Enabled) {
+	if !account.EventsEnabled && !e.Cfg.Event.Enabled {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(fmt.Sprintf("Account '%s' or server doesn't support events", eventRequest.AccountID)))
 		return

--- a/endpoints/events/event.go
+++ b/endpoints/events/event.go
@@ -105,9 +105,9 @@ func (e *eventEndpoint) Handle(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 
 	// account does not support events
-	if !account.EventsEnabled {
+	if !(account.EventsEnabled || e.Cfg.Event.Enabled) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(fmt.Sprintf("Account '%s' doesn't support events", eventRequest.AccountID)))
+		w.Write([]byte(fmt.Sprintf("Account '%s' or server doesn't support events", eventRequest.AccountID)))
 		return
 	}
 

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -71,6 +71,7 @@ type exchange struct {
 	hostSChainNode    *openrtb2.SupplyChainNode
 	adsCertSigner     adscert.Signer
 	server            config.Server
+	event             config.Event
 }
 
 // Container to pass out response ext data from the GetAllBids goroutines back into the main thread
@@ -334,7 +335,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r AuctionRequest, debugLog *
 			}
 		}
 
-		evTracking := getEventTracking(&requestExt.Prebid, r.StartTime, &r.Account, e.bidderInfo, e.externalURL)
+		evTracking := getEventTracking(&requestExt.Prebid, r.StartTime, &r.Account, e.bidderInfo, e.externalURL, &e.event)
 		adapterBids = evTracking.modifyBidsForEvents(adapterBids)
 
 		if targData != nil {


### PR DESCRIPTION
Addresses #2479.

Adds instance level config to enable PBS analytics events (`event.enabled`)

- Instance level config overrides account level config. This is because with the current `event_enable` config at account level, we need to create a stored account for every account that we want to enable events for. To avoid that, instance level config can override that. This way if hosting PBS, we can enable events for all accounts without the need for creating stored accounts for each. 
- When using PBS analytics events, I don't see many use cases that events would need to be disabled for an account, but if there's any, instance level `event.enabled` should be set to `false` or removed and events enablement should be managed through stored accounts then.

Example `pbs.yml` config to enable events at instance level:
```
event:
  enabled: true
```

![Screen Shot 2022-12-16 at 11 55 22 AM](https://user-images.githubusercontent.com/56240400/209899765-691d7779-2abc-49fa-82f0-7fefe22d4ecd.png)

![Screen Shot 2022-12-16 at 11 56 37 AM](https://user-images.githubusercontent.com/56240400/209899779-460dff02-91b1-44a7-9258-492953210e38.png)

![Screen Shot 2022-12-16 at 11 56 32 AM](https://user-images.githubusercontent.com/56240400/209899783-ab013c1a-bf45-4dbe-8baf-1206ac23a88d.png)
