### PR TITLE
Update `MakeAuctionResponse`  metric computation

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -154,7 +154,7 @@ type ExtraRequestInfo struct {
 
 type MakeBidsTimeInfo struct {
 	AfterMakeBidsStartTime time.Time
-	Durations              []time.Duration
+	TotalDurations         time.Duration
 }
 
 func NewExtraRequestInfo(c currency.Conversions) ExtraRequestInfo {

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -271,7 +271,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	labels, ao = sendAmpResponse(w, hookExecutor, response, reqWrapper, account, labels, ao, errL)
 	if len(ao.Errors) == 0 {
-		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine)
+		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine, time.Since)
 	}
 }
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -2369,7 +2369,12 @@ func generateStoredBidResponseValidationError(impID string) error {
 }
 
 func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo, me metrics.MetricsEngine) {
+	var maxDuration time.Duration
 	for _, info := range mbti {
-		me.RecordOverheadTime(metrics.MakeAuctionResponse, time.Since(info.AfterMakeBidsStartTime)+info.TotalDurations)
+		dur := time.Since(info.AfterMakeBidsStartTime) + info.TotalDurations
+		if maxDuration < dur {
+			maxDuration = dur
+		}
 	}
+	me.RecordOverheadTime(metrics.MakeAuctionResponse, maxDuration)
 }

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -2370,10 +2370,6 @@ func generateStoredBidResponseValidationError(impID string) error {
 
 func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo, me metrics.MetricsEngine) {
 	for _, info := range mbti {
-		duration := time.Since(info.AfterMakeBidsStartTime)
-		for _, makeBidsDuration := range info.Durations {
-			duration += makeBidsDuration
-		}
-		me.RecordOverheadTime(metrics.MakeAuctionResponse, duration)
+		me.RecordOverheadTime(metrics.MakeAuctionResponse, time.Since(info.AfterMakeBidsStartTime)+info.TotalDurations)
 	}
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prebid/prebid-server/hooks/hookexecution"
 	"github.com/prebid/prebid-server/hooks/hookstage"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	analyticsConf "github.com/prebid/prebid-server/analytics/config"
 	"github.com/prebid/prebid-server/config"
@@ -5560,10 +5559,19 @@ func (e mockStageExecutor) GetOutcomes() []hookexecution.StageOutcome {
 }
 
 func TestRecordResponsePreparationMetrics(t *testing.T) {
+	ns1 := 30 * time.Millisecond
+	ns2 := 40 * time.Millisecond
+	ns3 := 10 * time.Millisecond
+	ns4 := 15 * time.Millisecond
+	makeBidsStartTime1 := time.Date(2023, 1, 1, 1, 0, 0, int(ns1), time.UTC)
+	makeBidsStartTime2 := time.Date(2023, 1, 1, 1, 0, 0, int(ns2), time.UTC)
 	mbi := map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo{
-		openrtb_ext.BidderAppnexus: {TotalDurations: 15, AfterMakeBidsStartTime: time.Now()},
+		openrtb_ext.BidderAppnexus: {TotalDurations: ns3, AfterMakeBidsStartTime: makeBidsStartTime1},
+		openrtb_ext.BidderAMX:      {TotalDurations: ns4, AfterMakeBidsStartTime: makeBidsStartTime2},
 	}
+	nowTime := time.Date(2023, 1, 1, 1, 0, 0, int(50*time.Millisecond), time.UTC)
+	sinceFn := func(t time.Time) time.Duration { return nowTime.Sub(t) }
 	mockMetricEngine := &metrics.MetricsEngineMock{}
-	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, mock.Anything)
-	recordResponsePreparationMetrics(mbi, mockMetricEngine)
+	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, 30*time.Millisecond)
+	recordResponsePreparationMetrics(mbi, mockMetricEngine, sinceFn)
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -5561,7 +5561,7 @@ func (e mockStageExecutor) GetOutcomes() []hookexecution.StageOutcome {
 
 func TestRecordResponsePreparationMetrics(t *testing.T) {
 	mbi := map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo{
-		openrtb_ext.BidderAppnexus: {Durations: []time.Duration{10, 15}, AfterMakeBidsStartTime: time.Now()},
+		openrtb_ext.BidderAppnexus: {TotalDurations: 15, AfterMakeBidsStartTime: time.Now()},
 	}
 	mockMetricEngine := &metrics.MetricsEngineMock{}
 	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, mock.Anything)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -355,7 +355,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	}
 
 	if len(vo.Errors) == 0 {
-		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine)
+		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine, time.Since)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -373,7 +373,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 					errs = append(errs, err)
 				}
 			}
-			reqInfo.MakeBidsTimeInfo.Durations = append(reqInfo.MakeBidsTimeInfo.Durations, time.Since(startTime))
+			reqInfo.MakeBidsTimeInfo.TotalDurations += time.Since(startTime)
 		} else {
 			errs = append(errs, httpInfo.err)
 		}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -111,7 +111,7 @@ func TestSingleBidder(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
+		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.TotalDurations)
 		assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 
 		assert.Len(t, seatBids, 1)
@@ -237,7 +237,7 @@ func TestSingleBidderGzip(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
+		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.TotalDurations)
 		assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 		assert.Len(t, seatBids, 1)
 		seatBid := seatBids[0]
@@ -352,7 +352,7 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.TotalDurations)
 	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCalls)
 }
@@ -407,7 +407,7 @@ func TestSetGPCHeader(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.TotalDurations)
 	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)
 }
@@ -459,7 +459,7 @@ func TestSetGPCHeaderNil(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.TotalDurations)
 	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.Len(t, seatBids, 1)
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -178,7 +178,7 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	cacheWriteTimeBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1}
 	priceBuckets := []float64{250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
 	queuedRequestTimeBuckets := []float64{0, 1, 5, 30, 60, 120, 180, 240, 300}
-	overheadTimeBuckets := []float64{0.00005, 0.0001, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.05}
+	overheadTimeBuckets := []float64{0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1}
 
 	metrics := Metrics{}
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
PR makes following changes:

- Refactor MakeAuctionResponse histogram metric bucket size
- Sum bidder taking longest time to MakeBid bid and PBS preparation time into `MakeAuctionResponse` metric
- Also some unit test changes

