### PR TITLE
Sharethrough: Support multiformat bid request impression

### DIFF
--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -163,6 +163,10 @@ func splitImpressionsByMediaType(impression *openrtb2.Imp) ([]openrtb2.Imp, erro
 		return nil, &errortypes.BadInput{Message: "Invalid MediaType. Sharethrough only supports Banner, Video and Native."}
 	}
 
+	if impression.Audio != nil {
+		impression.Audio = nil
+	}
+
 	impressions := make([]openrtb2.Imp, 0, 3)
 
 	if impression.Banner != nil {

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -83,21 +83,29 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 		requestCopy.BCat = append(requestCopy.BCat, strImpParams.BCat...)
 		requestCopy.BAdv = append(requestCopy.BAdv, strImpParams.BAdv...)
 
-		requestCopy.Imp = []openrtb2.Imp{imp}
-
-		requestJSON, err := json.Marshal(requestCopy)
+		impressionsByMediaType, err := splitImpressionsByMediaType(&imp)
 		if err != nil {
 			errors = append(errors, err)
 			continue
 		}
 
-		requestData := &adapters.RequestData{
-			Method:  "POST",
-			Uri:     a.endpoint,
-			Body:    requestJSON,
-			Headers: headers,
+		for _, impression := range impressionsByMediaType {
+			requestCopy.Imp = []openrtb2.Imp{impression}
+
+			requestJSON, err := json.Marshal(requestCopy)
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+
+			requestData := &adapters.RequestData{
+				Method:  "POST",
+				Uri:     a.endpoint,
+				Body:    requestJSON,
+				Headers: headers,
+			}
+			requests = append(requests, requestData)
 		}
-		requests = append(requests, requestData)
 	}
 
 	return requests, errors
@@ -148,6 +156,36 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	}
 
 	return bidderResponse, errors
+}
+
+func splitImpressionsByMediaType(impression *openrtb2.Imp) ([]openrtb2.Imp, error) {
+	if impression.Banner == nil && impression.Video == nil && impression.Native == nil {
+		return nil, &errortypes.BadInput{Message: "Invalid MediaType. Sharethrough only supports Banner, Video and Native."}
+	}
+
+	impressions := make([]openrtb2.Imp, 0, 3)
+
+	if impression.Banner != nil {
+		impCopy := *impression
+		impCopy.Video = nil
+		impCopy.Native = nil
+		impressions = append(impressions, impCopy)
+	}
+
+	if impression.Video != nil {
+		impCopy := *impression
+		impCopy.Banner = nil
+		impCopy.Native = nil
+		impressions = append(impressions, impCopy)
+	}
+
+	if impression.Native != nil {
+		impression.Banner = nil
+		impression.Video = nil
+		impressions = append(impressions, *impression)
+	}
+
+	return impressions, nil
 }
 
 func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {

--- a/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
+++ b/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
@@ -1,0 +1,251 @@
+{
+  "mockBidRequest": {
+    "id": "web-banner",
+    "tmax": 3000,
+    "imp": [
+      {
+        "id": "banner-imp-id-1",
+        "ext": {
+          "bidder": {
+            "pkey": "pkey1"
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        }
+      },
+      {
+        "id": "banner-imp-id-2",
+        "ext": {
+          "bidder": {
+            "pkey": "pkey2"
+          }
+        },
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        }
+      }
+    ],
+    "site": {
+      "publisher": {
+        "id": "1"
+      },
+      "page": "https://some-site.com",
+      "ref": "https://some-site.com"
+    },
+    "device": {
+      "w": 1200,
+      "h": 900
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://whatever.url",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "body": {
+          "id": "web-banner",
+          "tmax": 3000,
+          "imp": [
+            {
+              "id": "banner-imp-id-1",
+              "tagid": "pkey1",
+              "ext": {
+                "bidder": {
+                  "pkey": "pkey1"
+                }
+              },
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              }
+            }
+          ],
+          "site": {
+            "publisher": {
+              "id": "1"
+            },
+            "page": "https://some-site.com",
+            "ref": "https://some-site.com"
+          },
+          "device": {
+            "w": 1200,
+            "h": 900
+          },
+          "source": {
+            "ext": {
+              "version": "",
+              "str": "10.0"
+            }
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "web-banner",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "web-banner",
+                  "impid": "banner-imp-id-1",
+                  "crid": "some-creative-id",
+                  "adm": "<div>Ad</div>",
+                  "price": 20,
+                  "w": 300,
+                  "h": 250,
+                  "ext": {
+                    "prebid": {
+                      "type": "banner"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "expectedRequest": {
+        "uri": "http://whatever.url",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "body": {
+          "id": "web-banner",
+          "tmax": 3000,
+          "imp": [
+            {
+              "id": "banner-imp-id-2",
+              "tagid": "pkey2",
+              "ext": {
+                "bidder": {
+                  "pkey": "pkey2"
+                }
+              },
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ]
+              }
+            }
+          ],
+          "site": {
+            "publisher": {
+              "id": "1"
+            },
+            "page": "https://some-site.com",
+            "ref": "https://some-site.com"
+          },
+          "device": {
+            "w": 1200,
+            "h": 900
+          },
+          "source": {
+            "ext": {
+              "version": "",
+              "str": "10.0"
+            }
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "web-banner",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "web-banner",
+                  "impid": "banner-imp-id-2",
+                  "crid": "some-creative-id",
+                  "adm": "<div>Ad</div>",
+                  "price": 20,
+                  "w": 300,
+                  "h": 600,
+                  "ext": {
+                    "prebid": {
+                      "type": "banner"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "web-banner",
+            "impid": "banner-imp-id-1",
+            "crid": "some-creative-id",
+            "adm": "<div>Ad</div>",
+            "price": 20,
+            "w": 300,
+            "h": 250,
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    },
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "web-banner",
+            "impid": "banner-imp-id-2",
+            "crid": "some-creative-id",
+            "adm": "<div>Ad</div>",
+            "price": 20,
+            "w": 300,
+            "h": 600,
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
+++ b/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
@@ -29,6 +29,15 @@
         "native": {
           "ver": "1.2",
           "request": "placeholder request"
+        },
+        "audio": {
+          "mimes": [
+            "audio/mp4"
+          ],
+          "protocols": [
+            1,
+            2
+          ]
         }
       }
     ],

--- a/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
+++ b/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
@@ -1,10 +1,10 @@
 {
   "mockBidRequest": {
-    "id": "web-banner",
+    "id": "parent-id",
     "tmax": 3000,
     "imp": [
       {
-        "id": "banner-imp-id-1",
+        "id": "impression-id",
         "ext": {
           "bidder": {
             "pkey": "pkey1"
@@ -19,16 +19,12 @@
           ]
         },
         "video": {
+          "w": 640,
+          "h": 480,
           "mimes": [
             "video/mp4"
           ],
-          "maxduration": 30,
-          "protocols": [
-            2,
-            3
-          ],
-          "w": 640,
-          "h": 480
+          "placement": 1
         }
       }
     ],
@@ -57,11 +53,11 @@
           ]
         },
         "body": {
-          "id": "web-banner",
+          "id": "parent-id",
           "tmax": 3000,
           "imp": [
             {
-              "id": "banner-imp-id-1",
+              "id": "impression-id",
               "tagid": "pkey1",
               "ext": {
                 "bidder": {
@@ -100,14 +96,14 @@
       "mockResponse": {
         "status": 200,
         "body": {
-          "id": "web-banner",
+          "id": "parent-id",
           "cur": "USD",
           "seatbid": [
             {
               "bid": [
                 {
-                  "id": "web-banner",
-                  "impid": "banner-imp-id-1",
+                  "id": "parent-id",
+                  "impid": "impression-id",
                   "crid": "some-creative-id",
                   "adm": "<div>Ad</div>",
                   "price": 20,
@@ -137,24 +133,24 @@
           ]
         },
         "body": {
-          "id": "web-banner",
+          "id": "parent-id",
           "tmax": 3000,
           "imp": [
             {
-              "id": "banner-imp-id-2",
-              "tagid": "pkey2",
+              "id": "impression-id",
+              "tagid": "pkey1",
               "ext": {
                 "bidder": {
-                  "pkey": "pkey2"
+                  "pkey": "pkey1"
                 }
               },
-              "banner": {
-                "format": [
-                  {
-                    "w": 300,
-                    "h": 600
-                  }
-                ]
+              "video": {
+                "w": 640,
+                "h": 480,
+                "mimes": [
+                  "video/mp4"
+                ],
+                "placement": 1
               }
             }
           ],
@@ -180,22 +176,22 @@
       "mockResponse": {
         "status": 200,
         "body": {
-          "id": "web-banner",
+          "id": "parent-id",
           "cur": "USD",
           "seatbid": [
             {
               "bid": [
                 {
-                  "id": "web-banner",
-                  "impid": "banner-imp-id-2",
+                  "id": "parent-id",
+                  "impid": "impression-id",
                   "crid": "some-creative-id",
-                  "adm": "<div>Ad</div>",
+                  "adm": "<VAST>TAG</VAST>",
                   "price": 20,
-                  "w": 300,
-                  "h": 600,
+                  "w": 640,
+                  "h": 480,
                   "ext": {
                     "prebid": {
-                      "type": "banner"
+                      "type": "video"
                     }
                   }
                 }
@@ -212,8 +208,8 @@
       "bids": [
         {
           "bid": {
-            "id": "web-banner",
-            "impid": "banner-imp-id-1",
+            "id": "parent-id",
+            "impid": "impression-id",
             "crid": "some-creative-id",
             "adm": "<div>Ad</div>",
             "price": 20,
@@ -234,20 +230,20 @@
       "bids": [
         {
           "bid": {
-            "id": "web-banner",
-            "impid": "banner-imp-id-2",
+            "id": "parent-id",
+            "impid": "impression-id",
             "crid": "some-creative-id",
-            "adm": "<div>Ad</div>",
+            "adm": "<VAST>TAG</VAST>",
             "price": 20,
-            "w": 300,
-            "h": 600,
+            "w": 640,
+            "h": 480,
             "ext": {
               "prebid": {
-                "type": "banner"
+                "type": "video"
               }
             }
           },
-          "type": "banner"
+          "type": "video"
         }
       ]
     }

--- a/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
+++ b/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
@@ -17,22 +17,18 @@
               "h": 250
             }
           ]
-        }
-      },
-      {
-        "id": "banner-imp-id-2",
-        "ext": {
-          "bidder": {
-            "pkey": "pkey2"
-          }
         },
-        "banner": {
-          "format": [
-            {
-              "w": 300,
-              "h": 600
-            }
-          ]
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "maxduration": 30,
+          "protocols": [
+            2,
+            3
+          ],
+          "w": 640,
+          "h": 480
         }
       }
     ],
@@ -53,8 +49,12 @@
       "expectedRequest": {
         "uri": "http://whatever.url",
         "headers": {
-          "Content-Type": ["application/json;charset=utf-8"],
-          "Accept": ["application/json"]
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
         },
         "body": {
           "id": "web-banner",
@@ -129,8 +129,12 @@
       "expectedRequest": {
         "uri": "http://whatever.url",
         "headers": {
-          "Content-Type": ["application/json;charset=utf-8"],
-          "Accept": ["application/json"]
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
         },
         "body": {
           "id": "web-banner",

--- a/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
+++ b/adapters/sharethrough/sharethroughtest/supplemental/multiformat-impression.json
@@ -25,6 +25,10 @@
             "video/mp4"
           ],
           "placement": 1
+        },
+        "native": {
+          "ver": "1.2",
+          "request": "placeholder request"
         }
       }
     ],
@@ -200,6 +204,82 @@
           ]
         }
       }
+    },
+    {
+      "expectedRequest": {
+        "uri": "http://whatever.url",
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "body": {
+          "id": "parent-id",
+          "tmax": 3000,
+          "imp": [
+            {
+              "id": "impression-id",
+              "tagid": "pkey1",
+              "ext": {
+                "bidder": {
+                  "pkey": "pkey1"
+                }
+              },
+              "native": {
+                "ver": "1.2",
+                "request": "placeholder request"
+              }
+            }
+          ],
+          "site": {
+            "publisher": {
+              "id": "1"
+            },
+            "page": "https://some-site.com",
+            "ref": "https://some-site.com"
+          },
+          "device": {
+            "w": 1200,
+            "h": 900
+          },
+          "source": {
+            "ext": {
+              "version": "",
+              "str": "10.0"
+            }
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "parent-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "parent-id",
+                  "impid": "impression-id",
+                  "crid": "some-creative-id",
+                  "adm": "<div>Ad</div>",
+                  "price": 20,
+                  "w": 640,
+                  "h": 480,
+                  "ext": {
+                    "prebid": {
+                      "type": "native"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   ],
   "expectedBidResponses": [
@@ -244,6 +324,28 @@
             }
           },
           "type": "video"
+        }
+      ]
+    },
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "parent-id",
+            "impid": "impression-id",
+            "crid": "some-creative-id",
+            "adm": "<div>Ad</div>",
+            "price": 20,
+            "w": 640,
+            "h": 480,
+            "ext": {
+              "prebid": {
+                "type": "native"
+              }
+            }
+          },
+          "type": "native"
         }
       ]
     }


### PR DESCRIPTION
# Before:

For an ad unit that supports multiple formats (e.g. banner, video and native), our adapter would send a single request towards Sharethrough that included all the formats. Sharethrough's adserver couldn't handle it

# After:
We split the single request into multiple requests by media type (format). For each format, the adapter sends 1 request and receives 1 response.
From the point of view of Prebid, we have 2 responses corresponding to the same ad unit and it picks a winner as usual.

## Explanation for the test JSON:

EDIT: Now there's a 3rd format, but you get the idea

![image](https://github.com/prebid/prebid-server/assets/118775839/37cb5ad7-cc63-426f-8afb-3644dd43621f)
![image](https://github.com/prebid/prebid-server/assets/118775839/ab3526e6-19c7-488e-bfd2-05fff6d1987e)
