### PR TITLE
introduce aliasOf in bidderInfo struct

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -267,19 +267,16 @@ func (infos BidderInfos) validate(errs []error) []error {
 		if bidder.IsEnabled() {
 			errs = validateAdapterEndpoint(bidder.Endpoint, bidderName, errs)
 
-			validateInfoErr := validateInfo(bidder, bidderName)
-			if validateInfoErr != nil {
-				errs = append(errs, validateInfoErr)
+			if err := validateInfo(bidder, bidderName); err != nil {
+				errs = append(errs, err)
 			}
 
-			validateSyncerErr := validateSyncer(bidder)
-			if validateSyncerErr != nil {
-				errs = append(errs, validateSyncerErr)
+			if err := validateSyncer(bidder); err != nil {
+				errs = append(errs, err)
 			}
 
-			validateAliasesErr := validateAliases(bidder, infos, bidderName)
-			if validateAliasesErr != nil {
-				errs = append(errs, validateAliasesErr)
+			if err := validateAliases(bidder, infos, bidderName); err != nil {
+				errs = append(errs, err)
 			}
 		}
 	}
@@ -290,10 +287,10 @@ func validateAliases(bidder BidderInfo, infos BidderInfos, bidderName string) er
 	if len(bidder.AliasOf) > 0 {
 		if parentBidder, ok := infos[bidder.AliasOf]; ok {
 			if len(parentBidder.AliasOf) > 0 {
-				return fmt.Errorf("Parent bidder: %s of an alias cannot be an alias: %s", bidder.AliasOf, bidderName)
+				return fmt.Errorf("bidder: %s cannot be an alias of an alias: %s", bidder.AliasOf, bidderName)
 			}
 		} else {
-			return fmt.Errorf("Parent bidder: %s not found for an alias: %s", bidder.AliasOf, bidderName)
+			return fmt.Errorf("bidder: %s not found for an alias: %s", bidder.AliasOf, bidderName)
 		}
 	}
 	return nil

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -276,9 +276,27 @@ func (infos BidderInfos) validate(errs []error) []error {
 			if validateSyncerErr != nil {
 				errs = append(errs, validateSyncerErr)
 			}
+
+			validateAliasesErr := validateAliases(bidder, infos, bidderName)
+			if validateAliasesErr != nil {
+				errs = append(errs, validateAliasesErr)
+			}
 		}
 	}
 	return errs
+}
+
+func validateAliases(bidder BidderInfo, infos BidderInfos, bidderName string) error {
+	if len(bidder.AliasOf) > 0 {
+		if parentBidder, ok := infos[bidder.AliasOf]; ok {
+			if len(parentBidder.AliasOf) > 0 {
+				return fmt.Errorf("Parent bidder: %s of an alias cannot be an alias: %s", bidder.AliasOf, bidderName)
+			}
+		} else {
+			return fmt.Errorf("Parent bidder: %s not found for an alias: %s", bidder.AliasOf, bidderName)
+		}
+	}
+	return nil
 }
 
 var testEndpointTemplateParams = macros.EndpointTemplateParams{

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -23,6 +23,7 @@ type BidderInfos map[string]BidderInfo
 
 // BidderInfo specifies all configuration for a bidder except for enabled status, endpoint, and extra information.
 type BidderInfo struct {
+	AliasOf          string `yaml:"aliasOf" mapstructure:"aliasOf"`
 	Disabled         bool   `yaml:"disabled" mapstructure:"disabled"`
 	Endpoint         string `yaml:"endpoint" mapstructure:"endpoint"`
 	ExtraAdapterInfo string `yaml:"extra_info" mapstructure:"extra_info"`

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -523,8 +523,8 @@ func TestBidderInfoValidationNegative(t *testing.T) {
 				},
 			},
 			[]error{
-				errors.New("Parent bidder: bidderB of an alias cannot be an alias: bidderA"),
-				errors.New("Parent bidder: bidderC not found for an alias: bidderB"),
+				errors.New("bidder: bidderB cannot be an alias of an alias: bidderA"),
+				errors.New("bidder: bidderC not found for an alias: bidderB"),
 			},
 		},
 		{

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -244,6 +244,29 @@ func TestBidderInfoValidationPositive(t *testing.T) {
 				},
 			},
 		},
+		"bidderC": BidderInfo{
+			Endpoint: "http://bidderB.com/openrtb2",
+			Maintainer: &MaintainerInfo{
+				Email: "maintainer@bidderA.com",
+			},
+			Capabilities: &CapabilitiesInfo{
+				Site: &PlatformInfo{
+					MediaTypes: []openrtb_ext.BidType{
+						openrtb_ext.BidTypeVideo,
+						openrtb_ext.BidTypeNative,
+						openrtb_ext.BidTypeBanner,
+					},
+				},
+			},
+			Syncer: &Syncer{
+				Key: "bidderBkey",
+				Redirect: &SyncerEndpoint{
+					URL:       "http://bidderB.com/usersync",
+					UserMacro: "UID",
+				},
+			},
+			AliasOf: "bidderB",
+		},
 	}
 	errs := bidderInfos.validate(make([]error, 0))
 	assert.Len(t, errs, 0, "All bidder infos should be correct")
@@ -465,6 +488,43 @@ func TestBidderInfoValidationNegative(t *testing.T) {
 			},
 			[]error{
 				errors.New("syncer could not be created, invalid supported endpoint: incorrect"),
+			},
+		},
+		{
+			"Invalid aliases",
+			BidderInfos{
+				"bidderA": BidderInfo{
+					Endpoint: "http://bidderA.com/openrtb2",
+					Maintainer: &MaintainerInfo{
+						Email: "maintainer@bidderA.com",
+					},
+					Capabilities: &CapabilitiesInfo{
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{
+								openrtb_ext.BidTypeVideo,
+							},
+						},
+					},
+					AliasOf: "bidderB",
+				},
+				"bidderB": BidderInfo{
+					Endpoint: "http://bidderA.com/openrtb2",
+					Maintainer: &MaintainerInfo{
+						Email: "maintainer@bidderA.com",
+					},
+					Capabilities: &CapabilitiesInfo{
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{
+								openrtb_ext.BidTypeVideo,
+							},
+						},
+					},
+					AliasOf: "bidderC",
+				},
+			},
+			[]error{
+				errors.New("Parent bidder: bidderB of an alias cannot be an alias: bidderA"),
+				errors.New("Parent bidder: bidderC not found for an alias: bidderB"),
 			},
 		},
 		{

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -258,13 +258,6 @@ func TestBidderInfoValidationPositive(t *testing.T) {
 					},
 				},
 			},
-			Syncer: &Syncer{
-				Key: "bidderBkey",
-				Redirect: &SyncerEndpoint{
-					URL:       "http://bidderB.com/usersync",
-					UserMacro: "UID",
-				},
-			},
 			AliasOf: "bidderB",
 		},
 	}

--- a/exchange/adapter_util.go
+++ b/exchange/adapter_util.go
@@ -33,6 +33,10 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 	var errs []error
 
 	for bidder, info := range infos {
+		if len(info.AliasOf) > 0 {
+			errs = append(errs, fmt.Errorf("This feature is currently under development"))
+			continue
+		}
 		bidderName, bidderNameFound := openrtb_ext.NormalizeBidderName(bidder)
 		if !bidderNameFound {
 			errs = append(errs, fmt.Errorf("%v: unknown bidder", bidder))

--- a/exchange/adapter_util_test.go
+++ b/exchange/adapter_util_test.go
@@ -67,6 +67,13 @@ func TestBuildAdapters(t *testing.T) {
 				errors.New("unknown: unknown bidder"),
 			},
 		},
+		{
+			description: "Alias feature disabled",
+			bidderInfos: map[string]config.BidderInfo{"appNexus": {AliasOf: "rubicon"}},
+			expectedErrors: []error{
+				errors.New("This feature is currently under development"),
+			},
+		},
 	}
 
 	cfg := &config.Configuration{}


### PR DESCRIPTION
We already have [a piece of code that reads all bidder-info/*.yaml files. ](https://github.com/prebid/prebid-server/blob/543f288dc854361724d4a658dce31b81bb864d33/config/bidderinfo.go#L233-L247). This code already un-marshals bidder yaml config into BidderInfo struct. Presently, this function returns map[String]BidderInfos. But we would need a way to also identify aliases so that we can run the validations checks etc.
- This PR introduces `aliasOf` of type string in BidderInfo struct. 
- Also adds a simple validation check that if adapter is an alias then make sure that it's parent is an actual adapter and not an alias else raise a validation error.
- Also throw a validation check if `aliasOf` is defined in BidderInfo struct saying that do not use this as this feature is currently under development.