### PR TITLE
Fix semgrep error message

### DIFF
--- a/.semgrep/adapter/parse-bid-type-check.yml
+++ b/.semgrep/adapter/parse-bid-type-check.yml
@@ -1,6 +1,8 @@
 rules:
   - id: parse-bid-type-check
-    message: The current implementation follows an anti-pattern, assumes that if there is a multi-format request, the media type defaults to $ORTBTYPE. Prebid server expects the media type to be explicitly set in the adapter response. Therefore, we strongly recommend implementing a pattern where the adapter server sets the [MType](https://github.com/prebid/openrtb/blob/main/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
+    message: > 
+      Prebid server expects the media type to be explicitly set in the adapter response. 
+      Therefore, recommends implementing a pattern where the adapter server sets the [MType](https://github.com/prebid/openrtb/blob/main/openrtb2/bid.go#L334) field in the response to accurately determine the media type for the impression.
     languages:
       - go
     severity: WARNING


### PR DESCRIPTION
`$ORTBTYPE` is not declared in `parse-bid-type-check.yml`. So message seems bit misleading