### PR TITLE
SetUID Error Handling Refactor

### DIFF
--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -126,7 +126,9 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			case http.StatusUnavailableForLegalReasons:
 				metricValue = metrics.SetUidGDPRHostCookieBlocked
 			}
-			handleBadStatus(w, status, metricValue, errors.New(body), metricsEngine, &so)
+			handleBadStatus(w, status, metricValue, nil, metricsEngine, &so)
+			so.Errors = []error{errors.New(body)}
+			w.Write([]byte(body))
 			return
 		}
 

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -126,9 +126,7 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			case http.StatusUnavailableForLegalReasons:
 				metricValue = metrics.SetUidGDPRHostCookieBlocked
 			}
-			handleBadStatus(w, status, metricValue, nil, metricsEngine, &so)
-			so.Errors = []error{errors.New(body)}
-			w.Write([]byte(body))
+			handleBadStatus(w, status, metricValue, errors.New(body), metricsEngine, &so)
 			return
 		}
 


### PR DESCRIPTION
I noticed in the `/setuid` endpoint, that the error handling seemed repetitive and could be consolidated. So I wrote a function to simplify the `NewSetUidEndpoint()` functions error handling.