### PR TITLE
Update keywords parameter to accept array of objects/object/string

### DIFF
--- a/adapters/appnexus/appnexus.go
+++ b/adapters/appnexus/appnexus.go
@@ -253,7 +253,7 @@ func preprocess(imp *openrtb2.Imp, defaultDisplayManagerVer string) (string, boo
 	impExt := appnexusImpExt{Appnexus: appnexusImpExtAppnexus{
 		PlacementID:       int(appnexusExt.PlacementId),
 		TrafficSourceCode: appnexusExt.TrafficSourceCode,
-		Keywords:          makeKeywordStr(appnexusExt.Keywords),
+		Keywords:          string(appnexusExt.Keywords),
 		UsePmtRule:        appnexusExt.UsePaymentRule,
 		PrivateSizes:      appnexusExt.PrivateSizes,
 	}}
@@ -263,21 +263,6 @@ func preprocess(imp *openrtb2.Imp, defaultDisplayManagerVer string) (string, boo
 	}
 
 	return appnexusExt.Member, appnexusExt.AdPodId, nil
-}
-
-func makeKeywordStr(keywords []*openrtb_ext.ExtImpAppnexusKeyVal) string {
-	kvs := make([]string, 0, len(keywords)*2)
-	for _, kv := range keywords {
-		if len(kv.Values) == 0 {
-			kvs = append(kvs, kv.Key)
-		} else {
-			for _, val := range kv.Values {
-				kvs = append(kvs, fmt.Sprintf("%s=%s", kv.Key, val))
-			}
-		}
-	}
-
-	return strings.Join(kvs, ",")
 }
 
 func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {

--- a/adapters/appnexus/appnexustest/exemplary/dynamic-keywords-params.json
+++ b/adapters/appnexus/appnexustest/exemplary/dynamic-keywords-params.json
@@ -1,0 +1,147 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "member": "103",
+            "inv_code": "abc",
+            "reserve": 20,
+            "position": "below",
+            "traffic_source_code": "trafficSource",
+            "keywords": {"abc": ["bas"], "xyz": ["bar","baz"]},
+            "use_pmt_rule": true,
+            "private_sizes": [{"w": 300, "h": 250}]
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://ib.adnxs.com/openrtb2?member_id=103",
+        "body": {
+          "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
+          "imp": [
+            {
+              "id":"test-imp-id",
+              "banner": {
+                "format": [
+                  {"w":300,"h":250},
+                  {"w":300,"h":600}
+                ],
+                "w": 300,
+                "h": 250,
+                "pos": 3
+              },
+              "tagid": "abc",
+              "bidfloor": 20,
+              "ext": {
+                "appnexus": {
+                  "keywords": "abc=bas,xyz=bar,xyz=baz",
+                  "traffic_source_code": "trafficSource",
+                  "use_pmt_rule": true,
+                  "private_sizes": [{"w": 300, "h": 250}]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["appnexus.com"],
+                "iurl": "http://nym1-ib.adnxs.com/cr?id=29681110",
+                "cid": "958",
+                "crid": "29681110",
+                "h": 250,
+                "w": 300,
+                "ext": {
+                  "appnexus": {
+                    "brand_id": 1,
+                    "brand_category_id": 1,
+                    "auction_id": 8189378542222915032,
+                    "bid_ad_type": 0,
+                    "bidder_id": 2,
+                    "ranking_price": 0.000000,
+                    "deal_priority": 5
+                  }
+                }
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "7706636740145184841",
+            "impid": "test-imp-id",
+            "price": 0.5,
+            "adm": "some-test-ad",
+            "adid": "29681110",
+            "adomain": ["appnexus.com"],
+            "iurl": "http://nym1-ib.adnxs.com/cr?id=29681110",
+            "cid": "958",
+            "crid": "29681110",
+            "w": 300,
+            "h": 250,
+            "cat": ["IAB20-3"],
+            "ext": {
+              "appnexus": {
+                "brand_id": 1,
+                "brand_category_id": 1,
+                "auction_id": 8189378542222915032,
+                "bid_ad_type": 0,
+                "bidder_id": 2,
+                "ranking_price": 0.000000,
+                "deal_priority": 5
+              }
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/appnexus/appnexustest/exemplary/string-keywords-params.json
+++ b/adapters/appnexus/appnexustest/exemplary/string-keywords-params.json
@@ -1,0 +1,147 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "member": "103",
+            "inv_code": "abc",
+            "reserve": 20,
+            "position": "below",
+            "traffic_source_code": "trafficSource",
+            "keywords": "foo=bar,foo=baz,valueless",
+            "use_pmt_rule": true,
+            "private_sizes": [{"w": 300, "h": 250}]
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://ib.adnxs.com/openrtb2?member_id=103",
+        "body": {
+          "id": "test-request-id",
+          "ext": {
+            "appnexus": {
+              "hb_source": 5
+            },
+            "prebid": {}
+          },
+          "imp": [
+            {
+              "id":"test-imp-id",
+              "banner": {
+                "format": [
+                  {"w":300,"h":250},
+                  {"w":300,"h":600}
+                ],
+                "w": 300,
+                "h": 250,
+                "pos": 3
+              },
+              "tagid": "abc",
+              "bidfloor": 20,
+              "ext": {
+                "appnexus": {
+                  "keywords": "foo=bar,foo=baz,valueless",
+                  "traffic_source_code": "trafficSource",
+                  "use_pmt_rule": true,
+                  "private_sizes": [{"w": 300, "h": 250}]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "958",
+              "bid": [{
+                "id": "7706636740145184841",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adid": "29681110",
+                "adm": "some-test-ad",
+                "adomain": ["appnexus.com"],
+                "iurl": "http://nym1-ib.adnxs.com/cr?id=29681110",
+                "cid": "958",
+                "crid": "29681110",
+                "h": 250,
+                "w": 300,
+                "ext": {
+                  "appnexus": {
+                    "brand_id": 1,
+                    "brand_category_id": 1,
+                    "auction_id": 8189378542222915032,
+                    "bid_ad_type": 0,
+                    "bidder_id": 2,
+                    "ranking_price": 0.000000,
+                    "deal_priority": 5
+                  }
+                }
+              }]
+            }
+          ],
+          "bidid": "5778926625248726496",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "7706636740145184841",
+            "impid": "test-imp-id",
+            "price": 0.5,
+            "adm": "some-test-ad",
+            "adid": "29681110",
+            "adomain": ["appnexus.com"],
+            "iurl": "http://nym1-ib.adnxs.com/cr?id=29681110",
+            "cid": "958",
+            "crid": "29681110",
+            "w": 300,
+            "h": 250,
+            "cat": ["IAB20-3"],
+            "ext": {
+              "appnexus": {
+                "brand_id": 1,
+                "brand_category_id": 1,
+                "auction_id": 8189378542222915032,
+                "bid_ad_type": 0,
+                "bidder_id": 2,
+                "ranking_price": 0.000000,
+                "deal_priority": 5
+              }
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/openrtb_ext/imp_appnexus.go
+++ b/openrtb_ext/imp_appnexus.go
@@ -14,7 +14,7 @@ type ExtImpAppnexus struct {
 	PlacementId              jsonutil.StringInt      `json:"placement_id"`
 	InvCode                  string                  `json:"inv_code"`
 	Member                   string                  `json:"member"`
-	Keywords                 []*ExtImpAppnexusKeyVal `json:"keywords"`
+	Keywords                 jsonutil.KeywordsString `json:"keywords"`
 	TrafficSourceCode        string                  `json:"traffic_source_code"`
 	Reserve                  float64                 `json:"reserve"`
 	Position                 string                  `json:"position"`
@@ -23,10 +23,4 @@ type ExtImpAppnexus struct {
 	// At this time we do no processing on the private sizes, so just leaving it as a JSON blob.
 	PrivateSizes json.RawMessage `json:"private_sizes"`
 	AdPodId      bool            `json:"generate_ad_pod_id"`
-}
-
-// ExtImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.prebid.bidder.appnexus.keywords[i]
-type ExtImpAppnexusKeyVal struct {
-	Key    string   `json:"key,omitempty"`
-	Values []string `json:"value,omitempty"`
 }

--- a/static/bidder-params/appnexus.json
+++ b/static/bidder-params/appnexus.json
@@ -26,7 +26,7 @@
       "description": "An ID which identifies the member selling the impression."
     },
     "keywords": {
-      "type": "array",
+      "type": ["array", "object", "string"],
       "minItems": 1,
       "items": {
         "type": "object",

--- a/util/jsonutil/keywordsutil.go
+++ b/util/jsonutil/keywordsutil.go
@@ -1,0 +1,59 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type KeywordsString string
+
+// extImpAppnexusKeyVal defines the contract for bidrequest.imp[i].ext.prebid.bidder.appnexus.keywords[i]
+type extImpAppnexusKeyVal struct {
+	Key    string   `json:"key,omitempty"`
+	Values []string `json:"value,omitempty"`
+}
+
+func (ks *KeywordsString) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	switch b[0] {
+	case '{':
+		var results map[string][]string
+		err := json.Unmarshal(b, &results)
+		if err != nil {
+			return err
+		}
+
+		var keywords string
+		for key, values := range results {
+			for _, val := range values {
+				keywords = keywords + fmt.Sprintf("%s=%s", key, val)
+			}
+		}
+		*ks = KeywordsString(strings.TrimSuffix(keywords, ","))
+	case '[':
+		var results []extImpAppnexusKeyVal
+		err := json.Unmarshal(b, &results)
+		if err != nil {
+			return err
+		}
+		var kvs string
+		for _, kv := range results {
+			if len(kv.Values) == 0 {
+				kvs = kvs + fmt.Sprintf("%s,", kv.Key)
+			} else {
+				for _, val := range kv.Values {
+					kvs = kvs + fmt.Sprintf("%s=%s,", kv.Key, val)
+				}
+			}
+		}
+
+		*ks = KeywordsString(strings.TrimSuffix(kvs, ","))
+	case '"':
+		*ks = KeywordsString(string(b[1 : len(b)-1]))
+	}
+	return nil
+}

--- a/util/jsonutil/keywordsutil_test.go
+++ b/util/jsonutil/keywordsutil_test.go
@@ -1,0 +1,34 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeywordsUtilUnmarshalJSON(t *testing.T) {
+	type Keywords struct {
+		Keywords KeywordsString `json:"keywords"`
+	}
+
+	t.Run("dynamic json", func(t *testing.T) {
+		jsonData := []byte(`{"keywords" : { "genre": ["rock", "pop"], "pets": ["dog"] }}`)
+		var keywords Keywords
+		assert.NoError(t, json.Unmarshal(jsonData, &keywords))
+	})
+
+	t.Run("json array", func(t *testing.T) {
+		jsonData := []byte(`{"keywords" : [{"key": "foo", "value": ["bar","baz"]},{"key": "valueless"}]}`)
+		var keywords Keywords
+		assert.NoError(t, json.Unmarshal(jsonData, &keywords))
+		assert.Equal(t, "foo=bar,foo=baz,valueless", string(keywords.Keywords))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		jsonData := []byte(`{"keywords" : "foo=bar,foo=baz,valueless"}`)
+		var keywords Keywords
+		assert.NoError(t, json.Unmarshal(jsonData, &keywords))
+		assert.Equal(t, "foo=bar,foo=baz,valueless", string(keywords.Keywords))
+	})
+}


### PR DESCRIPTION
In order to sync the keywords parameter with PBJS, we need to be able to accept the keywords parameter as array of objects(current implementation)/object/string. This PR introduces a data type and custom unmarshaller to handle these data types.

Benchmarking for current approach:-

```
BenchmarkKeywordsUtilUnmarshalArray-12             1117339          1092 ns/op
BenchmarkKeywordsUtilUnmarshalStringJSON-12        2577942          461.1 ns/op
BenchmarkKeywordsUtilUnmarshalDynamicJSON-12       204829           5628 ns/op
```

