### PR TITLE
Parse tmax_adjustments values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1477,3 +1477,46 @@ func isValidCookieSize(maxCookieSize int) error {
 	}
 	return nil
 }
+
+type TmaxAdjustments struct {
+	// Flag indicating whether to enable the tmax feature or not
+	Enabled bool `mapstructure:"enable"`
+	// The maximum allowable tmax for the auction endpoint
+	// The tmax value used for the endpoint will be the minimum of the auction_max and tmax specified in the incoming request
+	AuctionMax int `mapstructure:"auction_max"`
+	// The maximum allowable tmax for the video endpoint
+	// The tmax value used for the endpoint will be the minimum of the video_max and tmax specified in the incoming request
+	VideoMax int `mapstructure:"video_max"`
+	// The maximum allowable tmax for the AMP endpoint
+	// The tmax value used for the endpoint will be the minimum of the amp_max and tmax specified in the incoming request
+	AmpMax int `mapstructure:"amp_max"`
+	// The minimum duration needed for a bidder to respond back
+	// PBS will not send an HTTP request to the bidder server if the time needed for PBS processing, adapter's MakeRequests() implementation, building Prebid headers, and applying GZip compression (if needed) is less than bidder_response_min
+	BidderResponseMin int `mapstructure:"bidder_response_min"`
+	// Adjustment factor that provides a buffer for network delays between PBS and the bidder server
+	BidderLatencyAdjustment int `mapstructure:"bidder_latency_adjustment"`
+	// The duration needed to prepare PBS's response for an upstream client
+	// PBS will subtract the upstream response duration from the endpoint's tmax to account for time needed for adpater's MakeBids() calls and PBS processing
+	UpstreamResponseDuration int `mapstructure:"upstream_response_duration"`
+}
+
+func (adj *TmaxAdjustments) validate(errs []error) []error {
+	if adj.Enabled {
+		if adj.AuctionMax <= 0 {
+			errs = append(errs, fmt.Errorf("tmax_adjustments.auction_max cannot be less than or equal to zero"))
+		}
+
+		if adj.VideoMax <= 0 {
+			errs = append(errs, fmt.Errorf("tmax_adjustments.video_max cannot be less than or equal to zero"))
+		}
+
+		if adj.AmpMax <= 0 {
+			errs = append(errs, fmt.Errorf("tmax_adjustments.amp_max cannot be less than or equal to zero"))
+		}
+
+		if adj.BidderResponseMin == 0 {
+			errs = append(errs, fmt.Errorf("tmax_adjustments.bidder_response_min cannot be less than or equal to zero"))
+		}
+	}
+	return errs
+}

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	// If empty, it will return a 204 with no content.
 	StatusResponse    string          `mapstructure:"status_response"`
 	AuctionTimeouts   AuctionTimeouts `mapstructure:"auction_timeouts_ms"`
+	TmaxAdjustments   TmaxAdjustments `mapstructure:"tmax_adjustments"`
 	CacheURL          Cache           `mapstructure:"cache"`
 	ExtCacheURL       ExternalCache   `mapstructure:"external_cache"`
 	RecaptchaSecret   string          `mapstructure:"recaptcha_secret"`
@@ -1021,6 +1022,8 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("debug.timeout_notification.sampling_rate", 0.0)
 	v.SetDefault("debug.timeout_notification.fail_only", false)
 	v.SetDefault("debug.override_token", "")
+
+	v.SetDefault("tmax_adjustments.enable", false)
 
 	/* IPv4
 	/*  Site Local: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -455,6 +455,14 @@ account_defaults:
         use_dynamic_data: true
         max_rules: 120
         max_schema_dims: 5
+tmax_adjustments:
+  enabled: true
+  auction_max: 900
+  video_max: 900
+  amp_max: 900
+  bidder_response_min: 700
+  bidder_latency_adjustment: 100
+  upstream_response_duration: 100
 `)
 
 var oldStoredRequestsConfig = []byte(`
@@ -509,6 +517,13 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "garbage_collector_threshold", cfg.GarbageCollectorThreshold, 1)
 	cmpInts(t, "auction_timeouts_ms.default", int(cfg.AuctionTimeouts.Default), 50)
 	cmpInts(t, "auction_timeouts_ms.max", int(cfg.AuctionTimeouts.Max), 123)
+	cmpBools(t, "tmax_adjustments.enabled", cfg.TmaxAdjustments.Enabled, true)
+	cmpInts(t, "tmax_adjustments.auction_max", cfg.TmaxAdjustments.AuctionMax, 900)
+	cmpInts(t, "tmax_adjustments.video_max", cfg.TmaxAdjustments.VideoMax, 900)
+	cmpInts(t, "tmax_adjustments.amp_max", cfg.TmaxAdjustments.AmpMax, 900)
+	cmpInts(t, "tmax_adjustments.bidder_response_min", cfg.TmaxAdjustments.BidderResponseMin, 700)
+	cmpInts(t, "tmax_adjustments.bidder_latency_adjustment", cfg.TmaxAdjustments.BidderLatencyAdjustment, 100)
+	cmpInts(t, "tmax_adjustments.upstream_response_duration", cfg.TmaxAdjustments.UpstreamResponseDuration, 100)
 	cmpStrings(t, "cache.scheme", cfg.CacheURL.Scheme, "http")
 	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "prebidcache.net")
 	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -2340,3 +2340,23 @@ func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]adapters.M
 		me.RecordOverheadTime(metrics.MakeAuctionResponse, duration)
 	}
 }
+
+func LimitAuctionTimeout(adj *config.TmaxAdjustments, requested time.Duration, requestType metrics.RequestType) time.Duration {
+	if !adj.Enabled {
+		return requested
+	}
+
+	serverTmax := adj.AuctionMax
+	if requestType == metrics.ReqTypeAMP {
+		serverTmax = adj.AmpMax
+	} else if requestType == metrics.ReqTypeVideo {
+		serverTmax = adj.VideoMax
+	}
+
+	max := time.Duration(serverTmax)
+	if requested == 0 || requested > max {
+		return max
+	}
+
+	return requested
+}


### PR DESCRIPTION
PBS will maintain the tmax_adjustments values within its configuration file - pbs.yaml. Today, values from pbs.yaml are parsed in [configurations](https://github.com/prebid/prebid-server/blob/b17f95a9a56ce63e49ef5f87e41ab4c76f73e691/config/config.go#L23) object. This is done by [loadConfig](https://github.com/prebid/prebid-server/blob/f3e440389e3d57305be796c39359ff1fb09784b1/main.go#L60) at server start up. PR makes changes to parse tmax_adjustments value on server startup.

Note: Plan is to make Tmax related changes in separate PRs. We don't want partially made changes to go into master. Therefore PR is created against `TMAX-dev` branch. Once `TMAX-dev` has all changes then we will create PR against master.