### PR TITLE
Set lmt to 1 if device.ext.atts is 0 for ios versions 14.2 or greater

### DIFF
--- a/privacy/lmt/ios.go
+++ b/privacy/lmt/ios.go
@@ -56,7 +56,7 @@ func modifyForIOS142OrGreater(req *openrtb2.BidRequest) {
 
 	switch *atts {
 	case openrtb_ext.IOSAppTrackingStatusNotDetermined:
-		req.Device.Lmt = &int8Zero
+		req.Device.Lmt = &int8One
 	case openrtb_ext.IOSAppTrackingStatusRestricted:
 		req.Device.Lmt = &int8One
 	case openrtb_ext.IOSAppTrackingStatusDenied:

--- a/privacy/lmt/ios_test.go
+++ b/privacy/lmt/ios_test.go
@@ -54,7 +54,7 @@ func TestModifyForIOS(t *testing.T) {
 				App:    &openrtb2.App{},
 				Device: &openrtb2.Device{Ext: json.RawMessage(`{"atts":0}`), OS: "iOS", OSV: "14.2", IFA: "", Lmt: nil},
 			},
-			expectedLMT: openrtb2.Int8Ptr(0),
+			expectedLMT: openrtb2.Int8Ptr(1),
 		},
 		{
 			description: "14.2",
@@ -272,7 +272,7 @@ func TestModifyForIOS142OrGreater(t *testing.T) {
 		{
 			description: "Not Determined",
 			givenDevice: openrtb2.Device{Ext: json.RawMessage(`{"atts":0}`), Lmt: nil},
-			expectedLMT: openrtb2.Int8Ptr(0),
+			expectedLMT: openrtb2.Int8Ptr(1),
 		},
 		{
 			description: "Restricted",


### PR DESCRIPTION
Addressing update in requirements for #1699 