### PR TITLE
Smaato: Update userSync url

### DIFF
--- a/static/bidder-info/smaato.yaml
+++ b/static/bidder-info/smaato.yaml
@@ -16,6 +16,6 @@ capabilities:
       - native
 userSync:
   redirect:
-    url: "https://s.ad.smaato.net/c/?adExInit=p&redir={{.RedirectURL}}"
+    url: "https://s.ad.smaato.net/c/?adExInit=p&redir={{.RedirectURL}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}"
     userMacro: "$UID"
 


### PR DESCRIPTION
Updates bidder-info for Smaato adapter to add Gdpr macros in userSync url