### PR TITLE
Fix: floors flakey test

### DIFF
--- a/floors/enforce_test.go
+++ b/floors/enforce_test.go
@@ -661,12 +661,10 @@ func TestEnforce(t *testing.T) {
 	for _, tt := range tests {
 		actEligibleBids, actErrs, actRejecteBids := Enforce(tt.args.bidRequestWrapper, tt.args.seatBids, config.Account{PriceFloors: tt.args.priceFloorsCfg}, tt.args.conversions)
 		assert.Equal(t, tt.expErrs, actErrs, tt.name)
-		if !reflect.DeepEqual(tt.expRejectedBids, actRejecteBids) {
-			assert.Fail(t, tt.name+": rejected bids don't match. Got: ", actRejecteBids)
-		}
+		assert.ElementsMatch(t, tt.expRejectedBids, actRejecteBids, tt.name)
 
 		if !reflect.DeepEqual(tt.expEligibleBids, actEligibleBids) {
-			assert.Fail(t, tt.name+": eligible bids don't match. Got: ", actEligibleBids)
+			assert.Failf(t, "eligible bids don't match", "Expected: %v, Got: %v", tt.expEligibleBids, actEligibleBids)
 		}
 	}
 }

--- a/floors/enforce_test.go
+++ b/floors/enforce_test.go
@@ -575,7 +575,7 @@ func TestEnforce(t *testing.T) {
 					},
 				},
 				conversions:    convert{},
-				priceFloorsCfg: config.AccountPriceFloors{Enabled: true, EnforceFloorsRate: 100, EnforceDealFloors: true},
+				priceFloorsCfg: config.AccountPriceFloors{Enabled: true, EnforceFloorsRate: 0, EnforceDealFloors: true},
 			},
 			expEligibleBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
 				"pubmatic": {
@@ -632,7 +632,7 @@ func TestEnforce(t *testing.T) {
 					},
 				},
 				conversions:    convert{},
-				priceFloorsCfg: config.AccountPriceFloors{Enabled: true, EnforceFloorsRate: 100, EnforceDealFloors: false},
+				priceFloorsCfg: config.AccountPriceFloors{Enabled: true, EnforceFloorsRate: 0, EnforceDealFloors: false},
 			},
 			expEligibleBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
 				"pubmatic": {
@@ -662,11 +662,11 @@ func TestEnforce(t *testing.T) {
 		actEligibleBids, actErrs, actRejecteBids := Enforce(tt.args.bidRequestWrapper, tt.args.seatBids, config.Account{PriceFloors: tt.args.priceFloorsCfg}, tt.args.conversions)
 		assert.Equal(t, tt.expErrs, actErrs, tt.name)
 		if !reflect.DeepEqual(tt.expRejectedBids, actRejecteBids) {
-			assert.Fail(t, "rejected bids don't match")
+			assert.Fail(t, tt.name+": rejected bids don't match. Got: ", actRejecteBids)
 		}
 
 		if !reflect.DeepEqual(tt.expEligibleBids, actEligibleBids) {
-			assert.Fail(t, "eligible bids don't match")
+			assert.Fail(t, tt.name+": eligible bids don't match. Got: ", actEligibleBids)
 		}
 	}
 }


### PR DESCRIPTION
**Current behaviour:** Floors test case fail at random since floor enforcement is based on `rand.Intn`. 
```
--- FAIL: TestEnforce (0.00s)
    enforce_test.go:665: 
        	Error Trace:	/home/runner/work/prebid-server/prebid-server/floors/enforce_test.go:665
        	Error:      	rejected bids don't match
        	Test:       	TestEnforce
```

**Expected behaviour:** Unit tests should be consistent for all runs 

**Solution:** Removed the unit test dependency on `rand.Intn` using `EnforceFloorsRate=0` 