### PR TITLE
semgrep rule to flag undesirable package imports in adapter code

### DIFF
--- a/.semgrep/adapter/package-import.go
+++ b/.semgrep/adapter/package-import.go
@@ -1,0 +1,47 @@
+import (
+	// ok: package-import-check
+	"fmt"
+	// ok: package-import-check
+	"os"
+	// ruleid: package-import-check
+	"github.com/mitchellh/copystructure"
+	// ruleid: package-import-check
+	"github.com/golang/glog"
+)
+
+import (
+	// ok: package-import-check
+	"fmt"
+	// ruleid: package-import-check
+	cs "github.com/mitchellh/copystructure"
+	// ok: package-import-check
+	"os"
+	// ruleid: package-import-check
+	log "github.com/golang/glog"
+)
+
+import (
+	// ok: package-import-check
+	"fmt"
+	// ruleid: package-import-check
+	cs "github.com/mitchellh/copystructure/subpackage"
+	// ok: package-import-check
+	"os"
+	// ruleid: package-import-check
+	log "github.com/golang/glog/subpackage"
+)
+
+// ruleid: package-import-check
+import "github.com/golang/glog"
+
+// ruleid: package-import-check
+import "github.com/mitchellh/copystructure"
+
+// ruleid: package-import-check
+import log "github.com/golang/glog"
+
+// ruleid: package-import-check
+import copy "github.com/mitchellh/copystructure"
+
+// ok: package-import-check
+import "fmt"  

--- a/.semgrep/adapter/package-import.yml
+++ b/.semgrep/adapter/package-import.yml
@@ -1,0 +1,13 @@
+rules:
+  - id: package-import-check
+    message: Importing "$PKG" package is not recommended in adapter code
+    languages:
+      - go
+    severity: ERROR
+    pattern-either:
+      - patterns:
+          - pattern: import "$PKG"
+          - focus-metavariable: $PKG
+          - metavariable-regex:
+              metavariable: $PKG
+              regex: (^github\.com/mitchellh/copystructure(/.*)?$|^github\.com/golang/glog(/.*)?$)


### PR DESCRIPTION
## Description

 PR adds semgrep rule to flag undesirable package imports in adapter code. Plan here is to run this rule as adapter PR checks. Refer #2907 for more details.

 Semgrep uses import metavariable to match package imports - https://semgrep.dev/docs/writing-rules/pattern-syntax/#import-metavariables

## Testing

- Sample playground example: https://semgrep.dev/playground/s/QBlo

- Semgrep unit tests passing
  ```
   ~ » semgrep --test ./                              
  3/3: ✓ All tests passed
   No tests for fixes found.
  ```

- Found following instances in repo
  ```
   ~ » semgrep --config=./.semgrep/adapter/package-import.yml ./adapters/


   ┌─────────────┐
   │ Scan Status │
   └─────────────┘
     Scanning 2539 files tracked by git with 1 Code rule:
     Scanning 194 files.
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00


   ┌─────────────────┐
   │ 5 Code Findings │
   └─────────────────┘

       adapters/adapterstest/test_json.go
          semgrep.adapter.package-import-check
             Importing "github.com/mitchellh/copystructure" package is not recommended in adapter code

              13┆ "github.com/mitchellh/copystructure"

       adapters/adhese/adhese.go
          semgrep.adapter.package-import-check
             Importing "github.com/golang/glog" package is not recommended in adapter code

              13┆ "github.com/golang/glog"

       adapters/gamoshi/gamoshi.go
          semgrep.adapter.package-import-check
             Importing "github.com/golang/glog" package is not recommended in adapter code

               9┆ "github.com/golang/glog"

       adapters/pubmatic/pubmatic.go
          semgrep.adapter.package-import-check
             Importing "github.com/golang/glog" package is not recommended in adapter code

              13┆ "github.com/golang/glog"

       adapters/yeahmobi/yeahmobi.go
          semgrep.adapter.package-import-check
             Importing "github.com/golang/glog" package is not recommended in adapter code

              10┆ "github.com/golang/glog"



   ┌──────────────┐
   │ Scan Summary │
   └──────────────┘
   Some files were skipped or only partially analyzed.
     Scan was limited to files tracked by git.
     Scan skipped: 325 files matching .semgrepignore patterns
     For a full list of skipped files, run semgrep with the --verbose flag.

   Ran 1 rule on 194 files: 5 findings.
  ```


