### PR TITLE
inherit fields for alias from the parent adapter

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -246,6 +246,35 @@ func processBidderInfos(reader InfoReader, normalizeBidderName func(string) (ope
 			infos[string(normalizedBidderName)] = info
 		}
 	}
+	return processAliasBidderInfo(infos)
+}
+
+func processAliasBidderInfo(infos BidderInfos) (BidderInfos, error) {
+	for bidderName, bidderInfo := range infos {
+		if len(infos[bidderName].AliasOf) > 0 {
+			if err := validateAliases(bidderInfo, infos, bidderName); err != nil {
+				return nil, err
+			}
+			parentBidderInfo := infos[bidderInfo.AliasOf]
+			bidderInfo.AppSecret = parentBidderInfo.AppSecret
+			bidderInfo.Capabilities = parentBidderInfo.Capabilities
+			bidderInfo.Debug = parentBidderInfo.Debug
+			bidderInfo.Disabled = parentBidderInfo.Disabled
+			bidderInfo.Endpoint = parentBidderInfo.Endpoint
+			bidderInfo.EndpointCompression = parentBidderInfo.EndpointCompression
+			bidderInfo.Experiment = parentBidderInfo.Experiment
+			bidderInfo.ExtraAdapterInfo = parentBidderInfo.ExtraAdapterInfo
+			bidderInfo.GVLVendorID = parentBidderInfo.GVLVendorID
+			bidderInfo.Maintainer = parentBidderInfo.Maintainer
+			bidderInfo.ModifyingVastXmlAllowed = parentBidderInfo.ModifyingVastXmlAllowed
+			bidderInfo.OpenRTB = parentBidderInfo.OpenRTB
+			bidderInfo.PlatformID = parentBidderInfo.PlatformID
+			bidderInfo.Syncer = parentBidderInfo.Syncer
+			bidderInfo.UserSyncURL = parentBidderInfo.UserSyncURL
+			bidderInfo.XAPI = parentBidderInfo.XAPI
+			infos[bidderName] = bidderInfo
+		}
+	}
 	return infos, nil
 }
 
@@ -272,10 +301,6 @@ func (infos BidderInfos) validate(errs []error) []error {
 			}
 
 			if err := validateSyncer(bidder); err != nil {
-				errs = append(errs, err)
-			}
-
-			if err := validateAliases(bidder, infos, bidderName); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -42,6 +42,28 @@ endpointCompression: GZIP
 openrtb:
   version: 2.6
   gpp-supported: true
+endpoint: https://endpoint.com
+disabled: false
+extra_info: extra-info
+app_secret: app-secret
+platform_id: 123
+usersync_url: user-url
+userSync:
+  key: foo
+  default: iframe
+  iframe:
+    url: https://foo.com/sync?mode=iframe&r={{.RedirectURL}}
+    redirectUrl: https://redirect/setuid/iframe
+    externalUrl: https://iframe.host
+    userMacro: UID
+xapi:
+  username: uname
+  password: pwd
+  tracker: tracker
+`
+
+const testSimpleAliasYAML = `
+aliasOf: bidderA
 `
 
 func TestLoadBidderInfoFromDisk(t *testing.T) {
@@ -130,6 +152,112 @@ func TestProcessBidderInfo(t *testing.T) {
 			},
 			expectedBidderInfos: nil,
 			expectError:         "error parsing config for bidder bidderA.yaml",
+		},
+		{
+			description: "Valid aliases",
+			bidderInfos: map[string][]byte{
+				"bidderA.yaml": []byte(fullBidderYAMLConfig),
+				"bidderB.yaml": []byte(testSimpleAliasYAML),
+			},
+			expectedBidderInfos: BidderInfos{
+				"bidderA": BidderInfo{
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+				"bidderB": BidderInfo{
+					AliasOf:   "bidderA",
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+			},
 		},
 	}
 	for _, test := range testCases {
@@ -1041,7 +1169,6 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 
 	expectedBidderInfo := BidderInfos{
 		bidder: {
-			Disabled: false,
 			Maintainer: &MaintainerInfo{
 				Email: "some-email@domain.com",
 			},
@@ -1054,17 +1181,41 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 					MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
 				},
 			},
-			Debug:                   &DebugInfo{Allow: true},
 			ModifyingVastXmlAllowed: true,
-			Syncer: &Syncer{
-				Supports: []string{"iframe"},
+			Debug: &DebugInfo{
+				Allow: true,
 			},
-			Experiment:          BidderInfoExperiment{AdsCert: BidderAdsCert{Enabled: true}},
+			Experiment: BidderInfoExperiment{
+				AdsCert: BidderAdsCert{
+					Enabled: true,
+				},
+			},
 			EndpointCompression: "GZIP",
 			OpenRTB: &OpenRTBInfo{
-				Version:      "2.6",
 				GPPSupported: true,
+				Version:      "2.6",
 			},
+			Disabled:         false,
+			ExtraAdapterInfo: "extra-info",
+			AppSecret:        "app-secret",
+			PlatformID:       "123",
+			UserSyncURL:      "user-url",
+			Syncer: &Syncer{
+				Key: "foo",
+				IFrame: &SyncerEndpoint{
+					URL:         "user-url",
+					RedirectURL: "https://redirect/setuid/iframe",
+					ExternalURL: "https://iframe.host",
+					UserMacro:   "UID",
+				},
+				Supports: []string{"iframe"},
+			},
+			XAPI: AdapterXAPI{
+				Username: "uname",
+				Password: "pwd",
+				Tracker:  "tracker",
+			},
+			Endpoint: "https://endpoint.com",
 		},
 	}
 	assert.Equalf(t, expectedBidderInfo, actualBidderInfo, "Bidder info objects aren't matching")


### PR DESCRIPTION
This PR changes to inherit fields from the parent bidder information if aliasOf field is defined on BidderInfo struct. In the next PR changes, we will be overriding the fields if BidderInfo struct params is defined for an alias.