### PR TITLE
Implement tmax adjustment

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/config"
@@ -146,15 +145,8 @@ func (r *RequestData) SetBasicAuth(username string, password string) {
 
 type ExtraRequestInfo struct {
 	PbsEntryPoint              metrics.RequestType
-	BidderRequestStartTime     time.Time
 	GlobalPrivacyControlHeader string
 	CurrencyConversions        currency.Conversions
-	MakeBidsTimeInfo           MakeBidsTimeInfo
-}
-
-type MakeBidsTimeInfo struct {
-	AfterMakeBidsStartTime time.Time
-	Durations              []time.Duration
 }
 
 func NewExtraRequestInfo(c currency.Conversions) ExtraRequestInfo {

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -271,7 +271,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	labels, ao = sendAmpResponse(w, hookExecutor, response, reqWrapper, account, labels, ao, errL)
 	if len(ao.Errors) == 0 {
-		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine)
+		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine, time.Since)
 	}
 }
 

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -239,6 +239,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 		HookExecutor:               hookExecutor,
 		QueryParams:                r.URL.Query(),
 		TCF2Config:                 tcf2Config,
+		TmaxAdjustments:            &deps.cfg.TmaxAdjustments,
 	}
 
 	response, err := deps.ex.HoldAuction(ctx, auctionRequest, nil)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -233,6 +233,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		PubID:                      labels.PubID,
 		HookExecutor:               hookExecutor,
 		TCF2Config:                 tcf2Config,
+		TmaxAdjustments:            &deps.cfg.TmaxAdjustments,
 	}
 	response, err := deps.ex.HoldAuction(ctx, auctionRequest, nil)
 	ao.Request = req.BidRequest

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -2368,11 +2368,12 @@ func generateStoredBidResponseValidationError(impID string) error {
 }
 
 func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]exchange.MakeBidsTimeInfo, me metrics.MetricsEngine) {
+	var maxDuration time.Duration
 	for _, info := range mbti {
-		duration := time.Since(info.AfterMakeBidsStartTime)
-		for _, makeBidsDuration := range info.Durations {
-			duration += makeBidsDuration
+		duration := time.Since(info.AfterMakeBidsStartTime) + info.TotalDuration
+		if duration > time.Duration(maxDuration) {
+			maxDuration = duration
 		}
-		me.RecordOverheadTime(metrics.MakeAuctionResponse, duration)
 	}
+	me.RecordOverheadTime(metrics.MakeAuctionResponse, maxDuration)
 }

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -24,7 +24,6 @@ import (
 	nativeRequests "github.com/prebid/openrtb/v19/native1/request"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/openrtb/v19/openrtb3"
-	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/bidadjustment"
 	"github.com/prebid/prebid-server/hooks"
 	"github.com/prebid/prebid-server/ortb"
@@ -2368,7 +2367,7 @@ func generateStoredBidResponseValidationError(impID string) error {
 	return fmt.Errorf("request validation failed. Stored bid responses are specified for imp %s. Bidders specified in imp.ext should match with bidders specified in imp.ext.prebid.storedbidresponse", impID)
 }
 
-func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo, me metrics.MetricsEngine) {
+func recordResponsePreparationMetrics(mbti map[openrtb_ext.BidderName]exchange.MakeBidsTimeInfo, me metrics.MetricsEngine) {
 	for _, info := range mbti {
 		duration := time.Since(info.AfterMakeBidsStartTime)
 		for _, makeBidsDuration := range info.Durations {

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -5560,7 +5560,7 @@ func (e mockStageExecutor) GetOutcomes() []hookexecution.StageOutcome {
 
 func TestRecordResponsePreparationMetrics(t *testing.T) {
 	mbi := map[openrtb_ext.BidderName]exchange.MakeBidsTimeInfo{
-		openrtb_ext.BidderAppnexus: {Durations: []time.Duration{10, 15}, AfterMakeBidsStartTime: time.Now()},
+		openrtb_ext.BidderAppnexus: {TotalDuration: 25, AfterMakeBidsStartTime: time.Now()},
 	}
 	mockMetricEngine := &metrics.MetricsEngineMock{}
 	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, mock.Anything)

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prebid/prebid-server/hooks/hookexecution"
 	"github.com/prebid/prebid-server/hooks/hookstage"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	analyticsConf "github.com/prebid/prebid-server/analytics/config"
 	"github.com/prebid/prebid-server/config"
@@ -5559,10 +5558,19 @@ func (e mockStageExecutor) GetOutcomes() []hookexecution.StageOutcome {
 }
 
 func TestRecordResponsePreparationMetrics(t *testing.T) {
+	ns1 := 30 * time.Millisecond
+	ns2 := 40 * time.Millisecond
+	ns3 := 10 * time.Millisecond
+	ns4 := 15 * time.Millisecond
+	makeBidsStartTime1 := time.Date(2023, 1, 1, 1, 0, 0, int(ns1), time.UTC)
+	makeBidsStartTime2 := time.Date(2023, 1, 1, 1, 0, 0, int(ns2), time.UTC)
 	mbi := map[openrtb_ext.BidderName]exchange.MakeBidsTimeInfo{
-		openrtb_ext.BidderAppnexus: {TotalDuration: 25, AfterMakeBidsStartTime: time.Now()},
+		openrtb_ext.BidderAppnexus: {TotalDuration: ns3, AfterMakeBidsStartTime: makeBidsStartTime1},
+		openrtb_ext.BidderAMX:      {TotalDuration: ns4, AfterMakeBidsStartTime: makeBidsStartTime2},
 	}
+	nowTime := time.Date(2023, 1, 1, 1, 0, 0, int(50*time.Millisecond), time.UTC)
+	sinceFn := func(t time.Time) time.Duration { return nowTime.Sub(t) }
 	mockMetricEngine := &metrics.MetricsEngineMock{}
-	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, mock.Anything)
-	recordResponsePreparationMetrics(mbi, mockMetricEngine)
+	mockMetricEngine.On("RecordOverheadTime", metrics.MakeAuctionResponse, 30*time.Millisecond)
+	recordResponsePreparationMetrics(mbi, mockMetricEngine, sinceFn)
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prebid/openrtb/v19/native1"
 	nativeRequests "github.com/prebid/openrtb/v19/native1/request"
 	"github.com/prebid/openrtb/v19/openrtb2"
-	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/analytics"
 	"github.com/prebid/prebid-server/hooks"
 	"github.com/prebid/prebid-server/hooks/hookexecution"
@@ -5560,7 +5559,7 @@ func (e mockStageExecutor) GetOutcomes() []hookexecution.StageOutcome {
 }
 
 func TestRecordResponsePreparationMetrics(t *testing.T) {
-	mbi := map[openrtb_ext.BidderName]adapters.MakeBidsTimeInfo{
+	mbi := map[openrtb_ext.BidderName]exchange.MakeBidsTimeInfo{
 		openrtb_ext.BidderAppnexus: {Durations: []time.Duration{10, 15}, AfterMakeBidsStartTime: time.Now()},
 	}
 	mockMetricEngine := &metrics.MetricsEngineMock{}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -355,7 +355,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 	}
 
 	if len(vo.Errors) == 0 {
-		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine)
+		recordResponsePreparationMetrics(auctionRequest.MakeBidsTimeInfo, deps.metricsEngine, time.Since)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -307,6 +307,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		GlobalPrivacyControlHeader: secGPC,
 		PubID:                      labels.PubID,
 		HookExecutor:               hookexecution.EmptyHookExecutor{},
+		TmaxAdjustments:            &deps.cfg.TmaxAdjustments,
 	}
 
 	response, err := deps.ex.HoldAuction(ctx, auctionRequest, &debugLog)

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -73,7 +73,7 @@ type bidRequestOptions struct {
 
 type MakeBidsTimeInfo struct {
 	AfterMakeBidsStartTime time.Time
-	Durations              []time.Duration
+	TotalDuration          time.Duration
 }
 
 const ImpIdReqBody = "Stored bid response for impression id: "
@@ -380,7 +380,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 					errs = append(errs, err)
 				}
 			}
-			bidRequestOptions.makeBidsTimeInfo.Durations = append(bidRequestOptions.makeBidsTimeInfo.Durations, time.Since(startTime))
+			bidRequestOptions.makeBidsTimeInfo.TotalDuration += time.Since(startTime)
 		} else {
 			errs = append(errs, httpInfo.err)
 		}

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -240,6 +240,11 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 
 		if httpInfo.err == nil {
 			startTime := time.Now()
+			// Reducing the amount of time bidders have to compensate for the processing time used by PBS to fetch a stored request (if needed), validate the OpenRTB request and split it into multiple requests sanitized for each bidder.
+			// As well as for the time needed by PBS to prepare the auction response
+			if bidRequestOptions.tmaxAdjustments != nil && bidRequestOptions.tmaxAdjustments.Enabled && bidRequestOptions.tmaxAdjustments.BidderResponseDurationMin > 0 {
+				bidderRequest.BidRequest.TMax = getBidderTmax(&bidderTmaxCtx{ctx}, bidderRequest.BidRequest.TMax, *bidRequestOptions.tmaxAdjustments)
+			}
 			bidResponse, moreErrs := bidder.Bidder.MakeBids(bidderRequest.BidRequest, httpInfo.request, httpInfo.response)
 			errs = append(errs, moreErrs...)
 
@@ -716,4 +721,25 @@ func getBidTypeForAdjustments(bidType openrtb_ext.BidType, impID string, imp []o
 		return "video-instream"
 	}
 	return string(bidType)
+}
+
+type bidderTmaxContext interface {
+	Deadline() (deadline time.Time, ok bool)
+	RemainingDurationMS(deadline time.Time) int64
+}
+type bidderTmaxCtx struct{ ctx context.Context }
+
+func (b *bidderTmaxCtx) RemainingDurationMS(deadline time.Time) int64 {
+	return time.Until(deadline).Milliseconds()
+}
+func (b *bidderTmaxCtx) Deadline() (deadline time.Time, ok bool) {
+	deadline, ok = b.ctx.Deadline()
+	return
+}
+
+func getBidderTmax(ctx bidderTmaxContext, requestTmaxMS int64, tmaxAdjustments config.TmaxAdjustments) int64 {
+	if deadline, ok := ctx.Deadline(); ok {
+		return ctx.RemainingDurationMS(deadline) - int64(tmaxAdjustments.BidderNetworkLatencyBuffer) - int64(tmaxAdjustments.PBSResponsePreparationDuration)
+	}
+	return requestTmaxMS
 }

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -69,6 +69,7 @@ type bidRequestOptions struct {
 	bidAdjustments         map[string]float64
 	makeBidsTimeInfo       MakeBidsTimeInfo
 	bidderRequestStartTime time.Time
+	tmaxAdjustments        *config.TmaxAdjustments
 }
 
 type MakeBidsTimeInfo struct {

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -58,7 +58,7 @@ type AdaptedBidder interface {
 	//
 	// Any errors will be user-facing in the API.
 	// Error messages should help publishers understand what might account for "bad" bids.
-	requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error)
+	requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error)
 }
 
 // bidRequestOptions holds additional options for bid request execution to maintain clean code and reasonable number of parameters
@@ -117,7 +117,7 @@ type bidderAdapterConfig struct {
 	EndpointCompression string
 }
 
-func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
+func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
 	reject := hookExecutor.ExecuteBidderRequestStage(bidderRequest.BidRequest, string(bidderRequest.BidderName))
 	if reject != nil {
 		return nil, []error{reject}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -111,8 +111,8 @@ func TestSingleBidder(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
-		assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
+		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+		assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 
 		assert.Len(t, seatBids, 1)
 		seatBid := seatBids[0]
@@ -237,8 +237,8 @@ func TestSingleBidderGzip(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
-		assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
+		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+		assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 		assert.Len(t, seatBids, 1)
 		seatBid := seatBids[0]
 
@@ -352,8 +352,8 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
-	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCalls)
 }
 
@@ -407,8 +407,8 @@ func TestSetGPCHeader(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
-	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)
 }
 
@@ -459,8 +459,8 @@ func TestSetGPCHeaderNil(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.NotEmpty(t, extraInfo.MakeBidsTimeInfo.Durations)
-	assert.False(t, extraInfo.MakeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.Len(t, seatBids, 1)
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)
 }

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -111,7 +111,7 @@ func TestSingleBidder(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.TotalDuration)
 		assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 
 		assert.Len(t, seatBids, 1)
@@ -237,7 +237,7 @@ func TestSingleBidderGzip(t *testing.T) {
 		}
 		extraInfo := &adapters.ExtraRequestInfo{}
 		seatBids, errs := bidder.requestBid(ctx, bidderReq, currencyConverter.Rates(), extraInfo, &adscert.NilSigner{}, bidReqOptions, openrtb_ext.ExtAlternateBidderCodes{}, &hookexecution.EmptyHookExecutor{}, nil)
-		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+		assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.TotalDuration)
 		assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 		assert.Len(t, seatBids, 1)
 		seatBid := seatBids[0]
@@ -352,7 +352,7 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.TotalDuration)
 	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCalls)
 }
@@ -407,7 +407,7 @@ func TestSetGPCHeader(t *testing.T) {
 
 	assert.Empty(t, errs)
 	assert.Len(t, seatBids, 1)
-	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.TotalDuration)
 	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)
 }
@@ -459,7 +459,7 @@ func TestSetGPCHeaderNil(t *testing.T) {
 	}
 
 	assert.Empty(t, errs)
-	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.Durations)
+	assert.NotEmpty(t, bidReqOptions.makeBidsTimeInfo.TotalDuration)
 	assert.False(t, bidReqOptions.makeBidsTimeInfo.AfterMakeBidsStartTime.IsZero())
 	assert.Len(t, seatBids, 1)
 	assert.ElementsMatch(t, seatBids[0].HttpCalls, expectedHttpCall)

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -103,7 +103,7 @@ func TestSingleBidder(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: "test",
 		}
-		bidReqOptions := bidRequestOptions{
+		bidReqOptions := &bidRequestOptions{
 			accountDebugAllowed: true,
 			headerDebugAllowed:  false,
 			addCallSignHeader:   false,
@@ -229,7 +229,7 @@ func TestSingleBidderGzip(t *testing.T) {
 			BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 			BidderName: "test",
 		}
-		bidReqOptions := bidRequestOptions{
+		bidReqOptions := &bidRequestOptions{
 			accountDebugAllowed: true,
 			headerDebugAllowed:  false,
 			addCallSignHeader:   false,
@@ -332,7 +332,7 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 		BidderName: "test",
 	}
 	bidAdjustments := map[string]float64{"test": 1}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -386,7 +386,7 @@ func TestSetGPCHeader(t *testing.T) {
 		BidderName: "test",
 	}
 	bidAdjustments := map[string]float64{"test": 1}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -439,7 +439,7 @@ func TestSetGPCHeaderNil(t *testing.T) {
 		BidderName: "test",
 	}
 	bidAdjustments := map[string]float64{"test": 1}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -512,7 +512,7 @@ func TestMultiBidder(t *testing.T) {
 		BidderName: "test",
 	}
 	bidAdjustments := map[string]float64{"test": 1.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  true,
 		addCallSignHeader:   false,
@@ -891,7 +891,7 @@ func TestMultiCurrencies(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  true,
 				addCallSignHeader:   false,
@@ -1051,7 +1051,7 @@ func TestMultiCurrencies_RateConverterNotSet(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  true,
 				addCallSignHeader:   false,
@@ -1230,7 +1230,7 @@ func TestMultiCurrencies_RequestCurrencyPick(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  false,
 				addCallSignHeader:   false,
@@ -1548,7 +1548,7 @@ func TestMobileNativeTypes(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  true,
 				addCallSignHeader:   false,
@@ -1668,7 +1668,7 @@ func TestRequestBidsStoredBidResponses(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  true,
 				addCallSignHeader:   false,
@@ -1783,7 +1783,7 @@ func TestFledge(t *testing.T) {
 			currencyConverter.Rates(),
 			&adapters.ExtraRequestInfo{},
 			&adscert.NilSigner{},
-			bidRequestOptions{
+			&bidRequestOptions{
 				accountDebugAllowed: true,
 				headerDebugAllowed:  true,
 				addCallSignHeader:   false,
@@ -1809,7 +1809,7 @@ func TestErrorReporting(t *testing.T) {
 		BidderName: "test",
 	}
 	bidAdjustments := map[string]float64{"test": 1.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -2043,7 +2043,7 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 		BidRequest: &openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "impId"}}},
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  true,
 		addCallSignHeader:   false,
@@ -2290,7 +2290,7 @@ func TestRequestBidsWithAdsCertsSigner(t *testing.T) {
 	}
 	ctx := context.Background()
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 2.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,
@@ -2503,7 +2503,7 @@ func TestExtraBid(t *testing.T) {
 	}
 
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 2.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,
@@ -2617,7 +2617,7 @@ func TestExtraBidWithAlternateBidderCodeDisabled(t *testing.T) {
 		BidderName: openrtb_ext.BidderPubmatic,
 	}
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 2.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,
@@ -2728,7 +2728,7 @@ func TestExtraBidWithBidAdjustments(t *testing.T) {
 		"groupm":                           3,
 	}
 
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,
@@ -2841,7 +2841,7 @@ func TestExtraBidWithBidAdjustmentsUsingAdapterCode(t *testing.T) {
 		string(openrtb_ext.BidderPubmatic): 2,
 	}
 
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,
@@ -2966,7 +2966,7 @@ func TestExtraBidWithMultiCurrencies(t *testing.T) {
 	}
 
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 2.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: false,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   true,

--- a/exchange/bidder_validate_bids.go
+++ b/exchange/bidder_validate_bids.go
@@ -31,7 +31,7 @@ type validatedBidder struct {
 	bidder AdaptedBidder
 }
 
-func (v *validatedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
+func (v *validatedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
 	seatBids, errs := v.bidder.requestBid(ctx, bidderRequest, conversions, reqInfo, adsCertSigner, bidRequestOptions, alternateBidderCodes, hookExecutor, ruleToAdjustments)
 	for _, seatBid := range seatBids {
 		if validationErrors := removeInvalidBids(bidderRequest.BidRequest, seatBid); len(validationErrors) > 0 {

--- a/exchange/bidder_validate_bids_test.go
+++ b/exchange/bidder_validate_bids_test.go
@@ -59,7 +59,7 @@ func TestAllValidBids(t *testing.T) {
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -129,7 +129,7 @@ func TestAllBadBids(t *testing.T) {
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -210,7 +210,7 @@ func TestMixedBids(t *testing.T) {
 		BidderName: openrtb_ext.BidderAppnexus,
 	}
 	bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
-	bidReqOptions := bidRequestOptions{
+	bidReqOptions := &bidRequestOptions{
 		accountDebugAllowed: true,
 		headerDebugAllowed:  false,
 		addCallSignHeader:   false,
@@ -339,7 +339,7 @@ func TestCurrencyBids(t *testing.T) {
 		bidderRequest := BidderRequest{BidRequest: request, BidderName: openrtb_ext.BidderAppnexus}
 
 		bidAdjustments := map[string]float64{string(openrtb_ext.BidderAppnexus): 1.0}
-		bidReqOptions := bidRequestOptions{
+		bidReqOptions := &bidRequestOptions{
 			accountDebugAllowed: true,
 			headerDebugAllowed:  false,
 			addCallSignHeader:   false,
@@ -357,6 +357,6 @@ type mockAdaptedBidder struct {
 	errorResponse []error
 }
 
-func (b *mockAdaptedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
+func (b *mockAdaptedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, []error) {
 	return b.bidResponse, b.errorResponse
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -688,7 +688,7 @@ func (e *exchange) getAllBids(
 			reqInfo.GlobalPrivacyControlHeader = globalPrivacyControlHeader
 			reqInfo.BidderRequestStartTime = start
 
-			bidReqOptions := bidRequestOptions{
+			bidReqOptions := &bidRequestOptions{
 				accountDebugAllowed: accountDebugAllowed,
 				headerDebugAllowed:  headerDebugAllowed,
 				addCallSignHeader:   isAdsCertEnabled(experiment, e.bidderInfo[string(bidderRequest.BidderName)]),

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -5266,7 +5266,7 @@ type validatingBidder struct {
 	mockResponses map[string]bidderResponse
 }
 
-func (b *validatingBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) (seatBids []*entities.PbsOrtbSeatBid, errs []error) {
+func (b *validatingBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) (seatBids []*entities.PbsOrtbSeatBid, errs []error) {
 	if expectedRequest, ok := b.expectations[string(bidderRequest.BidderName)]; ok {
 		if expectedRequest != nil {
 			if !reflect.DeepEqual(expectedRequest.BidAdjustments, bidRequestOptions.bidAdjustments) {
@@ -5432,7 +5432,7 @@ func (e *emptyUsersync) HasAnyLiveSyncs() bool {
 
 type panicingAdapter struct{}
 
-func (panicingAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) (posb []*entities.PbsOrtbSeatBid, errs []error) {
+func (panicingAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata *bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) (posb []*entities.PbsOrtbSeatBid, errs []error) {
 	panic("Panic! Panic! The world is ending!")
 }
 

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -178,7 +178,7 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	cacheWriteTimeBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1}
 	priceBuckets := []float64{250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
 	queuedRequestTimeBuckets := []float64{0, 1, 5, 30, 60, 120, 180, 240, 300}
-	overheadTimeBuckets := []float64{0.00005, 0.0001, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.05}
+	overheadTimeBuckets := []float64{0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1}
 
 	metrics := Metrics{}
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
PR makes following tmax adjustment related change:
- Prefer bidRequestOptions for makeBidsTimeInfo and bidderRequestStartTime
   - d20dac8dcf38500c458c5db27b23924a7d7f2fbc 50560eb759ac7019722b1635cad30d7edbb9e494
- Fix PBS preparation time calculation
   - bd800ad468f014c67931e3ceba83e8f7f80f969b 759583bbae86e9d19512dae1254e6751b1c1f8e6
- Use tmax values only to decide whether to send request
   - 3b27cb286520378e776de06b75c64e71c6134b6a 2ad0b8408fd211214a36f2323f0844a4cebbdfef
- Pass updated tmax to bidder by updating bidderRequest.Tmax field (passed in bidder 's MakeRequest() implementation)
    - 28e9517d72fe1c1f44bc7d9ebd1a51cbd81d1833
- Also Update bucket size for make auction response metric
   - a7fa64a75ac202eeb28027a4b67e148eb7d5e94d

Recommended to review changes commit by commit
