### PR TITLE
OpenRTB 2.6: Remove 2.6-x Fields

### DIFF
--- a/openrtb_ext/convert_down.go
+++ b/openrtb_ext/convert_down.go
@@ -31,8 +31,8 @@ func ConvertDownTo25(r *RequestWrapper) error {
 		}
 	}
 
-	// Remove new OpenRTB 2.6 fields. The spec did not specify that bidders and exchanges
-	// must tolerate new or unexpected fields gracefully until 2.6.
+	// Remove fields introduced in OpenRTB 2.6+. The previous OpenRTB 2.5 spec did not specify that
+	// bidders must tolerate new or unexpected fields.
 	clear26Fields(r)
 	clear202211Fields(r)
 
@@ -179,117 +179,117 @@ func moveRewardedFrom26ToPrebidExt(i *ImpWrapper) error {
 	return nil
 }
 
-// clear26Fields sets all fields introduced in OpenRTB 2.6 to their defaults, which
+// clear26Fields sets all fields introduced in OpenRTB 2.6 to default values, which
 // will cause them to omitted during json marshal.
 func clear26Fields(r *RequestWrapper) {
 	r.WLangB = nil
 	r.CatTax = 0
 
-	if r.App != nil {
-		r.App.CatTax = 0
-		r.App.KwArray = nil
+	if app := r.App; app != nil {
+		app.CatTax = 0
+		app.KwArray = nil
 
-		if r.App.Content != nil {
-			r.App.Content.CatTax = 0
-			r.App.Content.KwArray = nil
-			r.App.Content.LangB = ""
-			r.App.Content.Network = nil
-			r.App.Content.Channel = nil
+		if content := r.App.Content; content != nil {
+			content.CatTax = 0
+			content.KwArray = nil
+			content.LangB = ""
+			content.Network = nil
+			content.Channel = nil
 
-			if r.App.Content.Producer != nil {
-				r.App.Content.Producer.CatTax = 0
+			if producer := r.App.Content.Producer; producer != nil {
+				producer.CatTax = 0
 			}
 		}
 
-		if r.App.Publisher != nil {
-			r.App.Publisher.CatTax = 0
+		if publisher := r.App.Publisher; publisher != nil {
+			publisher.CatTax = 0
 		}
 	}
 
-	if r.Site != nil {
-		r.Site.CatTax = 0
-		r.Site.KwArray = nil
+	if site := r.Site; site != nil {
+		site.CatTax = 0
+		site.KwArray = nil
 
-		if r.Site.Content != nil {
-			r.Site.Content.CatTax = 0
-			r.Site.Content.KwArray = nil
-			r.Site.Content.LangB = ""
-			r.Site.Content.Network = nil
-			r.Site.Content.Channel = nil
+		if content := r.Site.Content; content != nil {
+			content.CatTax = 0
+			content.KwArray = nil
+			content.LangB = ""
+			content.Network = nil
+			content.Channel = nil
 
-			if r.Site.Content.Producer != nil {
-				r.Site.Content.Producer.CatTax = 0
+			if producer := r.Site.Content.Producer; producer != nil {
+				producer.CatTax = 0
 			}
 		}
 
-		if r.Site.Publisher != nil {
-			r.Site.Publisher.CatTax = 0
+		if publisher := r.Site.Publisher; publisher != nil {
+			publisher.CatTax = 0
 		}
 	}
 
-	if r.Device != nil {
-		r.Device.UA = ""
-		r.Device.SUA = nil
-		r.Device.LangB = ""
+	if device := r.Device; device != nil {
+		device.UA = ""
+		device.SUA = nil
+		device.LangB = ""
 	}
 
-	if r.Regs != nil {
-		r.Regs.GDPR = nil
-		r.Regs.USPrivacy = ""
+	if regs := r.Regs; regs != nil {
+		regs.GDPR = nil
+		regs.USPrivacy = ""
 	}
 
-	if r.Source != nil {
-		r.Source.SChain = nil
+	if source := r.Source; source != nil {
+		source.SChain = nil
 	}
 
-	if r.User != nil {
-		r.User.KwArray = nil
-		r.User.Consent = ""
-		r.User.EIDs = nil
+	if user := r.User; user != nil {
+		user.KwArray = nil
+		user.Consent = ""
+		user.EIDs = nil
 	}
 
 	for _, imp := range r.GetImp() {
 		imp.Rwdd = 0
 		imp.SSAI = 0
 
-		if imp.Audio != nil {
-			imp.Audio.PodDur = 0
-			imp.Audio.RqdDurs = nil
-			imp.Audio.PodID = 0
-			imp.Audio.PodSeq = 0
-			imp.Audio.SlotInPod = 0
-			imp.Audio.MinCPMPerSec = 0
+		if audio := imp.Audio; audio != nil {
+			audio.PodDur = 0
+			audio.RqdDurs = nil
+			audio.PodID = 0
+			audio.PodSeq = 0
+			audio.SlotInPod = 0
+			audio.MinCPMPerSec = 0
 		}
 
-		if imp.Video != nil {
-			imp.Video.StartDelay = nil
-			imp.Video.MaxSeq = 0
-			imp.Video.PodDur = 0
-			imp.Video.PodID = 0
-			imp.Video.PodSeq = 0
-			imp.Video.RqdDurs = nil
-			imp.Video.SlotInPod = 0
-			imp.Video.MinCPMPerSec = 0
+		if video := imp.Video; video != nil {
+			video.StartDelay = nil
+			video.MaxSeq = 0
+			video.PodDur = 0
+			video.PodID = 0
+			video.PodSeq = 0
+			video.RqdDurs = nil
+			video.SlotInPod = 0
+			video.MinCPMPerSec = 0
 		}
 	}
 }
 
-// clear202211Fields sets all fields introduced in OpenRTB 2.6-202211 to their defaults,
+// clear202211Fields sets all fields introduced in OpenRTB 2.6-202211 to default values
 // which will cause them to omitted during json marshal.
 func clear202211Fields(r *RequestWrapper) {
 	r.DOOH = nil
 
-	if r.App != nil {
-		r.App.InventoryPartnerDomain = ""
+	if app := r.App; app != nil {
+		app.InventoryPartnerDomain = ""
 	}
 
-	if r.Site != nil {
-		r.Site.InventoryPartnerDomain = ""
+	if site := r.Site; site != nil {
+		site.InventoryPartnerDomain = ""
 	}
 
-	if r.Regs != nil {
-		r.Regs.GPP = ""
-		r.Regs.GPPSID = nil
+	if regs := r.Regs; regs != nil {
+		regs.GPP = ""
+		regs.GPPSID = nil
 	}
 
 	for _, imp := range r.GetImp() {

--- a/openrtb_ext/convert_down.go
+++ b/openrtb_ext/convert_down.go
@@ -228,7 +228,6 @@ func clear26Fields(r *RequestWrapper) {
 	}
 
 	if device := r.Device; device != nil {
-		device.UA = ""
 		device.SUA = nil
 		device.LangB = ""
 	}
@@ -262,7 +261,6 @@ func clear26Fields(r *RequestWrapper) {
 		}
 
 		if video := imp.Video; video != nil {
-			video.StartDelay = nil
 			video.MaxSeq = 0
 			video.PodDur = 0
 			video.PodID = 0

--- a/openrtb_ext/convert_down.go
+++ b/openrtb_ext/convert_down.go
@@ -31,9 +31,10 @@ func ConvertDownTo25(r *RequestWrapper) error {
 		}
 	}
 
-	// Do not remove new OpenRTB 2.6 fields. The spec specifies that bidders and exchanges
-	// must tolerate new or unexpected fields gracefully, either ignoring them or treating
-	// them as unknown.
+	// Remove new OpenRTB 2.6 fields. The spec did not specify that bidders and exchanges
+	// must tolerate new or unexpected fields gracefully until 2.6.
+	clear26Fields(r)
+	clear202211Fields(r)
 
 	return nil
 }
@@ -176,4 +177,123 @@ func moveRewardedFrom26ToPrebidExt(i *ImpWrapper) error {
 	impExt.SetPrebid(impExtPrebid)
 
 	return nil
+}
+
+// clear26Fields sets all fields introduced in OpenRTB 2.6 to their defaults, which
+// will cause them to omitted during json marshal.
+func clear26Fields(r *RequestWrapper) {
+	r.WLangB = nil
+	r.CatTax = 0
+
+	if r.App != nil {
+		r.App.CatTax = 0
+		r.App.KwArray = nil
+
+		if r.App.Content != nil {
+			r.App.Content.CatTax = 0
+			r.App.Content.KwArray = nil
+			r.App.Content.LangB = ""
+			r.App.Content.Network = nil
+			r.App.Content.Channel = nil
+
+			if r.App.Content.Producer != nil {
+				r.App.Content.Producer.CatTax = 0
+			}
+		}
+
+		if r.App.Publisher != nil {
+			r.App.Publisher.CatTax = 0
+		}
+	}
+
+	if r.Site != nil {
+		r.Site.CatTax = 0
+		r.Site.KwArray = nil
+
+		if r.Site.Content != nil {
+			r.Site.Content.CatTax = 0
+			r.Site.Content.KwArray = nil
+			r.Site.Content.LangB = ""
+			r.Site.Content.Network = nil
+			r.Site.Content.Channel = nil
+
+			if r.Site.Content.Producer != nil {
+				r.Site.Content.Producer.CatTax = 0
+			}
+		}
+
+		if r.Site.Publisher != nil {
+			r.Site.Publisher.CatTax = 0
+		}
+	}
+
+	if r.Device != nil {
+		r.Device.UA = ""
+		r.Device.SUA = nil
+		r.Device.LangB = ""
+	}
+
+	if r.Regs != nil {
+		r.Regs.GDPR = nil
+		r.Regs.USPrivacy = ""
+	}
+
+	if r.Source != nil {
+		r.Source.SChain = nil
+	}
+
+	if r.User != nil {
+		r.User.KwArray = nil
+		r.User.Consent = ""
+		r.User.EIDs = nil
+	}
+
+	for _, imp := range r.GetImp() {
+		imp.Rwdd = 0
+		imp.SSAI = 0
+
+		if imp.Audio != nil {
+			imp.Audio.PodDur = 0
+			imp.Audio.RqdDurs = nil
+			imp.Audio.PodID = 0
+			imp.Audio.PodSeq = 0
+			imp.Audio.SlotInPod = 0
+			imp.Audio.MinCPMPerSec = 0
+		}
+
+		if imp.Video != nil {
+			imp.Video.StartDelay = nil
+			imp.Video.MaxSeq = 0
+			imp.Video.PodDur = 0
+			imp.Video.PodID = 0
+			imp.Video.PodSeq = 0
+			imp.Video.RqdDurs = nil
+			imp.Video.SlotInPod = 0
+			imp.Video.MinCPMPerSec = 0
+		}
+	}
+}
+
+// clear202211Fields sets all fields introduced in OpenRTB 2.6-202211 to their defaults,
+// which will cause them to omitted during json marshal.
+func clear202211Fields(r *RequestWrapper) {
+	r.DOOH = nil
+
+	if r.App != nil {
+		r.App.InventoryPartnerDomain = ""
+	}
+
+	if r.Site != nil {
+		r.Site.InventoryPartnerDomain = ""
+	}
+
+	if r.Regs != nil {
+		r.Regs.GPP = ""
+		r.Regs.GPPSID = nil
+	}
+
+	for _, imp := range r.GetImp() {
+		imp.Qty = nil
+		imp.DT = 0
+	}
 }

--- a/openrtb_ext/convert_down_test.go
+++ b/openrtb_ext/convert_down_test.go
@@ -38,7 +38,7 @@ func TestConvertDownTo25(t *testing.T) {
 			givenRequest: openrtb2.BidRequest{
 				ID:     "anyID",
 				CatTax: adcom1.CatTaxIABContent10,
-				Device: &openrtb2.Device{UA: "anyUserAgent"},
+				Device: &openrtb2.Device{LangB: "anyLang"},
 			},
 			expectedRequest: openrtb2.BidRequest{
 				ID:     "anyID",
@@ -503,7 +503,6 @@ func TestClear26Fields(t *testing.T) {
 		},
 		Device: &openrtb2.Device{
 			IP:    "1.2.3.4",
-			UA:    "anyUserAgent",
 			LangB: "anyLang",
 			SUA: &openrtb2.UserAgent{
 				Model: "PBS 2000",
@@ -541,7 +540,6 @@ func TestClear26Fields(t *testing.T) {
 			},
 			Video: &openrtb2.Video{
 				MIMEs:        []string{"any/video"},
-				StartDelay:   adcom1.StartPreRoll.Ptr(),
 				MaxSeq:       30,
 				PodDur:       30,
 				PodID:        1,

--- a/openrtb_ext/convert_down_test.go
+++ b/openrtb_ext/convert_down_test.go
@@ -4,19 +4,20 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/prebid/openrtb/v17/adcom1"
 	"github.com/prebid/openrtb/v17/openrtb2"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertDownTo25(t *testing.T) {
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description: "2.6 -> 2.5",
+			name: "2.6-to-2.5",
 			givenRequest: openrtb2.BidRequest{
 				ID:     "anyID",
 				Imp:    []openrtb2.Imp{{Rwdd: 1}},
@@ -33,7 +34,30 @@ func TestConvertDownTo25(t *testing.T) {
 			},
 		},
 		{
-			description: "2.6 -> 2.5 + Other Ext Fields",
+			name: "2.6-dropped", // integration with clear26Fields
+			givenRequest: openrtb2.BidRequest{
+				ID:     "anyID",
+				CatTax: adcom1.CatTaxIABContent10,
+				Device: &openrtb2.Device{UA: "anyUserAgent"},
+			},
+			expectedRequest: openrtb2.BidRequest{
+				ID:     "anyID",
+				Device: &openrtb2.Device{},
+			},
+		},
+		{
+			name: "2.6-202211-dropped", // integration with clear202211Fields
+			givenRequest: openrtb2.BidRequest{
+				ID:  "anyID",
+				App: &openrtb2.App{InventoryPartnerDomain: "anyDomain"},
+			},
+			expectedRequest: openrtb2.BidRequest{
+				ID:  "anyID",
+				App: &openrtb2.App{},
+			},
+		},
+		{
+			name: "2.6-to-2.5-OtherExtFields",
 			givenRequest: openrtb2.BidRequest{
 				ID:     "anyID",
 				Imp:    []openrtb2.Imp{{Rwdd: 1, Ext: json.RawMessage(`{"other":"otherImp"}`)}},
@@ -52,7 +76,7 @@ func TestConvertDownTo25(t *testing.T) {
 			},
 		},
 		{
-			description: "Malformed - SChain",
+			name: "malformed-shhain",
 			givenRequest: openrtb2.BidRequest{
 				ID:     "anyID",
 				Source: &openrtb2.Source{SChain: &openrtb2.SupplyChain{Complete: 1, Nodes: []openrtb2.SupplyChainNode{}, Ver: "2"}, Ext: json.RawMessage(`malformed`)},
@@ -60,7 +84,7 @@ func TestConvertDownTo25(t *testing.T) {
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 		{
-			description: "Malformed - GDPR",
+			name: "malformed-gdpr",
 			givenRequest: openrtb2.BidRequest{
 				ID:   "anyID",
 				Regs: &openrtb2.Regs{GDPR: openrtb2.Int8Ptr(1), Ext: json.RawMessage(`malformed`)},
@@ -68,7 +92,7 @@ func TestConvertDownTo25(t *testing.T) {
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 		{
-			description: "Malformed - Consent",
+			name: "malformed-consent",
 			givenRequest: openrtb2.BidRequest{
 				ID:   "anyID",
 				User: &openrtb2.User{Consent: "1", Ext: json.RawMessage(`malformed`)},
@@ -76,7 +100,7 @@ func TestConvertDownTo25(t *testing.T) {
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 		{
-			description: "Malformed - USPrivacy",
+			name: "malformed-usprivacy",
 			givenRequest: openrtb2.BidRequest{
 				ID:   "anyID",
 				Regs: &openrtb2.Regs{USPrivacy: "3", Ext: json.RawMessage(`malformed`)},
@@ -84,7 +108,7 @@ func TestConvertDownTo25(t *testing.T) {
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 		{
-			description: "Malformed - EID",
+			name: "malformed-eid",
 			givenRequest: openrtb2.BidRequest{
 				ID:   "anyID",
 				User: &openrtb2.User{EIDs: []openrtb2.EID{{Source: "42"}}, Ext: json.RawMessage(`malformed`)},
@@ -92,7 +116,7 @@ func TestConvertDownTo25(t *testing.T) {
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 		{
-			description: "Malformed - Imp",
+			name: "malformed-imp",
 			givenRequest: openrtb2.BidRequest{
 				ID:  "anyID",
 				Imp: []openrtb2.Imp{{Rwdd: 1, Ext: json.RawMessage(`malformed`)}},
@@ -102,14 +126,17 @@ func TestConvertDownTo25(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := ConvertDownTo25(w)
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := ConvertDownTo25(w)
+
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
@@ -121,189 +148,197 @@ func TestMoveSupplyChainFrom26To25(t *testing.T) {
 	)
 
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description:     "Not Present - Source",
+			name:            "notpresent-source",
 			givenRequest:    openrtb2.BidRequest{},
 			expectedRequest: openrtb2.BidRequest{},
 		},
 		{
-			description:     "Not Present - Source Schain",
+			name:            "notpresent-source-schain",
 			givenRequest:    openrtb2.BidRequest{Source: &openrtb2.Source{}},
 			expectedRequest: openrtb2.BidRequest{Source: &openrtb2.Source{}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5",
+			name:            "2.6-migratedto-2.5",
 			givenRequest:    openrtb2.BidRequest{Source: &openrtb2.Source{SChain: schain1}},
 			expectedRequest: openrtb2.BidRequest{Source: &openrtb2.Source{Ext: schain1Json}},
 		},
 		{
-			description:     "2.5 Overwritten",
+			name:            "2.5-overwritten",
 			givenRequest:    openrtb2.BidRequest{Source: &openrtb2.Source{SChain: schain1, Ext: schain2Json}},
 			expectedRequest: openrtb2.BidRequest{Source: &openrtb2.Source{Ext: schain1Json}},
 		},
 		{
-			description:  "Malformed",
+			name:         "malformed",
 			givenRequest: openrtb2.BidRequest{Source: &openrtb2.Source{SChain: schain1, Ext: json.RawMessage(`malformed`)}},
 			expectedErr:  "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := moveSupplyChainFrom26To25(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := moveSupplyChainFrom26To25(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
 func TestMoveGDPRFrom26To25(t *testing.T) {
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description:     "Not Present - Regs",
+			name:            "notpresent-regs",
 			givenRequest:    openrtb2.BidRequest{},
 			expectedRequest: openrtb2.BidRequest{},
 		},
 		{
-			description:     "Not Present - Regs GDPR",
+			name:            "notpresent-regs-gdpr",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5",
+			name:            "2.6-migratedto-2.5",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{GDPR: openrtb2.Int8Ptr(0)}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"gdpr":0}`)}},
 		},
 		{
-			description:     "2.5 Overwritten",
+			name:            "2.5-overwritten",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{GDPR: openrtb2.Int8Ptr(0), Ext: json.RawMessage(`{"gdpr":1}`)}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"gdpr":0}`)}},
 		},
 		{
-			description:  "Malformed",
+			name:         "malformed",
 			givenRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{GDPR: openrtb2.Int8Ptr(0), Ext: json.RawMessage(`malformed`)}},
 			expectedErr:  "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := moveGDPRFrom26To25(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := moveGDPRFrom26To25(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
 func TestMoveConsentFrom26To25(t *testing.T) {
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description:     "Not Present - User",
+			name:            "notpresent-user",
 			givenRequest:    openrtb2.BidRequest{},
 			expectedRequest: openrtb2.BidRequest{},
 		},
 		{
-			description:     "Not Present - User Consent",
+			name:            "notpresent-user-consent",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5",
+			name:            "2.6-migratedto-2.5",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{Consent: "1"}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{Ext: json.RawMessage(`{"consent":"1"}`)}},
 		},
 		{
-			description:     "2.5 Overwritten",
+			name:            "2.5-overwritten",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{Consent: "1", Ext: json.RawMessage(`{"consent":"2"}`)}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{Ext: json.RawMessage(`{"consent":"1"}`)}},
 		},
 		{
-			description:  "Malformed",
+			name:         "malformed",
 			givenRequest: openrtb2.BidRequest{User: &openrtb2.User{Consent: "1", Ext: json.RawMessage(`malformed`)}},
 			expectedErr:  "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := moveConsentFrom26To25(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := moveConsentFrom26To25(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
 func TestMoveUSPrivacyFrom26To25(t *testing.T) {
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description:     "Not Present - Regs",
+			name:            "notpresent-regs",
 			givenRequest:    openrtb2.BidRequest{},
 			expectedRequest: openrtb2.BidRequest{},
 		},
 		{
-			description:     "Not Present - Regs USPrivacy",
+			name:            "notpresent-regs-usprivacy",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5",
+			name:            "2.6-migratedto-2.5",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{USPrivacy: "1"}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"1"}`)}},
 		},
 		{
-			description:     "2.5 Overwritten",
+			name:            "2.5-overwritten",
 			givenRequest:    openrtb2.BidRequest{Regs: &openrtb2.Regs{USPrivacy: "1", Ext: json.RawMessage(`{"us_privacy":"2"}`)}},
 			expectedRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"us_privacy":"1"}`)}},
 		},
 		{
-			description:  "Malformed",
+			name:         "malformed",
 			givenRequest: openrtb2.BidRequest{Regs: &openrtb2.Regs{USPrivacy: "1", Ext: json.RawMessage(`malformed`)}},
 			expectedErr:  "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := moveUSPrivacyFrom26To25(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := moveUSPrivacyFrom26To25(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
@@ -315,94 +350,319 @@ func TestMoveEIDFrom26To25(t *testing.T) {
 	)
 
 	testCases := []struct {
-		description     string
+		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
 		expectedErr     string
 	}{
 		{
-			description:     "Not Present - User",
+			name:            "notpresent-user",
 			givenRequest:    openrtb2.BidRequest{},
 			expectedRequest: openrtb2.BidRequest{},
 		},
 		{
-			description:     "Not Present - User EIDs",
+			name:            "notpresent-user-eids",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5",
+			name:            "2.6-migratedto-2.5",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{Ext: eid1Json}},
 		},
 		{
-			description:     "2.6 Migrated To 2.5 - Empty",
+			name:            "2.6-migratedto-2.5-empty",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{EIDs: []openrtb2.EID{}}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{}},
 		},
 		{
-			description:     "2.5 Overwritten",
+			name:            "2.5-overwritten",
 			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1, Ext: eid2Json}},
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{Ext: eid1Json}},
 		},
 		{
-			description:  "Malformed",
+			name:         "malformed",
 			givenRequest: openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1, Ext: json.RawMessage(`malformed`)}},
 			expectedErr:  "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &RequestWrapper{BidRequest: &test.givenRequest}
-		err := moveEIDFrom26To25(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &RequestWrapper{BidRequest: &test.givenRequest}
+			err := moveEIDFrom26To25(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildRequest(), test.description)
-			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildRequest(), "error")
+				assert.Equal(t, test.expectedRequest, *w.BidRequest, "result")
+			}
+		})
 	}
 }
 
 func TestMoveRewardedFrom26ToPrebidExt(t *testing.T) {
 	testCases := []struct {
-		description string
+		name        string
 		givenImp    openrtb2.Imp
 		expectedImp openrtb2.Imp
 		expectedErr string
 	}{
 		{
-			description: "Not Present",
+			name:        "notpresent-prebid",
 			givenImp:    openrtb2.Imp{},
 			expectedImp: openrtb2.Imp{},
 		},
 		{
-			description: "2.6 Migrated To Prebid Ext",
+			name:        "2.6-migratedto-2.5",
 			givenImp:    openrtb2.Imp{Rwdd: 1},
 			expectedImp: openrtb2.Imp{Ext: json.RawMessage(`{"prebid":{"is_rewarded_inventory":1}}`)},
 		},
 		{
-			description: "Prebid Ext Overwritten",
+			name:        "2.5-overwritten",
 			givenImp:    openrtb2.Imp{Rwdd: 1, Ext: json.RawMessage(`{"prebid":{"is_rewarded_inventory":2}}`)},
 			expectedImp: openrtb2.Imp{Ext: json.RawMessage(`{"prebid":{"is_rewarded_inventory":1}}`)},
 		},
 		{
-			description: "Malformed",
+			name:        "Malformed",
 			givenImp:    openrtb2.Imp{Rwdd: 1, Ext: json.RawMessage(`malformed`)},
 			expectedErr: "invalid character 'm' looking for beginning of value",
 		},
 	}
 
 	for _, test := range testCases {
-		w := &ImpWrapper{Imp: &test.givenImp}
-		err := moveRewardedFrom26ToPrebidExt(w)
+		t.Run(test.name, func(t *testing.T) {
+			w := &ImpWrapper{Imp: &test.givenImp}
+			err := moveRewardedFrom26ToPrebidExt(w)
 
-		if len(test.expectedErr) > 0 {
-			assert.EqualError(t, err, test.expectedErr, test.description)
-		} else {
-			assert.NoError(t, w.RebuildImp(), test.description)
-			assert.Equal(t, test.expectedImp, *w.Imp, test.description)
-		}
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "error")
+			} else {
+				assert.NoError(t, w.RebuildImp(), "error")
+				assert.Equal(t, test.expectedImp, *w.Imp, "result")
+			}
+		})
+	}
+}
+
+func TestClear26Fields(t *testing.T) {
+	var int8_1 int8 = 1
+
+	given := &openrtb2.BidRequest{
+		ID:     "anyID",
+		WLangB: []string{"anyLang"},
+		CatTax: adcom1.CatTaxIABAudience11,
+		App: &openrtb2.App{
+			CatTax:  adcom1.CatTaxIABAudience11,
+			KwArray: []string{"anyKeyword"},
+			Content: &openrtb2.Content{
+				ID:      "anyContent",
+				CatTax:  adcom1.CatTaxIABAudience11,
+				KwArray: []string{"anyKeyword"},
+				LangB:   "anyLang",
+				Network: &openrtb2.Network{
+					ID: "anyNetwork",
+				},
+				Channel: &openrtb2.Channel{
+					ID: "anyChannel",
+				},
+				Producer: &openrtb2.Producer{
+					ID:     "anyProcedure",
+					CatTax: adcom1.CatTaxIABAudience11,
+				},
+			},
+			Publisher: &openrtb2.Publisher{
+				ID:     "anyPublisher",
+				CatTax: adcom1.CatTaxIABAudience11,
+			},
+		},
+		Site: &openrtb2.Site{
+			CatTax:  adcom1.CatTaxIABAudience11,
+			KwArray: []string{"anyKeyword"},
+			Content: &openrtb2.Content{
+				ID:      "anyContent",
+				CatTax:  adcom1.CatTaxIABAudience11,
+				KwArray: []string{"anyKeyword"},
+				LangB:   "anyLang",
+				Network: &openrtb2.Network{
+					ID: "anyNetwork",
+				},
+				Channel: &openrtb2.Channel{
+					ID: "anyChannel",
+				},
+				Producer: &openrtb2.Producer{
+					ID:     "anyProcedure",
+					CatTax: adcom1.CatTaxIABAudience11,
+				},
+			},
+			Publisher: &openrtb2.Publisher{
+				ID:     "anyPublisher",
+				CatTax: adcom1.CatTaxIABAudience11,
+			},
+		},
+		Device: &openrtb2.Device{
+			IP:    "1.2.3.4",
+			UA:    "anyUserAgent",
+			LangB: "anyLang",
+			SUA: &openrtb2.UserAgent{
+				Model: "PBS 2000",
+			},
+		},
+		Regs: &openrtb2.Regs{
+			COPPA:     1,
+			GDPR:      &int8_1,
+			USPrivacy: "anyCCPA",
+		},
+		Source: &openrtb2.Source{
+			TID: "anyTransactionID",
+			SChain: &openrtb2.SupplyChain{
+				Complete: 1,
+			},
+		},
+		User: &openrtb2.User{
+			ID:      "anyUser",
+			KwArray: []string{"anyKeyword"},
+			Consent: "anyConsent",
+			EIDs:    []openrtb2.EID{{Source: "anySource"}},
+		},
+		Imp: []openrtb2.Imp{{
+			ID:   "imp1",
+			Rwdd: 1,
+			SSAI: openrtb2.AdInsertServer,
+			Audio: &openrtb2.Audio{
+				MIMEs:        []string{"any/audio"},
+				PodDur:       30,
+				RqdDurs:      []int64{15, 60},
+				PodID:        1,
+				PodSeq:       adcom1.PodSeqFirst,
+				SlotInPod:    adcom1.SlotPosFirst,
+				MinCPMPerSec: 100.0,
+			},
+			Video: &openrtb2.Video{
+				MIMEs:        []string{"any/video"},
+				StartDelay:   adcom1.StartPreRoll.Ptr(),
+				MaxSeq:       30,
+				PodDur:       30,
+				PodID:        1,
+				PodSeq:       adcom1.PodSeqFirst,
+				RqdDurs:      []int64{15, 60},
+				SlotInPod:    adcom1.SlotPosFirst,
+				MinCPMPerSec: 100.0,
+			},
+		}},
+	}
+
+	expected := &openrtb2.BidRequest{
+		ID: "anyID",
+		App: &openrtb2.App{
+			Content: &openrtb2.Content{
+				ID: "anyContent",
+				Producer: &openrtb2.Producer{
+					ID: "anyProcedure",
+				},
+			},
+			Publisher: &openrtb2.Publisher{
+				ID: "anyPublisher",
+			},
+		},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				ID: "anyContent",
+				Producer: &openrtb2.Producer{
+					ID: "anyProcedure",
+				},
+			},
+			Publisher: &openrtb2.Publisher{
+				ID: "anyPublisher",
+			},
+		},
+		Device: &openrtb2.Device{
+			IP: "1.2.3.4",
+		},
+		Regs: &openrtb2.Regs{
+			COPPA: 1,
+		},
+		Source: &openrtb2.Source{
+			TID: "anyTransactionID",
+		},
+		User: &openrtb2.User{
+			ID: "anyUser",
+		},
+		Imp: []openrtb2.Imp{{
+			ID: "imp1",
+			Audio: &openrtb2.Audio{
+				MIMEs: []string{"any/audio"},
+			},
+			Video: &openrtb2.Video{
+				MIMEs: []string{"any/video"},
+			},
+		}},
+	}
+
+	r := &RequestWrapper{BidRequest: given}
+	clear26Fields(r)
+	assert.Equal(t, expected, r.BidRequest)
+
+}
+
+func TestClear202211Fields(t *testing.T) {
+	testCases := []struct {
+		name     string
+		given    openrtb2.BidRequest
+		expected openrtb2.BidRequest
+	}{
+		{
+			name: "app",
+			given: openrtb2.BidRequest{
+				ID:   "anyID",
+				App:  &openrtb2.App{InventoryPartnerDomain: "anyDomain"},
+				Imp:  []openrtb2.Imp{{ID: "imp1", Qty: &openrtb2.Qty{Multiplier: 2.0}, DT: 42}},
+				Regs: &openrtb2.Regs{GPP: "anyGPP", GPPSID: []int8{1, 2, 3}},
+			},
+			expected: openrtb2.BidRequest{
+				ID:   "anyID",
+				App:  &openrtb2.App{},
+				Imp:  []openrtb2.Imp{{ID: "imp1"}},
+				Regs: &openrtb2.Regs{},
+			},
+		},
+		{
+			name: "site",
+			given: openrtb2.BidRequest{
+				ID:   "anyID",
+				Site: &openrtb2.Site{InventoryPartnerDomain: "anyDomain"},
+				Imp:  []openrtb2.Imp{{ID: "imp1", Qty: &openrtb2.Qty{Multiplier: 2.0}, DT: 42}},
+				Regs: &openrtb2.Regs{GPP: "anyGPP", GPPSID: []int8{1, 2, 3}},
+			},
+			expected: openrtb2.BidRequest{
+				ID:   "anyID",
+				Site: &openrtb2.Site{},
+				Imp:  []openrtb2.Imp{{ID: "imp1"}},
+				Regs: &openrtb2.Regs{},
+			},
+		},
+		{
+			name: "dooh",
+			given: openrtb2.BidRequest{
+				ID:   "anyID",
+				DOOH: &openrtb2.DOOH{ID: "anyDOOH"},
+				Imp:  []openrtb2.Imp{{ID: "imp1", Qty: &openrtb2.Qty{Multiplier: 2.0}, DT: 42}},
+				Regs: &openrtb2.Regs{GPP: "anyGPP", GPPSID: []int8{1, 2, 3}},
+			},
+			expected: openrtb2.BidRequest{
+				ID:   "anyID",
+				Imp:  []openrtb2.Imp{{ID: "imp1"}},
+				Regs: &openrtb2.Regs{},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			r := &RequestWrapper{BidRequest: &test.given}
+			clear202211Fields(r)
+			assert.Equal(t, &test.expected, r.BidRequest)
+		})
 	}
 }


### PR DESCRIPTION
Tried to avoid needing to clear out OpenRTB 2.6-x when downgrading to 2.5, but we are now aware of some bidders which fail on the new fields.