### PR TITLE
Mobilefuse: Added support for skadn. Forwarding imp.ext.skadn

### DIFF
--- a/adapters/mobilefuse/mobilefuse.go
+++ b/adapters/mobilefuse/mobilefuse.go
@@ -83,7 +83,7 @@ func (adapter *MobileFuseAdapter) MakeBids(incomingRequest *openrtb2.BidRequest,
 
 	for _, seatbid := range incomingBidResponse.SeatBid {
 		for i := range seatbid.Bid {
-			bidType := adapter.getBidType(seatbid.Bid[i])
+			bidType := getBidType(seatbid.Bid[i])
 			seatbid.Bid[i].Ext = nil
 
 			outgoingBidResponse.Bids = append(outgoingBidResponse.Bids, &adapters.TypedBid{
@@ -99,7 +99,7 @@ func (adapter *MobileFuseAdapter) MakeBids(incomingRequest *openrtb2.BidRequest,
 func (adapter *MobileFuseAdapter) makeRequest(bidRequest *openrtb2.BidRequest) (*adapters.RequestData, []error) {
 	var errs []error
 
-	mobileFuseExtension, errs := adapter.getFirstMobileFuseExtension(bidRequest)
+	mobileFuseExtension, errs := getFirstMobileFuseExtension(bidRequest)
 
 	if errs != nil {
 		return nil, errs
@@ -111,7 +111,7 @@ func (adapter *MobileFuseAdapter) makeRequest(bidRequest *openrtb2.BidRequest) (
 		return nil, append(errs, err)
 	}
 
-	validImps, err := adapter.getValidImps(bidRequest, mobileFuseExtension)
+	validImps, err := getValidImps(bidRequest, mobileFuseExtension)
 
 	if err != nil {
 		errs = append(errs, err)
@@ -138,7 +138,7 @@ func (adapter *MobileFuseAdapter) makeRequest(bidRequest *openrtb2.BidRequest) (
 	}, errs
 }
 
-func (adapter *MobileFuseAdapter) getFirstMobileFuseExtension(request *openrtb2.BidRequest) (*openrtb_ext.ExtImpMobileFuse, []error) {
+func getFirstMobileFuseExtension(request *openrtb2.BidRequest) (*openrtb_ext.ExtImpMobileFuse, []error) {
 	var mobileFuseImpExtension openrtb_ext.ExtImpMobileFuse
 	var errs []error
 
@@ -181,7 +181,7 @@ func (adapter *MobileFuseAdapter) getEndpoint(ext *openrtb_ext.ExtImpMobileFuse)
 	return url, nil
 }
 
-func (adapter *MobileFuseAdapter) getValidImps(bidRequest *openrtb2.BidRequest, ext *openrtb_ext.ExtImpMobileFuse) ([]openrtb2.Imp, error) {
+func getValidImps(bidRequest *openrtb2.BidRequest, ext *openrtb_ext.ExtImpMobileFuse) ([]openrtb2.Imp, error) {
 	var validImps []openrtb2.Imp
 
 	for _, imp := range bidRequest.Imp {
@@ -190,14 +190,12 @@ func (adapter *MobileFuseAdapter) getValidImps(bidRequest *openrtb2.BidRequest, 
 
 			var extSkadn ExtSkadn
 			err := json.Unmarshal(imp.Ext, &extSkadn)
-
 			if err != nil {
 				return nil, err
 			}
 
 			if extSkadn.Skadn != nil {
 				imp.Ext, err = json.Marshal(map[string]json.RawMessage{"skadn": extSkadn.Skadn})
-
 				if err != nil {
 					return nil, err
 				}
@@ -218,7 +216,7 @@ func (adapter *MobileFuseAdapter) getValidImps(bidRequest *openrtb2.BidRequest, 
 	return validImps, nil
 }
 
-func (adapter *MobileFuseAdapter) getBidType(bid openrtb2.Bid) openrtb_ext.BidType {
+func getBidType(bid openrtb2.Bid) openrtb_ext.BidType {
 	if bid.Ext != nil {
 		var bidExt BidExt
 		err := json.Unmarshal(bid.Ext, &bidExt)

--- a/adapters/mobilefuse/mobilefusetest/exemplary/skadn.json
+++ b/adapters/mobilefuse/mobilefusetest/exemplary/skadn.json
@@ -1,0 +1,74 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "imp": [
+            {
+                "id": "1",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
+                },
+                "ext": {
+                	   "skadn": {
+                        "versions": ["2.0", "2.1"],
+                        "sourceapp": "11111",
+                        "skadnetids": [
+                            "424m5254lk.skadnetwork",
+                            "4fzdc2evr5.skadnetwork"
+                        ]
+                    },
+                    "bidder": {
+                        "placement_id": 999999,
+                        "pub_id": 1111,
+                        "tagid_src": "ext"
+                    }
+                }
+            }
+        ]
+    },
+
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "http://mfx.mobilefuse.com/openrtb?pub_id=1111&tagid_src=ext",
+                "body": {
+                    "id": "test-request-id",
+                    "imp": [
+                        {
+                            "id": "1",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
+                                ]
+                            },
+                            "tagid": "999999",
+                            "ext" : {
+	                            "skadn": {
+		                            "versions": ["2.0", "2.1"],
+		                            "sourceapp": "11111",
+								   "skadnetids": [
+			                            "424m5254lk.skadnetwork",
+			                            "4fzdc2evr5.skadnetwork"
+			                        ]
+		                    	   }
+						   }
+                        }
+                    ]
+                }
+            },
+            "mockResponse": {
+                "status": 204,
+                "body": {}
+            }
+        }
+    ],
+
+    "expectedBidResponses": []
+}

--- a/adapters/mobilefuse/mobilefusetest/exemplary/skadn.json
+++ b/adapters/mobilefuse/mobilefusetest/exemplary/skadn.json
@@ -13,8 +13,11 @@
                     ]
                 },
                 "ext": {
-                	   "skadn": {
-                        "versions": ["2.0", "2.1"],
+                    "skadn": {
+                        "versions": [
+                            "2.0",
+                            "2.1"
+                        ],
                         "sourceapp": "11111",
                         "skadnetids": [
                             "424m5254lk.skadnetwork",
@@ -30,7 +33,6 @@
             }
         ]
     },
-
     "httpCalls": [
         {
             "expectedRequest": {
@@ -49,16 +51,19 @@
                                 ]
                             },
                             "tagid": "999999",
-                            "ext" : {
-	                            "skadn": {
-		                            "versions": ["2.0", "2.1"],
-		                            "sourceapp": "11111",
-								   "skadnetids": [
-			                            "424m5254lk.skadnetwork",
-			                            "4fzdc2evr5.skadnetwork"
-			                        ]
-		                    	   }
-						   }
+                            "ext": {
+                                "skadn": {
+                                    "versions": [
+                                        "2.0",
+                                        "2.1"
+                                    ],
+                                    "sourceapp": "11111",
+                                    "skadnetids": [
+                                        "424m5254lk.skadnetwork",
+                                        "4fzdc2evr5.skadnetwork"
+                                    ]
+                                }
+                            }
                         }
                     ]
                 }
@@ -69,6 +74,5 @@
             }
         }
     ],
-
     "expectedBidResponses": []
 }


### PR DESCRIPTION
This is a change to forward imp.ext.skadn whereas previously anything under imp.ext was not forwarded.