### PR TITLE
Add overhead metric for bidder_response_duration_min

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -561,7 +561,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 		}
 	}
 
-	bidder.me.RecordOverheadTime(metrics.BidderServerResponse, time.Since(httpCallStart))
+	bidder.me.RecordBidderServerResponseTime(time.Since(httpCallStart))
 	return &httpCallInfo{
 		request: req,
 		response: &adapters.ResponseData{

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -520,6 +520,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 		ctx = bidder.addClientTrace(ctx)
 	}
 	bidder.me.RecordOverheadTime(metrics.PreBidder, time.Since(pbsRequestStartTime))
+	httpCallStart := time.Now()
 	httpResp, err := ctxhttp.Do(ctx, bidder.Client, httpReq)
 	if err != nil {
 		if err == context.DeadlineExceeded {
@@ -560,6 +561,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 		}
 	}
 
+	bidder.me.RecordOverheadTime(metrics.MakeHTTPRequest, time.Since(httpCallStart))
 	return &httpCallInfo{
 		request: req,
 		response: &adapters.ResponseData{

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -561,7 +561,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 		}
 	}
 
-	bidder.me.RecordOverheadTime(metrics.MakeHTTPRequest, time.Since(httpCallStart))
+	bidder.me.RecordOverheadTime(metrics.BidderServerResponse, time.Since(httpCallStart))
 	return &httpCallInfo{
 		request: req,
 		response: &adapters.ResponseData{

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2026,7 +2026,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	mockMetricEngine.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
+	mockMetricEngine.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")
@@ -2088,7 +2088,7 @@ func TestCallRecordDNSTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordDNSTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	metricsMock.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
+	metricsMock.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})
@@ -2111,7 +2111,7 @@ func TestCallRecordTLSHandshakeTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordTLSHandshakeTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	metricsMock.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
+	metricsMock.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2026,6 +2026,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
+	mockMetricEngine.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")
@@ -2087,6 +2088,7 @@ func TestCallRecordDNSTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordDNSTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
+	metricsMock.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})
@@ -2109,6 +2111,7 @@ func TestCallRecordTLSHandshakeTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordTLSHandshakeTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
+	metricsMock.On("RecordOverheadTime", metrics.MakeHTTPRequest, mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2026,7 +2026,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	mockMetricEngine.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
+	mockMetricEngine.On("RecordBidderServerResponseTime", mock.Anything).Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")
@@ -2088,7 +2088,7 @@ func TestCallRecordDNSTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordDNSTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	metricsMock.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
+	metricsMock.On("RecordBidderServerResponseTime", mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})
@@ -2111,7 +2111,7 @@ func TestCallRecordTLSHandshakeTime(t *testing.T) {
 	metricsMock := &metrics.MetricsEngineMock{}
 	metricsMock.Mock.On("RecordTLSHandshakeTime", mock.Anything).Return()
 	metricsMock.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
-	metricsMock.On("RecordOverheadTime", metrics.BidderServerResponse, mock.Anything).Once()
+	metricsMock.On("RecordBidderServerResponseTime", mock.Anything).Once()
 
 	// Instantiate the bidder that will send the request. We'll make sure to use an
 	// http.Client that runs our mock RoundTripper so DNSDone(httptrace.DNSDoneInfo{})

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -149,6 +149,12 @@ func (me *MultiMetricsEngine) RecordTLSHandshakeTime(tlsHandshakeTime time.Durat
 	}
 }
 
+func (me *MultiMetricsEngine) RecordBidderServerResponseTime(bidderServerResponseTime time.Duration) {
+	for _, thisME := range *me {
+		thisME.RecordBidderServerResponseTime(bidderServerResponseTime)
+	}
+}
+
 // RecordAdapterBidReceived across all engines
 func (me *MultiMetricsEngine) RecordAdapterBidReceived(labels metrics.AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	for _, thisME := range *me {
@@ -423,6 +429,10 @@ func (me *NilMetricsEngine) RecordDNSTime(dnsLookupTime time.Duration) {
 
 // RecordTLSHandshakeTime as a noop
 func (me *NilMetricsEngine) RecordTLSHandshakeTime(tlsHandshakeTime time.Duration) {
+}
+
+// RecordBidderServerResponseTime as a noop
+func (me *NilMetricsEngine) RecordBidderServerResponseTime(bidderServerResponseTime time.Duration) {
 }
 
 // RecordAdapterBidReceived as a noop

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -307,7 +307,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.PrebidCacheRequestTimerError = metrics.GetOrRegisterTimer("prebid_cache_request_time.err", registry)
 	newMetrics.StoredResponsesMeter = metrics.GetOrRegisterMeter("stored_responses", registry)
 	newMetrics.OverheadTimer = makeOverheadTimerMetrics(registry)
-	newMetrics.BidderServerResponseTimer = metrics.GetOrRegisterTimer("bidder_server_response_time", registry)
+	newMetrics.BidderServerResponseTimer = metrics.GetOrRegisterTimer("bidder_server_response_time_seconds", registry)
 
 	for _, dt := range StoredDataTypes() {
 		for _, ft := range StoredDataFetchTypes() {

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -31,6 +31,7 @@ type Metrics struct {
 	AccountCacheMeter              map[CacheResult]metrics.Meter
 	DNSLookupTimer                 metrics.Timer
 	TLSHandshakeTimer              metrics.Timer
+	BidderServerResponseTimer      metrics.Timer
 	StoredResponsesMeter           metrics.Meter
 
 	// Metrics for OpenRTB requests specifically
@@ -219,7 +220,8 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderNa
 		exchanges: exchanges,
 		modules:   getModuleNames(moduleStageNames),
 
-		OverheadTimer: makeBlankOverheadTimerMetrics(),
+		OverheadTimer:             makeBlankOverheadTimerMetrics(),
+		BidderServerResponseTimer: blankTimer,
 	}
 
 	for _, a := range exchanges {
@@ -305,6 +307,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.PrebidCacheRequestTimerError = metrics.GetOrRegisterTimer("prebid_cache_request_time.err", registry)
 	newMetrics.StoredResponsesMeter = metrics.GetOrRegisterMeter("stored_responses", registry)
 	newMetrics.OverheadTimer = makeOverheadTimerMetrics(registry)
+	newMetrics.BidderServerResponseTimer = metrics.GetOrRegisterTimer("bidder_server_response_time", registry)
 
 	for _, dt := range StoredDataTypes() {
 		for _, ft := range StoredDataFetchTypes() {
@@ -809,6 +812,10 @@ func (me *Metrics) RecordDNSTime(dnsLookupTime time.Duration) {
 
 func (me *Metrics) RecordTLSHandshakeTime(tlsHandshakeTime time.Duration) {
 	me.TLSHandshakeTimer.Update(tlsHandshakeTime)
+}
+
+func (me *Metrics) RecordBidderServerResponseTime(bidderServerResponseTime time.Duration) {
+	me.BidderServerResponseTimer.Update(bidderServerResponseTime)
 }
 
 // RecordAdapterBidReceived implements a part of the MetricsEngine interface.

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -83,7 +83,6 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.pre-bidder", m.OverheadTimer[PreBidder])
 	ensureContains(t, registry, "request_over_head_time.make-auction-response", m.OverheadTimer[MakeAuctionResponse])
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
-	ensureContains(t, registry, "request_over_head_time.bidder-server-response", m.OverheadTimer[BidderServerResponse])
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {
@@ -418,6 +417,36 @@ func TestRecordTLSHandshakeTime(t *testing.T) {
 		m.RecordTLSHandshakeTime(test.tLSHandshakeDuration)
 
 		assert.Equal(t, test.expectedDuration.Nanoseconds(), m.TLSHandshakeTimer.Sum(), test.description)
+	}
+}
+
+func TestRecordBidderServerResponseTime(t *testing.T) {
+	testCases := []struct {
+		name          string
+		time          time.Duration
+		expectedCount int64
+		expectedSum   int64
+	}{
+		{
+			name:          "record-bidder-server-response-time-1",
+			time:          time.Duration(500),
+			expectedCount: 1,
+			expectedSum:   500,
+		},
+		{
+			name:          "record-bidder-server-response-time-2",
+			time:          time.Duration(500),
+			expectedCount: 2,
+			expectedSum:   1000,
+		},
+	}
+	for _, test := range testCases {
+		registry := metrics.NewRegistry()
+		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderAppnexus}, config.DisabledMetrics{AccountAdapterDetails: true}, nil, nil)
+
+		m.RecordBidderServerResponseTime(test.time)
+
+		assert.Equal(t, test.time.Nanoseconds(), m.BidderServerResponseTimer.Sum(), test.name)
 	}
 }
 

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -83,6 +83,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.pre-bidder", m.OverheadTimer[PreBidder])
 	ensureContains(t, registry, "request_over_head_time.make-auction-response", m.OverheadTimer[MakeAuctionResponse])
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
+	ensureContains(t, registry, "bidder_server_response_time_seconds", m.BidderServerResponseTimer)
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -83,6 +83,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.pre-bidder", m.OverheadTimer[PreBidder])
 	ensureContains(t, registry, "request_over_head_time.make-auction-response", m.OverheadTimer[MakeAuctionResponse])
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
+	ensureContains(t, registry, "request_over_head_time.bidder-server-response", m.OverheadTimer[BidderServerResponse])
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,8 +36,6 @@ const (
 	MakeAuctionResponse OverheadType = "make-auction-response"
 	// MakeBidderRequests - measures the time needed to fetch a stored request (if needed), parse, unmarshal, and validate the OpenRTB request, interpret its privacy policies, and split it into multiple requests sanitized for each bidder
 	MakeBidderRequests OverheadType = "make-bidder-requests"
-	// BidderServerResponse - measures the time needed to receive response back from the bidder server
-	BidderServerResponse OverheadType = "bidder-server-response"
 )
 
 func (t OverheadType) String() string {
@@ -45,7 +43,7 @@ func (t OverheadType) String() string {
 }
 
 func OverheadTypes() []OverheadType {
-	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests, BidderServerResponse}
+	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests}
 }
 
 // ImpLabels defines metric labels describing the impression type.
@@ -432,6 +430,7 @@ type MetricsEngine interface {
 	RecordAdapterConnections(adapterName openrtb_ext.BidderName, connWasReused bool, connWaitTime time.Duration)
 	RecordDNSTime(dnsLookupTime time.Duration)
 	RecordTLSHandshakeTime(tlsHandshakeTime time.Duration)
+	RecordBidderServerResponseTime(bidderServerResponseTime time.Duration)
 	RecordAdapterPanic(labels AdapterLabels)
 	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
 	RecordAdapterPrice(labels AdapterLabels, cpm float64)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,8 +36,8 @@ const (
 	MakeAuctionResponse OverheadType = "make-auction-response"
 	// MakeBidderRequests - measures the time needed to fetch a stored request (if needed), parse, unmarshal, and validate the OpenRTB request, interpret its privacy policies, and split it into multiple requests sanitized for each bidder
 	MakeBidderRequests OverheadType = "make-bidder-requests"
-	// MakeHTTPRequest - measures the time needed to receive response back from the bidder server
-	MakeHTTPRequest OverheadType = "make-http-request"
+	// BidderServerResponse - measures the time needed to receive response back from the bidder server
+	BidderServerResponse OverheadType = "bidder-server-response"
 )
 
 func (t OverheadType) String() string {
@@ -45,7 +45,7 @@ func (t OverheadType) String() string {
 }
 
 func OverheadTypes() []OverheadType {
-	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests, MakeHTTPRequest}
+	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests, BidderServerResponse}
 }
 
 // ImpLabels defines metric labels describing the impression type.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,6 +36,8 @@ const (
 	MakeAuctionResponse OverheadType = "make-auction-response"
 	// MakeBidderRequests - measures the time needed to fetch a stored request (if needed), parse, unmarshal, and validate the OpenRTB request, interpret its privacy policies, and split it into multiple requests sanitized for each bidder
 	MakeBidderRequests OverheadType = "make-bidder-requests"
+	// MakeHTTPRequest - measures the time needed to receive response back from the bidder server
+	MakeHTTPRequest OverheadType = "make-http-request"
 )
 
 func (t OverheadType) String() string {
@@ -43,7 +45,7 @@ func (t OverheadType) String() string {
 }
 
 func OverheadTypes() []OverheadType {
-	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests}
+	return []OverheadType{PreBidder, MakeAuctionResponse, MakeBidderRequests, MakeHTTPRequest}
 }
 
 // ImpLabels defines metric labels describing the impression type.

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -71,6 +71,11 @@ func (me *MetricsEngineMock) RecordTLSHandshakeTime(tlsHandshakeTime time.Durati
 	me.Called(tlsHandshakeTime)
 }
 
+// RecordBidderServerResponseTime mock
+func (me *MetricsEngineMock) RecordBidderServerResponseTime(bidderServerResponseTime time.Duration) {
+	me.Called(bidderServerResponseTime)
+}
+
 // RecordAdapterBidReceived mock
 func (me *MetricsEngineMock) RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
 	me.Called(labels, bidType, hasAdm)

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -55,6 +55,7 @@ type Metrics struct {
 	storedResponsesErrors        *prometheus.CounterVec
 	adsCertRequests              *prometheus.CounterVec
 	adsCertSignTimer             prometheus.Histogram
+	bidderServerResponseTimer    prometheus.Histogram
 
 	// Adapter Metrics
 	adapterBids                           *prometheus.CounterVec
@@ -438,6 +439,11 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		"adapter_request_time_seconds",
 		"Seconds to resolve each successful request labeled by adapter.",
 		[]string{adapterLabel},
+		standardTimeBuckets)
+
+	metrics.bidderServerResponseTimer = newHistogram(cfg, reg,
+		"bidder_server_response_time",
+		"Seconds to make a roundtrip to an adapter's bid server",
 		standardTimeBuckets)
 
 	metrics.syncerRequests = newCounter(cfg, reg,
@@ -891,6 +897,10 @@ func (m *Metrics) RecordDNSTime(dnsLookupTime time.Duration) {
 
 func (m *Metrics) RecordTLSHandshakeTime(tlsHandshakeTime time.Duration) {
 	m.tlsHandhakeTimer.Observe(tlsHandshakeTime.Seconds())
+}
+
+func (m *Metrics) RecordBidderServerResponseTime(bidderServerResponseTime time.Duration) {
+	m.bidderServerResponseTimer.Observe(bidderServerResponseTime.Seconds())
 }
 
 func (m *Metrics) RecordAdapterPanic(labels metrics.AdapterLabels) {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -442,8 +442,8 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		standardTimeBuckets)
 
 	metrics.bidderServerResponseTimer = newHistogram(cfg, reg,
-		"bidder_server_response_time",
-		"Seconds to make a roundtrip to an adapter's bid server",
+		"bidder_server_response_time_seconds",
+		"Duration needed to send HTTP request and receive response back from bidder server.",
 		standardTimeBuckets)
 
 	metrics.syncerRequests = newCounter(cfg, reg,

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1475,6 +1475,39 @@ func TestRecordTLSHandshakeTime(t *testing.T) {
 	}
 }
 
+func TestRecordBidderServerResponseTime(t *testing.T) {
+	testCases := []struct {
+		description   string
+		timeInMs      float64
+		expectedCount uint64
+		expectedSum   float64
+	}{
+		{
+			description:   "record-bidder-server-response-time-1",
+			timeInMs:      500,
+			expectedCount: 1,
+			expectedSum:   0.5,
+		},
+		{
+			description:   "record-bidder-server-response-time-2",
+			timeInMs:      400,
+			expectedCount: 1,
+			expectedSum:   0.4,
+		},
+	}
+	for _, test := range testCases {
+		pm := createMetricsForTesting()
+		pm.RecordBidderServerResponseTime(time.Duration(test.timeInMs) * time.Millisecond)
+
+		m := dto.Metric{}
+		pm.bidderServerResponseTimer.Write(&m)
+		histogram := *m.GetHistogram()
+
+		assert.Equal(t, test.expectedCount, histogram.GetSampleCount())
+		assert.Equal(t, test.expectedSum, histogram.GetSampleSum())
+	}
+}
+
 func TestRecordAdapterConnections(t *testing.T) {
 
 	type testIn struct {


### PR DESCRIPTION
Add new metric to record amount of time PBS has to wait to receive a response back from the bidder server. Data points recorded will help to set bidder_response_duration_min for PSP.