### PR TITLE
GPP passthrough for cookiesync

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -133,7 +133,7 @@ type Syncer struct {
 // In most cases, bidders will specify a URL with a `{{.RedirectURL}}` macro for the call back to
 // Prebid Server and a UserMacro which the bidder server will replace with the user's id. Example:
 //
-//	url: "https://sync.bidderserver.com/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+//	url: "https://sync.bidderserver.com/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
 //	userMacro: "$UID"
 //
 // Prebid Server is configured with a default RedirectURL template matching the /setuid call. This
@@ -152,6 +152,8 @@ type SyncerEndpoint struct {
 	//  {{.GDPR}}        - This will be replaced with the "gdpr" property sent to /cookie_sync.
 	//  {{.Consent}}     - This will be replaced with the "consent" property sent to /cookie_sync.
 	//  {{.USPrivacy}}   - This will be replaced with the "us_privacy" property sent to /cookie_sync.
+	//  {{.GPP}}		 - This will be replaced with the "gpp" property sent to /cookie_sync.
+	//  {{.GPPSID}}		 - This will be replaced with the "gpp_sid" property sent to /cookie_sync.
 	URL string `yaml:"url" mapstructure:"url"`
 
 	// RedirectURL is an endpoint on the host server the user will be redirected to when a user sync
@@ -165,7 +167,7 @@ type SyncerEndpoint struct {
 	//  {{.UserMacro}}   - This will be replaced with the bidder server's user id macro.
 	//
 	// The endpoint on the host server is usually Prebid Server's /setuid endpoint. The default value is:
-	// `{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&f={{.SyncType}}&uid={{.UserMacro}}`
+	// `{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&f={{.SyncType}}&uid={{.UserMacro}}`
 	RedirectURL string `yaml:"redirectUrl" mapstructure:"redirect_url"`
 
 	// ExternalURL is available as a macro to the RedirectURL template. If not specified, either the syncer configuration

--- a/config/config.go
+++ b/config/config.go
@@ -933,7 +933,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 
 	// some adapters append the user id to the end of the redirect url instead of using
 	// macro substitution. it is important for the uid to be the last query parameter.
-	v.SetDefault("user_sync.redirect_url", "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&f={{.SyncType}}&uid={{.UserMacro}}")
+	v.SetDefault("user_sync.redirect_url", "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&f={{.SyncType}}&uid={{.UserMacro}}")
 
 	v.SetDefault("max_request_size", 1024*256)
 	v.SetDefault("analytics.file.filename", "")

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -156,8 +156,8 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 			Consent: request.USPrivacy,
 		},
 		GPP: gppPrivacy.Policy{
-			String: request.GPP,
-			RawSID: request.GPPSid,
+			Consent: request.GPP,
+			RawSID:  request.GPPSid,
 		},
 	}
 

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prebid/prebid-server/privacy"
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	gdprPrivacy "github.com/prebid/prebid-server/privacy/gdpr"
+	gppPrivacy "github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -153,6 +154,10 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 		},
 		CCPA: ccpa.Policy{
 			Consent: request.USPrivacy,
+		},
+		GPP: gppPrivacy.Policy{
+			String: request.GPP,
+			RawSID: request.GPPSid,
 		},
 	}
 
@@ -398,6 +403,8 @@ type cookieSyncRequest struct {
 	GDPRConsent     string                           `json:"gdpr_consent"`
 	USPrivacy       string                           `json:"us_privacy"`
 	Limit           int                              `json:"limit"`
+	GPP             string                           `json:"gpp"`
+	GPPSid          string                           `json:"gpp_sid"`
 	CooperativeSync *bool                            `json:"coopSync"`
 	FilterSettings  *cookieSyncRequestFilterSettings `json:"filterSettings"`
 	Account         string                           `json:"account"`

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prebid/prebid-server/privacy"
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	gdprPrivacy "github.com/prebid/prebid-server/privacy/gdpr"
+	gppPrivacy "github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/usersync"
 
 	"github.com/stretchr/testify/assert"
@@ -324,6 +325,8 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				`"gdpr":1,` +
 				`"gdpr_consent":"anyGDPRConsent",` +
 				`"us_privacy":"1NYN",` +
+				`"gpp":"anyGPPString",` +
+				`"gpp_sid":"2",` +
 				`"limit":42,` +
 				`"coopSync":true,` +
 				`"filterSettings":{"iframe":{"bidders":"*","filter":"include"}, "image":{"bidders":["b"],"filter":"exclude"}}` +
@@ -343,6 +346,10 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				},
 				CCPA: ccpa.Policy{
 					Consent: "1NYN",
+				},
+				GPP: gppPrivacy.Policy{
+					String: "anyGPPString",
+					RawSID: "2",
 				},
 			},
 			expectedRequest: usersync.Request{

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -348,8 +348,8 @@ func TestCookieSyncParseRequest(t *testing.T) {
 					Consent: "1NYN",
 				},
 				GPP: gppPrivacy.Policy{
-					String: "anyGPPString",
-					RawSID: "2",
+					Consent: "anyGPPString",
+					RawSID:  "2",
 				},
 			},
 			expectedRequest: usersync.Request{

--- a/macros/macros.go
+++ b/macros/macros.go
@@ -20,6 +20,8 @@ type UserSyncTemplateParams struct {
 	GDPR        string
 	GDPRConsent string
 	USPrivacy   string
+	GPP         string
+	GPPSID      string
 }
 
 // ResolveMacros resolves macros in the given template with the provided params

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -1,0 +1,8 @@
+package gpp
+
+// Policy represents the GPP privacy string container.
+// Currently just a placeholder until more expansive support is made.
+type Policy struct {
+	String string
+	RawSID string
+}

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -3,6 +3,6 @@ package gpp
 // Policy represents the GPP privacy string container.
 // Currently just a placeholder until more expansive support is made.
 type Policy struct {
-	String string
-	RawSID string
+	Consent string
+	RawSID  string // This is the CSV format ("2,6") that the IAB recommends for passing the SID(s) on a query string.
 }

--- a/privacy/policies.go
+++ b/privacy/policies.go
@@ -3,6 +3,7 @@ package privacy
 import (
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	"github.com/prebid/prebid-server/privacy/gdpr"
+	"github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/privacy/lmt"
 )
 
@@ -11,4 +12,5 @@ type Policies struct {
 	CCPA ccpa.Policy
 	GDPR gdpr.Policy
 	LMT  lmt.Policy
+	GPP  gpp.Policy
 }

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -229,6 +229,8 @@ func (s standardSyncer) GetSync(syncTypes []SyncType, privacyPolicies privacy.Po
 		GDPR:        privacyPolicies.GDPR.Signal,
 		GDPRConsent: privacyPolicies.GDPR.Consent,
 		USPrivacy:   privacyPolicies.CCPA.Consent,
+		GPP:         privacyPolicies.GPP.String,
+		GPPSID:      privacyPolicies.GPP.RawSID,
 	})
 	if err != nil {
 		return Sync{}, err

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -229,7 +229,7 @@ func (s standardSyncer) GetSync(syncTypes []SyncType, privacyPolicies privacy.Po
 		GDPR:        privacyPolicies.GDPR.Signal,
 		GDPRConsent: privacyPolicies.GDPR.Consent,
 		USPrivacy:   privacyPolicies.CCPA.Consent,
-		GPP:         privacyPolicies.GPP.String,
+		GPP:         privacyPolicies.GPP.Consent,
 		GPPSID:      privacyPolicies.GPP.RawSID,
 	})
 	if err != nil {

--- a/usersync/syncer_test.go
+++ b/usersync/syncer_test.go
@@ -177,7 +177,7 @@ func TestBuildTemplate(t *testing.T) {
 		key           = "anyKey"
 		syncTypeValue = "x"
 		hostConfig    = config.UserSync{ExternalURL: "http://host.com", RedirectURL: "{{.ExternalURL}}/host"}
-		macroValues   = macros.UserSyncTemplateParams{GDPR: "A", GDPRConsent: "B", USPrivacy: "C"}
+		macroValues   = macros.UserSyncTemplateParams{GDPR: "A", GDPRConsent: "B", USPrivacy: "C", GPP: "D", GPPSID: "1"}
 	)
 
 	testCases := []struct {
@@ -199,11 +199,11 @@ func TestBuildTemplate(t *testing.T) {
 			description: "All Composed Macros",
 			givenSyncerEndpoint: config.SyncerEndpoint{
 				URL:         "https://bidder.com/sync?redirect={{.RedirectURL}}",
-				RedirectURL: "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&f={{.SyncType}}&gdpr={{.GDPR}}&uid={{.UserMacro}}",
+				RedirectURL: "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&f={{.SyncType}}&gdpr={{.GDPR}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&uid={{.UserMacro}}",
 				ExternalURL: "http://syncer.com",
 				UserMacro:   "$UID$",
 			},
-			expectedRendered: "https://bidder.com/sync?redirect=http%3A%2F%2Fsyncer.com%2Fsetuid%3Fbidder%3DanyKey%26f%3Dx%26gdpr%3DA%26uid%3D%24UID%24",
+			expectedRendered: "https://bidder.com/sync?redirect=http%3A%2F%2Fsyncer.com%2Fsetuid%3Fbidder%3DanyKey%26f%3Dx%26gdpr%3DA%26gpp%3DD%26gpp_sid%3D1%26uid%3D%24UID%24",
 		},
 		{
 			description: "Redirect URL + External URL From Host",


### PR DESCRIPTION
Allows GPP strings to pass through cookie sync endpoints.