### PR TITLE
Update smartadserver contact info

### DIFF
--- a/static/bidder-info/smartadserver.yaml
+++ b/static/bidder-info/smartadserver.yaml
@@ -1,6 +1,6 @@
 endpoint: "https://ssb-global.smartadserver.com"
 maintainer:
-  email: "support@smartadserver.com"
+  email: "support@equativ.com"
 gvlVendorID: 45
 capabilities:
   app:

--- a/static/bidder-info/smartadserver.yaml
+++ b/static/bidder-info/smartadserver.yaml
@@ -1,6 +1,6 @@
 endpoint: "https://ssb-global.smartadserver.com"
 maintainer:
-  email: "support@equativ.com"
+  email: "supply-partner-integration@equativ.com"
 gvlVendorID: 45
 capabilities:
   app:


### PR DESCRIPTION
SmartAdServer is now owned by Equativ.