### PR TITLE
Remove Legacy Endpoint Metrics

### DIFF
--- a/metrics/config/metrics_test.go
+++ b/metrics/config/metrics_test.go
@@ -34,7 +34,7 @@ func TestGoMetricsEngine(t *testing.T) {
 	testEngine := NewMetricsEngine(&cfg, adapterList, syncerKeys, modulesStages)
 	_, ok := testEngine.MetricsEngine.(*metrics.Metrics)
 	if !ok {
-		t.Error("Expected a legacy Metrics as MetricsEngine, but didn't get it")
+		t.Error("Expected a Metrics as MetricsEngine, but didn't get it")
 	}
 }
 
@@ -148,7 +148,6 @@ func TestMultiMetricsEngine(t *testing.T) {
 
 	//Make the metrics engine, instantiated here with goEngine, fill its RequestStatuses[RequestType][metrics.RequestStatusXX] with the new boolean values added to metrics.Labels
 	VerifyMetrics(t, "RequestStatuses.OpenRTB2.OK", goEngine.RequestStatuses[metrics.ReqTypeORTB2Web][metrics.RequestStatusOK].Count(), 5)
-	VerifyMetrics(t, "RequestStatuses.Legacy.OK", goEngine.RequestStatuses[metrics.ReqTypeLegacy][metrics.RequestStatusOK].Count(), 0)
 	VerifyMetrics(t, "RequestStatuses.AMP.OK", goEngine.RequestStatuses[metrics.ReqTypeAMP][metrics.RequestStatusOK].Count(), 0)
 	VerifyMetrics(t, "RequestStatuses.AMP.BlacklistedAcctOrApp", goEngine.RequestStatuses[metrics.ReqTypeAMP][metrics.RequestStatusBlacklisted].Count(), 1)
 	VerifyMetrics(t, "RequestStatuses.Video.OK", goEngine.RequestStatuses[metrics.ReqTypeVideo][metrics.RequestStatusOK].Count(), 0)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -11,7 +11,6 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 )
 
-// Metrics is the legacy Metrics object (go-metrics) expanded to also satisfy the MetricsEngine interface
 type Metrics struct {
 	MetricsRegistry                metrics.Registry
 	ConnectionCounter              metrics.Counter
@@ -34,8 +33,7 @@ type Metrics struct {
 	TLSHandshakeTimer              metrics.Timer
 	StoredResponsesMeter           metrics.Meter
 
-	// Metrics for OpenRTB requests specifically. So we can track what % of RequestsMeter are OpenRTB
-	// and know when legacy requests have been abandoned.
+	// Metrics for OpenRTB requests specifically
 	RequestStatuses       map[RequestType]map[RequestStatus]metrics.Meter
 	AmpNoCookieMeter      metrics.Meter
 	CookieSyncMeter       metrics.Meter
@@ -155,7 +153,7 @@ type ModuleMetrics struct {
 // testing routines to ensure that no metrics are written anywhere.
 //
 // This will be useful when removing endpoints, we can just run will the blank metrics function
-// rather than loading legacy metrics that never get filled.
+// rather than loading metrics that never get filled.
 // This will also eventually let us configure metrics, such as setting a limited set of metrics
 // for a production instance, and then expanding again when we need more debugging.
 func NewBlankMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, disabledMetrics config.DisabledMetrics, moduleStageNames map[string][]string) *Metrics {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -157,12 +157,20 @@ func DemandTypes() []DemandSource {
 
 // The request types (endpoints)
 const (
-	ReqTypeLegacy   RequestType = "legacy"
 	ReqTypeORTB2Web RequestType = "openrtb2-web"
 	ReqTypeORTB2App RequestType = "openrtb2-app"
 	ReqTypeAMP      RequestType = "amp"
 	ReqTypeVideo    RequestType = "video"
 )
+
+func RequestTypes() []RequestType {
+	return []RequestType{
+		ReqTypeORTB2Web,
+		ReqTypeORTB2App,
+		ReqTypeAMP,
+		ReqTypeVideo,
+	}
+}
 
 // The media types described in the "imp" json objects
 const (
@@ -171,16 +179,6 @@ const (
 	ImpTypeAudio  ImpMediaType = "audio"
 	ImpTypeNative ImpMediaType = "native"
 )
-
-func RequestTypes() []RequestType {
-	return []RequestType{
-		ReqTypeLegacy,
-		ReqTypeORTB2Web,
-		ReqTypeORTB2App,
-		ReqTypeAMP,
-		ReqTypeVideo,
-	}
-}
 
 func ImpTypes() []ImpMediaType {
 	return []ImpMediaType{
@@ -412,8 +410,6 @@ type MetricsEngine interface {
 	RecordDNSTime(dnsLookupTime time.Duration)
 	RecordTLSHandshakeTime(tlsHandshakeTime time.Duration)
 	RecordAdapterPanic(labels AdapterLabels)
-	// This records whether or not a bid of a particular type uses `adm` or `nurl`.
-	// Since the legacy endpoints don't have a bid type, it can only count bids from OpenRTB and AMP.
 	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)
 	RecordAdapterTime(labels AdapterLabels, length time.Duration)

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -24,7 +24,6 @@ type Metrics struct {
 	cookieSync                   *prometheus.CounterVec
 	setUid                       *prometheus.CounterVec
 	impressions                  *prometheus.CounterVec
-	impressionsLegacy            prometheus.Counter
 	prebidCacheWriteTimer        *prometheus.HistogramVec
 	requests                     *prometheus.CounterVec
 	debugRequests                prometheus.Counter
@@ -208,10 +207,6 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		"impressions_requests",
 		"Count of requested impressions to Prebid Server labeled by type.",
 		[]string{isBannerLabel, isVideoLabel, isAudioLabel, isNativeLabel})
-
-	metrics.impressionsLegacy = newCounterWithoutLabels(cfg, reg,
-		"impressions_requests_legacy",
-		"Count of requested impressions to Prebid Server using the legacy endpoint.")
 
 	metrics.prebidCacheWriteTimer = newHistogramVec(cfg, reg,
 		"prebidcache_write_time_seconds",


### PR DESCRIPTION
Removing metrics for the legacy endpoint which we missed.