### PR TITLE
skip Trivy scan for PRs with no go.mod changes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - go.mod
 
 jobs:
   build:


### PR DESCRIPTION
- Trivy checks whether any dependency mentioned in the go.mod file needs any security patch upgrade.

- Github action runs Trivy scans on pull request changes or the newly merged commit in the master branch.

- Pull requests may not make changes to the go.mod file. So we can skip Trivy scans for such cases. For this, commit adds the [paths filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) check for pull request event.
