### PR TITLE
Optimize SetCookieOnResponse()

### DIFF
--- a/usersync/cookie.go
+++ b/usersync/cookie.go
@@ -163,7 +163,9 @@ func (cookie *Cookie) SetCookieOnResponse(w http.ResponseWriter, setSiteCookie b
 		})
 
 		// Delete elements until we need no more space to free
-		for _, oldestKey := range uuidKeys {
+		var i int = 0
+		for currSize > cfg.MaxCookieSizeBytes && len(cookie.uids) > 0 {
+			oldestKey := uuidKeys[i]
 			delete(cookie.uids, oldestKey)
 
 			httpCookie = cookie.ToHTTPCookie(ttl)
@@ -172,10 +174,7 @@ func (cookie *Cookie) SetCookieOnResponse(w http.ResponseWriter, setSiteCookie b
 			}
 			currSize = len([]byte(httpCookie.String()))
 
-			// If we meet max size, stop
-			if currSize <= cfg.MaxCookieSizeBytes {
-				break
-			}
+			i++
 		}
 	}
 

--- a/usersync/cookie_test.go
+++ b/usersync/cookie_test.go
@@ -318,14 +318,12 @@ func getTestCookie() *Cookie {
 }
 
 func TestTrimCookiesClosestExpirationDates(t *testing.T) {
-	type aTest struct {
+	testCases := []struct {
 		desc          string
 		maxCookieSize int
 		inputCookie   *Cookie
 		expectedUids  []string
-	}
-
-	testCases := []aTest{
+	}{
 		{
 			desc:          "maxCookieSize big enough to fit all uid entries in sample cookie. Don't trim, set",
 			maxCookieSize: 2000,
@@ -364,7 +362,7 @@ func TestTrimCookiesClosestExpirationDates(t *testing.T) {
 		},
 		{
 			desc:          "maxCookieSize big enough to only hold one element: the newest element. Discard the rest",
-			maxCookieSize: 230,
+			maxCookieSize: 260,
 			inputCookie:   getTestCookie(),
 			expectedUids:  []string{"1"},
 		},


### PR DESCRIPTION
As implemented in #1004, function `SetCookieOnResponse()` removes the oldest elements from the `cookie.uids` map if it needs extra space to meet the `cfg.MaxCookieSizeBytes` threshold. But the implementation can be improved. Let:
```
   n = len(cookie.uids)
   m = cookie.uids that need to be removed  so cookieSize <= cfg.MaxCookieSizeBytes
```
The current implementatio has square time complexity `O(n^2)` because m = n in the worst case scenario. This pull request removes the nested for loop in favor of sorting by expiration date so the new time complexity is `O(n*logn)`.
