### PR TITLE
Exchange unit test fix

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2085,7 +2085,7 @@ func getTestBuildRequest(t *testing.T) *openrtb2.BidRequest {
 					H: 600,
 				}},
 			},
-			Ext: json.RawMessage(`{"ext_field":"value}"}`),
+			Ext: json.RawMessage(`{"prebid":{"bidder":{"appnexus": {"placementId": 1}}}}`),
 		}, {
 			Video: &openrtb2.Video{
 				MIMEs:       []string{"video/mp4"},
@@ -2094,7 +2094,7 @@ func getTestBuildRequest(t *testing.T) *openrtb2.BidRequest {
 				W:           300,
 				H:           600,
 			},
-			Ext: json.RawMessage(`{"ext_field":"value}"}`),
+			Ext: json.RawMessage(`{"prebid":{"bidder":{"appnexus": {"placementId": 1}}}}`),
 		}},
 	}
 }

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -505,7 +505,7 @@ func TestCleanOpenRTBRequestsWithFPD(t *testing.T) {
 		App:  &openrtb2.App{Name: "fpdApnApp"},
 		User: &openrtb2.User{Keywords: "fpdApnUser"},
 	}
-	fpd[openrtb_ext.BidderName("appnexus")] = &apnFpd
+	fpd[openrtb_ext.BidderName("rubicon")] = &apnFpd
 
 	brightrollFpd := firstpartydata.ResolvedFirstPartyData{
 		Site: &openrtb2.Site{Name: "fpdBrightrollSite"},


### PR DESCRIPTION
Unit test set up function `getTestBuildRequest` had invalid imp.ext: `{"ext_field":"value}"}` and no bid requests were returned from `cleanOpenRTBRequests` func in `TestCleanOpenRTBRequestsWithFPD`. 
`imp.ext` should have a valid bidder in order to return requests. 