### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,32 @@ jobs:
     outputs:
       releaseTag: ${{ steps.release.outputs.tag }}
 
+  publish-docker-image:
+    name: Publish docker image
+    needs: publish-tag
+    if: contains(inputs.debug, 'false')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prebid cache
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build image
+        run: |
+          docker build --build-arg DEPLOY_VERSION=${{ needs.publish-tag.outputs.releaseTag }} -t docker.io/prebid/prebid-server:${{ needs.publish-tag.outputs.releaseTag }} .
+      - name: Login to docker Hub
+        if: contains(inputs.debug, 'false')
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Publish to docker Hub
+        run: |
+          docker push docker.io/prebid/prebid-server:${{ needs.publish-tag.outputs.releaseTag }}
+
   publish-release:
     name: Publish release
-    needs: [publish-tag] 
+    needs: [publish-tag, publish-docker-image] 
     if: contains(inputs.debug, 'false')
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,21 @@ on:
         description: 'executes the workflow in debug mode (skip the publishing tag, docker image and release steps)'
 
 jobs:
-  release:
-    name: Create Release
-    if: github.event.base_ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+  check-permission:
+    name: Check permission
+    if: contains(github.ref, 'refs/heads/master')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Get Version
-        id: get_version
+      - name: Check user permission
+        uses: actions-cool/check-user-permission@v2.2.0
+        id: check
+        with:
+          require: 'write'
+    outputs:
+      hasWritePermission: ${{ steps.check.outputs.require-result }}
+
         run: |
           echo "tag=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF/refs\/tags\/v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
       - name: Build image
         run: |
-          docker build --build-arg DEPLOY_VERSION=${{ needs.publish-tag.outputs.releaseTag }} -t docker.io/prebid/prebid-server:${{ needs.publish-tag.outputs.releaseTag }} .
+          docker build -t docker.io/prebid/prebid-server:${{ needs.publish-tag.outputs.releaseTag }} .
       - name: Login to docker Hub
         if: contains(inputs.debug, 'false')
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           docker build --build-arg DEPLOY_VERSION=${{ needs.publish-tag.outputs.releaseTag }} -t docker.io/prebid/prebid-server:${{ needs.publish-tag.outputs.releaseTag }} .
       - name: Login to docker Hub
         if: contains(inputs.debug, 'false')
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout prebid cache
+      - name: Checkout Prebid Server
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -86,7 +86,7 @@ jobs:
     if: contains(inputs.debug, 'false')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout prebid cache
+      - name: Checkout Prebid Server
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout prebid cache
+      - name: Checkout Prebid Server
         uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,20 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        type: choice
+        options:
+          - minor
+          - patch
+        default: minor
+        required: true
+        description: 'minor: v0.X.0, patch: v0.0.X'
+      debug:
+        type: boolean
+        default: true
+        description: 'executes the workflow in debug mode (skip the publishing tag, docker image and release steps)'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,72 @@ jobs:
     outputs:
       hasWritePermission: ${{ steps.check.outputs.require-result }}
 
-        run: |
-          echo "tag=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_OUTPUT
-          echo "version=${GITHUB_REF/refs\/tags\/v}" >> $GITHUB_OUTPUT
-
-      - name: Create & Publish Release
-        uses: release-drafter/release-drafter@v5.12.1
+  publish-tag:
+    name: Publish tag
+    needs: check-permission
+    if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prebid cache
+        uses: actions/checkout@v3
         with:
-          name: ${{ steps.get_version.outputs.version }}
-          tag: ${{ steps.get_version.outputs.tag }}
-          version: ${{ steps.get_version.outputs.version }}
+          fetch-depth: 0
+      - name: Create & publish tag
+        id: release
+        run: |
+          currentTag=$(git describe --abbrev=0 --tags)
+          echo "Current release tag ${currentTag}"
+
+          echo ${currentTag} | grep -q "^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$"
+          if [ $? -ne 0 ]; then
+            echo "Current tag format won't let us compute the new tag name. Required format v[0-9]\+\.[0-9]\+\.[0-9]\+"
+            exit 1
+          fi
+
+          if [[ "${currentTag:0:1}" != "v" ]]; then
+            currentTag="v${currentTag}"
+          fi
+
+          nextTag=''
+          releaseType=${{ inputs.releaseType }}
+          if [ $releaseType == "minor" ]; then
+            # increment minor version and reset patch version
+            nextTag=$(echo "${currentTag}" | awk -F. '{OFS="."; $2+=1; $3=0; print $0}')
+          else
+            # increment patch version
+            nextTag=$(echo "${currentTag}" | awk -F. '{OFS="."; $3+=1; print $0}')
+          fi
+
+          if [ ${{ inputs.debug }} == 'true' ]; then
+            echo "running workflow in debug mode, next ${releaseType} tag: ${nextTag}"
+          else
+            git tag $nextTag
+            git push origin $nextTag
+            echo "tag=${nextTag}" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      releaseTag: ${{ steps.release.outputs.tag }}
+
+  publish-release:
+    name: Publish release
+    needs: [publish-tag] 
+    if: contains(inputs.debug, 'false')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prebid cache
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Create & publish release
+        uses: release-drafter/release-drafter@v5.22.0
+        with:
+          name: ${{ needs.publish-tag.outputs.releaseTag }}
+          tag: ${{ needs.publish-tag.outputs.releaseTag }}
+          version: ${{ needs.publish-tag.outputs.releaseTag }}
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Today release workflow is executed on tag push event.  PR updates release release workflow to:
- Execute on run manual event with dropdown option to select minor or major release type as input.
- Check if user has write permission. If not then aborts the workflow.
- Based on inputs publishes new tag, release notes and docker image to dockerHub.


## Testing
```
Changes tested on forked repo: https://github.com/onkarvhanumante/prebid-cache
```
Previous release:
<img width="256" height="128" alt="Screenshot 2023-05-11 at 3 15 51 PM" src="https://github.com/prebid/prebid-server/assets/24757781/8f14b0f0-81ce-44f8-8ebd-04e86aac27a7">

Publish new tag:
<img width="256" height="128" alt="Screenshot 2023-05-11 at 3 16 41 PM" src="https://github.com/prebid/prebid-server/assets/24757781/fb08f96c-758d-4cee-a121-b6bd67b7a689">

Publish docker image:
<img width="256" height="128" alt="Screenshot 2023-05-11 at 3 21 11 PM" src="https://github.com/prebid/prebid-server/assets/24757781/305abf15-52a0-45af-989a-6df5fd8a1b28"><img width="256" height="128" alt="Screenshot 2023-05-11 at 3 21 35 PM" src="https://github.com/prebid/prebid-server/assets/24757781/32e6566c-5e50-41cb-a268-112d5bdf5ca9">

Publish release notes:
<img width="256" height="128" alt="Screenshot 2023-05-11 at 3 22 20 PM" src="https://github.com/prebid/prebid-server/assets/24757781/54662dc6-6b8e-464e-8b1c-0d916aa0e4b4">
