### PR TITLE
Enable GPP support for PubMatic adapter

### DIFF
--- a/static/bidder-info/pubmatic.yaml
+++ b/static/bidder-info/pubmatic.yaml
@@ -21,3 +21,5 @@ userSync:
   redirect:
     url: "https://image8.pubmatic.com/AdServer/ImgSync?p=159706&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&pu={{.RedirectURL}}"
     userMacro: "#PMUID"
+openrtb:
+  gpp-supported: true


### PR DESCRIPTION
enabling `gpp-support` flag in bidderinfo.yaml under `openrtb`

