### PR TITLE
update validate.sh: run go vet command correctly

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -35,7 +35,6 @@ if [ "$RACE" -ne "0" ]; then
 fi
 
 if $VET; then
-  COMMAND="go vet"
-  echo "Running: $COMMAND"
-  `$COMMAND`
+  echo "Running go vet check"
+  go vet -composites=false ./...
 fi


### PR DESCRIPTION
- As of now, the `validate.sh` script has been executed as part of the PR checks. However, there was an issue with how the `go vet` command was invoked in the script.
- Currently, the `go vet` command is not checking all the files. The solution is to modify the command to `go vet ./...` which ensure that all files are thoroughly checked during the PR checks.

Testings:

- go vet reports error: https://github.com/prebid/prebid-server/actions/runs/5690443652/job/15423793885?pr=2984
- no errors: https://github.com/prebid/prebid-server/actions/runs/5690525560/job/15424024371?pr=2984 
