### PR TITLE
Handle set-output command deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          echo ::set-output name=tag::${GITHUB_REF/refs\/tags\/}
-          echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v}
+          echo "tag=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF/refs\/tags\/v}" >> $GITHUB_OUTPUT
 
       - name: Create & Publish Release
         uses: release-drafter/release-drafter@v5.12.1


### PR DESCRIPTION
Github has deprecated set-output and save-state commands and announced to end their support after 31st May 2023. Refer https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/for more details.

PR updates script to replace set-output with recommended command.