### PR TITLE
Appnexus: Add ext_inv_code and external_imp_id parameters

### DIFF
--- a/adapters/appnexus/params_test.go
+++ b/adapters/appnexus/params_test.go
@@ -53,6 +53,8 @@ var validParams = []string{
 	`{"placement_id":123, "keywords":"foo=bar,foo=baz"}`,
 	`{"placement_id":123, "keywords":{"genre": ["rock", "pop"], "pets": ["dog"]}}`,
 	`{"placement_id":123, "use_pmt_rule": true, "private_sizes": [{"w": 300, "h":250}]}`,
+	`{"placementId":123, "ext_inv_code": "invCode"}`,
+	`{"placementId":123, "external_imp_id": "impId"}`,
 }
 
 var invalidParams = []string{
@@ -78,4 +80,6 @@ var invalidParams = []string{
 	`{"placement_id":123, "use_pmt_rule": "true"}`,
 	`{"placement_id":123, "private_sizes": [[300,250]]}`,
 	`{"placement_id":123, "private_sizes": [{"w": "300", "h": "250"}]}`,
+	`{"placementId":123, "ext_inv_code": 1}`,
+	`{"placementId":123, "external_imp_id": 2}`,
 }

--- a/openrtb_ext/imp_appnexus.go
+++ b/openrtb_ext/imp_appnexus.go
@@ -23,8 +23,10 @@ type ExtImpAppnexus struct {
 	UsePaymentRule           *bool                  `json:"use_pmt_rule"`
 	DeprecatedUsePaymentRule *bool                  `json:"use_payment_rule"`
 	// At this time we do no processing on the private sizes, so just leaving it as a JSON blob.
-	PrivateSizes json.RawMessage `json:"private_sizes"`
-	AdPodId      bool            `json:"generate_ad_pod_id"`
+	PrivateSizes  json.RawMessage `json:"private_sizes"`
+	AdPodId       bool            `json:"generate_ad_pod_id"`
+	ExtInvCode    string          `json:"ext_inv_code"`
+	ExternalImpId string          `json:"external_imp_id"`
 }
 
 type ExtImpAppnexusKeywords string

--- a/static/bidder-params/appnexus.json
+++ b/static/bidder-params/appnexus.json
@@ -103,6 +103,14 @@
         "required": [ "w", "h"]
       },
       "description": "Private sizes (ex: [{\"w\": 300, \"h\": 250},{...}]), experimental, may not be supported."
+    },
+    "ext_inv_code" : {
+      "type": "string",
+      "description": "Unique identifier of an externally generated auction"
+    },
+    "external_imp_id" : {
+      "type": "string",
+      "description": "Specifies predefined value passed on the query string that can be used in reporting"
     }
   },
 


### PR DESCRIPTION
This PR adds ext_inv_code and external_imp_id parameters those are currently available in PrebidJS but not in Prebid server. We are adding these parameters for reporting capabilites.