### PR TITLE
use `pull_request_target` event in semgrep

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,6 @@
 name: Adapter semgrep checks
 on:
-  pull_request:
+  pull_request_target:
     paths: ["adapters/*/*.go"]
 permissions: 
     pull-requests: write


### PR DESCRIPTION
`pull_request_target` event is similar to pull_request, except that it runs in the context of the base repository of the pull request, rather than in the merge commit.  For example, this event allows you to create workflows that label and comment on pull requests, based on the contents of the event payload.