### PR TITLE
Adapter alias: syncer related changes

### DIFF
--- a/usersync/syncersbuilder.go
+++ b/usersync/syncersbuilder.go
@@ -26,21 +26,16 @@ func (e SyncerBuildError) Error() string {
 }
 
 func BuildSyncers(hostConfig *config.Configuration, bidderInfos config.BidderInfos) (map[string]Syncer, []error) {
-	// map syncer config by bidder
-	cfgByBidder := make(map[string]config.Syncer, len(bidderInfos))
+	// map syncer config by key
+	cfgBySyncerKey := make(map[string][]namedSyncerConfig)
 	for bidder, cfg := range bidderInfos {
 		if shouldCreateSyncer(cfg) {
-			cfgByBidder[bidder] = *cfg.Syncer
+			syncerCopy := *cfg.Syncer
+			if syncerCopy.Key == "" {
+				syncerCopy.Key = bidder
+			}
+			cfgBySyncerKey[syncerCopy.Key] = append(cfgBySyncerKey[syncerCopy.Key], namedSyncerConfig{bidder, syncerCopy})
 		}
-	}
-
-	// map syncer config by key
-	cfgBySyncerKey := make(map[string][]namedSyncerConfig, len(bidderInfos))
-	for bidder, cfg := range cfgByBidder {
-		if cfg.Key == "" {
-			cfg.Key = bidder
-		}
-		cfgBySyncerKey[cfg.Key] = append(cfgBySyncerKey[cfg.Key], namedSyncerConfig{bidder, cfg})
 	}
 
 	// resolve host endpoint

--- a/usersync/syncersbuilder.go
+++ b/usersync/syncersbuilder.go
@@ -28,12 +28,12 @@ func (e SyncerBuildError) Error() string {
 func BuildSyncers(hostConfig *config.Configuration, bidderInfos config.BidderInfos) (map[string]Syncer, []error) {
 	// map syncer config by key
 	cfgBySyncerKey := make(map[string][]namedSyncerConfig)
-	for bidder, cfg := range bidderInfos {
-		if shouldCreateSyncer(cfg) {
-			syncerCopy := *cfg.Syncer
+	for bidder, bidderInfo := range bidderInfos {
+		if shouldCreateSyncer(bidderInfo) {
+			syncerCopy := *bidderInfo.Syncer
 			if syncerCopy.Key == "" {
 				var err error
-				syncerCopy.Key, err = getSyncerKey(bidderInfos, bidder, cfg, syncerCopy)
+				syncerCopy.Key, err = getSyncerKey(bidderInfos, bidder, bidderInfo, syncerCopy)
 				if err != nil {
 					return nil, []error{err}
 				}

--- a/usersync/syncersbuilder.go
+++ b/usersync/syncersbuilder.go
@@ -97,9 +97,11 @@ func chooseSyncerConfig(biddersSyncerConfig []namedSyncerConfig) (namedSyncerCon
 		return biddersSyncerConfig[0], nil
 	}
 
-	var bidderNames []string
-	var bidderNamesWithEndpoints []string
-	var syncerConfig namedSyncerConfig
+	var (
+		bidderNames, bidderNamesWithEndpoints []string
+		syncerConfig                          namedSyncerConfig
+	)
+
 	for _, bidder := range biddersSyncerConfig {
 		bidderNames = append(bidderNames, bidder.name)
 		if bidder.cfg.IFrame != nil || bidder.cfg.Redirect != nil {

--- a/usersync/syncersbuilder_test.go
+++ b/usersync/syncersbuilder_test.go
@@ -293,10 +293,15 @@ func TestChooseSyncerConfig(t *testing.T) {
 			cfg:        syncerCfg,
 			bidderInfo: config.BidderInfo{AliasOf: ""},
 		}
-		alias = namedSyncerConfig{
-			name:       "alias",
+		alias1 = namedSyncerConfig{
+			name:       "alias-1",
 			cfg:        syncerCfg,
 			bidderInfo: config.BidderInfo{AliasOf: "parent"},
+		}
+		alias2 = namedSyncerConfig{
+			name:       "alias-2",
+			cfg:        syncerCfg,
+			bidderInfo: config.BidderInfo{AliasOf: "foo"},
 		}
 	)
 
@@ -333,8 +338,13 @@ func TestChooseSyncerConfig(t *testing.T) {
 		},
 		{
 			description:    "alias-can-have-same-key-as-parent",
-			given:          []namedSyncerConfig{parent, alias},
-			expectedConfig: alias,
+			given:          []namedSyncerConfig{parent, alias1},
+			expectedConfig: alias1,
+		},
+		{
+			description:   "aliases-syncer-key-conflicts-with-non-parent-bidder",
+			given:         []namedSyncerConfig{parent, alias1, alias2},
+			expectedError: "found aliases whose syncer key conflicts with a bidder other than their parent, aliases: foo",
 		},
 	}
 

--- a/usersync/syncersbuilder_test.go
+++ b/usersync/syncersbuilder_test.go
@@ -283,6 +283,21 @@ func TestChooseSyncerConfig(t *testing.T) {
 		bidderAEmpty     = namedSyncerConfig{name: "bidderA", cfg: config.Syncer{}}
 		bidderBPopulated = namedSyncerConfig{name: "bidderB", cfg: config.Syncer{Key: "a", IFrame: &config.SyncerEndpoint{URL: "anyURL"}}}
 		bidderBEmpty     = namedSyncerConfig{name: "bidderB", cfg: config.Syncer{}}
+
+		syncerCfg = config.Syncer{
+			Key:      "key",
+			Redirect: &config.SyncerEndpoint{RedirectURL: "redirect-url"},
+		}
+		parent = namedSyncerConfig{
+			name:       "parent",
+			cfg:        syncerCfg,
+			bidderInfo: config.BidderInfo{AliasOf: ""},
+		}
+		alias = namedSyncerConfig{
+			name:       "alias",
+			cfg:        syncerCfg,
+			bidderInfo: config.BidderInfo{AliasOf: "parent"},
+		}
 	)
 
 	testCases := []struct {
@@ -315,6 +330,11 @@ func TestChooseSyncerConfig(t *testing.T) {
 			description:    "Many - Same Key - Unique Configs",
 			given:          []namedSyncerConfig{bidderAEmpty, bidderBPopulated},
 			expectedConfig: bidderBPopulated,
+		},
+		{
+			description:    "alias-can-have-same-key-as-parent",
+			given:          []namedSyncerConfig{parent, alias},
+			expectedConfig: alias,
 		},
 	}
 


### PR DESCRIPTION
As per adapter alias feature,  if alias doesn't define syncher config in YAML then alias will inherit syncher config of its parent bider. This includes inheriting syncer urls, keys etc. 

As of now, PBS has logic that prevents bidders from using same syncer key. But this logic doesn't check if bidders using same key have parent alias relationship among them. Due to this, validation fails for alias which inherits syncer config from parent.  To address this issue, pull request introduces changes to allow the use of the same syncer key for aliases and their parent bidders.

Also, an alias can define its syncer key in  YAML configuration, but this key must not be the same as that of a bidder other than its parent. For this, pull introduces to catcg alias whose syncher key conflicts with bidder other than its parent
```
parent1:
  syncer:
     key: k1

alias1:
   aliasOf: parent1
   syncer:
     Key: k1

parent2:
  syncer:
    key: k2

alias2:
  aliasOf: parent2
  syncer:
     key: k1 // syncer key conflicts with parent1 key
```


