### PR TITLE
map alias bidder name to its parent builder

### DIFF
--- a/exchange/adapter_util.go
+++ b/exchange/adapter_util.go
@@ -43,6 +43,11 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 			continue
 		}
 
+		if err := SetAliasBuilder(info, builders, bidderName); err != nil {
+			errs = append(errs, fmt.Errorf("%v: failed to set alias builder: %v", bidder, err))
+			continue
+		}
+
 		builder, builderFound := builders[bidderName]
 		if !builderFound {
 			errs = append(errs, fmt.Errorf("%v: builder not registered", bidder))
@@ -61,6 +66,23 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 		}
 	}
 	return bidders, errs
+}
+
+func SetAliasBuilder(info config.BidderInfo, builders map[openrtb_ext.BidderName]adapters.Builder, bidderName openrtb_ext.BidderName) error {
+	if len(info.AliasOf) == 0 {
+		return nil
+	}
+	parentBidderName, parentBidderFound := openrtb_ext.NormalizeBidderName(info.AliasOf)
+	if !parentBidderFound {
+		return fmt.Errorf("unknown parent bidder: %v for alias: %v", info.AliasOf, bidderName)
+	}
+
+	builder, builderFound := builders[parentBidderName]
+	if !builderFound {
+		return fmt.Errorf("%v: parent builder not registered", parentBidderName)
+	}
+	builders[bidderName] = builder
+	return nil
 }
 
 func buildAdapterInfo(bidderInfo config.BidderInfo) config.Adapter {

--- a/exchange/adapter_util.go
+++ b/exchange/adapter_util.go
@@ -43,9 +43,11 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 			continue
 		}
 
-		if err := SetAliasBuilder(info, builders, bidderName); err != nil {
-			errs = append(errs, fmt.Errorf("%v: failed to set alias builder: %v", bidder, err))
-			continue
+		if len(info.AliasOf) > 0 {
+			if err := SetAliasBuilder(info, builders, bidderName); err != nil {
+				errs = append(errs, fmt.Errorf("%v: failed to set alias builder: %v", bidder, err))
+				continue
+			}
 		}
 
 		builder, builderFound := builders[bidderName]
@@ -69,9 +71,6 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 }
 
 func SetAliasBuilder(info config.BidderInfo, builders map[openrtb_ext.BidderName]adapters.Builder, bidderName openrtb_ext.BidderName) error {
-	if len(info.AliasOf) == 0 {
-		return nil
-	}
 	parentBidderName, parentBidderFound := openrtb_ext.NormalizeBidderName(info.AliasOf)
 	if !parentBidderFound {
 		return fmt.Errorf("unknown parent bidder: %v for alias: %v", info.AliasOf, bidderName)

--- a/exchange/adapter_util.go
+++ b/exchange/adapter_util.go
@@ -44,7 +44,7 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 		}
 
 		if len(info.AliasOf) > 0 {
-			if err := SetAliasBuilder(info, builders, bidderName); err != nil {
+			if err := setAliasBuilder(info, builders, bidderName); err != nil {
 				errs = append(errs, fmt.Errorf("%v: failed to set alias builder: %v", bidder, err))
 				continue
 			}
@@ -70,7 +70,7 @@ func buildBidders(infos config.BidderInfos, builders map[openrtb_ext.BidderName]
 	return bidders, errs
 }
 
-func SetAliasBuilder(info config.BidderInfo, builders map[openrtb_ext.BidderName]adapters.Builder, bidderName openrtb_ext.BidderName) error {
+func setAliasBuilder(info config.BidderInfo, builders map[openrtb_ext.BidderName]adapters.Builder, bidderName openrtb_ext.BidderName) error {
 	parentBidderName, parentBidderFound := openrtb_ext.NormalizeBidderName(info.AliasOf)
 	if !parentBidderFound {
 		return fmt.Errorf("unknown parent bidder: %v for alias: %v", info.AliasOf, bidderName)

--- a/exchange/adapter_util_test.go
+++ b/exchange/adapter_util_test.go
@@ -209,7 +209,7 @@ func TestSetAliasBuilder(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		err := SetAliasBuilder(test.bidderInfo, test.builders, test.bidderName)
+		err := setAliasBuilder(test.bidderInfo, test.builders, test.bidderName)
 
 		if test.expectedBuilders != nil {
 			assert.ObjectsAreEqual(test.builders, test.expectedBuilders)


### PR DESCRIPTION
This PR updates the builder map to associate alias name with the parent builder in the buildBidders function