### PR TITLE
replace deprecated ioutil function calls

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"github.com/prebid/prebid-server/privacy"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -420,7 +419,7 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request, labels *metric
 		N: deps.cfg.MaxRequestSize,
 	}
 
-	requestJson, err := ioutil.ReadAll(limitedReqReader)
+	requestJson, err := io.ReadAll(limitedReqReader)
 	if err != nil {
 		errs = []error{err}
 		return

--- a/stored_requests/backends/db_provider/mysql_dbprovider.go
+++ b/stored_requests/backends/db_provider/mysql_dbprovider.go
@@ -8,7 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -106,7 +106,7 @@ func (provider *MySqlDbProvider) ConnString() (string, error) {
 func setupTLSConfig(provider *MySqlDbProvider) error {
 	rootCertPool := x509.NewCertPool()
 
-	pem, err := ioutil.ReadFile(provider.cfg.TLS.RootCert)
+	pem, err := os.ReadFile(provider.cfg.TLS.RootCert)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Go 1.16 has deprecated `ioutil.ReadAll` and `ioutil.ReadFile` functions and recommended to use implementation from `io` and `os` package

Refer:
- https://pkg.go.dev/io/ioutil#ReadAll
- https://pkg.go.dev/io/ioutil#ReadFile