### PR TITLE
TMaxAdjustments: Update endpoints to use TMaxAdjustments.limitAuctionTimeout

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -175,7 +175,11 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 	ctx := context.Background()
 	var cancel context.CancelFunc
 	if reqWrapper.TMax > 0 {
-		ctx, cancel = context.WithDeadline(ctx, start.Add(time.Duration(reqWrapper.TMax)*time.Millisecond))
+		if deps.cfg.TmaxAdjustments.Enabled {
+			ctx, cancel = context.WithDeadline(ctx, start.Add(deps.cfg.TmaxAdjustments.LimitAuctionTimeout(time.Duration(reqWrapper.TMax)*time.Millisecond, labels.RType)))
+		} else {
+			ctx, cancel = context.WithDeadline(ctx, start.Add(time.Duration(reqWrapper.TMax)*time.Millisecond))
+		}
 	} else {
 		ctx, cancel = context.WithDeadline(ctx, start.Add(time.Duration(defaultAmpRequestTimeoutMillis)*time.Millisecond))
 	}

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -172,6 +172,10 @@ func TestAccountErrors(t *testing.T) {
 			BlacklistedAccts:   []string{"bad_acct"},
 			BlacklistedAcctMap: map[string]bool{"bad_acct": true},
 			MaxRequestSize:     maxSize,
+			TmaxAdjustments: config.TmaxAdjustments{
+				Enabled: true,
+				AmpMax:  900,
+			},
 		}
 		cfg.MarshalAccountDefaults()
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -188,7 +188,12 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	ctx := context.Background()
 
-	timeout := deps.cfg.AuctionTimeouts.LimitAuctionTimeout(time.Duration(req.TMax) * time.Millisecond)
+	var timeout time.Duration
+	if deps.cfg.TmaxAdjustments.Enabled {
+		timeout = deps.cfg.TmaxAdjustments.LimitAuctionTimeout(time.Duration(req.TMax)*time.Millisecond, labels.RType)
+	} else {
+		timeout = deps.cfg.AuctionTimeouts.LimitAuctionTimeout(time.Duration(req.TMax) * time.Millisecond)
+	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, start.Add(timeout))

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -376,6 +376,10 @@ func TestExplicitUserId(t *testing.T) {
 		HostCookie: config.HostCookie{
 			CookieName: cookieName,
 		},
+		TmaxAdjustments: config.TmaxAdjustments{
+			Enabled:    true,
+			AuctionMax: 900,
+		},
 	}
 	ex := &mockExchange{}
 

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -269,7 +269,12 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	}
 
 	ctx := context.Background()
-	timeout := deps.cfg.AuctionTimeouts.LimitAuctionTimeout(time.Duration(bidReqWrapper.TMax) * time.Millisecond)
+	var timeout time.Duration
+	if deps.cfg.TmaxAdjustments.Enabled {
+		timeout = deps.cfg.TmaxAdjustments.LimitAuctionTimeout(time.Duration(bidReqWrapper.TMax)*time.Millisecond, labels.RType)
+	} else {
+		timeout = deps.cfg.AuctionTimeouts.LimitAuctionTimeout(time.Duration(bidReqWrapper.TMax) * time.Millisecond)
+	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, start.Add(timeout))

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -73,6 +73,10 @@ func TestVideoEndpointImpressionsDuration(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	deps := mockDeps(t, ex)
+	deps.cfg.TmaxAdjustments = config.TmaxAdjustments{
+		Enabled:  true,
+		VideoMax: 900,
+	}
 	deps.VideoAuctionEndpoint(recorder, req, nil)
 
 	if ex.lastRequest == nil {


### PR DESCRIPTION
Currently, we are using AuctionTimeouts.LimitAuctionTimeout function to get min of requested and cfg.MaxAuctionTimeout. This PR adds a check to see if TMaxAdjustments is enabled and in this case, we will use TMaxAdjustments.LimitAuctionTimeout function. 