### PR TITLE
Add data field for custom renderers

### DIFF
--- a/exchange/exchangetest/request-ext-prebid-filtering.json
+++ b/exchange/exchangetest/request-ext-prebid-filtering.json
@@ -65,7 +65,10 @@
                         "renderers": [
                             {
                                 "name": "test-name",
-                                "version": "test-version"
+                                "version": "test-version",
+                                "data" : {
+                                    "complex": "data"
+                                }
                             }
                         ]
                     }
@@ -121,7 +124,10 @@
                                 "renderers": [
                                     {
                                         "name": "test-name",
-                                        "version": "test-version"
+                                        "version": "test-version",
+                                        "data": {
+                                            "complex": "data"
+                                        }
                                     }
                                 ]
                             }

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -66,6 +66,7 @@ type ExtBidPrebidMeta struct {
 	PrimaryCategoryID    string          `json:"primaryCatId,omitempty"`
 	RendererName         string          `json:"rendererName,omitempty"`
 	RendererVersion      string          `json:"rendererVersion,omitempty"`
+	RendererData         json.RawMessage `json:"rendererData,omitempty"`
 	SecondaryCategoryIDs []string        `json:"secondaryCatIds,omitempty"`
 }
 

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -352,8 +352,9 @@ type ExtRequestSdk struct {
 }
 
 type ExtRequestSdkRenderer struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
+	Name    string          `json:"name,omitempty"`
+	Version string          `json:"version,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }
 
 type ExtMultiBid struct {


### PR DESCRIPTION
## According to the proposal for the SDK Rendering API protocol
This PR adds a new field `data` to renderers object as discussed in the related [thread](https://github.com/prebid/prebid-server/issues/2908)

I switched to a more complex data type `raw object` instead of `string` to allow passing more datas into it.
Then all data related to the renderer SDK could be passed through this field.

Here is an example of how it could go:

```json
{
  "name": "myRenderer",
  "version": "2.4",
  "data": {
    "uiRendereringVersion": "1.2",
    "resizable": true
  }
}