### PR TITLE
release.yml run build before creating new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Build and validate
         run: |
           ./validate.sh
-          go build .
 
   publish-tag:
     name: Publish tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           ref: master
       - name: Build and validate
         run: |
-          make
+          go build .
           ./validate.sh
 
   publish-tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,24 @@ jobs:
     outputs:
       hasWritePermission: ${{ steps.check.outputs.require-result }}
 
+  build-master:
+    name: Build master
+    needs: check-permission
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Build
+        uses: actions/checkout@master
+        uses: skx/github-action-build@master
+        with:
+          builder: make
+
   publish-tag:
     name: Publish tag
-    needs: check-permission
+    needs: build-master
     if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,19 @@ jobs:
   build-master:
     name: Build master
     needs: check-permission
+    if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - name: Build
-        uses: actions/checkout@master
-        uses: skx/github-action-build@master
-        with:
-          builder: make
+          repository: ${{ github.repository }}
+          ref: master
+      - name: Build and validate
+        run: |
+          make
+          ./validate.sh
 
   publish-tag:
     name: Publish tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
           ref: master
       - name: Build and validate
         run: |
-          go build .
           ./validate.sh
+          go build .
 
   publish-tag:
     name: Publish tag


### PR DESCRIPTION
Github actions `release.yml` is tagging before verifying whether or not the code compiles sucessfully. This led to tags `0.268.0`  and `0.269.0` to both point to the same commit when the former's release failed. This pull request makes `release.yml` pull from current `master` branch and perform a build before moving on to create a new tag.