### PR TITLE
Refactor GPP functions

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -238,8 +238,7 @@ func (c *cookieSyncEndpoint) setCooperativeSync(request cookieSyncRequest, cooki
 
 func parseTypeFilter(request *cookieSyncRequestFilterSettings) (usersync.SyncTypeFilter, error) {
 	syncTypeFilter := usersync.SyncTypeFilter{
-		IFrame: cookieSyncBidderFilterAllowAll,
-
+		IFrame:   cookieSyncBidderFilterAllowAll,
 		Redirect: cookieSyncBidderFilterAllowAll,
 	}
 

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -129,7 +129,7 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 	if request.GDPR != nil {
 		gdprString = strconv.Itoa(*request.GDPR)
 	}
-	gdprSignal, err := gdpr.SignalParse(gdprString)
+	gdprSignal, err := gdpr.StrSignalParse(gdprString)
 	if err != nil {
 		return usersync.Request{}, privacy.Policies{}, err
 	}
@@ -238,7 +238,8 @@ func (c *cookieSyncEndpoint) setCooperativeSync(request cookieSyncRequest, cooki
 
 func parseTypeFilter(request *cookieSyncRequestFilterSettings) (usersync.SyncTypeFilter, error) {
 	syncTypeFilter := usersync.SyncTypeFilter{
-		IFrame:   cookieSyncBidderFilterAllowAll,
+		IFrame: cookieSyncBidderFilterAllowAll,
+
 		Redirect: cookieSyncBidderFilterAllowAll,
 	}
 

--- a/gdpr/signal.go
+++ b/gdpr/signal.go
@@ -16,15 +16,24 @@ const (
 
 var gdprSignalError = &errortypes.BadInput{Message: "GDPR signal should be integer 0 or 1"}
 
-// SignalParse returns a parsed GDPR signal or a parse error.
-func SignalParse(rawSignal string) (Signal, error) {
-	if rawSignal == "" {
+// StrSignalParse returns a parsed GDPR signal or a parse error.
+func StrSignalParse(strSignal string) (Signal, error) {
+	if strSignal == "" {
 		return SignalAmbiguous, nil
 	}
 
-	i, err := strconv.Atoi(rawSignal)
+	i, err := strconv.Atoi(strSignal)
 
-	if err != nil || (i != 0 && i != 1) {
+	if err != nil {
+		return SignalAmbiguous, gdprSignalError
+	}
+
+	return IntSignalParse(i)
+}
+
+// IntSignalParse checks parameter i is not out of bounds and returns a GDPR signal error
+func IntSignalParse(i int) (Signal, error) {
+	if i != 0 && i != 1 {
 		return SignalAmbiguous, gdprSignalError
 	}
 

--- a/gdpr/signal.go
+++ b/gdpr/signal.go
@@ -17,12 +17,12 @@ const (
 var gdprSignalError = &errortypes.BadInput{Message: "GDPR signal should be integer 0 or 1"}
 
 // StrSignalParse returns a parsed GDPR signal or a parse error.
-func StrSignalParse(strSignal string) (Signal, error) {
-	if strSignal == "" {
+func StrSignalParse(signal string) (Signal, error) {
+	if signal == "" {
 		return SignalAmbiguous, nil
 	}
 
-	i, err := strconv.Atoi(strSignal)
+	i, err := strconv.Atoi(signal)
 
 	if err != nil {
 		return SignalAmbiguous, gdprSignalError

--- a/gdpr/signal_test.go
+++ b/gdpr/signal_test.go
@@ -43,10 +43,16 @@ func TestSignalParse(t *testing.T) {
 			wantSignal:  SignalAmbiguous,
 			wantError:   true,
 		},
+		{
+			description: "Out of bounds signal - raw signal is 5",
+			rawSignal:   "5",
+			wantSignal:  SignalAmbiguous,
+			wantError:   true,
+		},
 	}
 
 	for _, test := range tests {
-		signal, err := SignalParse(test.rawSignal)
+		signal, err := StrSignalParse(test.rawSignal)
 
 		assert.Equal(t, test.wantSignal, signal, test.description)
 
@@ -55,6 +61,41 @@ func TestSignalParse(t *testing.T) {
 		} else {
 			assert.Nil(t, err, test.description)
 		}
+	}
+}
+
+func TestIntSignalParse(t *testing.T) {
+	type testOutput struct {
+		signal Signal
+		err    error
+	}
+	testCases := []struct {
+		desc     string
+		input    int
+		expected testOutput
+	}{
+		{
+			desc:  "input out of bounds, return SgnalAmbituous and gdprSignalError",
+			input: -1,
+			expected: testOutput{
+				signal: SignalAmbiguous,
+				err:    gdprSignalError,
+			},
+		},
+		{
+			desc:  "input in bounds, return valid signal and nil error",
+			input: 1,
+			expected: testOutput{
+				signal: SignalYes,
+				err:    nil,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		outSignal, outErr := IntSignalParse(tc.input)
+
+		assert.Equal(t, tc.expected.signal, outSignal, tc.desc)
+		assert.Equal(t, tc.expected.err, outErr, tc.desc)
 	}
 }
 

--- a/gdpr/signal_test.go
+++ b/gdpr/signal_test.go
@@ -52,15 +52,17 @@ func TestSignalParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		signal, err := StrSignalParse(test.rawSignal)
+		t.Run(test.description, func(t *testing.T) {
+			signal, err := StrSignalParse(test.rawSignal)
 
-		assert.Equal(t, test.wantSignal, signal, test.description)
+			assert.Equal(t, test.wantSignal, signal, test.description)
 
-		if test.wantError {
-			assert.NotNil(t, err, test.description)
-		} else {
-			assert.Nil(t, err, test.description)
-		}
+			if test.wantError {
+				assert.NotNil(t, err, test.description)
+			} else {
+				assert.Nil(t, err, test.description)
+			}
+		})
 	}
 }
 
@@ -100,10 +102,12 @@ func TestIntSignalParse(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		outSignal, outErr := IntSignalParse(tc.input)
+		t.Run(tc.desc, func(t *testing.T) {
+			outSignal, outErr := IntSignalParse(tc.input)
 
-		assert.Equal(t, tc.expected.signal, outSignal, tc.desc)
-		assert.Equal(t, tc.expected.err, outErr, tc.desc)
+			assert.Equal(t, tc.expected.signal, outSignal, tc.desc)
+			assert.Equal(t, tc.expected.err, outErr, tc.desc)
+		})
 	}
 }
 

--- a/gdpr/signal_test.go
+++ b/gdpr/signal_test.go
@@ -83,7 +83,15 @@ func TestIntSignalParse(t *testing.T) {
 			},
 		},
 		{
-			desc:  "input in bounds, return valid signal and nil error",
+			desc:  "input in bounds equals signalNo, return signalNo and nil error",
+			input: 0,
+			expected: testOutput{
+				signal: SignalNo,
+				err:    nil,
+			},
+		},
+		{
+			desc:  "input in bounds equals signalYes, return signalYes and nil error",
 			input: 1,
 			expected: testOutput{
 				signal: SignalYes,

--- a/privacy/ccpa/policy.go
+++ b/privacy/ccpa/policy.go
@@ -20,12 +20,10 @@ type Policy struct {
 
 // ReadFromRequestWrapper extracts the CCPA regulatory information from an OpenRTB bid request.
 func ReadFromRequestWrapper(req *openrtb_ext.RequestWrapper, gpp gpplib.GppContainer) (Policy, error) {
-	var consent string
 	var noSaleBidders []string
 	var gppSIDs []int8
 	var requestUSPrivacy string
-	var warn error = nil
-	var err error = nil
+	var warn error
 
 	if req == nil || req.BidRequest == nil {
 		return Policy{}, nil
@@ -36,7 +34,7 @@ func ReadFromRequestWrapper(req *openrtb_ext.RequestWrapper, gpp gpplib.GppConta
 		gppSIDs = req.BidRequest.Regs.GPPSID
 	}
 
-	consent, err = SelectCCPAConsent(requestUSPrivacy, gpp, gppSIDs)
+	consent, err := SelectCCPAConsent(requestUSPrivacy, gpp, gppSIDs)
 	if err != nil {
 		warn = &errortypes.Warning{
 			Message:     "regs.us_privacy consent does not match uspv1 in GPP, using regs.gpp",

--- a/privacy/ccpa/policy.go
+++ b/privacy/ccpa/policy.go
@@ -1,6 +1,7 @@
 package ccpa
 
 import (
+	"errors"
 	"fmt"
 
 	gpplib "github.com/prebid/go-gpp"
@@ -8,6 +9,7 @@ import (
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	gppPolicy "github.com/prebid/prebid-server/privacy/gpp"
 )
 
 // Policy represents the CCPA regulatory information from an OpenRTB bid request.
@@ -20,31 +22,25 @@ type Policy struct {
 func ReadFromRequestWrapper(req *openrtb_ext.RequestWrapper, gpp gpplib.GppContainer) (Policy, error) {
 	var consent string
 	var noSaleBidders []string
+	var gppSIDs []int8
+	var requestUSPrivacy string
 	var warn error = nil
+	var err error = nil
 
 	if req == nil || req.BidRequest == nil {
 		return Policy{}, nil
 	}
 
 	if req.BidRequest.Regs != nil {
-		for _, s := range req.BidRequest.Regs.GPPSID {
-			if s == int8(gppConstants.SectionUSPV1) {
-				for i, id := range gpp.SectionTypes {
-					if id == gppConstants.SectionUSPV1 {
-						consent = gpp.Sections[i].GetValue()
-					}
-				}
-			}
-		}
-		if req.BidRequest.Regs.USPrivacy != "" {
-			if consent == "" {
-				consent = req.BidRequest.Regs.USPrivacy
-			} else if consent != req.BidRequest.Regs.USPrivacy {
-				warn = &errortypes.Warning{
-					Message:     "regs.us_privacy consent does not match uspv1 in GPP, using regs.gpp",
-					WarningCode: errortypes.InvalidPrivacyConsentWarningCode}
-			}
-		}
+		requestUSPrivacy = req.BidRequest.Regs.USPrivacy
+		gppSIDs = req.BidRequest.Regs.GPPSID
+	}
+
+	consent, err = SelectCCPAConsent(requestUSPrivacy, gpp, gppSIDs)
+	if err != nil {
+		warn = &errortypes.Warning{
+			Message:     "regs.us_privacy consent does not match uspv1 in GPP, using regs.gpp",
+			WarningCode: errortypes.InvalidPrivacyConsentWarningCode}
 	}
 
 	if consent == "" {
@@ -98,6 +94,29 @@ func (p Policy) Write(req *openrtb_ext.RequestWrapper) error {
 	regsExt.SetUSPrivacy(p.Consent)
 	setPrebidNoSale(p.NoSaleBidders, reqExt)
 	return nil
+}
+
+func SelectCCPAConsent(requestUSPrivacy string, gpp gpplib.GppContainer, gppSIDs []int8) (string, error) {
+	var consent string
+	var err error
+
+	if len(gpp.SectionTypes) > 0 {
+		if gppPolicy.IsSIDInList(gppSIDs, gppConstants.SectionUSPV1) {
+			if i := gppPolicy.IndexOfSID(gpp, gppConstants.SectionUSPV1); i >= 0 {
+				consent = gpp.Sections[i].GetValue()
+			}
+		}
+	}
+
+	if requestUSPrivacy != "" {
+		if consent == "" {
+			consent = requestUSPrivacy
+		} else if consent != requestUSPrivacy {
+			err = errors.New("request.us_privacy consent does not match uspv1")
+		}
+	}
+
+	return consent, err
 }
 
 func setPrebidNoSale(noSaleBidders []string, ext *openrtb_ext.RequestExt) {

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -12,6 +12,8 @@ type Policy struct {
 	RawSID  string // This is the CSV format ("2,6") that the IAB recommends for passing the SID(s) on a query string.
 }
 
+// IsSIDInList returns true if the 'sid' value is found in the gppSIDs array. Its logic is used in more than
+// one place in our codebase, therefore it was decided to make it its own function.
 func IsSIDInList(gppSIDs []int8, sid gppConstants.SectionID) bool {
 	for _, id := range gppSIDs {
 		if id == int8(sid) {
@@ -21,6 +23,9 @@ func IsSIDInList(gppSIDs []int8, sid gppConstants.SectionID) bool {
 	return false
 }
 
+// IndexOfSID returns a zero or non-negative integer that represents the position of the 'sid' value in the
+// 'gpp.SectionTypes' array. If the 'sid' value is not found, returns -1. This logic is used in
+// more than one place in our codebase, therefore it was decided to make it its own function.
 func IndexOfSID(gpp gpplib.GppContainer, sid gppConstants.SectionID) int {
 	for i, id := range gpp.SectionTypes {
 		if id == sid {

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -1,8 +1,36 @@
 package gpp
 
+import (
+	gpplib "github.com/prebid/go-gpp"
+	gppConstants "github.com/prebid/go-gpp/constants"
+)
+
 // Policy represents the GPP privacy string container.
 // Currently just a placeholder until more expansive support is made.
 type Policy struct {
 	Consent string
 	RawSID  string // This is the CSV format ("2,6") that the IAB recommends for passing the SID(s) on a query string.
+}
+
+func IsSIDInList(gppSIDs []int8, sid gppConstants.SectionID) bool {
+	var rc bool = false
+
+	for _, id := range gppSIDs {
+		if id == int8(sid) {
+			rc = true
+			break
+		}
+	}
+	return rc
+}
+
+func IndexOfSID(gpp gpplib.GppContainer, sid gppConstants.SectionID) int {
+	var rv int = -1
+
+	for i, id := range gpp.SectionTypes {
+		if id == sid {
+			return i
+		}
+	}
+	return rv
 }

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -13,24 +13,19 @@ type Policy struct {
 }
 
 func IsSIDInList(gppSIDs []int8, sid gppConstants.SectionID) bool {
-	var rc bool = false
-
 	for _, id := range gppSIDs {
 		if id == int8(sid) {
-			rc = true
-			break
+			return true
 		}
 	}
-	return rc
+	return false
 }
 
 func IndexOfSID(gpp gpplib.GppContainer, sid gppConstants.SectionID) int {
-	var rv int = -1
-
 	for i, id := range gpp.SectionTypes {
 		if id == sid {
 			return i
 		}
 	}
-	return rv
+	return -1
 }

--- a/privacy/gpp/gpp_test.go
+++ b/privacy/gpp/gpp_test.go
@@ -1,0 +1,103 @@
+package gpp
+
+import (
+	"testing"
+
+	gpplib "github.com/prebid/go-gpp"
+	gppConstants "github.com/prebid/go-gpp/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSIDInList(t *testing.T) {
+	type testInput struct {
+		gppSIDs []int8
+		sid     gppConstants.SectionID
+	}
+	testCases := []struct {
+		desc     string
+		in       testInput
+		expected bool
+	}{
+		{
+			desc: "nil gppSID array, expect false",
+			in: testInput{
+				gppSIDs: nil,
+				sid:     gppConstants.SectionTCFEU2,
+			},
+			expected: false,
+		},
+		{
+			desc: "empty gppSID array, expect false",
+			in: testInput{
+				gppSIDs: []int8{},
+				sid:     gppConstants.SectionTCFEU2,
+			},
+			expected: false,
+		},
+		{
+			desc: "SID not found in gppSID array, expect false",
+			in: testInput{
+				gppSIDs: []int8{int8(8), int8(9)},
+				sid:     gppConstants.SectionTCFEU2,
+			},
+			expected: false,
+		},
+		{
+			desc: "SID found in gppSID array, expect true",
+			in: testInput{
+				gppSIDs: []int8{int8(2)},
+				sid:     gppConstants.SectionTCFEU2,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		// run
+		out := IsSIDInList(tc.in.gppSIDs, tc.in.sid)
+		// assertions
+		assert.Equal(t, tc.expected, out, tc.desc)
+	}
+}
+
+func TestIndexOfSID(t *testing.T) {
+	type testInput struct {
+		gpp gpplib.GppContainer
+		sid gppConstants.SectionID
+	}
+	testCases := []struct {
+		desc     string
+		in       testInput
+		expected int
+	}{
+		{
+			desc: "Empty SectionTypes array, expect -1 out",
+			in: testInput{
+				gpp: gpplib.GppContainer{},
+				sid: gppConstants.SectionTCFEU2,
+			},
+			expected: -1,
+		},
+		{
+			desc: "SID not found in SectionTypes array, expect -1 out",
+			in: testInput{
+				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1}},
+				sid: gppConstants.SectionTCFEU2,
+			},
+			expected: -1,
+		},
+		{
+			desc: "SID matches an element in SectionTypes array, expect index 1 out",
+			in: testInput{
+				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1, gppConstants.SectionTCFEU2}},
+				sid: gppConstants.SectionTCFEU2,
+			},
+			expected: 1,
+		},
+	}
+	for _, tc := range testCases {
+		// run
+		out := IndexOfSID(tc.in.gpp, tc.in.sid)
+		// assertions
+		assert.Equal(t, tc.expected, out, tc.desc)
+	}
+}

--- a/privacy/gpp/gpp_test.go
+++ b/privacy/gpp/gpp_test.go
@@ -77,7 +77,10 @@ func TestIndexOfSID(t *testing.T) {
 		{
 			desc: "SID_not_found_in_SectionTypes_array,_expect_-1_out",
 			in: testInput{
-				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1}},
+				gpp: gpplib.GppContainer{
+					Version:      1,
+					SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1},
+				},
 				sid: gppConstants.SectionTCFEU2,
 			},
 			expected: -1,
@@ -85,7 +88,14 @@ func TestIndexOfSID(t *testing.T) {
 		{
 			desc: "SID_matches_an_element_in_SectionTypes_array,_expect_index_1_out",
 			in: testInput{
-				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1, gppConstants.SectionTCFEU2}},
+				gpp: gpplib.GppContainer{
+					Version: 1,
+					SectionTypes: []gppConstants.SectionID{
+						gppConstants.SectionUSPV1,
+						gppConstants.SectionTCFEU2,
+						gppConstants.SectionUSPCA,
+					},
+				},
 				sid: gppConstants.SectionTCFEU2,
 			},
 			expected: 1,

--- a/privacy/gpp/gpp_test.go
+++ b/privacy/gpp/gpp_test.go
@@ -19,7 +19,7 @@ func TestIsSIDInList(t *testing.T) {
 		expected bool
 	}{
 		{
-			desc: "nil gppSID array, expect false",
+			desc: "nil_gppSID_array,_expect_false",
 			in: testInput{
 				gppSIDs: nil,
 				sid:     gppConstants.SectionTCFEU2,
@@ -27,7 +27,7 @@ func TestIsSIDInList(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "empty gppSID array, expect false",
+			desc: "empty_gppSID_array, expect_false",
 			in: testInput{
 				gppSIDs: []int8{},
 				sid:     gppConstants.SectionTCFEU2,
@@ -35,7 +35,7 @@ func TestIsSIDInList(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "SID not found in gppSID array, expect false",
+			desc: "SID_not_found_in_gppSID_array,_expect_false",
 			in: testInput{
 				gppSIDs: []int8{int8(8), int8(9)},
 				sid:     gppConstants.SectionTCFEU2,
@@ -43,7 +43,7 @@ func TestIsSIDInList(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "SID found in gppSID array, expect true",
+			desc: "SID_found_in_gppSID_array,_expect_true",
 			in: testInput{
 				gppSIDs: []int8{int8(2)},
 				sid:     gppConstants.SectionTCFEU2,
@@ -52,10 +52,7 @@ func TestIsSIDInList(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		// run
-		out := IsSIDInList(tc.in.gppSIDs, tc.in.sid)
-		// assertions
-		assert.Equal(t, tc.expected, out, tc.desc)
+		t.Run(tc.desc, func(t *testing.T) { assert.Equal(t, tc.expected, IsSIDInList(tc.in.gppSIDs, tc.in.sid)) })
 	}
 }
 
@@ -70,7 +67,7 @@ func TestIndexOfSID(t *testing.T) {
 		expected int
 	}{
 		{
-			desc: "Empty SectionTypes array, expect -1 out",
+			desc: "Empty_SectionTypes_array,_expect_-1_out",
 			in: testInput{
 				gpp: gpplib.GppContainer{},
 				sid: gppConstants.SectionTCFEU2,
@@ -78,7 +75,7 @@ func TestIndexOfSID(t *testing.T) {
 			expected: -1,
 		},
 		{
-			desc: "SID not found in SectionTypes array, expect -1 out",
+			desc: "SID_not_found_in_SectionTypes_array,_expect_-1_out",
 			in: testInput{
 				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1}},
 				sid: gppConstants.SectionTCFEU2,
@@ -86,7 +83,7 @@ func TestIndexOfSID(t *testing.T) {
 			expected: -1,
 		},
 		{
-			desc: "SID matches an element in SectionTypes array, expect index 1 out",
+			desc: "SID_matches_an_element_in_SectionTypes_array,_expect_index_1_out",
 			in: testInput{
 				gpp: gpplib.GppContainer{Version: 1, SectionTypes: []gppConstants.SectionID{gppConstants.SectionUSPV1, gppConstants.SectionTCFEU2}},
 				sid: gppConstants.SectionTCFEU2,
@@ -95,9 +92,6 @@ func TestIndexOfSID(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		// run
-		out := IndexOfSID(tc.in.gpp, tc.in.sid)
-		// assertions
-		assert.Equal(t, tc.expected, out, tc.desc)
+		t.Run(tc.desc, func(t *testing.T) { assert.Equal(t, tc.expected, IndexOfSID(tc.in.gpp, tc.in.sid)) })
 	}
 }

--- a/util/stringutil/stringutil.go
+++ b/util/stringutil/stringutil.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+// StrToInt8Slice breaks a string into a series of tokens using a comma as a delimiter but only
+// appends the tokens into the return array if tokens can be interpreted as an 'int8'
 func StrToInt8Slice(str string) []int8 {
 	var r []int8
 

--- a/util/stringutil/stringutil.go
+++ b/util/stringutil/stringutil.go
@@ -1,0 +1,21 @@
+package stringutil
+
+import (
+	"strconv"
+	"strings"
+)
+
+func StrToInt8Slice(str string) []int8 {
+	var r []int8
+
+	if len(str) > 0 {
+		strSlice := strings.Split(str, ",")
+		for _, s := range strSlice {
+			if v, err := strconv.ParseInt(s, 10, 8); err == nil {
+				r = append(r, int8(v))
+			}
+		}
+	}
+
+	return r
+}

--- a/util/stringutil/stringutil.go
+++ b/util/stringutil/stringutil.go
@@ -7,17 +7,19 @@ import (
 
 // StrToInt8Slice breaks a string into a series of tokens using a comma as a delimiter but only
 // appends the tokens into the return array if tokens can be interpreted as an 'int8'
-func StrToInt8Slice(str string) []int8 {
+func StrToInt8Slice(str string) ([]int8, error) {
 	var r []int8
 
 	if len(str) > 0 {
 		strSlice := strings.Split(str, ",")
 		for _, s := range strSlice {
-			if v, err := strconv.ParseInt(s, 10, 8); err == nil {
-				r = append(r, int8(v))
+			v, err := strconv.ParseInt(s, 10, 8)
+			if err != nil {
+				return nil, err
 			}
+			r = append(r, int8(v))
 		}
 	}
 
-	return r
+	return r, nil
 }

--- a/util/stringutil/stringutil_test.go
+++ b/util/stringutil/stringutil_test.go
@@ -45,8 +45,6 @@ func TestStrToInt8Slice(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out := StrToInt8Slice(tt.in)
-
-		assert.Equal(t, tt.expected, out)
+		t.Run(tt.desc, func(t *testing.T) { assert.Equal(t, tt.expected, StrToInt8Slice(tt.in)) })
 	}
 }

--- a/util/stringutil/stringutil_test.go
+++ b/util/stringutil/stringutil_test.go
@@ -1,50 +1,77 @@
 package stringutil
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStrToInt8Slice(t *testing.T) {
+	type testOutput struct {
+		arr []int8
+		err error
+	}
 	tests := []struct {
 		desc     string
 		in       string
-		expected []int8
+		expected testOutput
 	}{
 		{
-			desc:     "empty string, expect nil output array",
-			in:       "",
-			expected: nil,
+			desc: "empty string, expect nil output array",
+			in:   "",
+			expected: testOutput{
+				arr: nil,
+				err: nil,
+			},
 		},
 		{
-			desc:     "string doesn't contain digits, expect nil output array",
-			in:       "a,b,#$%",
-			expected: nil,
+			desc: "string doesn't contain digits, expect nil output array",
+			in:   "malformed",
+			expected: testOutput{
+				arr: nil,
+				err: &strconv.NumError{"ParseInt", "malformed", strconv.ErrSyntax},
+			},
 		},
 		{
-			desc:     "string contains int8 digits and non-digits, expect array with a single int8 element",
-			in:       "a,2,#$%",
-			expected: []int8{int8(2)},
+			desc: "string contains int8 digits and non-digits, expect array with a single int8 element",
+			in:   "malformed,2,malformed",
+			expected: testOutput{
+				arr: nil,
+				err: &strconv.NumError{"ParseInt", "malformed", strconv.ErrSyntax},
+			},
 		},
 		{
-			desc:     "string comes with single digit too big to fit into a signed int8, expect nil output array",
-			in:       "128",
-			expected: nil,
+			desc: "string comes with single digit too big to fit into a signed int8, expect nil output array",
+			in:   "128",
+			expected: testOutput{
+				arr: nil,
+				err: &strconv.NumError{"ParseInt", "128", strconv.ErrRange},
+			},
 		},
 		{
-			desc:     "string comes with single digit that fits into 8 bits, expect array with a single int8 element",
-			in:       "127",
-			expected: []int8{int8(127)},
+			desc: "string comes with single digit that fits into 8 bits, expect array with a single int8 element",
+			in:   "127",
+			expected: testOutput{
+				arr: []int8{int8(127)},
+				err: nil,
+			},
 		},
 		{
-			desc:     "string comes with multiple, comma-separated numbers that fit into 8 bits, expect array with int8 elements",
-			in:       "127,2,-127",
-			expected: []int8{int8(127), int8(2), int8(-127)},
+			desc: "string comes with multiple, comma-separated numbers that fit into 8 bits, expect array with int8 elements",
+			in:   "127,2,-127",
+			expected: testOutput{
+				arr: []int8{int8(127), int8(2), int8(-127)},
+				err: nil,
+			},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) { assert.Equal(t, tt.expected, StrToInt8Slice(tt.in)) })
+		t.Run(tt.desc, func(t *testing.T) {
+			outArr, outErr := StrToInt8Slice(tt.in)
+			assert.Equal(t, tt.expected.arr, outArr, tt.desc)
+			assert.Equal(t, tt.expected.err, outErr, tt.desc)
+		})
 	}
 }

--- a/util/stringutil/stringutil_test.go
+++ b/util/stringutil/stringutil_test.go
@@ -1,0 +1,52 @@
+package stringutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrToInt8Slice(t *testing.T) {
+	tests := []struct {
+		desc     string
+		in       string
+		expected []int8
+	}{
+		{
+			desc:     "empty string, expect nil output array",
+			in:       "",
+			expected: nil,
+		},
+		{
+			desc:     "string doesn't contain digits, expect nil output array",
+			in:       "a,b,#$%",
+			expected: nil,
+		},
+		{
+			desc:     "string contains int8 digits and non-digits, expect array with a single int8 element",
+			in:       "a,2,#$%",
+			expected: []int8{int8(2)},
+		},
+		{
+			desc:     "string comes with single digit too big to fit into a signed int8, expect nil output array",
+			in:       "128",
+			expected: nil,
+		},
+		{
+			desc:     "string comes with single digit that fits into 8 bits, expect array with a single int8 element",
+			in:       "127",
+			expected: []int8{int8(127)},
+		},
+		{
+			desc:     "string comes with multiple, comma-separated numbers that fit into 8 bits, expect array with int8 elements",
+			in:       "127,2,-127",
+			expected: []int8{int8(127), int8(2), int8(-127)},
+		},
+	}
+
+	for _, tt := range tests {
+		out := StrToInt8Slice(tt.in)
+
+		assert.Equal(t, tt.expected, out)
+	}
+}


### PR DESCRIPTION
In preparation to complete GPP phase 2 (more info in [this document](https://docs.google.com/document/d/1dRxFUFmhh2jGanzGZvfkK_6jtHPpHXWD7Qsi6KEugeE/edit#) and issue #2380)), it is useful to refactor a couple of functions in order to not have repetitive code when GPP parsing is done in the `/cookie_sync` and `/setuid` endpoints.
