### PR TITLE
fix workflow error

### DIFF
--- a/adapters/axis/axis.go
+++ b/adapters/axis/axis.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"text/template"
 
-	"github.com/prebid/openrtb/v17/openrtb2"
+	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/errortypes"


### PR DESCRIPTION
PR checks are failing after I merged [2655](https://github.com/prebid/prebid-server/pull/2655) . The reason is that PR is using v17 of openrtb instead of the latest one. This PR fixes that.