### PR TITLE
Semgrep rule to add warning to use MType

### DIFF
--- a/.semgrep/README.md
+++ b/.semgrep/README.md
@@ -6,7 +6,12 @@ semgrep --test
 ```
 
 
-Running semgrep rules against adapter code:
+Running single semgrep rules against adapter code:
 ```bash
 semgrep --config=./adapter/{rule}.yml ../adapters/
+```
+
+Running all semgrep rules simultaneously:
+```bash
+semgrep --config=./adapter ../adapters/
 ```

--- a/.semgrep/README.md
+++ b/.semgrep/README.md
@@ -1,0 +1,12 @@
+# Semgrep Test
+
+Running semgrep unit tests:
+```bash
+semgrep --test
+```
+
+
+Running semgrep rules against adapter code:
+```bash
+semgrep --config=./adapter/{rule}.yml ../adapters/
+```

--- a/.semgrep/adapter/bid-type-if-check.go
+++ b/.semgrep/adapter/bid-type-if-check.go
@@ -39,3 +39,17 @@ func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType,
 		Message: fmt.Sprintf("Failed to find native/banner/video impression \"%s\" ", impID),
 	}
 }
+
+func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType, error) {
+	for _, imp := range imps {
+		if imp.ID == impID {
+			// ruleid: bid-type-if-check
+			if imp.Banner != nil {
+				return openrtb_ext.BidTypeBanner
+			}
+		}
+	}
+	return "", &errortypes.BadInput{
+		Message: fmt.Sprintf("Failed to find native/banner/video impression \"%s\" ", impID),
+	}
+}

--- a/.semgrep/adapter/bid-type-if-check.go
+++ b/.semgrep/adapter/bid-type-if-check.go
@@ -1,0 +1,41 @@
+/*
+	bid-type-if-check tests
+	https://semgrep.dev/docs/writing-rules/testing-rules
+	"ruleid" prefix in comment indicates patterns that should be flagged by semgrep
+	"ok" prefix in comment indidcates  patterns that should not be flagged by the semgrep
+*/
+
+func getMediaTypeForImp(impID string, imps []openrtb2.Imp) openrtb_ext.BidType {
+	for _, imp := range imps {
+		if imp.ID == impID {
+			// ruleid: bid-type-if-check
+			if imp.Banner != nil {
+				return openrtb_ext.BidTypeBanner, nil
+				// ruleid: bid-type-if-check
+			} else if imp.Video != nil {
+				return openrtb_ext.BidTypeVideo, nil
+				// ruleid: bid-type-if-check
+			} else if imp.Native != nil {
+				return openrtb_ext.BidTypeNative, nil
+				// ruleid: bid-type-if-check
+			} else if imp.Audio != nil {
+				return openrtb_ext.BidTypeAudio, nil
+			}
+		}
+	}
+	return openrtb_ext.BidTypeBanner
+}
+
+func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType, error) {
+	for _, imp := range imps {
+		if imp.ID == impID {
+			// ruleid: bid-type-if-check
+			if imp.Banner != nil {
+				return openrtb_ext.BidTypeBanner, nil
+			}
+		}
+	}
+	return "", &errortypes.BadInput{
+		Message: fmt.Sprintf("Failed to find native/banner/video impression \"%s\" ", impID),
+	}
+}

--- a/.semgrep/adapter/bid-type-if-check.yml
+++ b/.semgrep/adapter/bid-type-if-check.yml
@@ -14,8 +14,7 @@ rules:
           metavariable: $ORTBTYPE
           patterns:
             - pattern-either:
-                - pattern: openrtb_ext.$W
-                - pattern: imp.$W
+                - pattern: openrtb_ext.$BIDTYPE
             - metavariable-regex:
-                metavariable: $W
+                metavariable: $BIDTYPE
                 regex: BidType*

--- a/.semgrep/adapter/bid-type-if-check.yml
+++ b/.semgrep/adapter/bid-type-if-check.yml
@@ -1,6 +1,6 @@
 rules:
   - id: bid-type-if-check
-    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    message: The current implementation follows an anti-pattern, assumes that if there is a multi-format request, the media type defaults to $ORTBTYPE. Prebid server expects the media type to be explicitly set in the adapter response. Therefore, we strongly recommend implementing a pattern where the adapter server sets the [MType](https://github.com/prebid/openrtb/blob/main/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
     languages:
       - go
     severity: WARNING

--- a/.semgrep/adapter/bid-type-if-check.yml
+++ b/.semgrep/adapter/bid-type-if-check.yml
@@ -7,9 +7,8 @@ rules:
     patterns:
       - pattern-inside: |
           if $CONDITION != nil {
-            return $ORTBTYPE, nil
+            return $ORTBTYPE
           }
-      - focus-metavariable: $CONDITION
       - metavariable-pattern:
           metavariable: $ORTBTYPE
           patterns:

--- a/.semgrep/adapter/bid-type-if-check.yml
+++ b/.semgrep/adapter/bid-type-if-check.yml
@@ -1,0 +1,21 @@
+rules:
+  - id: bid-type-if-check
+    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    languages:
+      - go
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          if $CONDITION != nil {
+            return $ORTBTYPE, nil
+          }
+      - focus-metavariable: $CONDITION
+      - metavariable-pattern:
+          metavariable: $ORTBTYPE
+          patterns:
+            - pattern-either:
+                - pattern: openrtb_ext.$W
+                - pattern: imp.$W
+            - metavariable-regex:
+                metavariable: $W
+                regex: BidType*

--- a/.semgrep/adapter/bid-type-switch-check.go
+++ b/.semgrep/adapter/bid-type-switch-check.go
@@ -1,0 +1,26 @@
+/*
+	bid-type-switch-check tests
+	https://semgrep.dev/docs/writing-rules/testing-rules
+	"ruleid" prefix in comment indicates patterns that should be flagged by semgrep
+	"ok" prefix in comment indidcates  patterns that should not be flagged by the semgrep
+*/
+
+// ruleid: bid-type-switch-check
+switch bidExt.AdCodeType {
+case "banner":
+	return openrtb_ext.BidTypeBanner, nil
+case "native":
+	return openrtb_ext.BidTypeNative, nil
+case "video":
+	return openrtb_ext.BidTypeVideo, nil
+}
+
+// ruleid: bid-type-switch-check
+switch impExt.Adot.MediaType {
+case string(openrtb_ext.BidTypeBanner):
+	return openrtb_ext.BidTypeBanner, nil
+case string(openrtb_ext.BidTypeVideo):
+	return openrtb_ext.BidTypeVideo, nil
+case string(openrtb_ext.BidTypeNative):
+	return openrtb_ext.BidTypeNative, nil
+}

--- a/.semgrep/adapter/bid-type-switch-check.go
+++ b/.semgrep/adapter/bid-type-switch-check.go
@@ -24,3 +24,13 @@ case string(openrtb_ext.BidTypeVideo):
 case string(openrtb_ext.BidTypeNative):
 	return openrtb_ext.BidTypeNative, nil
 }
+
+// ok: bid-type-switch-check
+switch bid.MType {
+case "banner":
+	return openrtb_ext.BidTypeBanner, nil
+case "native":
+	return openrtb_ext.BidTypeNative, nil
+case "video":
+	return openrtb_ext.BidTypeVideo, nil
+}

--- a/.semgrep/adapter/bid-type-switch-check.yml
+++ b/.semgrep/adapter/bid-type-switch-check.yml
@@ -1,6 +1,6 @@
 rules:
   - id: bid-type-switch-check
-    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    message: The current implementation follows an anti-pattern, assumes that if there is a multi-format request, the media type defaults to $ORTBTYPE. Prebid server expects the media type to be explicitly set in the adapter response. Therefore, we strongly recommend implementing a pattern where the adapter server sets the [MType](https://github.com/prebid/openrtb/blob/main/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
     languages:
       - go
     severity: WARNING

--- a/.semgrep/adapter/bid-type-switch-check.yml
+++ b/.semgrep/adapter/bid-type-switch-check.yml
@@ -1,0 +1,23 @@
+rules:
+  - id: bid-type-switch-check
+    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    languages:
+      - go
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          switch $BIDTYPE {
+          case ...:
+            return $ORTBTYPE, nil
+          }
+      - metavariable-regex:
+          metavariable: $BIDTYPE
+          regex: ^(?!bid\.MType$).*$
+      - metavariable-pattern:
+          metavariable: $ORTBTYPE
+          patterns:
+            - pattern-either:
+                - pattern: openrtb_ext.$W
+            - metavariable-regex:
+                metavariable: $W
+                regex: BidType*

--- a/.semgrep/adapter/parse-bid-type-check.go
+++ b/.semgrep/adapter/parse-bid-type-check.go
@@ -1,0 +1,29 @@
+/*
+	parse-bid-type-check tests
+	https://semgrep.dev/docs/writing-rules/testing-rules
+	"ruleid" prefix in comment indicates patterns that should be flagged by semgrep
+	"ok" prefix in comment indidcates  patterns that should not be flagged by the semgrep
+*/
+
+func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	if bid.Ext != nil {
+		var bidExt openrtb_ext.ExtBid
+		err := json.Unmarshal(bid.Ext, &bidExt)
+		if err == nil && bidExt.Prebid != nil {
+			// ruleid: parse-bid-type-check
+			return openrtb_ext.ParseBidType(string(bidExt.Prebid.Type))
+		}
+	}
+
+	return "", &errortypes.BadServerResponse{
+		Message: fmt.Sprintf("Failed to parse impression \"%s\" mediatype", bid.ImpID),
+	}
+}
+
+func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	var bidExt bidExt
+	// ruleid: parse-bid-type-check
+	bidType, err := openrtb_ext.ParseBidType(bidExt.Prebid.Type)
+
+	return bidType, err
+}

--- a/.semgrep/adapter/parse-bid-type-check.yml
+++ b/.semgrep/adapter/parse-bid-type-check.yml
@@ -1,0 +1,8 @@
+rules:
+  - id: parse-bid-type-check
+    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    languages:
+      - go
+    severity: WARNING
+    patterns:
+      - pattern: openrtb_ext.ParseBidType(...)

--- a/.semgrep/adapter/parse-bid-type-check.yml
+++ b/.semgrep/adapter/parse-bid-type-check.yml
@@ -1,6 +1,6 @@
 rules:
   - id: parse-bid-type-check
-    message: Prebid server expects media type set in adapter response. we recommend implementing a pattern where adapter server sets the [MType](https://github.com/prebid/openrtb/blob/53ac1b9ca7ddf860988ff69bf5018b32ced1fbc5/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    message: The current implementation follows an anti-pattern, assumes that if there is a multi-format request, the media type defaults to $ORTBTYPE. Prebid server expects the media type to be explicitly set in the adapter response. Therefore, we strongly recommend implementing a pattern where the adapter server sets the [MType](https://github.com/prebid/openrtb/blob/main/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
     languages:
       - go
     severity: WARNING


### PR DESCRIPTION
Currently, adapters identify bidType based on request imps or bid extensions in the response. Now that we have bid.MType available as part of openrtb 2.6, which can be used to set bid type in adapter response on the adapter server side, we recommend using MType. This PR adds semgrep rule to add warning to use MType.