### PR TITLE
Deprecate events_enabled field and start using Events.Enabled field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,12 +138,11 @@ func (cfg *Configuration) validate(v *viper.Viper) []error {
 	if cfg.AccountDefaults.Disabled {
 		glog.Warning(`With account_defaults.disabled=true, host-defined accounts must exist and have "disabled":false. All other requests will be rejected.`)
 	}
-	if cfg.AccountDefaults.Events.Enabled {
-		glog.Warning(`account_defaults.events will currently not do anything as the feature is still under development. Please follow https://github.com/prebid/prebid-server/issues/1725 for more updates`)
-	}
-
 	if cfg.PriceFloors.Enabled {
 		glog.Warning(`cfg.PriceFloors.Enabled will currently not do anything as price floors feature is still under development.`)
+	}
+	if len(cfg.AccountDefaults.Events.VASTEvents) > 0 {
+		errs = append(errs, fmt.Errorf("account_defaults.Events.VASTEvents will currently not do anything as the feature is still under development. Please follow https://github.com/prebid/prebid-server/issues/1725 for more updates"))
 	}
 
 	errs = cfg.Experiment.validate(errs)
@@ -688,6 +687,12 @@ func New(v *viper.Viper, bidderInfos BidderInfos, normalizeBidderName func(strin
 
 	// Update account defaults and generate base json for patch
 	c.AccountDefaults.CacheTTL = c.CacheURL.DefaultTTLs // comment this out to set explicitly in config
+
+	// explicitly set the new Field events.enabled field to nil to deprecate events_enabled field.
+	// This value will be overridden by the account-level config if the publisher sets this field in the account-JSON.
+	// Whererver required, we can check the nil value and determine if the account-JSON contains this "events.enabled" field or not.
+	c.AccountDefaults.Events.Enabled = nil
+
 	if err := c.MarshalAccountDefaults(); err != nil {
 		return nil, err
 	}
@@ -1053,6 +1058,15 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	migrateConfigTCF2PurposeFlags(v)
 	migrateConfigDatabaseConnection(v)
 
+	// The events_enabled field is getting deprecated and will be replaced by events.enabled field in the future.
+	// During the process of deprecation, if the user provides both account-level and host-level value, then we need to follow the below precedence order.
+	// (1) account-level new field, (2) account-level deprecated field, (3) host-level new field, (4) host-level deprecated field
+	// To achieve this, we will apply the precedence within host-level fields and set the result in the deprecated field.
+	// We will set the new field to nil so that when we fetch and merge the account-level JSON into the account-default JSON then,
+	// account-level value will become available in the new field.
+	// If new field is not present in the account-level JSON, then we will copy the value of the deprecated field and set it to the new field.
+	migrateConfigEventsEnabled(v)
+
 	// These defaults must be set after the migrate functions because those functions look for the presence of these
 	// config fields and there isn't a way to detect presence of a config field using the viper package if a default
 	// is set. Viper IsSet and Get functions consider default values.
@@ -1102,8 +1116,8 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("experiment.adscert.inprocess.domain_renewal_interval_seconds", 30)
 	v.SetDefault("experiment.adscert.remote.url", "")
 	v.SetDefault("experiment.adscert.remote.signing_timeout_ms", 5)
-
 	v.SetDefault("hooks.enabled", false)
+	v.SetDefault("account_defaults.events_enabled", false)
 
 	for bidderName := range bidderInfos {
 		setBidderDefaults(v, strings.ToLower(bidderName))
@@ -1368,6 +1382,27 @@ func migrateConfigDatabaseConnection(v *viper.Viper) {
 				}
 			}
 		}
+	}
+}
+
+// migrateConfigEventsEnabled is responsible for ensuring backward compatibility of events_enabled field.
+// This function copies the value of newField "events.enabled" and set it to the oldField "events_enabled".
+func migrateConfigEventsEnabled(v *viper.Viper) {
+	newField := "account_defaults.events.enabled"
+	oldField := "account_defaults.events_enabled"
+
+	hasOldField := v.IsSet(oldField)
+
+	if hasOldField {
+		glog.Warningf("%s is deprecated and should be changed to %s", oldField, newField)
+	}
+
+	if v.IsSet(newField) {
+		if hasOldField {
+			glog.Warningf("using %s and ignoring deprecated %s", newField, oldField)
+		}
+		newValue := v.GetBool(newField)
+		v.Set(oldField, newValue)
 	}
 }
 

--- a/config/events.go
+++ b/config/events.go
@@ -61,14 +61,19 @@ type VASTEvent struct {
 // within the VAST XML
 // Don't enable this feature. It is still under developmment. Please follow https://github.com/prebid/prebid-server/issues/1725 for more updates
 type Events struct {
-	Enabled    bool        `mapstructure:"enabled" json:"enabled"`
+	Enabled    *bool       `mapstructure:"enabled" json:"enabled"` //TODO: once events_enabled field gets deprecated, change the data-type to bool.
 	DefaultURL string      `mapstructure:"default_url" json:"default_url"`
 	VASTEvents []VASTEvent `mapstructure:"vast_events" json:"vast_events,omitempty"`
 }
 
+// isEnabled function returns the value of events.enabled field
+func (e Events) IsEnabled() bool {
+	return e.Enabled != nil && *e.Enabled
+}
+
 // validate verifies the events object  and returns error if at least one is invalid.
 func (e Events) validate(errs []error) []error {
-	if e.Enabled {
+	if e.IsEnabled() {
 		if !isValidURL(e.DefaultURL) {
 			return append(errs, errors.New("Invalid events.default_url"))
 		}

--- a/config/events_test.go
+++ b/config/events_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/prebid/prebid-server/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -261,14 +262,14 @@ func TestValidate(t *testing.T) {
 		{
 			description: "Empty default URL",
 			events: Events{
-				Enabled: true,
+				Enabled: ptrutil.ToPtr(true),
 			},
 			expectErr: true,
 		},
 		{
 			description: "Events are disabled. Skips validations",
 			events: Events{
-				Enabled:    false,
+				Enabled:    ptrutil.ToPtr(false),
 				DefaultURL: "",
 			},
 			expectErr: false,
@@ -276,7 +277,7 @@ func TestValidate(t *testing.T) {
 		{
 			description: "No VAST Events and default URL present",
 			events: Events{
-				Enabled:    true,
+				Enabled:    ptrutil.ToPtr(true),
 				DefaultURL: "http://prebid.org",
 			},
 			expectErr: false,
@@ -284,7 +285,7 @@ func TestValidate(t *testing.T) {
 		{
 			description: "Invalid VAST Event",
 			events: Events{
-				Enabled:    true,
+				Enabled:    ptrutil.ToPtr(true),
 				DefaultURL: "http://prebid.org",
 				VASTEvents: []VASTEvent{
 					{},

--- a/endpoints/events/event.go
+++ b/endpoints/events/event.go
@@ -108,7 +108,7 @@ func (e *eventEndpoint) Handle(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 
 	// account does not support events
-	if !account.EventsEnabled {
+	if !account.Events.IsEnabled() {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(fmt.Sprintf("Account '%s' doesn't support events", eventRequest.AccountID)))
 		return

--- a/exchange/events.go
+++ b/exchange/events.go
@@ -28,7 +28,7 @@ type eventTracking struct {
 func getEventTracking(requestExtPrebid *openrtb_ext.ExtRequestPrebid, ts time.Time, account *config.Account, bidderInfos config.BidderInfos, externalURL string) *eventTracking {
 	return &eventTracking{
 		accountID:          account.ID,
-		enabledForAccount:  account.EventsEnabled,
+		enabledForAccount:  account.Events.IsEnabled(),
 		enabledForRequest:  requestExtPrebid != nil && requestExtPrebid.Events != nil,
 		auctionTimestampMs: ts.UnixNano() / 1e+6,
 		integrationType:    getIntegrationType(requestExtPrebid),

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2398,10 +2398,12 @@ func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
 	auctionRequest := AuctionRequest{
 		BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: &spec.IncomingRequest.OrtbRequest},
 		Account: config.Account{
-			ID:            "testaccount",
-			EventsEnabled: spec.EventsEnabled,
-			DebugAllow:    true,
-			Validations:   spec.AccountConfigBidValidation,
+			ID: "testaccount",
+			Events: config.Events{
+				Enabled: &spec.EventsEnabled,
+			},
+			DebugAllow:  true,
+			Validations: spec.AccountConfigBidValidation,
 		},
 		UserSyncs:     mockIdFetcher(spec.IncomingRequest.Usersyncs),
 		ImpExtInfoMap: impExtInfoMap,


### PR DESCRIPTION
This PR contains the changes to deprecate events_enabled field and recommends to use the Events.Enabled field.
As per the discussion (https://prebid.slack.com/archives/C01ALRKJFQ8/p1678759095508369) over slack, the order of precedence is maintained in following order 

1.  account config new field. (account.Events.Enabled)
2.  account config deprecated field. (account.events_enabled)
3.  host config new field. (account_defaults.Events.Enabled)
4.  host config deprecated field. (account_defaults.events_enabled)

The logic to deprecate this account level field is like below - 

- On startup, we apply precedence rule to the two host-level events enabled config flags on the AccountDefaults account object and set the result to the deprecated field AccountDefaults.EventsEnabled.
- We explicitly set the new field AccountDefaults.Events.Enabled to nil. This happens prior to the call to MarshalAccountDefaults().The new-field is set to nil so that when we fetch account-level-config and merge it with default-account-json then we can identify whether the new-field is set by user. After json-merge, if the value of new-field is 

1.  nil means value for new-field is not set by user so set value of old-field to new-field and start using new-field in all downstream processing.
2. true/false means value for new-field is set by user and we should give high precedence to it.

Note:

1.  The feature of https://github.com/prebid/prebid-server/issues/1725 is in-progress hence if user set the value for account_defaults.Events.VASTEvents then we will throw an error and will not start the prebid-server. If user set the value for account.Events.VASTEvents (account-JSON) then we will print the warning statement in logs.
2. _TODO_ - Once the events_enabled field is completely deprecated then we should change the data-type of new-field Events.Enabled from *bool to bool.

