### PR TITLE
Flipp: remove IP as a bidder request parameter

### DIFF
--- a/adapters/flipp/flipp.go
+++ b/adapters/flipp/flipp.go
@@ -114,9 +114,7 @@ func (a *adapter) processImp(request *openrtb2.BidRequest, imp openrtb2.Imp) (*a
 	}
 
 	var userIP string
-	if flippExtParams.IP != "" {
-		userIP = flippExtParams.IP
-	} else if request.Device != nil && request.Device.IP != "" {
+	if request.Device != nil && request.Device.IP != "" {
 		userIP = request.Device.IP
 	} else {
 		return nil, fmt.Errorf("no IP set in flipp bidder params or request device")

--- a/adapters/flipp/flipptest/exemplary/simple-banner-native.json
+++ b/adapters/flipp/flipptest/exemplary/simple-banner-native.json
@@ -30,7 +30,6 @@
                                 "creativeType": "NativeX",
                                 "siteId": 1243066,
                                 "zoneIds": [285431],
-                                "ip": "123.123.123.124",
                                 "options": {
                                    "startCompact": true,
                                    "contentCode": "publisher-test-2"
@@ -46,7 +45,7 @@
             "expectedRequest": {
                 "uri": "http://example.com/pserver",
                 "body": {
-                    "ip":"123.123.123.124",
+                    "ip":"123.123.123.123",
                     "keywords":[
                        ""
                     ],

--- a/openrtb_ext/imp_flipp.go
+++ b/openrtb_ext/imp_flipp.go
@@ -6,7 +6,6 @@ type ImpExtFlipp struct {
 	SiteID                  int64              `json:"siteId"`
 	ZoneIds                 []int64            `json:"zoneIds,omitempty"`
 	UserKey                 string             `json:"userKey,omitempty"`
-	IP                      string             `json:"ip,omitempty"`
 	Options                 ImpExtFlippOptions `json:"options,omitempty"`
 }
 


### PR DESCRIPTION
Based on the discussion here https://github.com/prebid/prebid.github.io/pull/4551#discussion_r1222098377, we are removing ip as a bidder request parameter. IP will be retrieved from `request.Device.IP`.