### PR TITLE
Bid Response Validation Test Fix

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2299,7 +2299,7 @@ func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
 
 	}
 
-	if spec.BidValidationEnforcement == config.ValidationEnforce {
+	if spec.HostConfigBidValidation.BannerCreativeMaxSize == config.ValidationEnforce || spec.HostConfigBidValidation.SecureMarkup == config.ValidationEnforce {
 		actualBidRespExt := &openrtb_ext.ExtBidResponse{}
 		expectedBidRespExt := &openrtb_ext.ExtBidResponse{}
 		if bid.Ext != nil {
@@ -2311,7 +2311,7 @@ func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
 			assert.NoError(t, err, fmt.Sprintf("Error when unmarshalling: %s", err))
 		}
 
-		assert.Equal(t, expectedBidRespExt.Errors, actualBidRespExt.Errors, "Oh no")
+		assert.Equal(t, expectedBidRespExt.Errors, actualBidRespExt.Errors, "Expected errors from response ext do not match")
 	}
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -4674,7 +4674,6 @@ type exchangeSpec struct {
 	RequestType                *metrics.RequestType   `json:"requestType,omitempty"`
 	PassthroughFlag            bool                   `json:"passthrough_flag,omitempty"`
 	HostSChainFlag             bool                   `json:"host_schain_flag,omitempty"`
-	BidValidationEnforcement   string                 `json:"bid_validation_flag,omitempty"`
 	HostConfigBidValidation    config.Validations     `json:"host_bid_validations"`
 	AccountConfigBidValidation config.Validations     `json:"account_bid_validations"`
 }


### PR DESCRIPTION
As pointed out by @laurb9 in the Bid Response Validation PR https://github.com/prebid/prebid-server/pull/2450, on line 2302 in `exchange/exchange_test.go`, the validation flag that is used for the JSON tests, wasn't being set. So we were getting a false pass in the tests, without actually asserting what's within the validation flag code block.

The reason it wasn't being set is because I changed how I wanted my validation flag to work, and implemented this change elsewhere in this test file, but forgot to change this line. To fix this, I updated the line so that the proper validation object is being utilized.

This validation object is set based on the info that's present in the `bid_response` json files specified at `host_bid_validations` within the json file.