### PR TITLE
Unruly: Add support for "siteId" bidder parameter (different casing)

### DIFF
--- a/adapters/unruly/params_test.go
+++ b/adapters/unruly/params_test.go
@@ -35,12 +35,16 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"siteid": 123}`,
+	`{"siteId": 123}`,
 }
 
 var invalidParams = []string{
 	`{}`,                // Missing required siteId
-	`{"siteid": "123"}`, // Invalid siteId type
+	`{"siteid": "123"}`, // Invalid siteid type
+	`{"siteId": "123"}`, // Invalid siteId type (string)
 	`{"uuid": "123"}`,   // Missing required siteId
 	`{"SiteId": "abc"}`, // Invalid capitalization (json is case sensitive)
+	`{"Siteid": 123}`,   // Invalid capitalization (json is case sensitive)
+	`{"siteid": []}`,    // Invalid siteid data type
 	`{"siteId": []}`,    // Invalid siteid data type
 }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
@@ -39,7 +39,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -94,7 +94,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             },
@@ -115,7 +115,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
@@ -18,7 +18,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       },
@@ -39,7 +40,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -94,7 +96,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             },
@@ -115,7 +118,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-app.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       },

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-gdpr.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-gdpr.json
@@ -18,7 +18,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       },
@@ -39,7 +40,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -79,7 +81,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             },
@@ -100,7 +103,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-gdpr.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-gdpr.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       },
@@ -39,7 +39,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -79,7 +79,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             },
@@ -100,7 +100,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-site.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-site.json
@@ -18,7 +18,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       },
@@ -39,7 +40,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -84,7 +86,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             },
@@ -105,7 +108,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video-site.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video-site.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       },
@@ -39,7 +39,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -84,7 +84,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             },
@@ -105,7 +105,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video.json
@@ -18,7 +18,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       },
@@ -54,7 +55,8 @@
         },
         "ext": {
           "bidder": {
-            "siteId": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -83,7 +85,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             },
@@ -119,7 +122,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/banner-and-video.json
+++ b/adapters/unruly/unrulytest/exemplary/banner-and-video.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       },
@@ -54,7 +54,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -83,7 +83,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             },
@@ -119,7 +119,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/simple-banner.json
+++ b/adapters/unruly/unrulytest/exemplary/simple-banner.json
@@ -18,7 +18,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -47,7 +47,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/simple-banner.json
+++ b/adapters/unruly/unrulytest/exemplary/simple-banner.json
@@ -47,7 +47,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/simple-video.json
+++ b/adapters/unruly/unrulytest/exemplary/simple-video.json
@@ -21,7 +21,7 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721
           }
         }
       }
@@ -53,7 +53,7 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721
                 }
               }
             }

--- a/adapters/unruly/unrulytest/exemplary/simple-video.json
+++ b/adapters/unruly/unrulytest/exemplary/simple-video.json
@@ -53,7 +53,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteId": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/supplemental/no-matching-impid.json
+++ b/adapters/unruly/unrulytest/supplemental/no-matching-impid.json
@@ -21,7 +21,8 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -53,7 +54,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/supplemental/status-code-204.json
+++ b/adapters/unruly/unrulytest/supplemental/status-code-204.json
@@ -21,7 +21,8 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -53,7 +54,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/supplemental/status-code-400.json
+++ b/adapters/unruly/unrulytest/supplemental/status-code-400.json
@@ -34,7 +34,8 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -66,7 +67,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/adapters/unruly/unrulytest/supplemental/status-code-401.json
+++ b/adapters/unruly/unrulytest/supplemental/status-code-401.json
@@ -21,7 +21,8 @@
         },
         "ext": {
           "bidder": {
-            "siteid": 72721
+            "siteId": 72721,
+            "siteid": 0
           }
         }
       }
@@ -53,7 +54,8 @@
               },
               "ext": {
                 "bidder": {
-                  "siteid": 72721
+                  "siteId": 72721,
+                  "siteid": 0
                 }
               }
             }

--- a/openrtb_ext/imp_unruly.go
+++ b/openrtb_ext/imp_unruly.go
@@ -1,6 +1,6 @@
 package openrtb_ext
 
 type ExtImpUnruly struct {
-	SiteIDOld int  `json:"siteid"`
-	SiteID int `json:"siteId"`
+	SiteIDOld int `json:"siteid"`
+	SiteID    int `json:"siteId"`
 }

--- a/openrtb_ext/imp_unruly.go
+++ b/openrtb_ext/imp_unruly.go
@@ -1,5 +1,6 @@
 package openrtb_ext
 
 type ExtImpUnruly struct {
+	SiteIDOld int  `json:"siteid"`
 	SiteID int `json:"siteId"`
 }

--- a/openrtb_ext/imp_unruly.go
+++ b/openrtb_ext/imp_unruly.go
@@ -1,5 +1,5 @@
 package openrtb_ext
 
 type ExtImpUnruly struct {
-	SiteID int `json:"siteid"`
+	SiteID int `json:"siteId"`
 }

--- a/static/bidder-params/unruly.json
+++ b/static/bidder-params/unruly.json
@@ -10,7 +10,7 @@
     },
     "siteId": {
       "type": "integer",
-      "description": "ID for publisher site"
+      "description": "ID for publisher site,preferred"
     }
   },
   "oneOf": [

--- a/static/bidder-params/unruly.json
+++ b/static/bidder-params/unruly.json
@@ -1,13 +1,20 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Unruly Adapter Params",
-    "description": "A schema which validates params accepted by the Unruly adapter",
-    "type": "object",
-    "properties": {
-      "siteid": {
-        "type": "integer",
-        "description": "ID for publisher site"
-      }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Unruly Adapter Params",
+  "description": "A schema which validates params accepted by the Unruly adapter",
+  "type": "object",
+  "properties": {
+    "siteid": {
+      "type": "integer",
+      "description": "ID for publisher site"
     },
-  "required": ["siteid"]
+    "siteId": {
+      "type": "integer",
+      "description": "ID for publisher site"
+    }
+  },
+  "oneOf": [
+    { "required": ["siteId"] },
+    { "required": ["siteid"] }
+  ]
 }


### PR DESCRIPTION
Currently, unruly.json supported only "siteid" but our ssp now supports "siteId" with a capital I.
We need to add this property to the unruly.json.
