### PR TITLE
semgrep script:  specify repository during checkout step

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Calculate diff
         id: calculate_diff


### PR DESCRIPTION
This is needed when PR is raised from fork branch. In this case repository will be fork repo and correct version of code will be checkout

Testing: 
- https://github.com/onkarvhanumante/prebid-server/pull/6
  PR raised on `onkarvhanumante/prebid-server` from `onkarhanumante30/prebid-server` repo. This mimics scenario where adapter forks raise PR against main prebid-server repo
  ```
        fetch-depth: 0
        ref: patch-2
        repository: onkarhanumante30/prebid-server
  ```