### PR TITLE
Taboola Bidder Adapter:  Change Endpoint 

### DIFF
--- a/static/bidder-info/taboola.yaml
+++ b/static/bidder-info/taboola.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://{{.MediaType}}.bidder.taboola.com/OpenRTB/PS/auction/{{.GvlID}}/{{.PublisherID}}"
+endpoint: "https://{{.MediaType}}.bidder.taboola.com/OpenRTB/PS/auction?exchange={{.GvlID}}&publisher={{.PublisherID}}"
 maintainer:
   email:  ps-team@taboola.com
 gvlVendorID: 42


### PR DESCRIPTION
 changes in the server endpoint, using query params for publisher id and exchange params instead of path params 