### PR TITLE
Openx: Pass through imp.ext wholesale except prebid, bidder

### DIFF
--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -144,8 +144,8 @@ func preprocess(imp *openrtb2.Imp, reqExt *openxReqExt) error {
 			Message: err.Error(),
 		}
 	}
-	delete(impExt, "bidder")
-	delete(impExt, "prebid")
+	delete(impExt, openrtb_ext.PrebidExtKey)
+	delete(impExt, openrtb_ext.PrebidExtBidderKey)
 
 	if openxExt.CustomParams != nil {
 		var err error

--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -19,10 +19,7 @@ type OpenxAdapter struct {
 	endpoint   string
 }
 
-type openxImpExt struct {
-	CustomParams       map[string]interface{}             `json:"customParams,omitempty"`
-	AuctionEnvironment openrtb_ext.AuctionEnvironmentType `json:"ae,omitempty"`
-}
+type openxImpExt map[string]json.RawMessage
 
 type openxReqExt struct {
 	DelDomain    string `json:"delDomain,omitempty"`
@@ -140,18 +137,26 @@ func preprocess(imp *openrtb2.Imp, reqExt *openxReqExt) error {
 		imp.BidFloor = openxExt.CustomFloor
 	}
 
+	// outgoing imp.ext should be same as incoming imp.ext minus prebid and bidder
 	impExt := openxImpExt{}
-	addImpExt := false
+	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
+		return &errortypes.BadInput{
+			Message: err.Error(),
+		}
+	}
+	delete(impExt, "bidder")
+	delete(impExt, "prebid")
 
 	if openxExt.CustomParams != nil {
-		impExt.CustomParams = openxExt.CustomParams
-		addImpExt = true
+		var err error
+		if impExt["customParams"], err = json.Marshal(openxExt.CustomParams); err != nil {
+			return &errortypes.BadInput{
+				Message: err.Error(),
+			}
+		}
 	}
-	if bidderExt.AuctionEnvironment != openrtb_ext.ServerSideAuction {
-		impExt.AuctionEnvironment = bidderExt.AuctionEnvironment
-		addImpExt = true
-	}
-	if addImpExt {
+
+	if len(impExt) > 0 {
 		var err error
 		if imp.Ext, err = json.Marshal(impExt); err != nil {
 			return &errortypes.BadInput{

--- a/adapters/openx/openxtest/exemplary/imp-ext-passthrough.json
+++ b/adapters/openx/openxtest/exemplary/imp-ext-passthrough.json
@@ -1,0 +1,83 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [{"w": 728, "h": 90}]
+        },
+        "ext": {
+          "ae": 1,
+          "bidder": {
+            "unit": "539439964",
+            "delDomain": "se-demo-d.openx.net",
+            "customParams": {"foo": "bar"}
+          },
+          "data": {
+            "pbadslot": "adslotvalue"
+          },
+          "gpid": "gpidvalue",
+          "otherfields": "othervalues",
+          "prebid": {
+            "foo": "bar"
+          },
+          "skadn": {
+            "version": "2.0"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://rtb.openx.net/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [{"w": 728, "h": 90}]
+              },
+              "tagid": "539439964",
+              "ext": {
+                "ae": 1,
+                "customParams": {"foo": "bar"},
+                "data": {
+                  "pbadslot": "adslotvalue"
+                },
+                "gpid": "gpidvalue",
+                "otherfields": "othervalues",
+                "skadn": {
+                  "version": "2.0"
+                }
+              }
+            }
+          ],
+          "ext": {
+            "bc": "hb_pbs_1.0.0",
+            "delDomain": "se-demo-d.openx.net"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "nbr": 1
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ]
+}


### PR DESCRIPTION
OpenX adapter: pass all of incoming `imp.ext` through to endpoint, except for `prebid` and `bidder` fields.

This should not impact existing functionality (`customParams` are still merged into `imp.ext`) but allows reading `gpid` and a host of other `data` of interest server-side while keeping the adapter code simple.

Resolves #2604 

PBS-Java implementation is at https://github.com/prebid/prebid-server-java/pull/2180