### PR TITLE
Remove log lines from adapter

### DIFF
--- a/adapters/adhese/adhese.go
+++ b/adapters/adhese/adhese.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
@@ -201,7 +200,6 @@ func (a *AdheseAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalR
 func convertAdheseBid(adheseBid AdheseBid, adheseExt AdheseExt, adheseOriginData AdheseOriginData) openrtb2.BidResponse {
 	adheseExtJson, err := json.Marshal(adheseOriginData)
 	if err != nil {
-		glog.Error(fmt.Sprintf("Unable to parse adhese Origin Data as JSON due to %v", err))
 		adheseExtJson = make([]byte, 0)
 	}
 	return openrtb2.BidResponse{

--- a/adapters/gamoshi/gamoshi.go
+++ b/adapters/gamoshi/gamoshi.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/golang/glog"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
@@ -48,7 +47,6 @@ func (a *GamoshiAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ada
 			err := &errortypes.BadInput{
 				Message: fmt.Sprintf("Gamoshi only supports banner and video media types. Ignoring imp id=%s", request.Imp[i].ID),
 			}
-			glog.Warning("Gamoshi SUPPORT VIOLATION: only banner and video media types supported")
 			errs = append(errs, err)
 			request.Imp = append(request.Imp[:i], request.Imp[i+1:]...)
 			i--

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/golang/glog"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
@@ -390,7 +389,6 @@ func getAlternateBidderCodesFromRequestExt(reqExt *openrtb_ext.ExtRequest) []str
 func addKeywordsToExt(keywords []*openrtb_ext.ExtImpPubmaticKeyVal, extMap map[string]interface{}) {
 	for _, keyVal := range keywords {
 		if len(keyVal.Values) == 0 {
-			logf("No values present for key = %s", keyVal.Key)
 			continue
 		} else {
 			key := keyVal.Key
@@ -612,12 +610,6 @@ func getBidType(bidExt *pubmaticBidExt) openrtb_ext.BidType {
 		}
 	}
 	return bidType
-}
-
-func logf(msg string, args ...interface{}) {
-	if glog.V(2) {
-		glog.Infof(msg, args...)
-	}
 }
 
 // Builder builds a new instance of the Pubmatic adapter for the given bidder with the given config.

--- a/adapters/yeahmobi/yeahmobi.go
+++ b/adapters/yeahmobi/yeahmobi.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/config"
@@ -50,7 +49,6 @@ func (adapter *YeahmobiAdapter) makeRequest(request *openrtb2.BidRequest) (*adap
 	yeahmobiExt, errs := getYeahmobiExt(request)
 
 	if yeahmobiExt == nil {
-		glog.Fatal("Invalid ExtImpYeahmobi value")
 		return nil, errs
 	}
 	endPoint, err := adapter.getEndpoint(yeahmobiExt)


### PR DESCRIPTION
- Adding log lines in adapters incurs additional risk of flooding PBS host logs. Therefore their usage is discouraged in adapter code
- PR makes changes to remove `github.com/golang/glog` log lines from adapter code

```
% semgrep --config=.semgrep/adapter/package-import.yml ./adapters


    adapters/adhese/adhese.go
       semgrep.adapter.package-import-check
          Usage of "github.com/golang/glog" package is prohibited in adapter code

           13┆ "github.com/golang/glog"

    adapters/gamoshi/gamoshi.go
       semgrep.adapter.package-import-check
          Usage of "github.com/golang/glog" package is prohibited in adapter code

            9┆ "github.com/golang/glog"

    adapters/pubmatic/pubmatic.go
       semgrep.adapter.package-import-check
          Usage of "github.com/golang/glog" package is prohibited in adapter code

           13┆ "github.com/golang/glog"

    adapters/yeahmobi/yeahmobi.go
       semgrep.adapter.package-import-check
          Usage of "github.com/golang/glog" package is prohibited in adapter code

           10┆ "github.com/golang/glog"

```