### PR TITLE
imds: Change imds/synacormedia adapter hostname to be static

### DIFF
--- a/adapters/imds/imds.go
+++ b/adapters/imds/imds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"text/template"
 
 	"github.com/prebid/openrtb/v19/openrtb2"
@@ -13,6 +14,8 @@ import (
 	"github.com/prebid/prebid-server/macros"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
+
+const adapterVersion string = "pbs-go/1.0.0"
 
 type adapter struct {
 	EndpointTemplate *template.Template
@@ -127,7 +130,7 @@ func (a *adapter) makeRequest(request *openrtb2.BidRequest) (*adapters.RequestDa
 
 // Builds enpoint url based on adapter-specific pub settings from imp.ext
 func (adapter *adapter) buildEndpointURL(params *openrtb_ext.ExtImpImds) (string, error) {
-	return macros.ResolveMacros(adapter.EndpointTemplate, macros.EndpointTemplateParams{Host: params.SeatId})
+	return macros.ResolveMacros(adapter.EndpointTemplate, macros.EndpointTemplateParams{AccountID: url.QueryEscape(params.SeatId), SourceId: url.QueryEscape(adapterVersion)})
 }
 
 func getExtImpObj(imp *openrtb2.Imp) (*openrtb_ext.ExtImpImds, error) {

--- a/adapters/imds/imds_test.go
+++ b/adapters/imds/imds_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderImds, config.Adapter{
-		Endpoint: "http://{{.Host}}.technoratimedia.com/openrtb/bids/{{.Host}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+		Endpoint: "http://pbs.technoratimedia.com/openrtb/bids/{{.AccountID}}?src={{.SourceId}}&adapter=imds"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/imds/imdstest/exemplary/simple-banner.json
+++ b/adapters/imds/imdstest/exemplary/simple-banner.json
@@ -25,7 +25,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/exemplary/simple-video.json
+++ b/adapters/imds/imdstest/exemplary/simple-video.json
@@ -31,7 +31,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "1",
           "site": {

--- a/adapters/imds/imdstest/supplemental/audio_response.json
+++ b/adapters/imds/imdstest/supplemental/audio_response.json
@@ -20,7 +20,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/bad_response.json
+++ b/adapters/imds/imdstest/supplemental/bad_response.json
@@ -29,7 +29,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/native_response.json
+++ b/adapters/imds/imdstest/supplemental/native_response.json
@@ -20,7 +20,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/one_bad_ext.json
+++ b/adapters/imds/imdstest/supplemental/one_bad_ext.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/status_204.json
+++ b/adapters/imds/imdstest/supplemental/status_204.json
@@ -29,7 +29,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/status_400.json
+++ b/adapters/imds/imdstest/supplemental/status_400.json
@@ -29,7 +29,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/adapters/imds/imdstest/supplemental/status_500.json
+++ b/adapters/imds/imdstest/supplemental/status_500.json
@@ -29,7 +29,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://prebid.technoratimedia.com/openrtb/bids/prebid",
+        "uri": "http://pbs.technoratimedia.com/openrtb/bids/prebid?src=pbs-go%2F1.0.0&adapter=imds",
         "body": {
           "id": "test-request-id",
           "ext": {

--- a/static/bidder-info/imds.yaml
+++ b/static/bidder-info/imds.yaml
@@ -1,4 +1,4 @@
-endpoint: "http://{{.Host}}.technoratimedia.com/openrtb/bids/{{.Host}}"
+endpoint: "https://pbs.technoratimedia.com/openrtb/bids/{{.AccountID}}?src={{.SourceId}}&adapter=imds"
 maintainer:
   email: "eng-demand@imds.tv"
 capabilities:

--- a/static/bidder-info/synacormedia.yaml
+++ b/static/bidder-info/synacormedia.yaml
@@ -1,5 +1,5 @@
 # DEPRECATED: Use imds bidder instead
-endpoint: "http://{{.Host}}.technoratimedia.com/openrtb/bids/{{.Host}}"
+endpoint: "https://pbs.technoratimedia.com/openrtb/bids/{{.AccountID}}?src={{.SourceId}}&adapter=synacormedia"
 maintainer:
   email: "eng-demand@imds.tv"
 capabilities:


### PR DESCRIPTION
imds: Changes the imds/synacormedia adapter hostname to be static (see: https://github.com/prebid/prebid-server/issues/2612) for connection efficiency. Also adds adapter names and version metrics in the request so we can evaluate when to remove the deprecated `synacormedia` adapter based upon usage. Endpoint also utilized https now so HTTP/2 may be negotiated.