### PR TITLE
Activity Control: Refactor To Separate Files

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -529,5 +529,5 @@ func (p usersyncPrivacy) CCPAAllowsBidderSync(bidder string) bool {
 
 func (p usersyncPrivacy) ActivityAllowsUserSync(bidder string) bool {
 	return p.activityControl.Allow(privacy.ActivitySyncUser,
-		privacy.ScopedName{Scope: privacy.ScopeTypeBidder, Name: bidder})
+		privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidder})
 }

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -112,7 +112,7 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 		}
 
 		userSyncActivityAllowed := activities.Allow(privacy.ActivitySyncUser,
-			privacy.ScopedName{Scope: privacy.ScopeTypeBidder, Name: bidderName})
+			privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidderName})
 		if !userSyncActivityAllowed {
 			w.WriteHeader(http.StatusUnavailableForLegalReasons)
 			return

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -152,7 +152,7 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		}
 
 		// fetchBids activity
-		scopedName := privacy.ScopedName{Scope: privacy.ScopeTypeBidder, Name: bidderRequest.BidderName.String()}
+		scopedName := privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidderRequest.BidderName.String()}
 		fetchBidsActivityAllowed := auctionReq.Activities.Allow(privacy.ActivityFetchBids, scopedName)
 		if !fetchBidsActivityAllowed {
 			// skip the call to a bidder if fetchBids activity is not allowed

--- a/privacy/activitycontrol_test.go
+++ b/privacy/activitycontrol_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestNewActivityControl(t *testing.T) {
-
 	testCases := []struct {
 		name            string
 		privacyConf     *config.AccountPrivacy
@@ -57,7 +56,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_FetchBids_is_incorrect",
@@ -67,7 +66,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_EnrichUserFPD_is_incorrect",
@@ -77,7 +76,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_ReportAnalytics_is_incorrect",
@@ -87,7 +86,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_TransmitUserFPD_is_incorrect",
@@ -97,7 +96,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_TransmitPreciseGeo_is_incorrect",
@@ -107,7 +106,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_TransmitUniqueRequestIds_is_incorrect",
@@ -117,7 +116,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 		{
 			name: "privacy_config_is_specified_and_TransmitTids_is_incorrect",
@@ -127,7 +126,7 @@ func TestNewActivityControl(t *testing.T) {
 				},
 			},
 			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse condition: bidder.bidderA.bidderB"),
+			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 	}
 
@@ -181,14 +180,14 @@ func TestAllowActivityControl(t *testing.T) {
 		name            string
 		activityControl ActivityControl
 		activity        Activity
-		target          ScopedName
+		target          Component
 		activityResult  bool
 	}{
 		{
 			name:            "plans_is_nil",
 			activityControl: ActivityControl{plans: nil},
 			activity:        ActivityFetchBids,
-			target:          ScopedName{Scope: "bidder", Name: "bidderA"},
+			target:          Component{Type: "bidder", Name: "bidderA"},
 			activityResult:  true,
 		},
 		{
@@ -196,7 +195,7 @@ func TestAllowActivityControl(t *testing.T) {
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
 				ActivitySyncUser: getDefaultActivityPlan()}},
 			activity:       ActivityFetchBids,
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
+			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
 		},
 		{
@@ -204,7 +203,7 @@ func TestAllowActivityControl(t *testing.T) {
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
 				ActivityFetchBids: getDefaultActivityPlan()}},
 			activity:       ActivityFetchBids,
-			target:         ScopedName{Scope: "bidder", Name: "bidderB"},
+			target:         Component{Type: "bidder", Name: "bidderB"},
 			activityResult: true,
 		},
 		{
@@ -212,7 +211,7 @@ func TestAllowActivityControl(t *testing.T) {
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
 				ActivityFetchBids: getDefaultActivityPlan()}},
 			activity:       ActivityFetchBids,
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
+			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
 		},
 	}
@@ -222,166 +221,6 @@ func TestAllowActivityControl(t *testing.T) {
 			actualResult := test.activityControl.Allow(test.activity, test.target)
 			assert.Equal(t, test.activityResult, actualResult)
 
-		})
-	}
-}
-
-func TestComponentEnforcementRuleEvaluate(t *testing.T) {
-	testCases := []struct {
-		name           string
-		componentRule  ComponentEnforcementRule
-		target         ScopedName
-		activityResult ActivityResult
-	}{
-		{
-			name: "activity_is_allowed",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []ScopedName{
-					{Scope: "bidder", Name: "bidderA"},
-				},
-				componentType: []string{"bidder"},
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
-			activityResult: ActivityAllow,
-		},
-		{
-			name: "activity_is_not_allowed",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityDeny,
-				componentName: []ScopedName{
-					{Scope: "bidder", Name: "bidderA"},
-				},
-				componentType: []string{"bidder"},
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
-			activityResult: ActivityDeny,
-		},
-		{
-			name: "abstain_both_clauses_do_not_match",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []ScopedName{
-					{Scope: "bidder", Name: "bidderA"},
-				},
-				componentType: []string{"bidder"},
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderB"},
-			activityResult: ActivityAbstain,
-		},
-		{
-			name: "activity_is_not_allowed_componentName_only",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []ScopedName{
-					{Scope: "bidder", Name: "bidderA"},
-				},
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
-			activityResult: ActivityAllow,
-		},
-		{
-			name: "activity_is_allowed_componentType_only",
-			componentRule: ComponentEnforcementRule{
-				result:        ActivityAllow,
-				componentType: []string{"bidder"},
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderB"},
-			activityResult: ActivityAllow,
-		},
-		{
-			name: "no-conditions-allow",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
-			activityResult: ActivityAllow,
-		},
-		{
-			name: "no-conditions-deny",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityDeny,
-			},
-			target:         ScopedName{Scope: "bidder", Name: "bidderA"},
-			activityResult: ActivityDeny,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			actualResult := test.componentRule.Evaluate(test.target)
-			assert.Equal(t, test.activityResult, actualResult)
-
-		})
-	}
-}
-
-func TestNewScopedName(t *testing.T) {
-	testCases := []struct {
-		name              string
-		condition         string
-		expectedScopeName ScopedName
-		err               error
-	}{
-		{
-			name:              "empty",
-			condition:         "",
-			expectedScopeName: ScopedName{},
-			err:               errors.New("unable to parse empty condition"),
-		},
-		{
-			name:              "incorrect",
-			condition:         "bidder.bidderA.bidderB",
-			expectedScopeName: ScopedName{},
-			err:               errors.New("unable to parse condition: bidder.bidderA.bidderB"),
-		},
-		{
-			name:              "scope-bidder",
-			condition:         "bidder.bidderA",
-			expectedScopeName: ScopedName{Scope: "bidder", Name: "bidderA"},
-			err:               nil,
-		},
-		{
-			name:              "scope-analytics",
-			condition:         "analytics.bidderA",
-			expectedScopeName: ScopedName{Scope: "analytics", Name: "bidderA"},
-			err:               nil,
-		},
-		{
-			name:              "scope-userid",
-			condition:         "userid.bidderA",
-			expectedScopeName: ScopedName{Scope: "userid", Name: "bidderA"},
-			err:               nil,
-		},
-		{
-			name:              "scope-default",
-			condition:         "bidderA",
-			expectedScopeName: ScopedName{Scope: "bidder", Name: "bidderA"},
-			err:               nil,
-		},
-		{
-			name:              "scope-rtf",
-			condition:         "rtd.test",
-			expectedScopeName: ScopedName{Scope: "rtd", Name: "test"},
-			err:               nil,
-		},
-		{
-			name:              "scope-general",
-			condition:         "test.test",
-			expectedScopeName: ScopedName{Scope: "general", Name: "test"},
-			err:               nil,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			actualSN, actualErr := NewScopedName(test.condition)
-			if test.err == nil {
-				assert.Equal(t, test.expectedScopeName, actualSN)
-				assert.NoError(t, actualErr)
-			} else {
-				assert.EqualError(t, actualErr, test.err.Error())
-			}
 		})
 	}
 }
@@ -405,11 +244,11 @@ func getDefaultActivityConfig() config.Activity {
 func getDefaultActivityPlan() ActivityPlan {
 	return ActivityPlan{
 		defaultResult: true,
-		rules: []ActivityRule{
+		rules: []Rule{
 			ComponentEnforcementRule{
 				result: ActivityAllow,
-				componentName: []ScopedName{
-					{Scope: "bidder", Name: "bidderA"},
+				componentName: []Component{
+					{Type: "bidder", Name: "bidderA"},
 				},
 				componentType: []string{"bidder"},
 			},

--- a/privacy/component.go
+++ b/privacy/component.go
@@ -1,0 +1,65 @@
+package privacy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	ComponentTypeBidder       = "bidder"
+	ComponentTypeAnalytics    = "analytics"
+	ComponentTypeRealTimeData = "rtd"
+	ComponentTypeGeneral      = "general"
+)
+
+type Component struct {
+	Type string
+	Name string
+}
+
+func (c Component) Matches(target Component) bool {
+	return strings.EqualFold(c.Type, target.Type) && (c.Name == "*" || strings.EqualFold(c.Name, target.Name))
+}
+
+var ErrComponentEmpty = errors.New("unable to parse empty component")
+
+func ParseComponent(v string) (Component, error) {
+	if len(v) == 0 {
+		return Component{}, ErrComponentEmpty
+	}
+
+	split := strings.Split(v, ".")
+
+	if len(split) == 2 {
+		if !validComponentType(split[0]) {
+			return Component{}, fmt.Errorf("unable to parse component (invalid type): %s", v)
+		}
+		return Component{
+			Type: split[0],
+			Name: split[1],
+		}, nil
+	}
+
+	if len(split) == 1 {
+		return Component{
+			Type: ComponentTypeBidder,
+			Name: split[0],
+		}, nil
+	}
+
+	return Component{}, fmt.Errorf("unable to parse component: %s", v)
+}
+
+func validComponentType(t string) bool {
+	t = strings.ToLower(t)
+
+	if t == ComponentTypeBidder ||
+		t == ComponentTypeAnalytics ||
+		t == ComponentTypeRealTimeData ||
+		t == ComponentTypeGeneral {
+		return true
+	}
+
+	return false
+}

--- a/privacy/component_test.go
+++ b/privacy/component_test.go
@@ -1,0 +1,124 @@
+package privacy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentMatches(t *testing.T) {
+	testCases := []struct {
+		name   string
+		given  Component
+		target Component
+		result bool
+	}{
+		{
+			name:   "full",
+			given:  Component{Type: "a", Name: "b"},
+			target: Component{Type: "a", Name: "b"},
+			result: true,
+		},
+		{
+			name:   "name-wildcard",
+			given:  Component{Type: "a", Name: "*"},
+			target: Component{Type: "a", Name: "b"},
+			result: true,
+		},
+		{
+			name:   "different",
+			given:  Component{Type: "a", Name: "b"},
+			target: Component{Type: "foo", Name: "bar"},
+			result: false,
+		},
+		{
+			name:   "different-type",
+			given:  Component{Type: "a", Name: "b"},
+			target: Component{Type: "foo", Name: "b"},
+			result: false,
+		},
+		{
+			name:   "different-name",
+			given:  Component{Type: "a", Name: "b"},
+			target: Component{Type: "a", Name: "foo"},
+			result: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.result, test.given.Matches(test.target))
+		})
+	}
+}
+
+func TestParseComponent(t *testing.T) {
+	testCases := []struct {
+		name          string
+		component     string
+		expected      Component
+		expectedError error
+	}{
+		{
+			name:          "empty",
+			component:     "",
+			expected:      Component{},
+			expectedError: errors.New("unable to parse empty component"),
+		},
+		{
+			name:          "too-many-parts",
+			component:     "bidder.bidderA.bidderB",
+			expected:      Component{},
+			expectedError: errors.New("unable to parse component: bidder.bidderA.bidderB"),
+		},
+		{
+			name:          "type-bidder",
+			component:     "bidder.bidderA",
+			expected:      Component{Type: "bidder", Name: "bidderA"},
+			expectedError: nil,
+		},
+		{
+			name:          "type-analytics",
+			component:     "analytics.bidderA",
+			expected:      Component{Type: "analytics", Name: "bidderA"},
+			expectedError: nil,
+		},
+		{
+			name:          "type-default",
+			component:     "bidderA",
+			expected:      Component{Type: "bidder", Name: "bidderA"},
+			expectedError: nil,
+		},
+		{
+			name:          "type-rtd",
+			component:     "rtd.test",
+			expected:      Component{Type: "rtd", Name: "test"},
+			expectedError: nil,
+		},
+		{
+			name:          "type-general",
+			component:     "general.test",
+			expected:      Component{Type: "general", Name: "test"},
+			expectedError: nil,
+		},
+		{
+			name:          "type-invalid",
+			component:     "invalid.test",
+			expected:      Component{},
+			expectedError: errors.New("unable to parse component (invalid type): invalid.test"),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualSN, actualErr := ParseComponent(test.component)
+			if test.expectedError == nil {
+				assert.Equal(t, test.expected, actualSN)
+				assert.NoError(t, actualErr)
+			} else {
+				assert.EqualError(t, actualErr, test.expectedError.Error())
+			}
+		})
+	}
+}

--- a/privacy/rules.go
+++ b/privacy/rules.go
@@ -1,0 +1,59 @@
+package privacy
+
+import (
+	"strings"
+)
+
+type Rule interface {
+	Evaluate(target Component) ActivityResult
+}
+
+type ComponentEnforcementRule struct {
+	result        ActivityResult
+	componentName []Component
+	componentType []string
+}
+
+func (r ComponentEnforcementRule) Evaluate(target Component) ActivityResult {
+	if matched := evaluateComponentName(target, r.componentName); !matched {
+		return ActivityAbstain
+	}
+
+	if matched := evaluateComponentType(target, r.componentType); !matched {
+		return ActivityAbstain
+	}
+
+	return r.result
+}
+
+func evaluateComponentName(target Component, componentNames []Component) bool {
+	// no clauses are considered a match
+	if len(componentNames) == 0 {
+		return true
+	}
+
+	// if there are clauses, at least one needs to match
+	for _, n := range componentNames {
+		if n.Matches(target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func evaluateComponentType(target Component, componentTypes []string) bool {
+	// no clauses are considered a match
+	if len(componentTypes) == 0 {
+		return true
+	}
+
+	// if there are clauses, at least one needs to match
+	for _, s := range componentTypes {
+		if strings.EqualFold(s, target.Type) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/privacy/rules_test.go
+++ b/privacy/rules_test.go
@@ -1,0 +1,97 @@
+package privacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentEnforcementRuleEvaluate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		componentRule  ComponentEnforcementRule
+		target         Component
+		activityResult ActivityResult
+	}{
+		{
+			name: "activity_is_allowed",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityAllow,
+				componentName: []Component{
+					{Type: "bidder", Name: "bidderA"},
+				},
+				componentType: []string{"bidder"},
+			},
+			target:         Component{Type: "bidder", Name: "bidderA"},
+			activityResult: ActivityAllow,
+		},
+		{
+			name: "activity_is_not_allowed",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityDeny,
+				componentName: []Component{
+					{Type: "bidder", Name: "bidderA"},
+				},
+				componentType: []string{"bidder"},
+			},
+			target:         Component{Type: "bidder", Name: "bidderA"},
+			activityResult: ActivityDeny,
+		},
+		{
+			name: "abstain_both_clauses_do_not_match",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityAllow,
+				componentName: []Component{
+					{Type: "bidder", Name: "bidderA"},
+				},
+				componentType: []string{"bidder"},
+			},
+			target:         Component{Type: "bidder", Name: "bidderB"},
+			activityResult: ActivityAbstain,
+		},
+		{
+			name: "activity_is_not_allowed_componentName_only",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityAllow,
+				componentName: []Component{
+					{Type: "bidder", Name: "bidderA"},
+				},
+			},
+			target:         Component{Type: "bidder", Name: "bidderA"},
+			activityResult: ActivityAllow,
+		},
+		{
+			name: "activity_is_allowed_componentType_only",
+			componentRule: ComponentEnforcementRule{
+				result:        ActivityAllow,
+				componentType: []string{"bidder"},
+			},
+			target:         Component{Type: "bidder", Name: "bidderB"},
+			activityResult: ActivityAllow,
+		},
+		{
+			name: "no-conditions-allow",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityAllow,
+			},
+			target:         Component{Type: "bidder", Name: "bidderA"},
+			activityResult: ActivityAllow,
+		},
+		{
+			name: "no-conditions-deny",
+			componentRule: ComponentEnforcementRule{
+				result: ActivityDeny,
+			},
+			target:         Component{Type: "bidder", Name: "bidderA"},
+			activityResult: ActivityDeny,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualResult := test.componentRule.Evaluate(test.target)
+			assert.Equal(t, test.activityResult, actualResult)
+
+		})
+	}
+}


### PR DESCRIPTION
Breaking out thee Privacy Activity Control feature into separate files, as a follow-up PR will begin adding complexity for passing requests to the rules.