### PR TITLE
AMX RTB: indicate support for GZIP, GPP, and add iframe sync

### DIFF
--- a/static/bidder-info/amx.yaml
+++ b/static/bidder-info/amx.yaml
@@ -14,7 +14,12 @@ capabilities:
       - video
       - native
 userSync:
+  iframe:
+    url: "https://prebid.a-mo.net/isyn?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&s=pbs&cb={{.RedirectURL}}"
+    userMacro: "$UID"
   redirect:
-    url: "https://prebid.a-mo.net/cchain/0?gdpr={{.GDPR}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
-    userMacro: ""
-
+    url: "https://prebid.a-mo.net/cchain/0?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&s=pbs&cb={{.RedirectURL}}"
+    userMacro: "$UID"
+endpointCompression: GZIP
+openrtb:
+  gpp-supported: true


### PR DESCRIPTION
Updates bidder-info for AMX adapter / amx.go to:

- indicate support for GZIP requests
- add GPP macros  in sync & indicate support for GPP
- add iframe sync, which will be the default sync. We've also deployed fixes to the redirect sync on our side that should resolve #2832 (iframe sync as default of course also helps reduce risk of future issues)