### PR TITLE
inherit fields for an alias from parent adapter

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -269,7 +269,10 @@ func processBidderInfos(reader InfoReader, normalizeBidderName func(string) (ope
 
 func processBidderAliases(aliasNillableFieldsByBidder map[string]aliasNillableFields, bidderInfos BidderInfos) (BidderInfos, error) {
 	for bidderName := range aliasNillableFieldsByBidder {
-		aliasBidderInfo := bidderInfos[bidderName]
+		aliasBidderInfo, ok := bidderInfos[bidderName]
+		if !ok {
+			return nil, fmt.Errorf("bidder info not found for an alias: %s", bidderName)
+		}
 		if err := validateAliases(aliasBidderInfo, bidderInfos, bidderName); err != nil {
 			return nil, err
 		}

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -52,14 +52,12 @@ type BidderInfo struct {
 	OpenRTB             *OpenRTBInfo `yaml:"openrtb" mapstructure:"openrtb"`
 }
 
-type bidderInfoNullableFields struct {
+type aliasNillableFields struct {
 	Disabled                *bool                 `yaml:"disabled" mapstructure:"disabled"`
 	ModifyingVastXmlAllowed *bool                 `yaml:"modifyingVastXmlAllowed" mapstructure:"modifyingVastXmlAllowed"`
 	Experiment              *BidderInfoExperiment `yaml:"experiment" mapstructure:"experiment"`
 	XAPI                    *AdapterXAPI          `yaml:"xapi" mapstructure:"xapi"`
 }
-
-type aliasInfos map[string]bidderInfoNullableFields
 
 // BidderInfoExperiment specifies non-production ready feature config for a bidder
 type BidderInfoExperiment struct {
@@ -239,7 +237,7 @@ func processBidderInfos(reader InfoReader, normalizeBidderName func(string) (ope
 	}
 
 	bidderInfos := BidderInfos{}
-	aliasInfos := aliasInfos{} //maintains map of bidderName to nullable fields in BidderInfo struct
+	aliasNillableFieldsByBidder := map[string]aliasNillableFields{}
 	for fileName, data := range bidderConfigs {
 		bidderName := strings.Split(fileName, ".")
 		if len(bidderName) == 2 && bidderName[1] == "yaml" {
@@ -257,24 +255,24 @@ func processBidderInfos(reader InfoReader, normalizeBidderName func(string) (ope
 			//need to maintain nullable fields from BidderInfo struct into bidderInfoNullableFields
 			//to handle the default values in aliases yaml
 			if len(info.AliasOf) > 0 {
-				aliasInfo := bidderInfoNullableFields{}
-				if err := yaml.Unmarshal(data, &aliasInfo); err != nil {
+				aliasFields := aliasNillableFields{}
+				if err := yaml.Unmarshal(data, &aliasFields); err != nil {
 					return nil, fmt.Errorf("error parsing config for aliased bidder %s: %v", fileName, err)
 				}
 
-				aliasInfos[string(normalizedBidderName)] = aliasInfo
+				aliasNillableFieldsByBidder[string(normalizedBidderName)] = aliasFields
 			}
 		}
 	}
-	return processBidderAliases(aliasInfos, bidderInfos)
+	return processBidderAliases(aliasNillableFieldsByBidder, bidderInfos)
 }
 
-func processBidderAliases(aliasInfos aliasInfos, bidderInfos BidderInfos) (BidderInfos, error) {
-	for bidderName := range aliasInfos {
-		if err := validateAliases(bidderInfos[bidderName], bidderInfos, bidderName); err != nil {
+func processBidderAliases(aliasNillableFieldsByBidder map[string]aliasNillableFields, bidderInfos BidderInfos) (BidderInfos, error) {
+	for bidderName := range aliasNillableFieldsByBidder {
+		aliasBidderInfo := bidderInfos[bidderName]
+		if err := validateAliases(aliasBidderInfo, bidderInfos, bidderName); err != nil {
 			return nil, err
 		}
-		aliasBidderInfo := bidderInfos[bidderName]
 		parentBidderInfo := bidderInfos[aliasBidderInfo.AliasOf]
 		aliasBidderInfo.AppSecret = parentBidderInfo.AppSecret
 		aliasBidderInfo.Capabilities = parentBidderInfo.Capabilities

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -274,23 +274,19 @@ func (infos BidderInfos) validate(errs []error) []error {
 			if err := validateSyncer(bidder); err != nil {
 				errs = append(errs, err)
 			}
-
-			if err := validateAliases(bidder, infos, bidderName); err != nil {
-				errs = append(errs, err)
-			}
 		}
 	}
 	return errs
 }
 
-func validateAliases(bidder BidderInfo, infos BidderInfos, bidderName string) error {
-	if len(bidder.AliasOf) > 0 {
-		if parentBidder, ok := infos[bidder.AliasOf]; ok {
+func validateAliases(aliasBidderInfo BidderInfo, infos BidderInfos, bidderName string) error {
+	if len(aliasBidderInfo.AliasOf) > 0 {
+		if parentBidder, ok := infos[aliasBidderInfo.AliasOf]; ok {
 			if len(parentBidder.AliasOf) > 0 {
-				return fmt.Errorf("bidder: %s cannot be an alias of an alias: %s", bidder.AliasOf, bidderName)
+				return fmt.Errorf("bidder: %s cannot be an alias of an alias: %s", aliasBidderInfo.AliasOf, bidderName)
 			}
 		} else {
-			return fmt.Errorf("bidder: %s not found for an alias: %s", bidder.AliasOf, bidderName)
+			return fmt.Errorf("bidder: %s not found for an alias: %s", aliasBidderInfo.AliasOf, bidderName)
 		}
 	}
 	return nil

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -275,15 +275,15 @@ func TestProcessBidderInfo(t *testing.T) {
 func TestProcessAliasBidderInfo(t *testing.T) {
 	testCases := []struct {
 		description         string
-		aliasInfos          aliasInfos
+		aliasFields          map[string]aliasNillableFields
 		bidderInfos         BidderInfos
 		expectedBidderInfos BidderInfos
 		expectError         string
 	}{
 		{
 			description: "valid alias - replace alias with parent info",
-			aliasInfos: aliasInfos{
-				"bidderB": bidderInfoNullableFields{},
+			aliasFields: map[string]aliasNillableFields{
+				"bidderB": {},
 			},
 			bidderInfos: BidderInfos{
 				"bidderA": BidderInfo{
@@ -440,8 +440,8 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 		},
 		{
 			description: "invalid alias",
-			aliasInfos: aliasInfos{
-				"bidderB": bidderInfoNullableFields{},
+			aliasFields: map[string]aliasNillableFields{
+				"bidderB": {},
 			},
 			bidderInfos: BidderInfos{
 				"bidderB": BidderInfo{
@@ -453,7 +453,7 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		bidderInfos, err := processBidderAliases(test.aliasInfos, test.bidderInfos)
+		bidderInfos, err := processBidderAliases(test.aliasFields, test.bidderInfos)
 		if test.expectError != "" {
 			assert.ErrorContains(t, err, test.expectError)
 		} else {

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -275,7 +275,7 @@ func TestProcessBidderInfo(t *testing.T) {
 func TestProcessAliasBidderInfo(t *testing.T) {
 	testCases := []struct {
 		description         string
-		aliasFields          map[string]aliasNillableFields
+		aliasFields         map[string]aliasNillableFields
 		bidderInfos         BidderInfos
 		expectedBidderInfos BidderInfos
 		expectError         string
@@ -449,6 +449,13 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 				},
 			},
 			expectError: "bidderA not found for an alias: bidderB",
+		},
+		{
+			description: "bidder info not found for an alias",
+			aliasFields: map[string]aliasNillableFields{
+				"bidderB": {},
+			},
+			expectError: "bidder info not found for an alias: bidderB",
 		},
 	}
 

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -42,6 +42,27 @@ endpointCompression: GZIP
 openrtb:
   version: 2.6
   gpp-supported: true
+endpoint: https://endpoint.com
+disabled: false
+extra_info: extra-info
+app_secret: app-secret
+platform_id: 123
+usersync_url: user-url
+userSync:
+  key: foo
+  default: iframe
+  iframe:
+    url: https://foo.com/sync?mode=iframe&r={{.RedirectURL}}
+    redirectUrl: https://redirect/setuid/iframe
+    externalUrl: https://iframe.host
+    userMacro: UID
+xapi:
+  username: uname
+  password: pwd
+  tracker: tracker
+`
+const testSimpleAliasYAML = `
+aliasOf: bidderA
 `
 
 func TestLoadBidderInfoFromDisk(t *testing.T) {
@@ -131,6 +152,112 @@ func TestProcessBidderInfo(t *testing.T) {
 			expectedBidderInfos: nil,
 			expectError:         "error parsing config for bidder bidderA.yaml",
 		},
+		{
+			description: "Valid aliases",
+			bidderInfos: map[string][]byte{
+				"bidderA.yaml": []byte(fullBidderYAMLConfig),
+				"bidderB.yaml": []byte(testSimpleAliasYAML),
+			},
+			expectedBidderInfos: BidderInfos{
+				"bidderA": BidderInfo{
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+				"bidderB": BidderInfo{
+					AliasOf:   "bidderA",
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range testCases {
 		reader := StubInfoReader{test.bidderInfos}
@@ -143,6 +270,197 @@ func TestProcessBidderInfo(t *testing.T) {
 
 	}
 
+}
+
+func TestProcessAliasBidderInfo(t *testing.T) {
+	testCases := []struct {
+		description         string
+		aliasInfos          aliasInfos
+		bidderInfos         BidderInfos
+		expectedBidderInfos BidderInfos
+		expectError         string
+	}{
+		{
+			description: "valid alias - replace alias with parent info",
+			aliasInfos: aliasInfos{
+				"bidderB": bidderInfoNullableFields{},
+			},
+			bidderInfos: BidderInfos{
+				"bidderA": BidderInfo{
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+				"bidderB": BidderInfo{
+					AliasOf: "bidderA",
+				},
+			},
+			expectedBidderInfos: BidderInfos{
+				"bidderA": BidderInfo{
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+				"bidderB": BidderInfo{
+					AliasOf:   "bidderA",
+					AppSecret: "app-secret",
+					Capabilities: &CapabilitiesInfo{
+						App: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+						Site: &PlatformInfo{
+							MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
+						},
+					},
+					Debug: &DebugInfo{
+						Allow: true,
+					},
+					Disabled:            false,
+					Endpoint:            "https://endpoint.com",
+					EndpointCompression: "GZIP",
+					Experiment: BidderInfoExperiment{
+						AdsCert: BidderAdsCert{
+							Enabled: true,
+						},
+					},
+					ExtraAdapterInfo: "extra-info",
+					GVLVendorID:      42,
+					Maintainer: &MaintainerInfo{
+						Email: "some-email@domain.com",
+					},
+					ModifyingVastXmlAllowed: true,
+					OpenRTB: &OpenRTBInfo{
+						GPPSupported: true,
+						Version:      "2.6",
+					},
+					PlatformID: "123",
+					Syncer: &Syncer{
+						Key: "foo",
+						IFrame: &SyncerEndpoint{
+							URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
+							RedirectURL: "https://redirect/setuid/iframe",
+							ExternalURL: "https://iframe.host",
+							UserMacro:   "UID",
+						},
+					},
+					UserSyncURL: "user-url",
+					XAPI: AdapterXAPI{
+						Username: "uname",
+						Password: "pwd",
+						Tracker:  "tracker",
+					},
+				},
+			},
+		},
+		{
+			description: "invalid alias",
+			aliasInfos: aliasInfos{
+				"bidderB": bidderInfoNullableFields{},
+			},
+			bidderInfos: BidderInfos{
+				"bidderB": BidderInfo{
+					AliasOf: "bidderA",
+				},
+			},
+			expectError: "bidderA not found for an alias: bidderB",
+		},
+	}
+
+	for _, test := range testCases {
+		bidderInfos, err := processBidderAliases(test.aliasInfos, test.bidderInfos)
+		if test.expectError != "" {
+			assert.ErrorContains(t, err, test.expectError)
+		} else {
+			assert.Equal(t, test.expectedBidderInfos, bidderInfos)
+		}
+
+	}
 }
 
 type StubInfoReader struct {
@@ -1041,7 +1359,6 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 
 	expectedBidderInfo := BidderInfos{
 		bidder: {
-			Disabled: false,
 			Maintainer: &MaintainerInfo{
 				Email: "some-email@domain.com",
 			},
@@ -1054,17 +1371,41 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 					MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative},
 				},
 			},
-			Debug:                   &DebugInfo{Allow: true},
 			ModifyingVastXmlAllowed: true,
-			Syncer: &Syncer{
-				Supports: []string{"iframe"},
+			Debug: &DebugInfo{
+				Allow: true,
 			},
-			Experiment:          BidderInfoExperiment{AdsCert: BidderAdsCert{Enabled: true}},
+			Experiment: BidderInfoExperiment{
+				AdsCert: BidderAdsCert{
+					Enabled: true,
+				},
+			},
 			EndpointCompression: "GZIP",
 			OpenRTB: &OpenRTBInfo{
-				Version:      "2.6",
 				GPPSupported: true,
+				Version:      "2.6",
 			},
+			Disabled:         false,
+			ExtraAdapterInfo: "extra-info",
+			AppSecret:        "app-secret",
+			PlatformID:       "123",
+			UserSyncURL:      "user-url",
+			Syncer: &Syncer{
+				Key: "foo",
+				IFrame: &SyncerEndpoint{
+					URL:         "user-url",
+					RedirectURL: "https://redirect/setuid/iframe",
+					ExternalURL: "https://iframe.host",
+					UserMacro:   "UID",
+				},
+				Supports: []string{"iframe"},
+			},
+			XAPI: AdapterXAPI{
+				Username: "uname",
+				Password: "pwd",
+				Tracker:  "tracker",
+			},
+			Endpoint: "https://endpoint.com",
 		},
 	}
 	assert.Equalf(t, expectedBidderInfo, actualBidderInfo, "Bidder info objects aren't matching")


### PR DESCRIPTION
This PR makes the following changes - 
- It introduces a new struct `bidderInfoNullableFields` to maintain any nullable fields from BidderInfo struct. For example - the default value of `Disabled` in BidderInfo struct is always false and not `nil`.
- It may be the case where `Disabled` value of parent adapter is `true` but no value is set for an aliased adapter(default is false). In this case, we cannot just outright replace `Disabled` value of alias adapter with parent. Consider the case where aliased adapter `Disabled` value is actually set.
- To handle cases like above, we have introduced `bidderInfoNullableFields` struct.
- The approach is to maintain a map of bidderName to `bidderInfoNullableFields`. 
- Loop information from that map to determine if `Disabled` is actually set in aliased adapter or not since pointer values are defaulted to nil in golang. We do not have more than 20 aliases as of today so this loop is not expensive.
- This PR just inherits the fields from parent adapter to aliased adapter. In the subsequent PR, we will be handling the cases where nullable fields of BidderInfo struct is set.