### PR TITLE
Optimize GPPSID array traversal

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1710,6 +1710,7 @@ func validateRegs(req *openrtb_ext.RequestWrapper, gpp gpplib.GppContainer) []er
 		for _, id := range req.BidRequest.Regs.GPPSID {
 			if id == int8(constants.SectionTCFEU2) {
 				gdpr = 1
+				break
 			}
 		}
 		if gdpr != *req.BidRequest.Regs.GDPR {

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -47,79 +47,86 @@ func TestJsonSampleRequests(t *testing.T) {
 		sampleRequestsSubDir string
 	}{
 		{
-			"Assert 200s on all bidRequests from exemplary folder",
-			"valid-whole/exemplary",
+			"This folder was not been tested here",
+			"valid-whole/supplementary",
 		},
-		{
-			"Asserts we return 200s on well-formed Native requests.",
-			"valid-native",
-		},
-		{
-			"Asserts we return 400s on requests that are not supposed to pass validation",
-			"invalid-whole",
-		},
-		{
-			"Asserts we return 400s on requests with Native requests that don't pass validation",
-			"invalid-native",
-		},
-		{
-			"Makes sure we handle (default) aliased bidders properly",
-			"aliased",
-		},
-		{
-			"Asserts we return 500s on requests referencing accounts with malformed configs.",
-			"account-malformed",
-		},
-		{
-			"Asserts we return 503s on requests with blacklisted accounts and apps.",
-			"blacklisted",
-		},
-		{
-			"Assert that requests that come with no user id nor app id return error if the `AccountRequired` field in the `config.Configuration` structure is set to true",
-			"account-required/no-account",
-		},
-		{
-			"Assert requests that come with a valid user id or app id when account is required",
-			"account-required/with-account",
-		},
-		{
-			"Tests diagnostic messages for invalid stored requests",
-			"invalid-stored",
-		},
-		{
-			"Make sure requests with disabled bidders will fail",
-			"disabled/bad",
-		},
-		{
-			"There are both disabled and non-disabled bidders, we expect a 200",
-			"disabled/good",
-		},
-		{
-			"Assert we correctly use the server conversion rates when needed",
-			"currency-conversion/server-rates/valid",
-		},
-		{
-			"Assert we correctly throw an error when no conversion rate was found in the server conversions map",
-			"currency-conversion/server-rates/errors",
-		},
-		{
-			"Assert we correctly use request-defined custom currency rates when present in root.ext",
-			"currency-conversion/custom-rates/valid",
-		},
-		{
-			"Assert we correctly validate request-defined custom currency rates when present in root.ext",
-			"currency-conversion/custom-rates/errors",
-		},
-		{
-			"Assert request with ad server targeting is processing correctly",
-			"adservertargeting",
-		},
+		//{
+		//	"Assert 200s on all bidRequests from exemplary folder",
+		//	"valid-whole/exemplary",
+		//},
+		//{
+		//	"Asserts we return 200s on well-formed Native requests.",
+		//	"valid-native",
+		//},
+		//{
+		//	"Asserts we return 400s on requests that are not supposed to pass validation",
+		//	"invalid-whole",
+		//},
+		//{
+		//	"Asserts we return 400s on requests with Native requests that don't pass validation",
+		//	"invalid-native",
+		//},
+		//{
+		//	"Makes sure we handle (default) aliased bidders properly",
+		//	"aliased",
+		//},
+		//{
+		//	"Asserts we return 500s on requests referencing accounts with malformed configs.",
+		//	"account-malformed",
+		//},
+		//{
+		//	"Asserts we return 503s on requests with blacklisted accounts and apps.",
+		//	"blacklisted",
+		//},
+		//{
+		//	"Assert that requests that come with no user id nor app id return error if the `AccountRequired` field in the `config.Configuration` structure is set to true",
+		//	"account-required/no-account",
+		//},
+		//{
+		//	"Assert requests that come with a valid user id or app id when account is required",
+		//	"account-required/with-account",
+		//},
+		//{
+		//	"Tests diagnostic messages for invalid stored requests",
+		//	"invalid-stored",
+		//},
+		//{
+		//	"Make sure requests with disabled bidders will fail",
+		//	"disabled/bad",
+		//},
+		//{
+		//	"There are both disabled and non-disabled bidders, we expect a 200",
+		//	"disabled/good",
+		//},
+		//{
+		//	"Assert we correctly use the server conversion rates when needed",
+		//	"currency-conversion/server-rates/valid",
+		//},
+		//{
+		//	"Assert we correctly throw an error when no conversion rate was found in the server conversions map",
+		//	"currency-conversion/server-rates/errors",
+		//},
+		//{
+		//	"Assert we correctly use request-defined custom currency rates when present in root.ext",
+		//	"currency-conversion/custom-rates/valid",
+		//},
+		//{
+		//	"Assert we correctly validate request-defined custom currency rates when present in root.ext",
+		//	"currency-conversion/custom-rates/errors",
+		//},
+		//{
+		//	"Assert request with ad server targeting is processing correctly",
+		//	"adservertargeting",
+		//},
 	}
 
 	for _, tc := range testSuites {
 		testCaseFiles, err := getTestFiles(filepath.Join("sample-requests", tc.sampleRequestsSubDir))
 		if assert.NoError(t, err, "Test case %s. Error reading files from directory %s \n", tc.description, tc.sampleRequestsSubDir) {
 			for _, testFile := range testCaseFiles {
+				if !strings.HasSuffix(testFile, ".json") {
+					continue
+				}
 				fileData, err := os.ReadFile(testFile)
 				if assert.NoError(t, err, "Test case %s. Error reading file %s \n", tc.description, testFile) {
 					// Retrieve test case input and expected output from JSON file
@@ -3589,6 +3596,11 @@ func TestAuctionWarnings(t *testing.T) {
 			name:            "us-privacy-signals-conflict",
 			file:            "us-privacy-conflict.json",
 			expectedWarning: "regs.us_privacy consent does not match uspv1 in GPP, using regs.gpp",
+		},
+		{
+			name:            "empty-gppsid-array-conflicts-with-regs-gdpr", // gdpr set to 1, an empty non-nil gpp_sid array doesn't match
+			file:            "empty-gppsid-conflict.json",
+			expectedWarning: "regs.gdpr signal conflicts with GPP (regs.gpp_sid) and will be ignored",
 		},
 		{
 			name:            "gdpr-signals-conflict", // gdpr signals do not match

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -47,86 +47,79 @@ func TestJsonSampleRequests(t *testing.T) {
 		sampleRequestsSubDir string
 	}{
 		{
-			"This folder was not been tested here",
-			"valid-whole/supplementary",
+			"Assert 200s on all bidRequests from exemplary folder",
+			"valid-whole/exemplary",
 		},
-		//{
-		//	"Assert 200s on all bidRequests from exemplary folder",
-		//	"valid-whole/exemplary",
-		//},
-		//{
-		//	"Asserts we return 200s on well-formed Native requests.",
-		//	"valid-native",
-		//},
-		//{
-		//	"Asserts we return 400s on requests that are not supposed to pass validation",
-		//	"invalid-whole",
-		//},
-		//{
-		//	"Asserts we return 400s on requests with Native requests that don't pass validation",
-		//	"invalid-native",
-		//},
-		//{
-		//	"Makes sure we handle (default) aliased bidders properly",
-		//	"aliased",
-		//},
-		//{
-		//	"Asserts we return 500s on requests referencing accounts with malformed configs.",
-		//	"account-malformed",
-		//},
-		//{
-		//	"Asserts we return 503s on requests with blacklisted accounts and apps.",
-		//	"blacklisted",
-		//},
-		//{
-		//	"Assert that requests that come with no user id nor app id return error if the `AccountRequired` field in the `config.Configuration` structure is set to true",
-		//	"account-required/no-account",
-		//},
-		//{
-		//	"Assert requests that come with a valid user id or app id when account is required",
-		//	"account-required/with-account",
-		//},
-		//{
-		//	"Tests diagnostic messages for invalid stored requests",
-		//	"invalid-stored",
-		//},
-		//{
-		//	"Make sure requests with disabled bidders will fail",
-		//	"disabled/bad",
-		//},
-		//{
-		//	"There are both disabled and non-disabled bidders, we expect a 200",
-		//	"disabled/good",
-		//},
-		//{
-		//	"Assert we correctly use the server conversion rates when needed",
-		//	"currency-conversion/server-rates/valid",
-		//},
-		//{
-		//	"Assert we correctly throw an error when no conversion rate was found in the server conversions map",
-		//	"currency-conversion/server-rates/errors",
-		//},
-		//{
-		//	"Assert we correctly use request-defined custom currency rates when present in root.ext",
-		//	"currency-conversion/custom-rates/valid",
-		//},
-		//{
-		//	"Assert we correctly validate request-defined custom currency rates when present in root.ext",
-		//	"currency-conversion/custom-rates/errors",
-		//},
-		//{
-		//	"Assert request with ad server targeting is processing correctly",
-		//	"adservertargeting",
-		//},
+		{
+			"Asserts we return 200s on well-formed Native requests.",
+			"valid-native",
+		},
+		{
+			"Asserts we return 400s on requests that are not supposed to pass validation",
+			"invalid-whole",
+		},
+		{
+			"Asserts we return 400s on requests with Native requests that don't pass validation",
+			"invalid-native",
+		},
+		{
+			"Makes sure we handle (default) aliased bidders properly",
+			"aliased",
+		},
+		{
+			"Asserts we return 500s on requests referencing accounts with malformed configs.",
+			"account-malformed",
+		},
+		{
+			"Asserts we return 503s on requests with blacklisted accounts and apps.",
+			"blacklisted",
+		},
+		{
+			"Assert that requests that come with no user id nor app id return error if the `AccountRequired` field in the `config.Configuration` structure is set to true",
+			"account-required/no-account",
+		},
+		{
+			"Assert requests that come with a valid user id or app id when account is required",
+			"account-required/with-account",
+		},
+		{
+			"Tests diagnostic messages for invalid stored requests",
+			"invalid-stored",
+		},
+		{
+			"Make sure requests with disabled bidders will fail",
+			"disabled/bad",
+		},
+		{
+			"There are both disabled and non-disabled bidders, we expect a 200",
+			"disabled/good",
+		},
+		{
+			"Assert we correctly use the server conversion rates when needed",
+			"currency-conversion/server-rates/valid",
+		},
+		{
+			"Assert we correctly throw an error when no conversion rate was found in the server conversions map",
+			"currency-conversion/server-rates/errors",
+		},
+		{
+			"Assert we correctly use request-defined custom currency rates when present in root.ext",
+			"currency-conversion/custom-rates/valid",
+		},
+		{
+			"Assert we correctly validate request-defined custom currency rates when present in root.ext",
+			"currency-conversion/custom-rates/errors",
+		},
+		{
+			"Assert request with ad server targeting is processing correctly",
+			"adservertargeting",
+		},
 	}
 
 	for _, tc := range testSuites {
 		testCaseFiles, err := getTestFiles(filepath.Join("sample-requests", tc.sampleRequestsSubDir))
 		if assert.NoError(t, err, "Test case %s. Error reading files from directory %s \n", tc.description, tc.sampleRequestsSubDir) {
 			for _, testFile := range testCaseFiles {
-				if !strings.HasSuffix(testFile, ".json") {
-					continue
-				}
 				fileData, err := os.ReadFile(testFile)
 				if assert.NoError(t, err, "Test case %s. Error reading file %s \n", tc.description, testFile) {
 					// Retrieve test case input and expected output from JSON file

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/empty-gppsid-conflict.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/empty-gppsid-conflict.json
@@ -1,0 +1,56 @@
+{
+  "description": "Well formed amp request with  conflicting (2.6 gdpr consent vs. GPP) gdpr signals",
+  "mockBidRequest": {
+    "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+    "site": {
+      "page": "prebid.org",
+      "publisher": {
+        "id": "a3de7af2-a86a-4043-a77b-c7e86744155e"
+      }
+    },
+    "source": {
+      "tid": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5"
+    },
+    "tmax": 1000,
+    "imp": [
+      {
+        "id": "/19968336/header-bid-tag-0",
+        "ext": {
+          "appnexus": {
+            "placementId": 12883451
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            },
+            {
+              "w": 300,
+              "h": 300
+            }
+          ]
+        }
+      }
+    ],
+    "regs": {
+      "gpp": "DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1NYN",
+      "gpp_sid": [ ],
+      "gdpr": 1,
+      "ext": {
+        "us_privacy": "1YYY"
+      }
+    },
+    "user": {
+      "consent": "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+      "ext": {}
+    }
+  },
+  "expectedBidResponse": {
+      "id":"b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
+      "bidid":"test bid id",
+      "nbr":0
+  },
+  "expectedReturnCode": 200
+}


### PR DESCRIPTION
Inside the `validateRegs(req *openrtb_ext.RequestWrapper, gpp gpplib.GppContainer)` function found in `endpoints/openrtb2/auction.go` we can `break` after we find the first occurrence of `constants.SectionTCFEU2` is found. This is a small optimization to not traverse the entire `GPPSID` array.

Additionally, test case `"empty-gppsid-conflict.json"` was added to test the scenario when the incoming request has a non-nil, empty `GPPSID` array.