### PR TITLE
Separate Analytics Data Model

### DIFF
--- a/analytics/core.go
+++ b/analytics/core.go
@@ -9,14 +9,9 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-/*
-  	PBSAnalyticsModule must be implemented by any analytics module that does transactional logging.
-
-	New modules can use the /analytics/endpoint_data_objects, extract the
-	information required and are responsible for handling all their logging activities inside LogAuctionObject, LogAmpObject
-	LogCookieSyncObject and LogSetUIDObject method implementations.
-*/
-
+// PBSAnalyticsModule must be implemented by analytics modules to extract the required information and logging
+// activities. Do not use marshal the parameter objects directly as they can change over time. Use a separate
+// model for each analytics module and transform as appropriate.
 type PBSAnalyticsModule interface {
 	LogAuctionObject(*AuctionObject)
 	LogVideoObject(*VideoObject)
@@ -88,7 +83,7 @@ type UsersyncInfo struct {
 	SupportCORS bool   `json:"supportCORS,omitempty"`
 }
 
-// NotificationEvent is a loggable object
+// NotificationEvent object of a transaction at /event
 type NotificationEvent struct {
 	Request *EventRequest   `json:"request"`
 	Account *config.Account `json:"account"`

--- a/analytics/filesystem/file_module.go
+++ b/analytics/filesystem/file_module.go
@@ -27,7 +27,6 @@ type FileLogger struct {
 
 // Writes AuctionObject to file
 func (f *FileLogger) LogAuctionObject(ao *analytics.AuctionObject) {
-	//Code to parse the object and log in a way required
 	var b bytes.Buffer
 	b.WriteString(jsonifyAuctionObject(ao))
 	f.Logger.Debug(b.String())
@@ -103,13 +102,25 @@ func NewFileLogger(filename string) (analytics.PBSAnalyticsModule, error) {
 }
 
 func jsonifyAuctionObject(ao *analytics.AuctionObject) string {
-	type alias analytics.AuctionObject
+	var logEntry *logAuction
+	if ao != nil {
+		logEntry = &logAuction{
+			Status:               ao.Status,
+			Errors:               ao.Errors,
+			Request:              ao.Request,
+			Response:             ao.Response,
+			Account:              ao.Account,
+			StartTime:            ao.StartTime,
+			HookExecutionOutcome: ao.HookExecutionOutcome,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logAuction
 	}{
-		Type:  AUCTION,
-		alias: (*alias)(ao),
+		Type:       AUCTION,
+		logAuction: logEntry,
 	})
 
 	if err == nil {
@@ -120,13 +131,25 @@ func jsonifyAuctionObject(ao *analytics.AuctionObject) string {
 }
 
 func jsonifyVideoObject(vo *analytics.VideoObject) string {
-	type alias analytics.VideoObject
+	var logEntry *logVideo
+	if vo != nil {
+		logEntry = &logVideo{
+			Status:        vo.Status,
+			Errors:        vo.Errors,
+			Request:       vo.Request,
+			Response:      vo.Response,
+			VideoRequest:  vo.VideoRequest,
+			VideoResponse: vo.VideoResponse,
+			StartTime:     vo.StartTime,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logVideo
 	}{
-		Type:  VIDEO,
-		alias: (*alias)(vo),
+		Type:     VIDEO,
+		logVideo: logEntry,
 	})
 
 	if err == nil {
@@ -137,14 +160,21 @@ func jsonifyVideoObject(vo *analytics.VideoObject) string {
 }
 
 func jsonifyCookieSync(cso *analytics.CookieSyncObject) string {
-	type alias analytics.CookieSyncObject
+	var logEntry *logUserSync
+	if cso != nil {
+		logEntry = &logUserSync{
+			Status:       cso.Status,
+			Errors:       cso.Errors,
+			BidderStatus: cso.BidderStatus,
+		}
+	}
 
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logUserSync
 	}{
-		Type:  COOKIE_SYNC,
-		alias: (*alias)(cso),
+		Type:        COOKIE_SYNC,
+		logUserSync: logEntry,
 	})
 
 	if err == nil {
@@ -155,13 +185,23 @@ func jsonifyCookieSync(cso *analytics.CookieSyncObject) string {
 }
 
 func jsonifySetUIDObject(so *analytics.SetUIDObject) string {
-	type alias analytics.SetUIDObject
+	var logEntry *logSetUID
+	if so != nil {
+		logEntry = &logSetUID{
+			Status:  so.Status,
+			Bidder:  so.Bidder,
+			UID:     so.UID,
+			Errors:  so.Errors,
+			Success: so.Success,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logSetUID
 	}{
-		Type:  SETUID,
-		alias: (*alias)(so),
+		Type:      SETUID,
+		logSetUID: logEntry,
 	})
 
 	if err == nil {
@@ -172,13 +212,26 @@ func jsonifySetUIDObject(so *analytics.SetUIDObject) string {
 }
 
 func jsonifyAmpObject(ao *analytics.AmpObject) string {
-	type alias analytics.AmpObject
+	var logEntry *logAMP
+	if ao != nil {
+		logEntry = &logAMP{
+			Status:               ao.Status,
+			Errors:               ao.Errors,
+			Request:              ao.Request,
+			AuctionResponse:      ao.AuctionResponse,
+			AmpTargetingValues:   ao.AmpTargetingValues,
+			Origin:               ao.Origin,
+			StartTime:            ao.StartTime,
+			HookExecutionOutcome: ao.HookExecutionOutcome,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logAMP
 	}{
-		Type:  AMP,
-		alias: (*alias)(ao),
+		Type:   AMP,
+		logAMP: logEntry,
 	})
 
 	if err == nil {
@@ -189,13 +242,20 @@ func jsonifyAmpObject(ao *analytics.AmpObject) string {
 }
 
 func jsonifyNotificationEventObject(ne *analytics.NotificationEvent) string {
-	type alias analytics.NotificationEvent
+	var logEntry *logEvent
+	if ne != nil {
+		logEntry = &logEvent{
+			Request: ne.Request,
+			Account: ne.Account,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*alias
+		*logEvent
 	}{
-		Type:  NOTIFICATION_EVENT,
-		alias: (*alias)(ne),
+		Type:     NOTIFICATION_EVENT,
+		logEvent: logEntry,
 	})
 
 	if err == nil {

--- a/analytics/filesystem/file_module.go
+++ b/analytics/filesystem/file_module.go
@@ -242,9 +242,9 @@ func jsonifyAmpObject(ao *analytics.AmpObject) string {
 }
 
 func jsonifyNotificationEventObject(ne *analytics.NotificationEvent) string {
-	var logEntry *logEvent
+	var logEntry *logNotificationEvent
 	if ne != nil {
-		logEntry = &logEvent{
+		logEntry = &logNotificationEvent{
 			Request: ne.Request,
 			Account: ne.Account,
 		}
@@ -252,10 +252,10 @@ func jsonifyNotificationEventObject(ne *analytics.NotificationEvent) string {
 
 	b, err := json.Marshal(&struct {
 		Type RequestType `json:"type"`
-		*logEvent
+		*logNotificationEvent
 	}{
-		Type:     NOTIFICATION_EVENT,
-		logEvent: logEntry,
+		Type:                 NOTIFICATION_EVENT,
+		logNotificationEvent: logEntry,
 	})
 
 	if err == nil {

--- a/analytics/filesystem/file_module_test.go
+++ b/analytics/filesystem/file_module_test.go
@@ -1,7 +1,6 @@
 package filesystem
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -24,8 +23,6 @@ func TestAmpObject_ToJson(t *testing.T) {
 	}
 	if aoJson := jsonifyAmpObject(ao); strings.Contains(aoJson, "Transactional Logs Error") {
 		t.Fatalf("AmpObject failed to convert to json")
-	} else {
-		fmt.Println(aoJson)
 	}
 }
 

--- a/analytics/filesystem/file_module_test.go
+++ b/analytics/filesystem/file_module_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -23,6 +24,8 @@ func TestAmpObject_ToJson(t *testing.T) {
 	}
 	if aoJson := jsonifyAmpObject(ao); strings.Contains(aoJson, "Transactional Logs Error") {
 		t.Fatalf("AmpObject failed to convert to json")
+	} else {
+		fmt.Println(aoJson)
 	}
 }
 

--- a/analytics/filesystem/model.go
+++ b/analytics/filesystem/model.go
@@ -1,0 +1,61 @@
+package filesystem
+
+import (
+	"time"
+
+	"github.com/prebid/openrtb/v19/openrtb2"
+	"github.com/prebid/prebid-server/analytics"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/hooks/hookexecution"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type logAuction struct {
+	Status               int
+	Errors               []error
+	Request              *openrtb2.BidRequest
+	Response             *openrtb2.BidResponse
+	Account              *config.Account
+	StartTime            time.Time
+	HookExecutionOutcome []hookexecution.StageOutcome
+}
+
+type logVideo struct {
+	Status        int
+	Errors        []error
+	Request       *openrtb2.BidRequest
+	Response      *openrtb2.BidResponse
+	VideoRequest  *openrtb_ext.BidRequestVideo
+	VideoResponse *openrtb_ext.BidResponseVideo
+	StartTime     time.Time
+}
+
+type logSetUID struct {
+	Status  int
+	Bidder  string
+	UID     string
+	Errors  []error
+	Success bool
+}
+
+type logUserSync struct {
+	Status       int
+	Errors       []error
+	BidderStatus []*analytics.CookieSyncBidder
+}
+
+type logAMP struct {
+	Status               int
+	Errors               []error
+	Request              *openrtb2.BidRequest
+	AuctionResponse      *openrtb2.BidResponse
+	AmpTargetingValues   map[string]string
+	Origin               string
+	StartTime            time.Time
+	HookExecutionOutcome []hookexecution.StageOutcome
+}
+
+type logEvent struct {
+	Request *analytics.EventRequest `json:"request"`
+	Account *config.Account         `json:"account"`
+}

--- a/analytics/filesystem/model.go
+++ b/analytics/filesystem/model.go
@@ -55,7 +55,7 @@ type logAMP struct {
 	HookExecutionOutcome []hookexecution.StageOutcome
 }
 
-type logEvent struct {
+type logNotificationEvent struct {
 	Request *analytics.EventRequest `json:"request"`
 	Account *config.Account         `json:"account"`
 }

--- a/analytics/pubstack/helpers/json.go
+++ b/analytics/pubstack/helpers/json.go
@@ -8,12 +8,25 @@ import (
 )
 
 func JsonifyAuctionObject(ao *analytics.AuctionObject, scope string) ([]byte, error) {
+	var logEntry *logAuction
+	if ao != nil {
+		logEntry = &logAuction{
+			Status:               ao.Status,
+			Errors:               ao.Errors,
+			Request:              ao.Request,
+			Response:             ao.Response,
+			Account:              ao.Account,
+			StartTime:            ao.StartTime,
+			HookExecutionOutcome: ao.HookExecutionOutcome,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Scope string `json:"scope"`
-		*analytics.AuctionObject
+		*logAuction
 	}{
-		Scope:         scope,
-		AuctionObject: ao,
+		Scope:      scope,
+		logAuction: logEntry,
 	})
 
 	if err == nil {
@@ -24,12 +37,25 @@ func JsonifyAuctionObject(ao *analytics.AuctionObject, scope string) ([]byte, er
 }
 
 func JsonifyVideoObject(vo *analytics.VideoObject, scope string) ([]byte, error) {
+	var logEntry *logVideo
+	if vo != nil {
+		logEntry = &logVideo{
+			Status:        vo.Status,
+			Errors:        vo.Errors,
+			Request:       vo.Request,
+			Response:      vo.Response,
+			VideoRequest:  vo.VideoRequest,
+			VideoResponse: vo.VideoResponse,
+			StartTime:     vo.StartTime,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Scope string `json:"scope"`
-		*analytics.VideoObject
+		*logVideo
 	}{
-		Scope:       scope,
-		VideoObject: vo,
+		Scope:    scope,
+		logVideo: logEntry,
 	})
 
 	if err == nil {
@@ -40,12 +66,21 @@ func JsonifyVideoObject(vo *analytics.VideoObject, scope string) ([]byte, error)
 }
 
 func JsonifyCookieSync(cso *analytics.CookieSyncObject, scope string) ([]byte, error) {
+	var logEntry *logUserSync
+	if cso != nil {
+		logEntry = &logUserSync{
+			Status:       cso.Status,
+			Errors:       cso.Errors,
+			BidderStatus: cso.BidderStatus,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Scope string `json:"scope"`
-		*analytics.CookieSyncObject
+		*logUserSync
 	}{
-		Scope:            scope,
-		CookieSyncObject: cso,
+		Scope:       scope,
+		logUserSync: logEntry,
 	})
 
 	if err == nil {
@@ -56,12 +91,23 @@ func JsonifyCookieSync(cso *analytics.CookieSyncObject, scope string) ([]byte, e
 }
 
 func JsonifySetUIDObject(so *analytics.SetUIDObject, scope string) ([]byte, error) {
+	var logEntry *logSetUID
+	if so != nil {
+		logEntry = &logSetUID{
+			Status:  so.Status,
+			Bidder:  so.Bidder,
+			UID:     so.UID,
+			Errors:  so.Errors,
+			Success: so.Success,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Scope string `json:"scope"`
-		*analytics.SetUIDObject
+		*logSetUID
 	}{
-		Scope:        scope,
-		SetUIDObject: so,
+		Scope:     scope,
+		logSetUID: logEntry,
 	})
 
 	if err == nil {
@@ -72,12 +118,26 @@ func JsonifySetUIDObject(so *analytics.SetUIDObject, scope string) ([]byte, erro
 }
 
 func JsonifyAmpObject(ao *analytics.AmpObject, scope string) ([]byte, error) {
+	var logEntry *logAMP
+	if ao != nil {
+		logEntry = &logAMP{
+			Status:               ao.Status,
+			Errors:               ao.Errors,
+			Request:              ao.Request,
+			AuctionResponse:      ao.AuctionResponse,
+			AmpTargetingValues:   ao.AmpTargetingValues,
+			Origin:               ao.Origin,
+			StartTime:            ao.StartTime,
+			HookExecutionOutcome: ao.HookExecutionOutcome,
+		}
+	}
+
 	b, err := json.Marshal(&struct {
 		Scope string `json:"scope"`
-		*analytics.AmpObject
+		*logAMP
 	}{
-		Scope:     scope,
-		AmpObject: ao,
+		Scope:  scope,
+		logAMP: logEntry,
 	})
 
 	if err == nil {

--- a/analytics/pubstack/helpers/model.go
+++ b/analytics/pubstack/helpers/model.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	"time"
+
+	"github.com/prebid/openrtb/v19/openrtb2"
+	"github.com/prebid/prebid-server/analytics"
+	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/hooks/hookexecution"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type logAuction struct {
+	Status               int
+	Errors               []error
+	Request              *openrtb2.BidRequest
+	Response             *openrtb2.BidResponse
+	Account              *config.Account
+	StartTime            time.Time
+	HookExecutionOutcome []hookexecution.StageOutcome
+}
+
+type logVideo struct {
+	Status        int
+	Errors        []error
+	Request       *openrtb2.BidRequest
+	Response      *openrtb2.BidResponse
+	VideoRequest  *openrtb_ext.BidRequestVideo
+	VideoResponse *openrtb_ext.BidResponseVideo
+	StartTime     time.Time
+}
+
+type logSetUID struct {
+	Status  int
+	Bidder  string
+	UID     string
+	Errors  []error
+	Success bool
+}
+
+type logUserSync struct {
+	Status       int
+	Errors       []error
+	BidderStatus []*analytics.CookieSyncBidder
+}
+
+type logAMP struct {
+	Status               int
+	Errors               []error
+	Request              *openrtb2.BidRequest
+	AuctionResponse      *openrtb2.BidResponse
+	AmpTargetingValues   map[string]string
+	Origin               string
+	StartTime            time.Time
+	HookExecutionOutcome []hookexecution.StageOutcome
+}


### PR DESCRIPTION
Each analytics adapter should use it's own model for serialization, such that the core data model objects are free to evolve as needed.

FYI: @gpolaert