### PR TITLE
GDPR: support bidders without a GVL ID

### DIFF
--- a/gdpr/consent_parser.go
+++ b/gdpr/consent_parser.go
@@ -53,10 +53,6 @@ func validateVersions(pc api.VendorConsents) (err error) {
 	if version != 2 {
 		return fmt.Errorf("invalid encoding format version: %d", version)
 	}
-	policyVersion := pc.TCFPolicyVersion()
-	if policyVersion > 4 {
-		return fmt.Errorf("invalid TCF policy version: %d", policyVersion)
-	}
 	return
 }
 
@@ -64,11 +60,8 @@ func validateVersions(pc api.VendorConsents) (err error) {
 // version that should be used to calculate legal basis. A zero value is returned if the policy version
 // is invalid
 func getSpecVersion(policyVersion uint8) uint16 {
-	if policyVersion == 4 {
+	if policyVersion >= 4 {
 		return 3
 	}
-	if policyVersion < 4 {
-		return 2
-	}
-	return 0
+	return 2
 }

--- a/gdpr/consent_parser.go
+++ b/gdpr/consent_parser.go
@@ -13,55 +13,44 @@ import (
 // metadata object that allows easy examination of encoded purpose and vendor information
 type parsedConsent struct {
 	encodingVersion uint8
-	specVersion     uint16
 	listVersion     uint16
+	specVersion     uint16
 	consentMeta     tcf2.ConsentMetadata
 }
 
 // parseConsent parses and validates the specified consent string returning an instance of parsedConsent
-func parseConsent(consent string) (parsedConsent, error) {
-	pc := parsedConsent{}
-
-	parsedConsent, err := vendorconsent.ParseString(consent)
+func parseConsent(consent string) (*parsedConsent, error) {
+	pc, err := vendorconsent.ParseString(consent)
 	if err != nil {
-		err = &ErrorMalformedConsent{
+		return nil, &ErrorMalformedConsent{
 			Consent: consent,
 			Cause:   err,
 		}
-		return pc, err
 	}
-
-	err = validateVersions(parsedConsent)
-	if err != nil {
-		err = &ErrorMalformedConsent{
+	if err = validateVersions(pc); err != nil {
+		return nil, &ErrorMalformedConsent{
 			Consent: consent,
 			Cause:   err,
 		}
-		return pc, err
 	}
-
-	pc.encodingVersion = parsedConsent.Version()
-	if pc.encodingVersion == 1 {
-		return pc, nil
-	}
-
-	pc.specVersion = getSpecVersion(parsedConsent.TCFPolicyVersion())
-	pc.listVersion = parsedConsent.VendorListVersion()
-	cm, ok := parsedConsent.(tcf2.ConsentMetadata)
+	cm, ok := pc.(tcf2.ConsentMetadata)
 	if !ok {
 		err = errors.New("Unable to access TCF2 parsed consent")
-		return pc, err
+		return nil, err
 	}
-	pc.consentMeta = cm
-
-	return pc, nil
+	return &parsedConsent{
+		encodingVersion: pc.Version(),
+		listVersion:     pc.VendorListVersion(),
+		specVersion:     getSpecVersion(pc.TCFPolicyVersion()),
+		consentMeta:     cm,
+	}, nil
 }
 
 // validateVersions ensures that certain version fields in the consent string contain valid values.
 // An error is returned if at least one of them is invalid
 func validateVersions(pc api.VendorConsents) (err error) {
 	version := pc.Version()
-	if version != 1 && version != 2 {
+	if version != 2 {
 		return fmt.Errorf("invalid encoding format version: %d", version)
 	}
 	policyVersion := pc.TCFPolicyVersion()

--- a/gdpr/consent_parser.go
+++ b/gdpr/consent_parser.go
@@ -1,0 +1,85 @@
+package gdpr
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prebid/go-gdpr/api"
+	"github.com/prebid/go-gdpr/vendorconsent"
+	tcf2 "github.com/prebid/go-gdpr/vendorconsent/tcf2"
+)
+
+// parsedConsent represents a parsed consent string containing notable version information and a convenient
+// metadata object that allows easy examination of encoded purpose and vendor information
+type parsedConsent struct {
+	encodingVersion uint8
+	specVersion     uint16
+	listVersion     uint16
+	consentMeta     tcf2.ConsentMetadata
+}
+
+// parseConsent parses and validates the specified consent string returning an instance of parsedConsent
+func parseConsent(consent string) (parsedConsent, error) {
+	pc := parsedConsent{}
+
+	parsedConsent, err := vendorconsent.ParseString(consent)
+	if err != nil {
+		err = &ErrorMalformedConsent{
+			Consent: consent,
+			Cause:   err,
+		}
+		return pc, err
+	}
+
+	err = validateVersions(parsedConsent)
+	if err != nil {
+		err = &ErrorMalformedConsent{
+			Consent: consent,
+			Cause:   err,
+		}
+		return pc, err
+	}
+
+	pc.encodingVersion = parsedConsent.Version()
+	if pc.encodingVersion == 1 {
+		return pc, nil
+	}
+
+	pc.specVersion = getSpecVersion(parsedConsent.TCFPolicyVersion())
+	pc.listVersion = parsedConsent.VendorListVersion()
+	cm, ok := parsedConsent.(tcf2.ConsentMetadata)
+	if !ok {
+		err = errors.New("Unable to access TCF2 parsed consent")
+		return pc, err
+	}
+	pc.consentMeta = cm
+
+	return pc, nil
+}
+
+// validateVersions ensures that certain version fields in the consent string contain valid values.
+// An error is returned if at least one of them is invalid
+func validateVersions(pc api.VendorConsents) (err error) {
+	version := pc.Version()
+	if version != 1 && version != 2 {
+		return fmt.Errorf("invalid encoding format version: %d", version)
+	}
+	policyVersion := pc.TCFPolicyVersion()
+	if policyVersion > 4 {
+		return fmt.Errorf("invalid TCF policy version: %d", policyVersion)
+	}
+	return
+}
+
+// getSpecVersion looks at the TCF policy version and determines the corresponding GVL specification
+// version that should be used to calculate legal basis. A zero value is returned if the policy version
+// is invalid
+func getSpecVersion(policyVersion uint8) uint16 {
+	if policyVersion == 4 {
+		return 3
+	}
+	if policyVersion < 4 {
+		return 2
+	}
+	return 0
+}

--- a/gdpr/consent_parser_test.go
+++ b/gdpr/consent_parser_test.go
@@ -1,0 +1,171 @@
+package gdpr
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prebid/go-gdpr/consentconstants"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConsent(t *testing.T) {
+	consentValid := "CPuKGCPPuKGCPNEAAAENCZCAAAAAAAAAAAAAAAAAAAAA"
+	consentWithInvalidPolicyVersion := "CPuKGCPPuKGCPNEAAAENCZFAAAAAAAAAAAAAAAAAAAAA"
+
+	tests := []struct {
+		name                    string
+		consent                 string
+		expectedEncodingVersion uint8
+		expectedListVersion     uint16
+		expectedSpecVersion     uint16
+		expectedError           error
+	}{
+
+		{
+			name:                    "valid_consent_with_encoding_version_2",
+			consent:                 consentValid,
+			expectedEncodingVersion: 2,
+			expectedListVersion:     153,
+			expectedSpecVersion:     2,
+		},
+		{
+			name:    "invalid_consent_parsing_error",
+			consent: "",
+			expectedError: &ErrorMalformedConsent{
+				Consent: "",
+				Cause:   consentconstants.ErrEmptyDecodedConsent,
+			},
+		},
+		{
+			name:    "invalid_consent_version_validation_error",
+			consent: consentWithInvalidPolicyVersion,
+			expectedError: &ErrorMalformedConsent{
+				Consent: consentWithInvalidPolicyVersion,
+				Cause:   errors.New("invalid TCF policy version: 5"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedConsent, err := parseConsent(tt.consent)
+
+			if tt.expectedError != nil {
+				assert.Equal(t, tt.expectedError, err)
+				assert.Nil(t, parsedConsent)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, parsedConsent)
+				assert.Equal(t, uint8(2), parsedConsent.encodingVersion)
+				assert.Equal(t, uint16(153), parsedConsent.listVersion)
+				assert.Equal(t, uint16(2), parsedConsent.specVersion)
+				assert.Equal(t, tt.expectedEncodingVersion, parsedConsent.consentMeta.Version())
+				assert.Equal(t, tt.expectedListVersion, parsedConsent.consentMeta.VendorListVersion())
+			}
+		})
+	}
+}
+
+func TestValidateVersions(t *testing.T) {
+	tests := []struct {
+		name           string
+		consentVersion uint8
+		policyVersion  uint8
+		expectedError  error
+	}{
+		{
+			name:           "valid_versions_consent=2_and_policy<=4",
+			consentVersion: 2,
+			policyVersion:  4,
+		},
+		{
+			name:           "invalid_versions_consent<>2_and_policy<=4",
+			consentVersion: 3,
+			policyVersion:  4,
+			expectedError:  errors.New("invalid encoding format version: 3"),
+		},
+		{
+			name:           "invalid_versions_consent=2_and_policy>4",
+			consentVersion: 2,
+			policyVersion:  5,
+			expectedError:  errors.New("invalid TCF policy version: 5"),
+		},
+		{
+			name:           "invalid_versions_consent<>2_and_policy>4",
+			consentVersion: 3,
+			policyVersion:  5,
+			expectedError:  errors.New("invalid encoding format version: 3"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcs := mockConsentString{
+				version:       tt.consentVersion,
+				policyVersion: tt.policyVersion,
+			}
+			err := validateVersions(&mcs)
+			if tt.expectedError != nil {
+				assert.Equal(t, tt.expectedError, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSpecVersion(t *testing.T) {
+	tests := []struct {
+		name                string
+		policyVersion       uint8
+		expectedSpecVersion uint16
+	}{
+		{
+			name:                "policy_version_0_gives_spec_version_2",
+			policyVersion:       0,
+			expectedSpecVersion: 2,
+		},
+		{
+			name:                "policy_version_3_gives_spec_version_2",
+			policyVersion:       3,
+			expectedSpecVersion: 2,
+		},
+		{
+			name:                "policy_version_4_spec_version_3",
+			policyVersion:       4,
+			expectedSpecVersion: 3,
+		},
+		{
+			name:                "policy_version_5_error",
+			policyVersion:       5,
+			expectedSpecVersion: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specVersion := getSpecVersion(tt.policyVersion)
+			assert.Equal(t, tt.expectedSpecVersion, specVersion)
+		})
+	}
+}
+
+type mockConsentString struct {
+	version       uint8
+	policyVersion uint8
+}
+
+func (mcs *mockConsentString) Version() uint8                                  { return mcs.version }
+func (mcs *mockConsentString) Created() time.Time                              { return time.Time{} }
+func (mcs *mockConsentString) LastUpdated() time.Time                          { return time.Time{} }
+func (mcs *mockConsentString) CmpID() uint16                                   { return 0 }
+func (mcs *mockConsentString) CmpVersion() uint16                              { return 0 }
+func (mcs *mockConsentString) ConsentScreen() uint8                            { return 0 }
+func (mcs *mockConsentString) ConsentLanguage() string                         { return "" }
+func (mcs *mockConsentString) VendorListVersion() uint16                       { return 0 }
+func (mcs *mockConsentString) TCFPolicyVersion() uint8                         { return mcs.policyVersion }
+func (mcs *mockConsentString) MaxVendorID() uint16                             { return 0 }
+func (mcs *mockConsentString) PurposeAllowed(id consentconstants.Purpose) bool { return false }
+func (mcs *mockConsentString) VendorConsent(id uint16) bool                    { return false }

--- a/gdpr/consent_parser_test.go
+++ b/gdpr/consent_parser_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestParseConsent(t *testing.T) {
-	consentValid := "CPuKGCPPuKGCPNEAAAENCZCAAAAAAAAAAAAAAAAAAAAA"
-	consentWithInvalidPolicyVersion := "CPuKGCPPuKGCPNEAAAENCZFAAAAAAAAAAAAAAAAAAAAA"
+	validTCF1Consent := "BONV8oqONXwgmADACHENAO7pqzAAppY"
+	validTCF2Consent := "CPuKGCPPuKGCPNEAAAENCZCAAAAAAAAAAAAAAAAAAAAA"
 
 	tests := []struct {
 		name                    string
@@ -25,7 +25,7 @@ func TestParseConsent(t *testing.T) {
 
 		{
 			name:                    "valid_consent_with_encoding_version_2",
-			consent:                 consentValid,
+			consent:                 validTCF2Consent,
 			expectedEncodingVersion: 2,
 			expectedListVersion:     153,
 			expectedSpecVersion:     2,
@@ -40,10 +40,10 @@ func TestParseConsent(t *testing.T) {
 		},
 		{
 			name:    "invalid_consent_version_validation_error",
-			consent: consentWithInvalidPolicyVersion,
+			consent: validTCF1Consent,
 			expectedError: &ErrorMalformedConsent{
-				Consent: consentWithInvalidPolicyVersion,
-				Cause:   errors.New("invalid TCF policy version: 5"),
+				Consent: validTCF1Consent,
+				Cause:   errors.New("invalid encoding format version: 1"),
 			},
 		},
 	}
@@ -70,41 +70,30 @@ func TestParseConsent(t *testing.T) {
 
 func TestValidateVersions(t *testing.T) {
 	tests := []struct {
-		name           string
-		consentVersion uint8
-		policyVersion  uint8
-		expectedError  error
+		name          string
+		version       uint8
+		expectedError error
 	}{
 		{
-			name:           "valid_versions_consent=2_and_policy<=4",
-			consentVersion: 2,
-			policyVersion:  4,
+			name:    "valid_consent_version=2",
+			version: 2,
 		},
 		{
-			name:           "invalid_versions_consent<>2_and_policy<=4",
-			consentVersion: 3,
-			policyVersion:  4,
-			expectedError:  errors.New("invalid encoding format version: 3"),
+			name:          "invalid_consent_version<2",
+			version:       1,
+			expectedError: errors.New("invalid encoding format version: 1"),
 		},
 		{
-			name:           "invalid_versions_consent=2_and_policy>4",
-			consentVersion: 2,
-			policyVersion:  5,
-			expectedError:  errors.New("invalid TCF policy version: 5"),
-		},
-		{
-			name:           "invalid_versions_consent<>2_and_policy>4",
-			consentVersion: 3,
-			policyVersion:  5,
-			expectedError:  errors.New("invalid encoding format version: 3"),
+			name:          "invalid_consent_version>2",
+			version:       3,
+			expectedError: errors.New("invalid encoding format version: 3"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcs := mockConsentString{
-				version:       tt.consentVersion,
-				policyVersion: tt.policyVersion,
+				version: tt.version,
 			}
 			err := validateVersions(&mcs)
 			if tt.expectedError != nil {
@@ -133,14 +122,14 @@ func TestGetSpecVersion(t *testing.T) {
 			expectedSpecVersion: 2,
 		},
 		{
-			name:                "policy_version_4_spec_version_3",
+			name:                "policy_version_4_gives_spec_version_3",
 			policyVersion:       4,
 			expectedSpecVersion: 3,
 		},
 		{
-			name:                "policy_version_5_error",
+			name:                "policy_version_5_gives_spec_version_3",
 			policyVersion:       5,
-			expectedSpecVersion: 0,
+			expectedSpecVersion: 3,
 		},
 	}
 

--- a/gdpr/full_enforcement.go
+++ b/gdpr/full_enforcement.go
@@ -67,6 +67,9 @@ func (fe *FullEnforcement) applyEnforceOverrides(overrides Overrides) (enforcePu
 // must declare the purpose as either consent or flex and the user must consent in accordance with
 // the purpose configs.
 func (fe *FullEnforcement) consentEstablished(consent tcf2.ConsentMetadata, vi VendorInfo, enforcePurpose bool, enforceVendors bool) bool {
+	if vi.vendor == nil {
+		return false
+	}
 	if !vi.vendor.Purpose(fe.cfg.PurposeID) {
 		return false
 	}
@@ -84,6 +87,9 @@ func (fe *FullEnforcement) consentEstablished(consent tcf2.ConsentMetadata, vi V
 // established, the vendor must declare the purpose as either legit interest or flex and the user
 // must have been provided notice for the legit interest basis in accordance with the purpose configs.
 func (fe *FullEnforcement) legitInterestEstablished(consent tcf2.ConsentMetadata, vi VendorInfo, enforcePurpose bool, enforceVendors bool) bool {
+	if vi.vendor == nil {
+		return false
+	}
 	if !vi.vendor.LegitimateInterest(fe.cfg.PurposeID) {
 		return false
 	}

--- a/gdpr/full_enforcement_test.go
+++ b/gdpr/full_enforcement_test.go
@@ -898,6 +898,66 @@ func TestLegalBasisWithPubRestrictionRequireLI(t *testing.T) {
 	}
 }
 
+func TestLegalBasisWithoutVendor(t *testing.T) {
+	P1P2P3PurposeConsent := "CPfCRQAPfCRQAAAAAAENCgCAAOAAAAAAAAAAAAAAAAAA"
+	tests := []struct{
+		name       string
+		config     purposeConfig
+		wantResult bool
+	}{
+		{
+			name: "enforce_purpose_&_vendors_off",
+			config: purposeConfig{
+				EnforcePurpose: false,
+				EnforceVendors: false,
+			},
+			wantResult: true,
+		},
+		{
+			name: "enforce_purpose_on,_bidder_is_a_vendor_exception",
+			config: purposeConfig{
+				EnforcePurpose:     true,
+				EnforceVendors:     false,
+				VendorExceptionMap: map[openrtb_ext.BidderName]struct{}{openrtb_ext.BidderAppnexus: {}},
+			},
+			wantResult: true,
+		},
+		{
+			name: "enforce_purpose_on",
+			config: purposeConfig{
+				EnforcePurpose: true,
+				EnforceVendors: false,
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// convert consent string to TCF2 object
+			parsedConsent, err := vendorconsent.ParseString(P1P2P3PurposeConsent)
+			if err != nil {
+				t.Fatalf("Failed to parse consent %s\n", P1P2P3PurposeConsent)
+			}
+			consentMeta, ok := parsedConsent.(tcf2.ConsentMetadata)
+			if !ok {
+				t.Fatalf("Failed to convert consent %s\n", P1P2P3PurposeConsent)
+			}
+
+			vendorInfo := VendorInfo{
+				vendorID: 32,
+				vendor: nil,
+			}
+
+			enforcer := FullEnforcement{cfg: tt.config}
+			enforcer.cfg.PurposeID = consentconstants.Purpose(3)
+
+			result := enforcer.LegalBasis(vendorInfo, openrtb_ext.BidderAppnexus, consentMeta, Overrides{})
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
 func getVendorList(t *testing.T) vendorlist.VendorList {
 	GVL := makeVendorList()
 

--- a/gdpr/full_enforcement_test.go
+++ b/gdpr/full_enforcement_test.go
@@ -900,7 +900,7 @@ func TestLegalBasisWithPubRestrictionRequireLI(t *testing.T) {
 
 func TestLegalBasisWithoutVendor(t *testing.T) {
 	P1P2P3PurposeConsent := "CPfCRQAPfCRQAAAAAAENCgCAAOAAAAAAAAAAAAAAAAAA"
-	tests := []struct{
+	tests := []struct {
 		name       string
 		config     purposeConfig
 		wantResult bool
@@ -946,7 +946,7 @@ func TestLegalBasisWithoutVendor(t *testing.T) {
 
 			vendorInfo := VendorInfo{
 				vendorID: 32,
-				vendor: nil,
+				vendor:   nil,
 			}
 
 			enforcer := FullEnforcement{cfg: tt.config}

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -2,12 +2,9 @@ package gdpr
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
-	"github.com/prebid/go-gdpr/vendorconsent"
 	tcf2 "github.com/prebid/go-gdpr/vendorconsent/tcf2"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
@@ -63,53 +60,32 @@ func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCo
 	if _, ok := p.nonStandardPublishers[p.publisherID]; ok {
 		return AllowAll, nil
 	}
-
 	if p.gdprSignal != SignalYes {
 		return AllowAll, nil
 	}
-
 	if p.consent == "" {
 		return p.defaultPermissions(), nil
 	}
-
-	// note the bidder here is guaranteed to be enabled
-	vendorID, vendorFound := p.resolveVendorID(bidderCoreName, bidder)
-	basicEnforcementVendors := p.cfg.BasicEnforcementVendors()
-	_, weakVendorEnforcement := basicEnforcementVendors[string(bidder)]
-
-	if !vendorFound && !weakVendorEnforcement {
-		return DenyAll, nil
-	}
-
-	parsedConsent, vendor, err := p.parseVendor(ctx, vendorID, p.consent)
+	pc, err := parseConsent(p.consent)
 	if err != nil {
 		return p.defaultPermissions(), err
 	}
-
-	// vendor will be nil if not a valid TCF2 consent string
-	if vendor == nil {
-		if weakVendorEnforcement && parsedConsent.Version() == 2 {
-			vendor = vendorTrue{}
-		} else {
-			return p.defaultPermissions(), nil
-		}
+	// TCF1 strings are not treated as an error
+	if pc.encodingVersion == 1 {
+		return p.defaultPermissions(), nil
 	}
 
-	if !p.cfg.IsEnabled() {
-		return AllowBidRequestOnly, nil
-	}
-
-	consentMeta, ok := parsedConsent.(tcf2.ConsentMetadata)
-	if !ok {
-		err = fmt.Errorf("Unable to access TCF2 parsed consent")
+	vendorID, _ := p.resolveVendorID(bidderCoreName, bidder)
+	vendor, err := p.getVendor(ctx, vendorID, pc)
+	if err != nil {
 		return p.defaultPermissions(), err
 	}
-
 	vendorInfo := VendorInfo{vendorID: vendorID, vendor: vendor}
+
 	permissions = AuctionPermissions{}
-	permissions.AllowBidRequest = p.allowBidRequest(bidderCoreName, consentMeta, vendorInfo)
-	permissions.PassGeo = p.allowGeo(bidderCoreName, consentMeta, vendor)
-	permissions.PassID = p.allowID(bidderCoreName, consentMeta, vendorInfo)
+	permissions.AllowBidRequest = p.allowBidRequest(bidderCoreName, pc.consentMeta, vendorInfo)
+	permissions.PassGeo = p.allowGeo(bidderCoreName, pc.consentMeta, vendor)
+	permissions.PassID = p.allowID(bidderCoreName, pc.consentMeta, vendorInfo)
 
 	return permissions, nil
 }
@@ -148,34 +124,28 @@ func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, bidder
 	if p.consent == "" {
 		return false, nil
 	}
-
-	parsedConsent, vendor, err := p.parseVendor(ctx, vendorID, p.consent)
+	pc, err := parseConsent(p.consent)
 	if err != nil {
 		return false, err
 	}
-
-	if vendor == nil {
+	vendor, err := p.getVendor(ctx, vendorID, pc)
+	if err != nil {
 		return false, nil
 	}
+	vendorInfo := VendorInfo{vendorID: vendorID, vendor: vendor}
 
 	if !p.cfg.PurposeEnforced(consentconstants.Purpose(1)) {
 		return true, nil
 	}
-	consentMeta, ok := parsedConsent.(tcf2.ConsentMetadata)
-	if !ok {
-		err := errors.New("Unable to access TCF2 parsed consent")
-		return false, err
-	}
 
-	if p.cfg.PurposeOneTreatmentEnabled() && consentMeta.PurposeOneTreatment() {
+	if p.cfg.PurposeOneTreatmentEnabled() && pc.consentMeta.PurposeOneTreatment() {
 		return p.cfg.PurposeOneTreatmentAccessAllowed(), nil
 	}
 
 	purpose := consentconstants.Purpose(1)
 	enforcer := p.purposeEnforcerBuilder(purpose, bidder)
 
-	vendorInfo := VendorInfo{vendorID: vendorID, vendor: vendor}
-	if enforcer.LegalBasis(vendorInfo, bidder, consentMeta, Overrides{blockVendorExceptions: !vendorException}) {
+	if enforcer.LegalBasis(vendorInfo, bidder, pc.consentMeta, Overrides{blockVendorExceptions: !vendorException}) {
 		return true, nil
 	}
 	return false, nil
@@ -205,7 +175,7 @@ func (p *permissionsImpl) allowGeo(bidder openrtb_ext.BidderName, consentMeta tc
 
 	basicEnforcementVendors := p.cfg.BasicEnforcementVendors()
 	_, weakVendorEnforcement := basicEnforcementVendors[string(bidder)]
-	return consentMeta.SpecialFeatureOptIn(1) && (vendor.SpecialFeature(1) || weakVendorEnforcement)
+	return consentMeta.SpecialFeatureOptIn(1) && ((vendor != nil && vendor.SpecialFeature(1)) || weakVendorEnforcement)
 }
 
 // allowID computes the pass user ID activity legal basis for a given bidder using the enforcement algorithms
@@ -229,53 +199,13 @@ func (p *permissionsImpl) allowID(bidder openrtb_ext.BidderName, consentMeta tcf
 	return false
 }
 
-// parseVendor parses the consent string and fetches the specified vendor's information from the GVL
-func (p *permissionsImpl) parseVendor(ctx context.Context, vendorID uint16, consent string) (parsedConsent api.VendorConsents, vendor api.Vendor, err error) {
-	parsedConsent, err = vendorconsent.ParseString(consent)
+// getVendor...
+func (p *permissionsImpl) getVendor(ctx context.Context, vendorID uint16, pc parsedConsent) (api.Vendor, error) {
+	vendorList, err := p.fetchVendorList(ctx, pc.specVersion, pc.listVersion)
 	if err != nil {
-		err = &ErrorMalformedConsent{
-			Consent: consent,
-			Cause:   err,
-		}
-		return
+		return nil, err
 	}
-
-	version := parsedConsent.Version()
-	if version != 2 {
-		return
-	}
-
-	policyVersion := parsedConsent.TCFPolicyVersion()
-	specVersion, err := getSpecVersion(policyVersion)
-	if err != nil {
-		err = &ErrorMalformedConsent{
-			Consent: consent,
-			Cause:   err,
-		}
-		return
-	}
-
-	vendorList, err := p.fetchVendorList(ctx, uint16(specVersion), parsedConsent.VendorListVersion())
-	if err != nil {
-		return
-	}
-
-	vendor = vendorList.Vendor(vendorID)
-	return
-}
-
-// getSpecVersion looks at the TCF policy version and determines the corresponding GVL specification
-// version that should be used to calculate legal basis
-func getSpecVersion(policyVersion uint8) (uint16, error) {
-	var specVersion uint16 = 3
-
-	if policyVersion > 4 {
-		return 0, fmt.Errorf("invalid TCF policy version %d", policyVersion)
-	}
-	if policyVersion < 4 {
-		specVersion = 2
-	}
-	return specVersion, nil
+	return vendorList.Vendor(vendorID), nil
 }
 
 // AllowHostCookies represents a GDPR permissions policy with host cookie syncing always allowed
@@ -299,26 +229,4 @@ func (a AlwaysAllow) BidderSyncAllowed(ctx context.Context, bidder openrtb_ext.B
 }
 func (a AlwaysAllow) AuctionActivitiesAllowed(ctx context.Context, bidderCoreName openrtb_ext.BidderName, bidder openrtb_ext.BidderName) (permissions AuctionPermissions, err error) {
 	return AllowAll, nil
-}
-
-// vendorTrue claims everything.
-type vendorTrue struct{}
-
-func (v vendorTrue) Purpose(purposeID consentconstants.Purpose) bool {
-	return true
-}
-func (v vendorTrue) PurposeStrict(purposeID consentconstants.Purpose) bool {
-	return true
-}
-func (v vendorTrue) LegitimateInterest(purposeID consentconstants.Purpose) bool {
-	return true
-}
-func (v vendorTrue) LegitimateInterestStrict(purposeID consentconstants.Purpose) bool {
-	return true
-}
-func (v vendorTrue) SpecialFeature(featureID consentconstants.SpecialFeature) (hasSpecialFeature bool) {
-	return true
-}
-func (v vendorTrue) SpecialPurpose(purposeID consentconstants.Purpose) (hasSpecialPurpose bool) {
-	return true
 }

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -194,7 +194,7 @@ func (p *permissionsImpl) allowID(bidder openrtb_ext.BidderName, consentMeta tcf
 	return false
 }
 
-// getVendor...
+// getVendor retrieves the GVL vendor information for a particular bidder
 func (p *permissionsImpl) getVendor(ctx context.Context, vendorID uint16, pc parsedConsent) (api.Vendor, error) {
 	vendorList, err := p.fetchVendorList(ctx, pc.specVersion, pc.listVersion)
 	if err != nil {

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -70,11 +70,6 @@ func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCo
 	if err != nil {
 		return p.defaultPermissions(), err
 	}
-	// TCF1 strings are not treated as an error
-	if pc.encodingVersion == 1 {
-		return p.defaultPermissions(), nil
-	}
-
 	vendorID, _ := p.resolveVendorID(bidderCoreName, bidder)
 	vendor, err := p.getVendor(ctx, vendorID, *pc)
 	if err != nil {

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -76,7 +76,7 @@ func (p *permissionsImpl) AuctionActivitiesAllowed(ctx context.Context, bidderCo
 	}
 
 	vendorID, _ := p.resolveVendorID(bidderCoreName, bidder)
-	vendor, err := p.getVendor(ctx, vendorID, pc)
+	vendor, err := p.getVendor(ctx, vendorID, *pc)
 	if err != nil {
 		return p.defaultPermissions(), err
 	}
@@ -128,7 +128,7 @@ func (p *permissionsImpl) allowSync(ctx context.Context, vendorID uint16, bidder
 	if err != nil {
 		return false, err
 	}
-	vendor, err := p.getVendor(ctx, vendorID, pc)
+	vendor, err := p.getVendor(ctx, vendorID, *pc)
 	if err != nil {
 		return false, nil
 	}

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -347,7 +347,7 @@ func TestAllowActivitiesBidderWithoutGVLID(t *testing.T) {
 	purpose2Consent := "CPuDXznPuDXznMOAAAENCZCAAEAAAAAAAAAAAAAAAAAA"
 	noPurposeConsent := "CPuDXznPuDXznMOAAAENCZCAAAAAAAAAAAAAAAAAAAAA"
 
-	tests := []struct{
+	tests := []struct {
 		name                    string
 		enforceAlgoID           config.TCF2EnforcementAlgo
 		vendorExceptions        map[openrtb_ext.BidderName]struct{}
@@ -357,65 +357,65 @@ func TestAllowActivitiesBidderWithoutGVLID(t *testing.T) {
 		passID                  bool
 	}{
 		{
-			name: "full_enforcement_no_exceptions_user_consents_to_purpose_2",
+			name:          "full_enforcement_no_exceptions_user_consents_to_purpose_2",
 			enforceAlgoID: config.TCF2FullEnforcement,
+			consent:       purpose2Consent,
+		},
+		{
+			name:             "full_enforcement_vendor_exception_user_consents_to_purpose_2",
+			enforceAlgoID:    config.TCF2FullEnforcement,
+			vendorExceptions: map[openrtb_ext.BidderName]struct{}{bidderWithoutGVLID: {}},
+			consent:          purpose2Consent,
+			allowBidRequest:  true,
+			passID:           true,
+		},
+		{
+			name:    "basic_enforcement_no_exceptions_user_consents_to_purpose_2",
 			consent: purpose2Consent,
 		},
 		{
-			name: "full_enforcement_vendor_exception_user_consents_to_purpose_2",
-			enforceAlgoID: config.TCF2FullEnforcement,
-			vendorExceptions: map[openrtb_ext.BidderName]struct{}{bidderWithoutGVLID:{}},
-			consent: purpose2Consent,
-			allowBidRequest: true,
-			passID: true,
+			name:             "basic_enforcement_vendor_exception_user_consents_to_purpose_2",
+			vendorExceptions: map[openrtb_ext.BidderName]struct{}{bidderWithoutGVLID: {}},
+			consent:          purpose2Consent,
+			allowBidRequest:  true,
+			passID:           true,
 		},
 		{
-			name: "basic_enforcement_no_exceptions_user_consents_to_purpose_2",
-			consent: purpose2Consent,
+			name:                    "full_enforcement_soft_vendor_exception_user_consents_to_purpose_2", // allow bid request and pass ID
+			enforceAlgoID:           config.TCF2FullEnforcement,
+			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID): {}},
+			consent:                 purpose2Consent,
+			allowBidRequest:         true,
+			passID:                  true,
 		},
 		{
-			name: "basic_enforcement_vendor_exception_user_consents_to_purpose_2",
-			vendorExceptions: map[openrtb_ext.BidderName]struct{}{bidderWithoutGVLID:{}},
-			consent: purpose2Consent,
-			allowBidRequest: true,
-			passID: true,
+			name:                    "basic_enforcement_soft_vendor_exception_user_consents_to_purpose_2", // allow bid request and pass ID
+			enforceAlgoID:           config.TCF2BasicEnforcement,
+			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID): {}},
+			consent:                 purpose2Consent,
+			allowBidRequest:         true,
+			passID:                  true,
 		},
 		{
-			name: "full_enforcement_soft_vendor_exception_user_consents_to_purpose_2",// allow bid request and pass ID
-			enforceAlgoID: config.TCF2FullEnforcement,
-			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID):{}},
-			consent: purpose2Consent,
-			allowBidRequest: true,
-			passID: true,
+			name:                    "full_enforcement_soft_vendor_exception_user_consents_to_purpose_4",
+			enforceAlgoID:           config.TCF2FullEnforcement,
+			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID): {}},
+			consent:                 noPurposeConsent,
+			allowBidRequest:         false,
+			passID:                  false,
 		},
 		{
-			name: "basic_enforcement_soft_vendor_exception_user_consents_to_purpose_2", // allow bid request and pass ID
-			enforceAlgoID: config.TCF2BasicEnforcement,
-			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID):{}},
-			consent: purpose2Consent,
-			allowBidRequest: true,
-			passID: true,
-		},
-		{
-			name: "full_enforcement_soft_vendor_exception_user_consents_to_purpose_4",
-			enforceAlgoID: config.TCF2FullEnforcement,
-			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID):{}},
-			consent: noPurposeConsent,
-			allowBidRequest: false,
-			passID: false,
-		},
-		{
-			name: "basic_enforcement_soft_vendor_exception_user_consents_to_purpose_4",
-			enforceAlgoID: config.TCF2BasicEnforcement,
-			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID):{}},
-			consent: noPurposeConsent,
-			allowBidRequest: false,
-			passID: false,
+			name:                    "basic_enforcement_soft_vendor_exception_user_consents_to_purpose_4",
+			enforceAlgoID:           config.TCF2BasicEnforcement,
+			basicEnforcementVendors: map[string]struct{}{string(bidderWithoutGVLID): {}},
+			consent:                 noPurposeConsent,
+			allowBidRequest:         false,
+			passID:                  false,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T){
+		t.Run(tt.name, func(t *testing.T) {
 			tcf2AggConfig := allPurposesEnabledTCF2Config()
 			tcf2AggConfig.AccountConfig.BasicEnforcementVendorsMap = tt.basicEnforcementVendors
 			tcf2AggConfig.HostConfig.Purpose2.VendorExceptionMap = tt.vendorExceptions
@@ -423,13 +423,13 @@ func TestAllowActivitiesBidderWithoutGVLID(t *testing.T) {
 			tcf2AggConfig.HostConfig.PurposeConfigs[consentconstants.Purpose(2)] = &tcf2AggConfig.HostConfig.Purpose2
 
 			perms := permissionsImpl{
-				cfg:                    &tcf2AggConfig,
-				consent:                tt.consent,
-				gdprSignal:             SignalYes,
-				hostVendorID:           2,
-				nonStandardPublishers:  map[string]struct{}{},
-				vendorIDs:              map[openrtb_ext.BidderName]uint16{},
-				fetchVendorList:        listFetcher(map[uint16]map[uint16]vendorlist.VendorList{
+				cfg:                   &tcf2AggConfig,
+				consent:               tt.consent,
+				gdprSignal:            SignalYes,
+				hostVendorID:          2,
+				nonStandardPublishers: map[string]struct{}{},
+				vendorIDs:             map[openrtb_ext.BidderName]uint16{},
+				fetchVendorList: listFetcher(map[uint16]map[uint16]vendorlist.VendorList{
 					2: {
 						153: parseVendorListDataV2(t, MarshalVendorList(vendorList{GVLSpecificationVersion: 2, VendorListVersion: 153, Vendors: map[string]*vendor{}})),
 					},
@@ -1109,28 +1109,6 @@ func TestAllowActivitiesBidRequests(t *testing.T) {
 	}
 }
 
-func TestTCF1Consent(t *testing.T) {
-	bidderAllowedByConsent := openrtb_ext.BidderAppnexus
-	tcf1Consent := "BOS2bx5OS2bx5ABABBAAABoAAAABBwAA"
-
-	perms := permissionsImpl{
-		cfg: &tcf2Config{},
-		vendorIDs: map[openrtb_ext.BidderName]uint16{
-			openrtb_ext.BidderAppnexus: 2,
-		},
-		aliasGVLIDs: map[string]uint16{},
-		consent:     tcf1Consent,
-		gdprSignal:  SignalYes,
-	}
-
-	permissions, err := perms.AuctionActivitiesAllowed(context.Background(), bidderAllowedByConsent, bidderAllowedByConsent)
-
-	assert.Nil(t, err, "TCF1 consent - no error returned")
-	assert.Equal(t, true, permissions.AllowBidRequest, "TCF1 consent - bid request not allowed")
-	assert.Equal(t, true, permissions.PassGeo, "TCF1 consent - passing geo not allowed")
-	assert.Equal(t, false, permissions.PassID, "TCF1 consent - passing id not allowed")
-}
-
 func TestAllowActivitiesVendorException(t *testing.T) {
 	noPurposeOrVendorConsentAndPubRestrictsP2 := "CPF_61ePF_61eFxAAAENAiCAAAAAAAAAAAAAACEAAAACEAAgAgAA"
 	noPurposeOrVendorConsentAndPubRestrictsNone := "CPF_61ePF_61eFxAAAENAiCAAAAAAAAAAAAAACEAAAAA"
@@ -1344,42 +1322,6 @@ func TestDefaultPermissions(t *testing.T) {
 		result := perms.defaultPermissions()
 
 		assert.Equal(t, result, tt.wantPermissions, tt.description)
-	}
-}
-
-func TestGetSpecVersion(t *testing.T) {
-	tests := []struct {
-		name                string
-		policyVersion       uint8
-		expectedSpecVersion uint16
-	}{
-		{
-			name:                "policy_version_0_gives_spec_version_2",
-			policyVersion:       0,
-			expectedSpecVersion: 2,
-		},
-		{
-			name:                "policy_version_3_gives_spec_version_2",
-			policyVersion:       3,
-			expectedSpecVersion: 2,
-		},
-		{
-			name:                "policy_version_4_spec_version_3",
-			policyVersion:       4,
-			expectedSpecVersion: 3,
-		},
-		{
-			name:                "policy_version_5_error",
-			policyVersion:       5,
-			expectedSpecVersion: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			specVersion := getSpecVersion(tt.policyVersion)
-			assert.Equal(t, tt.expectedSpecVersion, specVersion)
-		})
 	}
 }
 

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -1328,7 +1328,6 @@ func TestDefaultPermissions(t *testing.T) {
 func TestVendorListSelection(t *testing.T) {
 	policyVersion3WithVendor2AndPurpose1Consent := "CPGWbY_PGWbY_GYAAAENABDAAIAAAAAAAAAAACEAAAAA"
 	policyVersion4WithVendor2AndPurpose1Consent := "CPGWbY_PGWbY_GYAAAENABEAAIAAAAAAAAAAACEAAAAA"
-	policyVersion5WithVendor2AndPurpose1Consent := "CPGWbY_PGWbY_GYAAAENABFAAIAAAAAAAAAAACEAAAAA"
 
 	specVersion2vendorListData := MarshalVendorList(vendorList{
 		GVLSpecificationVersion: 2,
@@ -1396,11 +1395,6 @@ func TestVendorListSelection(t *testing.T) {
 			name:              "consent_tcf_policy_version_4_uses_gvl_spec_version_3",
 			consent:           policyVersion4WithVendor2AndPurpose1Consent,
 			expectedAllowSync: true,
-		},
-		{
-			name:        "consent_tcf_policy_version_5_causes_error",
-			consent:     policyVersion5WithVendor2AndPurpose1Consent,
-			expectedErr: true,
 		},
 	}
 


### PR DESCRIPTION
This PR addresses https://github.com/prebid/prebid-server/issues/2809.

If a bidder does not have a GVL ID, the only scenarios where they pass a purpose are:
- if a bidder code is a vendor exception
- if a bidder code is entered as a soft vendor exception (which means they are listed as a basic enforcement vendor in the account config), and the user has consented at the purpose level
- if enforcing the purpose and enforcing the vendor for that purpose are disabled in the config

While investigating this issue, I realized that the logic in `impl.go` could be simplified. There was no need to create a `vendorTrue` instance anymore, nor do we need to check if the bidder is a `basicEnforcementVendor`. As a result, I refactored `impl.go` a bit, extracting anything that involves parsing the consent (parsing, validation, mapping, deriving values from the parsed data) into a new `consent_parser.go` file.