### PR TITLE
inherit bidder params from parent for an alias

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -278,7 +278,7 @@ func processBidderAliases(aliasNillableFieldsByBidder map[string]aliasNillableFi
 		}
 
 		//required for CoreBidderNames function to also return aliasBiddernames
-		if err := openrtb_ext.SetAliasBidderName(openrtb_ext.BidderName(string(bidderName)), openrtb_ext.BidderName(aliasBidderInfo.AliasOf)); err != nil {
+		if err := openrtb_ext.SetAliasBidderName(bidderName, openrtb_ext.BidderName(aliasBidderInfo.AliasOf)); err != nil {
 			return nil, err
 		}
 		parentBidderInfo := bidderInfos[aliasBidderInfo.AliasOf]

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -276,8 +276,11 @@ func processBidderAliases(aliasNillableFieldsByBidder map[string]aliasNillableFi
 		if err := validateAliases(aliasBidderInfo, bidderInfos, bidderName); err != nil {
 			return nil, err
 		}
+
 		//required for CoreBidderNames function to also return aliasBiddernames
-		openrtb_ext.SetAliasBidderName(openrtb_ext.BidderName(string(bidderName)))
+		if err := openrtb_ext.SetAliasBidderName(openrtb_ext.BidderName(string(bidderName)), openrtb_ext.BidderName(aliasBidderInfo.AliasOf)); err != nil {
+			return nil, err
+		}
 		parentBidderInfo := bidderInfos[aliasBidderInfo.AliasOf]
 		if aliasBidderInfo.AppSecret == "" {
 			aliasBidderInfo.AppSecret = parentBidderInfo.AppSecret

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -434,6 +434,17 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 			},
 			expectedErr: errors.New("bidder info not found for an alias: bidderB"),
 		},
+		{
+			description: "unable to set an alias",
+			aliasInfos: map[string]aliasNillableFields{
+				"all": {},
+			},
+			bidderInfos: BidderInfos{
+				"bidderA": parentBidderInfo,
+				"all":     aliasBidderInfo,
+			},
+			expectedErr: errors.New("alias all is a reserved bidder name and cannot be used"),
+		},
 	}
 
 	for _, test := range testCases {

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -222,12 +222,13 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderZetaGlobalSsp,
 }
 
-func SetAliasBidderName(aliasBidderName BidderName, parentBidderName BidderName) error {
-	if IsBidderNameReserved(string(aliasBidderName)) {
+func SetAliasBidderName(aliasBidderName string, parentBidderName BidderName) error {
+	if IsBidderNameReserved(aliasBidderName) {
 		return fmt.Errorf("alias %s is a reserved bidder name and cannot be used", aliasBidderName)
 	}
-	coreBidderNames = append(coreBidderNames, aliasBidderName)
-	aliasBidderToParentBidder[aliasBidderName] = parentBidderName
+	aliasBidder := BidderName(aliasBidderName)
+	coreBidderNames = append(coreBidderNames, aliasBidder)
+	aliasBidderToParentBidder[aliasBidder] = parentBidderName
 	return nil
 }
 

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -632,6 +632,15 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 		schemaContents[BidderName(bidderName)] = string(fileBytes)
 	}
 
+	//set alias bidder params schema to its parent
+	for alias, parent := range aliasBidderToParentBidder {
+		parentSchema := schemas[parent]
+		parentSchemaContents := schemaContents[parent]
+
+		schemas[alias] = parentSchema
+		schemaContents[alias] = parentSchemaContents
+	}
+
 	return &bidderParamValidator{
 		schemaContents: schemaContents,
 		parsedSchemas:  schemas,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -637,7 +637,7 @@ func NewBidderParamsValidator(schemaDirectory string) (BidderParamValidator, err
 	for alias, parent := range aliasBidderToParent {
 		parentSchema := schemas[parent]
 		schemas[alias] = parentSchema
-		
+
 		parentSchemaContents := schemaContents[parent]
 		schemaContents[alias] = parentSchemaContents
 	}

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -15,7 +15,7 @@ import (
 // BidderName refers to a core bidder id or an alias id.
 type BidderName string
 
-var aliasBidderNames []BidderName
+var aliasBidderToParentBidder map[BidderName]BidderName = map[BidderName]BidderName{}
 
 var coreBidderNames []BidderName = []BidderName{
 	Bidder33Across,
@@ -222,17 +222,13 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderZetaGlobalSsp,
 }
 
-func SetAliasBidderName(name BidderName) {
-	aliasBidderNames = append(aliasBidderNames, name)
-	coreBidderNames = append(coreBidderNames, name)
-}
-
-func GetAliasBidderNamesSet() map[BidderName]struct{} {
-	set := map[BidderName]struct{}{}
-	for _, name := range aliasBidderNames {
-		set[name] = struct{}{}
+func SetAliasBidderName(aliasBidderName BidderName, parentBidderName BidderName) error {
+	if IsBidderNameReserved(string(aliasBidderName)) {
+		return fmt.Errorf("alias %s is a reserved bidder name and cannot be used", aliasBidderName)
 	}
-	return set
+	coreBidderNames = append(coreBidderNames, aliasBidderName)
+	aliasBidderToParentBidder[aliasBidderName] = parentBidderName
+	return nil
 }
 
 func (name BidderName) MarshalJSON() ([]byte, error) {

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -164,26 +164,26 @@ type mockParamsHelper struct {
 	readFileErr     error
 }
 
-func (m mockParamsHelper) readDir(name string) ([]os.DirEntry, error) {
+func (m *mockParamsHelper) readDir(name string) ([]os.DirEntry, error) {
 	return m.fs.ReadDir(name)
 }
 
-func (m mockParamsHelper) readFile(name string) ([]byte, error) {
+func (m *mockParamsHelper) readFile(name string) ([]byte, error) {
 	if m.readFileErr != nil {
 		return nil, m.readFileErr
 	}
 	return m.fs.ReadFile(name)
 }
 
-func (m mockParamsHelper) newReferenceLoader(source string) gojsonschema.JSONLoader {
+func (m *mockParamsHelper) newReferenceLoader(source string) gojsonschema.JSONLoader {
 	return nil
 }
 
-func (m mockParamsHelper) newSchema(l gojsonschema.JSONLoader) (*gojsonschema.Schema, error) {
+func (m *mockParamsHelper) newSchema(l gojsonschema.JSONLoader) (*gojsonschema.Schema, error) {
 	return nil, m.schemaLoaderErr
 }
 
-func (m mockParamsHelper) abs(path string) (string, error) {
+func (m *mockParamsHelper) abs(path string) (string, error) {
 	return m.absFilePath, m.absPathErr
 }
 
@@ -267,7 +267,7 @@ func TestNewBidderParamsValidator(t *testing.T) {
 
 	for _, test := range testCases {
 		aliasBidderToParentBidder = map[BidderName]BidderName{"rubicon": "appnexus"}
-		paramsValidator = test.paramsValidator
+		paramsValidator = &test.paramsValidator
 		bidderValidator, err := NewBidderParamsValidator(test.dir)
 		if test.expectedErr == nil {
 			assert.NoError(t, err)

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -266,11 +266,13 @@ func TestNewBidderParamsValidator(t *testing.T) {
 	}
 
 	for _, test := range testCases {
+		aliasBidderToParentBidder = map[BidderName]BidderName{"rubicon": "appnexus"}
 		paramsValidator = test.paramsValidator
 		bidderValidator, err := NewBidderParamsValidator(test.dir)
 		if test.expectedErr == nil {
 			assert.NoError(t, err)
 			assert.Contains(t, bidderValidator.Schema("appnexus"), "{}")
+			assert.Contains(t, bidderValidator.Schema("rubicon"), "{}")
 		} else {
 			assert.Equal(t, err, test.expectedErr)
 		}

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -147,13 +147,13 @@ func TestSetAliasBidderName(t *testing.T) {
 			assert.Equal(t, test.err, err)
 		} else {
 			assert.Contains(t, CoreBidderNames(), BidderName(test.aliasBidderName))
-			assert.Contains(t, aliasBidderToParentBidder, BidderName(test.aliasBidderName))
+			assert.Contains(t, aliasBidderToParent, BidderName(test.aliasBidderName))
 		}
 	}
 
 	//reset package variables to not interfere with other test cases. Example - TestBidderParamSchemas
 	coreBidderNames = existingCoreBidderNames
-	aliasBidderToParentBidder = map[BidderName]BidderName{}
+	aliasBidderToParent = map[BidderName]BidderName{}
 }
 
 type mockParamsHelper struct {
@@ -266,15 +266,17 @@ func TestNewBidderParamsValidator(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		aliasBidderToParentBidder = map[BidderName]BidderName{"rubicon": "appnexus"}
-		paramsValidator = &test.paramsValidator
-		bidderValidator, err := NewBidderParamsValidator(test.dir)
-		if test.expectedErr == nil {
-			assert.NoError(t, err)
-			assert.Contains(t, bidderValidator.Schema("appnexus"), "{}")
-			assert.Contains(t, bidderValidator.Schema("rubicon"), "{}")
-		} else {
-			assert.Equal(t, err, test.expectedErr)
-		}
+		t.Run(test.description, func(t *testing.T) {
+			aliasBidderToParent = map[BidderName]BidderName{"rubicon": "appnexus"}
+			paramsValidator = &test.paramsValidator
+			bidderValidator, err := NewBidderParamsValidator(test.dir)
+			if test.expectedErr == nil {
+				assert.NoError(t, err)
+				assert.Contains(t, bidderValidator.Schema("appnexus"), "{}")
+				assert.Contains(t, bidderValidator.Schema("rubicon"), "{}")
+			} else {
+				assert.Equal(t, err, test.expectedErr)
+			}
+		})
 	}
 }

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -134,7 +134,7 @@ func TestSetAliasBidderName(t *testing.T) {
 	existingCoreBidderNames := coreBidderNames
 
 	testCases := []struct {
-		aliasBidderName BidderName
+		aliasBidderName string
 		err             error
 	}{
 		{"aBidder", nil},
@@ -146,8 +146,8 @@ func TestSetAliasBidderName(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, test.err, err)
 		} else {
-			assert.Contains(t, CoreBidderNames(), test.aliasBidderName)
-			assert.Contains(t, aliasBidderToParentBidder, test.aliasBidderName)
+			assert.Contains(t, CoreBidderNames(), BidderName(test.aliasBidderName))
+			assert.Contains(t, aliasBidderToParentBidder, BidderName(test.aliasBidderName))
 		}
 	}
 

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -126,8 +126,31 @@ func TestIsBidderNameReserved(t *testing.T) {
 	}
 }
 
-func TestCoreBidderNames(t *testing.T) {
-	bidderA := "BidderA"
-	SetAliasBidderName(BidderName(bidderA))
-	assert.Contains(t, CoreBidderNames(), BidderName(bidderA))
+func TestSetAliasBidderName(t *testing.T) {
+	parentBidder := BidderName("pBidder")
+	existingCoreBidderNames := coreBidderNames
+
+	testCases := []struct {
+		aliasBidderName BidderName
+		err             error
+	}{
+		{"aBidder", nil},
+		{"all", errors.New("alias all is a reserved bidder name and cannot be used")},
+	}
+
+	for _, test := range testCases {
+		err := SetAliasBidderName(test.aliasBidderName, parentBidder)
+		if err != nil {
+			assert.Equal(t, test.err, err)
+		} else {
+			assert.Contains(t, CoreBidderNames(), test.aliasBidderName)
+			assert.Contains(t, aliasBidderToParentBidder, test.aliasBidderName)
+		}
+	}
+
+	//reset package variables to not interfere with other test cases. Example - TestBidderParamSchemas
+	coreBidderNames = existingCoreBidderNames
+	aliasBidderToParentBidder = map[BidderName]BidderName{}
+}
+
 }

--- a/openrtb_ext/bidders_validate_test.go
+++ b/openrtb_ext/bidders_validate_test.go
@@ -24,9 +24,6 @@ var validator BidderParamValidator
 // returns valid JSON for all known CoreBidderNames.
 func TestBidderParamSchemas(t *testing.T) {
 	for _, bidderName := range CoreBidderNames() {
-		if _, ok := GetAliasBidderNamesSet()[bidderName]; ok {
-			continue
-		}
 		schema := validator.Schema(bidderName)
 		if schema == "" {
 			t.Errorf("No schema exists for bidder %s. Does static/bidder-params/%s.json exist?", bidderName, bidderName)


### PR DESCRIPTION
Currently, we have adapter aliases that defines Bidder params explicitly using json file. However, after the adapter aliases feature, we will have the bidder params inherited from its parent adapter.
To accomplish this, we had to do some refactoring and remove the unnecessary code. We also refactored NewBidderParamsValidator function so that we can write the test cases. 