### PR TITLE
Taboola Bid Adapter: Support insensitive tagId, gvlID as host name

### DIFF
--- a/adapters/taboola/params_test.go
+++ b/adapters/taboola/params_test.go
@@ -34,14 +34,16 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"publisherId" : "1", "tagid": "tag-id-for-example"}`,
+	`{"publisherId" : "1", "tagId": "tag-id-for-example"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","position":1}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","pageType":"pageType"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`,
-	`{"publisherId" : "1", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`}
+}
 
 var invalidParams = []string{
 	`{}`,
 	`{"tagId" : "1"}`,
+	`{"publisherId" : "1", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`,
 	`{"publisherId" : 1, "tagid": "tag-id-for-example"}`,
 	`{"publisherId" : "1"", "tagid": 2}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "bcat":"incorrect-type"}`,

--- a/adapters/taboola/params_test.go
+++ b/adapters/taboola/params_test.go
@@ -37,18 +37,17 @@ var validParams = []string{
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","position":1}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","pageType":"pageType"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`,
-}
+	`{"publisherId" : "1", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`}
 
 var invalidParams = []string{
 	`{}`,
-	`{"publisherId" : "1"}`,
+	`{"tagId" : "1"}`,
 	`{"publisherId" : 1, "tagid": "tag-id-for-example"}`,
 	`{"publisherId" : "1"", "tagid": 2}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "bcat":"incorrect-type"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "badv":"incorrect-type"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "bidfloor":"incorrect-type"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example", "publisherDomain":1}`,
-	`{"publisherId" : "1", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`,
 	`{"tagid": "tag-id-for-example", "bcat": ["excluded-category"], "badv": ["excluded-advertiser"], "bidfloor": 1.2, "publisherDomain": "http://domain.com"}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","position":null}`,
 	`{"publisherId" : "1", "tagid": "tag-id-for-example","position":"1"}`,

--- a/adapters/taboola/taboola.go
+++ b/adapters/taboola/taboola.go
@@ -291,10 +291,9 @@ func overrideBidRequestImp(originBidRequest *openrtb2.BidRequest, imp []openrtb2
 }
 
 func resolveMacros(bid *openrtb2.Bid) {
-	if bid == nil {
-		return
+	if bid != nil {
+		price := strconv.FormatFloat(bid.Price, 'f', -1, 64)
+		bid.NURL = strings.Replace(bid.NURL, "${AUCTION_PRICE}", price, -1)
+		bid.AdM = strings.Replace(bid.AdM, "${AUCTION_PRICE}", price, -1)
 	}
-	price := strconv.FormatFloat(bid.Price, 'f', -1, 64)
-	bid.NURL = strings.Replace(bid.NURL, "${AUCTION_PRICE}", price, -1)
-	bid.AdM = strings.Replace(bid.AdM, "${AUCTION_PRICE}", price, -1)
 }

--- a/adapters/taboola/taboola_test.go
+++ b/adapters/taboola/taboola_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderTaboola, config.Adapter{
-		Endpoint: "http://{{.MediaType}}.whatever.com/{{.Host}}/{{.PublisherID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 12, DataCenter: "2"})
+		Endpoint: "http://{{.MediaType}}.whatever.com/{{.GvlID}}/{{.PublisherID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 12, DataCenter: "2"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/taboola/taboola_test.go
+++ b/adapters/taboola/taboola_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderTaboola, config.Adapter{
-		Endpoint: "http://{{.MediaType}}.whatever.com/{{.Host}}/{{.PublisherID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+		Endpoint: "http://{{.MediaType}}.whatever.com/{{.Host}}/{{.PublisherID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 12, DataCenter: "2"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)
@@ -32,5 +32,5 @@ func TestEmptyExternalUrl(t *testing.T) {
 
 	bidderTaboola := bidder.(*adapter)
 
-	assert.Equal(t, "", bidderTaboola.hostName)
+	assert.Equal(t, "", bidderTaboola.gvlID)
 }

--- a/adapters/taboola/taboolatest/exemplary/banner.json
+++ b/adapters/taboola/taboolatest/exemplary/banner.json
@@ -23,7 +23,8 @@
         "ext": {
           "bidder": {
             "publisherId": "publisher-id",
-            "tagid": "tag-id"
+            "tagid": "tag-id",
+            "tagId": "tag-Id"
           }
         }
       }
@@ -42,7 +43,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [
@@ -64,11 +65,12 @@
                   }
                 ]
               },
-              "tagid" : "tag-id",
+              "tagid" : "tag-Id",
               "ext": {
                 "bidder": {
                   "publisherId": "publisher-id",
-                  "tagid": "tag-id"
+                  "tagid": "tag-id",
+                  "tagId": "tag-Id"
                 }
               }
             }

--- a/adapters/taboola/taboolatest/exemplary/bannerResolveMacro.json
+++ b/adapters/taboola/taboolatest/exemplary/bannerResolveMacro.json
@@ -1,0 +1,154 @@
+{
+  "mockBidRequest": {
+    "id": "request-id",
+    "imp": [
+      {
+        "id": "impression-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 600
+            },
+            {
+              "w": 160,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "publisher-id",
+            "tagid": "tag-id",
+            "tagId": "tag-Id"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "http://domain.com",
+      "page": "http://page-domain.com",
+      "ref": "http://page-domain.com"
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.62 Mobile Safari/537.36",
+      "h": 300,
+      "w": 300
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://display.whatever.com/12/publisher-id",
+        "body": {
+          "id": "request-id",
+          "imp": [
+            {
+              "id": "impression-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  },
+                  {
+                    "w": 300,
+                    "h": 600
+                  },
+                  {
+                    "w": 160,
+                    "h": 600
+                  }
+                ]
+              },
+              "tagid" : "tag-Id",
+              "ext": {
+                "bidder": {
+                  "publisherId": "publisher-id",
+                  "tagid": "tag-id",
+                  "tagId": "tag-Id"
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "publisher-id",
+            "name": "publisher-id",
+            "domain": "http://domain.com",
+            "page": "http://page-domain.com",
+            "ref": "http://page-domain.com",
+            "publisher": {
+              "id": "publisher-id"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.62 Mobile Safari/537.36",
+            "h": 300,
+            "w": 300
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "123",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "request-id",
+                  "impid": "impression-id",
+                  "price": 2.1,
+                  "adid": "1",
+                  "adm": "<hrml></html>&wp=${AUCTION_PRICE}",
+                  "adomain": [
+                    "adomain.com"
+                  ],
+                  "cid": "cid",
+                  "crid": "crid",
+                  "w": 300,
+                  "h": 250,
+                  "exp": 60,
+                  "lurl": "https://lurl.domain.com/"
+                }
+              ],
+              "seat": "1111"
+            }
+          ],
+          "bidid": "123",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "request-id",
+            "impid": "impression-id",
+            "price": 2.1,
+            "adid": "1",
+            "adm": "<hrml></html>&wp=2.1",
+            "adomain": [
+              "adomain.com"
+            ],
+            "cid": "cid",
+            "crid": "crid",
+            "w": 300,
+            "h": 250,
+            "exp": 60,
+            "lurl": "https://lurl.domain.com/"
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/taboola/taboolatest/exemplary/multiFormatImpressionsRequest.json
+++ b/adapters/taboola/taboolatest/exemplary/multiFormatImpressionsRequest.json
@@ -80,7 +80,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://native.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://native.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [
@@ -150,7 +150,7 @@
     },
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/exemplary/native.json
+++ b/adapters/taboola/taboolatest/exemplary/native.json
@@ -30,7 +30,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://native.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://native.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/exemplary/nativeResolveMacro.json
+++ b/adapters/taboola/taboolatest/exemplary/nativeResolveMacro.json
@@ -1,0 +1,125 @@
+{
+  "mockBidRequest": {
+    "id": "request-id",
+    "imp": [
+      {
+        "id": "impression-id",
+        "native": {
+          "request": "\"{\\\"ver\\\":\\\"1.1\\\",\\\"plcmttype\\\": 4,\\\"plcmtcnt\\\": 1,\\\"assets\\\":[{\\\"id\\\": 1,\\\"required\\\": 1,\\\"title\\\":{\\\"len\\\": 140}},{\\\"id\\\": 4,\\\"required\\\": 1,\\\"img\\\":{\\\"type\\\": 3,\\\"wmin\\\": 600,\\\"hmin\\\": 315}},{\\\"id\\\": 6,\\\"required\\\": 1,\\\"data\\\":{\\\"type\\\": 2,\\\"len\\\": 205}},{\\\"id\\\": 5,\\\"required\\\": 1,\\\"data\\\":{\\\"type\\\": 1,\\\"len\\\": 140}}]}}\"",
+          "ver": "1.1"
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "publisher-id",
+            "tagid": "tag-id"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "http://domain.com",
+      "page": "http://page-domain.com",
+      "ref": "http://page-domain.com"
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.62 Mobile Safari/537.36",
+      "h": 300,
+      "w": 300
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://native.whatever.com/12/publisher-id",
+        "body": {
+          "id": "request-id",
+          "imp": [
+            {
+              "id": "impression-id",
+              "native": {
+                "request": "\"{\\\"ver\\\":\\\"1.1\\\",\\\"plcmttype\\\": 4,\\\"plcmtcnt\\\": 1,\\\"assets\\\":[{\\\"id\\\": 1,\\\"required\\\": 1,\\\"title\\\":{\\\"len\\\": 140}},{\\\"id\\\": 4,\\\"required\\\": 1,\\\"img\\\":{\\\"type\\\": 3,\\\"wmin\\\": 600,\\\"hmin\\\": 315}},{\\\"id\\\": 6,\\\"required\\\": 1,\\\"data\\\":{\\\"type\\\": 2,\\\"len\\\": 205}},{\\\"id\\\": 5,\\\"required\\\": 1,\\\"data\\\":{\\\"type\\\": 1,\\\"len\\\": 140}}]}}\"",
+                "ver": "1.1"
+              },
+              "tagid": "tag-id",
+              "ext": {
+                "bidder": {
+                  "publisherId": "publisher-id",
+                  "tagid": "tag-id"
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "publisher-id",
+            "name": "publisher-id",
+            "domain": "http://domain.com",
+            "page": "http://page-domain.com",
+            "ref": "http://page-domain.com",
+            "publisher": {
+              "id": "publisher-id"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.62 Mobile Safari/537.36",
+            "h": 300,
+            "w": 300
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "123",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "request-id",
+                  "impid": "impression-id",
+                  "price": 2.1,
+                  "adid": "1",
+                  "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":7,\"required\":1,\"img\":{\"url\":\"http://image.taboola.com\",\"w\":600,\"h\":315}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Title For Example\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://clickUrl.com\"},\"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://tracker.com\"},{\"event\":1,\"method\":2,\"url\":\"http://tracker-2.com\"}]}&wp=${AUCTION_PRICE}",
+                  "adomain": [
+                    "adomain.comadomain.com"
+                  ],
+                  "cid": "cid",
+                  "crid": "crid",
+                  "lurl": "https://lurl.domain.com/",
+                  "nurl": "nurl.com&wp=${AUCTION_PRICE}"
+                }
+              ],
+              "seat": "1111"
+            }
+          ],
+          "bidid": "123",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "request-id",
+            "impid": "impression-id",
+            "price": 2.1,
+            "adid": "1",
+            "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":7,\"required\":1,\"img\":{\"url\":\"http://image.taboola.com\",\"w\":600,\"h\":315}},{\"id\":0,\"required\":1,\"title\":{\"text\":\"Title For Example\"}},{\"id\":5,\"data\":{\"value\":\"Test sponsor\"}}],\"link\":{\"url\":\"http://clickUrl.com\"},\"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://tracker.com\"},{\"event\":1,\"method\":2,\"url\":\"http://tracker-2.com\"}]}&wp=2.1",
+
+          "adomain": [
+              "adomain.comadomain.com"
+            ],
+            "cid": "cid",
+            "crid": "crid",
+            "lurl": "https://lurl.domain.com/",
+            "nurl": "nurl.com&wp=2.1"
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/taboola/taboolatest/exemplary/withPageType.json
+++ b/adapters/taboola/taboolatest/exemplary/withPageType.json
@@ -43,7 +43,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/exemplary/withPosition.json
+++ b/adapters/taboola/taboolatest/exemplary/withPosition.json
@@ -43,7 +43,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/bidParamsOverrideRequestFields.json
+++ b/adapters/taboola/taboolatest/supplemental/bidParamsOverrideRequestFields.json
@@ -45,7 +45,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/bidderServerError.json
+++ b/adapters/taboola/taboolatest/supplemental/bidderServerError.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/emptyReponseFromBidder.json
+++ b/adapters/taboola/taboolatest/supplemental/emptyReponseFromBidder.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/emptySiteInRequest.json
+++ b/adapters/taboola/taboolatest/supplemental/emptySiteInRequest.json
@@ -40,7 +40,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/incorrectResponseImpMapping.json
+++ b/adapters/taboola/taboolatest/supplemental/incorrectResponseImpMapping.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/multiImpressionsRequest.json
+++ b/adapters/taboola/taboolatest/supplemental/multiImpressionsRequest.json
@@ -51,7 +51,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/optionalParamsProvided.json
+++ b/adapters/taboola/taboolatest/supplemental/optionalParamsProvided.json
@@ -46,7 +46,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/adapters/taboola/taboolatest/supplemental/unexpectedStatusCode.json
+++ b/adapters/taboola/taboolatest/supplemental/unexpectedStatusCode.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://display.whatever.com/hosturl.com/publisher-id",
+        "uri": "http://display.whatever.com/12/publisher-id",
         "body": {
           "id": "request-id",
           "imp": [

--- a/macros/macros.go
+++ b/macros/macros.go
@@ -14,6 +14,7 @@ type EndpointTemplateParams struct {
 	AccountID   string
 	AdUnit      string
 	MediaType   string
+	GvlID       string
 }
 
 // UserSyncTemplateParams specifies params for an user sync URL template

--- a/openrtb_ext/imp_taboola.go
+++ b/openrtb_ext/imp_taboola.go
@@ -5,6 +5,7 @@ type ImpExtTaboola struct {
 	PublisherDomain string   `json:"publisherDomain"`
 	BidFloor        float64  `json:"bidfloor"`
 	TagId           string   `json:"tagid"`
+	TagID           string   `json:"tagId"`
 	BCat            []string `json:"bcat"`
 	BAdv            []string `json:"badv"`
 	PageType        string   `json:"pageType"`

--- a/static/bidder-info/taboola.yaml
+++ b/static/bidder-info/taboola.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://{{.MediaType}}.bidder.taboola.com/OpenRTB/PS/auction/{{.Host}}/{{.PublisherID}}"
+endpoint: "https://{{.MediaType}}.bidder.taboola.com/OpenRTB/PS/auction/{{.GvlID}}/{{.PublisherID}}"
 maintainer:
   email:  ps-team@taboola.com
 gvlVendorID: 42

--- a/static/bidder-params/taboola.json
+++ b/static/bidder-params/taboola.json
@@ -12,7 +12,8 @@
       "type": "string"
     },
     "tagid": {
-      "type": "string"
+      "type": "string",
+      "description": "Deprecated, use tagId instead."
     },
     "tagId": {
       "type": "string",

--- a/static/bidder-params/taboola.json
+++ b/static/bidder-params/taboola.json
@@ -40,5 +40,12 @@
       "type": "integer"
     }
   },
-  "required": ["publisherId"]
+  "oneOf": [
+    {
+      "required": [ "tagid", "publisherId" ]
+    },
+    {
+      "required": [ "tagId", "publisherId" ]
+    }
+  ]
 }

--- a/static/bidder-params/taboola.json
+++ b/static/bidder-params/taboola.json
@@ -14,6 +14,10 @@
     "tagid": {
       "type": "string"
     },
+    "tagId": {
+      "type": "string",
+      "description": "preferred"
+    },
     "bidfloor": {
       "type": "number"
     },
@@ -36,5 +40,5 @@
       "type": "integer"
     }
   },
-  "required": ["tagid","publisherId"]
+  "required": ["publisherId"]
 }

--- a/static/bidder-params/taboola.json
+++ b/static/bidder-params/taboola.json
@@ -17,7 +17,7 @@
     },
     "tagId": {
       "type": "string",
-      "description": "preferred"
+      "description": "preferred, will get precedence if both tagId and tagid are defined"
     },
     "bidfloor": {
       "type": "number"


### PR DESCRIPTION
Two changes that the first one is a bug fix: 
- Make the bidder param "tagId" case insensitive, already live publishers pass it as "tagid" and we expect it in the guide and prebid.js adapter to be "tagId" - we would to support both if any passed to not hurt live publisher and align the documentation and the bidder param with Prebid.js adapter 
- Passing gvlID instead of the host "top domain"  
- resolve AUCTION_PRICD macro