### PR TITLE
Richaudience: Shared memory fix

### DIFF
--- a/adapters/richaudience/richaudience.go
+++ b/adapters/richaudience/richaudience.go
@@ -71,8 +71,12 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			}
 
 			if raiExt.Test {
-				deviceCopy := *request.Device
-				request.Device = &deviceCopy
+				if request.Device != nil {
+					deviceCopy := *request.Device
+					request.Device = &deviceCopy
+				} else {
+					request.Device = &openrtb2.Device{}
+				}
 
 				request.Device.IP = "11.222.33.44"
 				request.Test = int8(1)

--- a/adapters/richaudience/richaudience.go
+++ b/adapters/richaudience/richaudience.go
@@ -52,10 +52,18 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		}
 
 		if request.App != nil {
+
+			appCopy := *request.App
+			request.App = &appCopy
+
 			request.App.Keywords = "tagid=" + imp.TagID
 		}
 
 		if request.Site != nil {
+
+			siteCopy := *request.Site
+			request.Site = &siteCopy
+
 			request.Site.Keywords = "tagid=" + imp.TagID
 		}
 

--- a/adapters/richaudience/richaudience.go
+++ b/adapters/richaudience/richaudience.go
@@ -71,6 +71,9 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			}
 
 			if raiExt.Test {
+				deviceCopy := *request.Device
+				request.Device = &deviceCopy
+
 				request.Device.IP = "11.222.33.44"
 				request.Test = int8(1)
 			}
@@ -166,18 +169,18 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	bidResponse.Currency = bidResp.Cur
 
 	for _, reqBid := range bidReq.Imp {
-		for j := range bidResp.SeatBid {
-			for i := range bidResp.SeatBid[j].Bid {
+		for _, seatBid := range bidResp.SeatBid {
+			for i := range seatBid.Bid {
 
-				bidType := getMediaType(bidResp.SeatBid[j].Bid[i].ImpID, reqBid)
+				bidType := getMediaType(seatBid.Bid[i].ImpID, reqBid)
 
 				if bidType == "video" {
-					bidResp.SeatBid[j].Bid[i].W = reqBid.Video.W
-					bidResp.SeatBid[j].Bid[i].H = reqBid.Video.H
+					seatBid.Bid[i].W = reqBid.Video.W
+					seatBid.Bid[i].H = reqBid.Video.H
 				}
 
 				b := &adapters.TypedBid{
-					Bid:     &bidResp.SeatBid[j].Bid[i],
+					Bid:     &seatBid.Bid[i],
 					BidType: bidType,
 				}
 

--- a/adapters/richaudience/richaudience.go
+++ b/adapters/richaudience/richaudience.go
@@ -168,18 +168,18 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	bidResponse.Currency = bidResp.Cur
 
 	for _, reqBid := range bidReq.Imp {
-		for _, seatBid := range bidResp.SeatBid {
-			for i := range seatBid.Bid {
+		for j := range bidResp.SeatBid {
+			for i := range bidResp.SeatBid[j].Bid {
 
-				bidType := getMediaType(seatBid.Bid[i].ImpID, reqBid)
+				bidType := getMediaType(bidResp.SeatBid[j].Bid[i].ImpID, reqBid)
 
 				if bidType == "video" {
-					seatBid.Bid[i].W = reqBid.Video.W
-					seatBid.Bid[i].H = reqBid.Video.H
+					bidResp.SeatBid[j].Bid[i].W = reqBid.Video.W
+					bidResp.SeatBid[j].Bid[i].H = reqBid.Video.H
 				}
 
 				b := &adapters.TypedBid{
-					Bid:     &seatBid.Bid[i],
+					Bid:     &bidResp.SeatBid[j].Bid[i],
 					BidType: bidType,
 				}
 

--- a/adapters/richaudience/richaudience.go
+++ b/adapters/richaudience/richaudience.go
@@ -52,7 +52,6 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		}
 
 		if request.App != nil {
-
 			appCopy := *request.App
 			request.App = &appCopy
 
@@ -60,7 +59,6 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		}
 
 		if request.Site != nil {
-
 			siteCopy := *request.Site
 			request.Site = &siteCopy
 

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-app.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-app.json
@@ -25,7 +25,6 @@
       ],
       "app": {
         "id": "12345678",
-        "keywords": "tagid=",
         "name": "Richaudience TV",
         "bundle": "R12345678901011",
         "publisher": {
@@ -42,7 +41,7 @@
         }
     },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-app.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-app.json
@@ -13,6 +13,7 @@
           },
           "bidfloor": 1e-05,
           "bidfloorcur": "USD",
+          "tagid": "testTag",
           "ext": {
            "bidder": {
               "pid": "OsNsyeF68q",
@@ -86,7 +87,7 @@
             ],
             "app": {
               "id": "12345678",
-              "keywords": "tagid=",
+              "keywords": "tagid=testTag",
               "name": "Richaudience TV",
               "bundle": "R12345678901011",
               "publisher": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-defaultCurrency.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-defaultCurrency.json
@@ -25,12 +25,11 @@
       }
     ],
     "site": {
-      "keywords": "tagid=",
       "domain": "bridge.richmediastudio.com",
       "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
     },
     "device": {
-      "ip": "11.222.33.44",
+      "ip": "10.20.30.40",
       "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
     "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-defaultCurrency.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-defaultCurrency.json
@@ -14,6 +14,7 @@
           ]
         },
         "bidfloor": 1e-05,
+        "tagid": "testTag",
         "ext": {
           "bidder": {
             "pid": "OsNsyeF68q",
@@ -80,7 +81,7 @@
             }
           ],
           "site": {
-            "keywords": "tagid=",
+            "keywords": "tagid=testTag",
             "domain": "bridge.richmediastudio.com",
             "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
           },

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-deviceConfig.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-deviceConfig.json
@@ -13,6 +13,7 @@
           },
           "bidfloor": 1e-05,
           "bidfloorcur": "USD",
+          "tagid": "testTag",
           "ext": {
            "bidder": {
               "pid": "OsNsyeF68q",
@@ -23,14 +24,13 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
           "dnt": 1,
           "lmt": 1,
-        "ip": "11.222.33.44"
+        "ip": "10.20.30.40"
     },
       "user": {
         "buyeruid": "189f4055-78a3-46eb-b7fd-0915a1a43bd2a",
@@ -73,7 +73,7 @@
               }
             ],
             "site": {
-              "keywords": "tagid=",
+              "keywords": "tagid=testTag",
               "domain": "bridge.richmediastudio.com",
               "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
             },

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-extUser.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-extUser.json
@@ -25,12 +25,11 @@
       }
     ],
     "site": {
-      "keywords": "tagid=",
       "domain": "bridge.richmediastudio.com",
       "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
     },
     "device": {
-      "ip": "11.222.33.44",
+      "ip": "10.20.30.40",
       "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
     "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-floorPrice.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-floorPrice.json
@@ -24,12 +24,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-iPv6.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-iPv6.json
@@ -25,12 +25,11 @@
       }
     ],
     "site": {
-      "keywords": "tagid=",
       "domain": "bridge.richmediastudio.com",
       "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
     },
     "device": {
-      "ip": "11.222.33.44",
+      "ip": "10.20.30.40",
       "ipv6": "2607:fb90:f27:4512:d800:cb23:a603:e245",
       "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-nil-device.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-nil-device.json
@@ -1,0 +1,168 @@
+{
+  "mockBidRequest": {
+    "id": "4d3f84eb-787b-42fb-a0cf-062690dadce3",
+    "test": 0,
+    "imp": [
+      {
+        "id": "div-gpt-ad-1460505748561-0",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 1e-05,
+        "bidfloorcur": "USD",
+        "tagid": "testTag",
+        "ext": {
+          "bidder": {
+            "pid": "OsNsyeF68q",
+            "supplyType": "site",
+            "test": true
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "12345678",
+      "name": "Richaudience TV",
+      "bundle": "R12345678901011",
+      "publisher": {
+        "id": "1234567",
+        "ext": {
+          "prebid": {
+            "parentAccount": "891011"
+          }
+        }
+      },
+      "content": {
+        "title": "Richaudience TV",
+        "series": "Richaudience TV"
+      }
+    },
+    "user": {
+      "buyeruid": "189f4055-78a3-46eb-b7fd-0915a1a43bd2a",
+      "ext": {}
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://ortb.richaudience.com/ortb/?bidder=pbs",
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ],
+          "X-Openrtb-Version": [
+            "2.5"
+          ]
+        },
+        "body": {
+          "id": "4d3f84eb-787b-42fb-a0cf-062690dadce3",
+          "test": 1,
+          "imp": [
+            {
+              "id": "div-gpt-ad-1460505748561-0",
+              "tagid": "OsNsyeF68q",
+              "secure": 0,
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 1e-05,
+              "bidfloorcur": "USD",
+              "ext": {
+                "bidder": {
+                  "pid": "OsNsyeF68q",
+                  "supplyType": "site",
+                  "test": true
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "12345678",
+            "keywords": "tagid=testTag",
+            "name": "Richaudience TV",
+            "bundle": "R12345678901011",
+            "publisher": {
+              "id": "1234567",
+              "ext": {
+                "prebid": {
+                  "parentAccount": "891011"
+                }
+              }
+            },
+            "content": {
+              "title": "Richaudience TV",
+              "series": "Richaudience TV"
+            }
+          },
+          "device": {
+            "ip": "11.222.33.44"
+          },
+          "user": {
+            "buyeruid": "189f4055-78a3-46eb-b7fd-0915a1a43bd2a",
+            "ext": {
+            }
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ff935bea-4661-40bf-95b7-80c354cf0cdc",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "47286888",
+                  "impid": "div-gpt-ad-1460505748561-0",
+                  "price": 99,
+                  "crid": "999999",
+                  "adm": "<!-- creative -->",
+                  "adomain": [
+                    "richaudience.com"
+                  ],
+                  "h": 250,
+                  "w": 300
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "47286888",
+            "impid": "div-gpt-ad-1460505748561-0",
+            "price": 99,
+            "adm": "<!-- creative -->",
+            "adomain": [
+              "richaudience.com"
+            ],
+            "crid": "999999",
+            "w": 300,
+            "h": 250
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-nosecure.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-nosecure.json
@@ -23,12 +23,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "http://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-setCurrency.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-setCurrency.json
@@ -23,12 +23,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner-sitePage.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner-sitePage.json
@@ -23,12 +23,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-banner.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-banner.json
@@ -23,12 +23,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {

--- a/adapters/richaudience/richaudiencetest/exemplary/single-video.json
+++ b/adapters/richaudience/richaudiencetest/exemplary/single-video.json
@@ -23,12 +23,11 @@
         }
       ],
       "site": {
-        "keywords": "tagid=",
         "domain": "bridge.richmediastudio.com",
         "page": "https://bridge.richmediastudio.com//ab083674fb8200b877a6983126e4477d/PrebidServer/indexRa.html?pbjs_debug=true"
       },
       "device": {
-        "ip": "11.222.33.44",
+        "ip": "10.20.30.40",
         "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     },
       "user": {


### PR DESCRIPTION
Adapters receive a shallow copy of a request In MakeBids. It means this request has shared pointer values: site, app and other pointer structures are shared between all adapters in request. In order to modify pointer structures you need to create own copy of it and set it back to request. 
The reason why previous unit tests didn't show it is because `imp.tagid` was empty and result `app/site.keywords` didn't change. 
Please review. @richaudience 