### PR TITLE
fix errors reported by go vet 

### DIFF
--- a/adapters/bidder_test.go
+++ b/adapters/bidder_test.go
@@ -52,12 +52,12 @@ type mockConversions struct {
 	mock.Mock
 }
 
-func (m mockConversions) GetRate(from string, to string) (float64, error) {
+func (m *mockConversions) GetRate(from string, to string) (float64, error) {
 	args := m.Called(from, to)
 	return args.Get(0).(float64), args.Error(1)
 }
 
-func (m mockConversions) GetRates() *map[string]map[string]float64 {
+func (m *mockConversions) GetRates() *map[string]map[string]float64 {
 	args := m.Called()
 	return args.Get(0).(*map[string]map[string]float64)
 }

--- a/bidadjustment/apply_test.go
+++ b/bidadjustment/apply_test.go
@@ -223,12 +223,12 @@ type mockConversions struct {
 	mock.Mock
 }
 
-func (m mockConversions) GetRate(from string, to string) (float64, error) {
+func (m *mockConversions) GetRate(from string, to string) (float64, error) {
 	args := m.Called(from, to)
 	return args.Get(0).(float64), args.Error(1)
 }
 
-func (m mockConversions) GetRates() *map[string]map[string]float64 {
+func (m *mockConversions) GetRates() *map[string]map[string]float64 {
 	args := m.Called()
 	return args.Get(0).(*map[string]map[string]float64)
 }

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -88,7 +88,7 @@ func TestGoodAmpRequests(t *testing.T) {
 				continue
 			}
 
-			test.storedRequest = map[string]json.RawMessage{tagID: test.BidRequest}
+			test.StoredRequest = map[string]json.RawMessage{tagID: test.BidRequest}
 			test.endpointType = AMP_ENDPOINT
 
 			cfg := &config.Configuration{
@@ -165,7 +165,7 @@ func TestAccountErrors(t *testing.T) {
 		if !assert.NoError(t, json.Unmarshal(fileJsonData, &test), "Failed to unmarshal data from file: %s. Error: %v", tt.filename, err) {
 			continue
 		}
-		test.storedRequest = map[string]json.RawMessage{tt.storedReqID: test.BidRequest}
+		test.StoredRequest = map[string]json.RawMessage{tt.storedReqID: test.BidRequest}
 		test.endpointType = AMP_ENDPOINT
 
 		cfg := &config.Configuration{
@@ -2190,7 +2190,7 @@ func TestValidAmpResponseWhenRequestRejected(t *testing.T) {
 			query := request.URL.Query()
 			tagID := query.Get("tag_id")
 
-			test.storedRequest = map[string]json.RawMessage{tagID: test.BidRequest}
+			test.StoredRequest = map[string]json.RawMessage{tagID: test.BidRequest}
 			test.planBuilder = tc.planBuilder
 			test.endpointType = AMP_ENDPOINT
 

--- a/endpoints/openrtb2/test_utils.go
+++ b/endpoints/openrtb2/test_utils.go
@@ -76,7 +76,7 @@ type testCase struct {
 	ExpectedBidResponse json.RawMessage `json:"expectedBidResponse"`
 
 	// "/openrtb2/amp" endpoint JSON test info
-	storedRequest       map[string]json.RawMessage `json:"mockAmpStoredRequest"`
+	StoredRequest       map[string]json.RawMessage `json:"mockAmpStoredRequest"`
 	StoredResponse      map[string]json.RawMessage `json:"mockAmpStoredResponse"`
 	ExpectedAmpResponse json.RawMessage            `json:"expectedAmpResponse"`
 }
@@ -1265,8 +1265,8 @@ func buildTestEndpoint(test testCase, cfg *config.Configuration) (httprouter.Han
 	testExchange, mockBidServersArray := buildTestExchange(test.Config, adapterMap, mockBidServersArray, mockCurrencyRatesServer, bidderInfos, cfg, met, mockFetcher)
 
 	var storedRequestFetcher stored_requests.Fetcher
-	if len(test.storedRequest) > 0 {
-		storedRequestFetcher = &mockAmpStoredReqFetcher{test.storedRequest}
+	if len(test.StoredRequest) > 0 {
+		storedRequestFetcher = &mockAmpStoredReqFetcher{test.StoredRequest}
 	} else {
 		storedRequestFetcher = &mockStoredReqFetcher{}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,7 @@ import (
 
 // Listen blocks forever, serving PBS requests on the given port. This will block forever, until the process is shut down.
 func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.Handler, metrics *metricsconfig.DetailedMetricsEngine) (err error) {
-	stopSignals := make(chan os.Signal)
+	stopSignals := make(chan os.Signal, 1)
 	signal.Notify(stopSignals, syscall.SIGTERM, syscall.SIGINT)
 
 	// Run the servers. Fan any process-stopper signals out to each server for graceful shutdowns.


### PR DESCRIPTION
- As of now, the `validate.sh` script has been executed as part of the PR checks. However, there was an issue with how the `go vet` command was invoked in the script.

   https://github.com/prebid/prebid-server/blob/95c269f3740c4c0e1bf82b481ca78f52e634cb17/validate.sh#L59-L63
![image](https://github.com/prebid/prebid-server/assets/24757781/51ec56d8-25cb-436e-9493-9d04cae61186)

- Currently, the `go vet` command is not checking all the files. This resulted to errors/ warnings not being captured during the PR checks. 

- The solution is to modify the command to `go vet ./...` which will ensure that all files are thoroughly checked during the PR checks.

  ```
  % (go vet ./... 2>&1) | grep -v -E "composite literal uses unkeyed fields"
  # github.com/prebid/prebid-server/amp
  # github.com/prebid/prebid-server/adapters/adoppler
  # github.com/prebid/prebid-server/adapters/huaweiads
  adapters/huaweiads/huaweiads.go:905:14: result of fmt.Errorf call not used
  # github.com/prebid/prebid-server/adapters/rubicon
  adapters/rubicon/rubicon_test.go:293:9: GetRate passes lock by value: github.com/prebid/prebid- 
  server/adapters/rubicon.mockCurrencyConversion contains github.com/stretchr/testify/mock.Mock contains sync.Mutex
  adapters/rubicon/rubicon_test.go:298:9: GetRates passes lock by value: github.com/prebid/prebid- 
  server/adapters/rubicon.mockCurrencyConversion contains github.com/stretchr/testify/mock.Mock contains sync.Mutex
  # github.com/prebid/prebid-server/adapters/taboola
  adapters/taboola/taboola.go:256:13: result of fmt.Errorf call not used
  ```

- The plan here is to update the script to execute the `go vet ./...` command. However, before implementing this change, let's address any previously uncaught errors or warnings.  PR makes changes to fix some errors or warnings reported by `go vet`