### PR TITLE
IX Adapter: remove disable config from ix adapter configs

### DIFF
--- a/static/bidder-info/ix.yaml
+++ b/static/bidder-info/ix.yaml
@@ -1,4 +1,3 @@
-disabled: true
 maintainer:
   email: "pdu-supply-prebid@indexexchange.com"
 gvlVendorID: 10


### PR DESCRIPTION
Historically bidders were disabled by default. That's not the case anymore. This change is to remove `disabled` config from ix adapter configs.

More info: https://docs.prebid.org/prebid-server/developers/add-new-bidder-go.html#prebid-server---new-bid-adapter-go