### PR TITLE
update validate.sh: run go vet command correctly

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -35,7 +35,7 @@ if [ "$RACE" -ne "0" ]; then
 fi
 
 if $VET; then
-  COMMAND="go vet"
-  echo "Running: $COMMAND"
-  `$COMMAND`
+  COMMAND=$(go vet ./... 2>&1 | grep -v -E "literal uses unkeyed fields")
+  echo "Running go vet check"
+  echo "$COMMAND"
 fi


### PR DESCRIPTION
- As of now, the `validate.sh` script has been executed as part of the PR checks. However, there was an issue with how the go vet command was invoked in the script.
- Currently, the `go vet` command is not checking all the files. The solution is to modify the command to `go vet ./...` which ensure that all files are thoroughly checked during the PR checks.

```
prebid-server % ./validate.sh
Running go vet check
# github.com/prebid/prebid-server/adapters/adoppler
# github.com/prebid/prebid-server/amp
# github.com/prebid/prebid-server/endpoints/info
# github.com/prebid/prebid-server/endpoints/events
# github.com/prebid/prebid-server/endpoints
# github.com/prebid/prebid-server/router/aspects
# github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher
# github.com/prebid/prebid-server/stored_requests/backends/db_fetcher
# github.com/prebid/prebid-server/stored_requests/backends/file_fetcher
# github.com/prebid/prebid-server/util/stringutil
# github.com/prebid/prebid-server/exchange
```