### PR TITLE
Activities: Back To Spec

### DIFF
--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -149,12 +149,7 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 		}
 	}
 
-	activityControl, activitiesErr := privacy.NewActivityControl(&account.Privacy)
-	if activitiesErr != nil {
-		if errortypes.ContainsFatalError([]error{activitiesErr}) {
-			activityControl = privacy.ActivityControl{}
-		}
-	}
+	activityControl := privacy.NewActivityControl(&account.Privacy)
 
 	syncTypeFilter, err := parseTypeFilter(request.FilterSettings)
 	if err != nil {

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -974,38 +974,6 @@ func TestCookieSyncParseRequest(t *testing.T) {
 			expectedError:        errCookieSyncAccountBlocked.Error(),
 			givenAccountRequired: true,
 		},
-
-		{
-			description: "Account Defaults - Invalid Activities",
-			givenBody: strings.NewReader(`{` +
-				`"bidders":["a", "b"],` +
-				`"account":"ValidAccountInvalidActivities"` +
-				`}`),
-			givenGDPRConfig:  config.GDPR{Enabled: true, DefaultValue: "0"},
-			givenCCPAEnabled: true,
-			givenConfig: config.UserSync{
-				Cooperative: config.UserSyncCooperative{
-					EnabledByDefault: false,
-					PriorityGroups:   [][]string{{"a", "b", "c"}},
-				},
-			},
-			expectedPrivacy: privacy.Policies{},
-			expectedRequest: usersync.Request{
-				Bidders: []string{"a", "b"},
-				Cooperative: usersync.Cooperative{
-					Enabled:        false,
-					PriorityGroups: [][]string{{"a", "b", "c"}},
-				},
-				Limit: 0,
-				Privacy: usersyncPrivacy{
-					gdprPermissions: &fakePermissions{},
-				},
-				SyncTypeFilter: usersync.SyncTypeFilter{
-					IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-					Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-				},
-			},
-		},
 	}
 
 	for _, test := range testCases {
@@ -1934,8 +1902,7 @@ func TestCookieSyncActivityControlIntegration(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			activities, err := privacy.NewActivityControl(test.accountPrivacy)
-			assert.NoError(t, err)
+			activities := privacy.NewActivityControl(test.accountPrivacy)
 			up := usersyncPrivacy{
 				activityControl: activities,
 			}

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/prebid/prebid-server/privacy"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/prebid/prebid-server/privacy"
 
 	"github.com/buger/jsonparser"
 	"github.com/golang/glog"
@@ -229,12 +230,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	tcf2Config := gdpr.NewTCF2Config(deps.cfg.GDPR.TCF2, account.GDPR)
 
-	activities, activitiesErr := privacy.NewActivityControl(&account.Privacy)
-	if activitiesErr != nil {
-		errL = append(errL, activitiesErr)
-		writeError(errL, w, &labels)
-		return
-	}
+	activitiesControl := privacy.NewActivityControl(&account.Privacy)
 
 	secGPC := r.Header.Get("Sec-GPC")
 
@@ -253,7 +249,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 		HookExecutor:               hookExecutor,
 		QueryParams:                r.URL.Query(),
 		TCF2Config:                 tcf2Config,
-		Activities:                 activities,
+		Activities:                 activitiesControl,
 		TmaxAdjustments:            deps.tmaxAdjustments,
 	}
 

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -230,7 +230,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	tcf2Config := gdpr.NewTCF2Config(deps.cfg.GDPR.TCF2, account.GDPR)
 
-	activityControll := privacy.NewActivityControl(&account.Privacy)
+	activityControl := privacy.NewActivityControl(&account.Privacy)
 
 	secGPC := r.Header.Get("Sec-GPC")
 
@@ -249,7 +249,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 		HookExecutor:               hookExecutor,
 		QueryParams:                r.URL.Query(),
 		TCF2Config:                 tcf2Config,
-		Activities:                 activityControll,
+		Activities:                 activityControl,
 		TmaxAdjustments:            deps.tmaxAdjustments,
 	}
 

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -230,7 +230,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 
 	tcf2Config := gdpr.NewTCF2Config(deps.cfg.GDPR.TCF2, account.GDPR)
 
-	activitiesControl := privacy.NewActivityControl(&account.Privacy)
+	activityControll := privacy.NewActivityControl(&account.Privacy)
 
 	secGPC := r.Header.Get("Sec-GPC")
 
@@ -249,7 +249,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 		HookExecutor:               hookExecutor,
 		QueryParams:                r.URL.Query(),
 		TCF2Config:                 tcf2Config,
-		Activities:                 activitiesControl,
+		Activities:                 activityControll,
 		TmaxAdjustments:            deps.tmaxAdjustments,
 	}
 

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -194,7 +194,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	tcf2Config := gdpr.NewTCF2Config(deps.cfg.GDPR.TCF2, account.GDPR)
 
-	activitiesControl := privacy.NewActivityControl(&account.Privacy)
+	activityControl := privacy.NewActivityControl(&account.Privacy)
 
 	ctx := context.Background()
 
@@ -245,7 +245,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		PubID:                      labels.PubID,
 		HookExecutor:               hookExecutor,
 		TCF2Config:                 tcf2Config,
-		Activities:                 activitiesControl,
+		Activities:                 activityControl,
 		TmaxAdjustments:            deps.tmaxAdjustments,
 	}
 	auctionResponse, err := deps.ex.HoldAuction(ctx, auctionRequest, nil)

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -194,14 +194,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 
 	tcf2Config := gdpr.NewTCF2Config(deps.cfg.GDPR.TCF2, account.GDPR)
 
-	activities, activitiesErr := privacy.NewActivityControl(&account.Privacy)
-	if activitiesErr != nil {
-		errL = append(errL, activitiesErr)
-		if errortypes.ContainsFatalError(errL) {
-			writeError(errL, w, &labels)
-			return
-		}
-	}
+	activitiesControl := privacy.NewActivityControl(&account.Privacy)
 
 	ctx := context.Background()
 
@@ -252,7 +245,7 @@ func (deps *endpointDeps) Auction(w http.ResponseWriter, r *http.Request, _ http
 		PubID:                      labels.PubID,
 		HookExecutor:               hookExecutor,
 		TCF2Config:                 tcf2Config,
-		Activities:                 activities,
+		Activities:                 activitiesControl,
 		TmaxAdjustments:            deps.tmaxAdjustments,
 	}
 	auctionResponse, err := deps.ex.HoldAuction(ctx, auctionRequest, nil)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -303,7 +303,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	activitiesControl := privacy.NewActivityControl(&account.Privacy)
+	activityControl := privacy.NewActivityControl(&account.Privacy)
 
 	secGPC := r.Header.Get("Sec-GPC")
 	auctionRequest := &exchange.AuctionRequest{
@@ -317,7 +317,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		PubID:                      labels.PubID,
 		HookExecutor:               hookexecution.EmptyHookExecutor{},
 		TmaxAdjustments:            deps.tmaxAdjustments,
-		Activities:                 activitiesControl,
+		Activities:                 activityControl,
 	}
 
 	auctionResponse, err := deps.ex.HoldAuction(ctx, auctionRequest, &debugLog)

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -303,14 +303,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	activities, activitiesErr := privacy.NewActivityControl(&account.Privacy)
-	if activitiesErr != nil {
-		errL = append(errL, activitiesErr)
-		if errortypes.ContainsFatalError(errL) {
-			handleError(&labels, w, errL, &vo, &debugLog)
-			return
-		}
-	}
+	activitiesControl := privacy.NewActivityControl(&account.Privacy)
 
 	secGPC := r.Header.Get("Sec-GPC")
 	auctionRequest := &exchange.AuctionRequest{
@@ -324,7 +317,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		PubID:                      labels.PubID,
 		HookExecutor:               hookexecution.EmptyHookExecutor{},
 		TmaxAdjustments:            deps.tmaxAdjustments,
-		Activities:                 activities,
+		Activities:                 activitiesControl,
 	}
 
 	auctionResponse, err := deps.ex.HoldAuction(ctx, auctionRequest, &debugLog)

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -65,20 +65,6 @@ func TestVideoEndpointImpressionsNumber(t *testing.T) {
 	assert.Equal(t, resp.AdPods[0].Targeting[0].HbDeal, "ABC_123", "If DealID exists in bid response, hb_deal targeting needs to be added to resp")
 }
 
-func TestVideoEndpointInvalidPrivacyConfig(t *testing.T) {
-	ex := &mockExchangeVideo{}
-	reqBody := readVideoTestFile(t, "sample-requests/video/video_valid_sample.json")
-	req := httptest.NewRequest("POST", "/openrtb2/video", strings.NewReader(reqBody))
-	recorder := httptest.NewRecorder()
-
-	deps := mockDepsInvalidPrivacy(t, ex)
-	deps.VideoAuctionEndpoint(recorder, req, nil)
-
-	respBytes := recorder.Body.Bytes()
-	expectedErrorMessage := "Critical error while running the video endpoint:  unable to parse component: bidderA.BidderB.bidderC"
-	assert.Equal(t, expectedErrorMessage, string(respBytes), "error message is incorrect")
-}
-
 func TestVideoEndpointImpressionsDuration(t *testing.T) {
 	ex := &mockExchangeVideo{}
 	reqBody := readVideoTestFile(t, "sample-requests/video/video_valid_sample_different_durations.json")

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -104,9 +104,9 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			return
 		}
 
-		activitiesControl := privacy.NewActivityControl(&account.Privacy)
+		activityControl := privacy.NewActivityControl(&account.Privacy)
 
-		userSyncActivityAllowed := activitiesControl.Allow(privacy.ActivitySyncUser,
+		userSyncActivityAllowed := activityControl.Allow(privacy.ActivitySyncUser,
 			privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidderName})
 		if !userSyncActivityAllowed {
 			w.WriteHeader(http.StatusUnavailableForLegalReasons)

--- a/endpoints/setuid.go
+++ b/endpoints/setuid.go
@@ -104,14 +104,9 @@ func NewSetUIDEndpoint(cfg *config.Configuration, syncersByBidder map[string]use
 			return
 		}
 
-		activities, activitiesErr := privacy.NewActivityControl(&account.Privacy)
-		if activitiesErr != nil {
-			if errortypes.ContainsFatalError([]error{activitiesErr}) {
-				activities = privacy.ActivityControl{}
-			}
-		}
+		activitiesControl := privacy.NewActivityControl(&account.Privacy)
 
-		userSyncActivityAllowed := activities.Allow(privacy.ActivitySyncUser,
+		userSyncActivityAllowed := activitiesControl.Allow(privacy.ActivitySyncUser,
 			privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidderName})
 		if !userSyncActivityAllowed {
 			w.WriteHeader(http.StatusUnavailableForLegalReasons)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2352,10 +2352,7 @@ func runSpec(t *testing.T, filename string, spec *exchangeSpec) {
 		impExtInfoMap[impID] = ImpExtInfo{}
 	}
 
-	activityControl, err := privacy.NewActivityControl(spec.AccountPrivacy)
-	if err != nil {
-		t.Errorf("%s: Exchange returned an unexpected error. Got %s", filename, err.Error())
-	}
+	activityControl := privacy.NewActivityControl(spec.AccountPrivacy)
 
 	auctionRequest := &AuctionRequest{
 		BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: &spec.IncomingRequest.OrtbRequest},

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -4364,8 +4364,7 @@ func TestCleanOpenRTBRequestsActivities(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		activities, err := privacy.NewActivityControl(&test.privacyConfig)
-		assert.NoError(t, err, "")
+		activities := privacy.NewActivityControl(&test.privacyConfig)
 		auctionReq := AuctionRequest{
 			BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: test.req},
 			UserSyncs:         &emptyUsersync{},

--- a/privacy/activitycontrol_test.go
+++ b/privacy/activitycontrol_test.go
@@ -23,25 +23,25 @@ func TestNewActivityControl(t *testing.T) {
 			name: "specified_and_correct",
 			privacyConf: config.AccountPrivacy{
 				AllowActivities: &config.AllowActivities{
-					SyncUser:                 getTestActivityConfig(),
-					FetchBids:                getTestActivityConfig(),
-					EnrichUserFPD:            getTestActivityConfig(),
-					ReportAnalytics:          getTestActivityConfig(),
-					TransmitUserFPD:          getTestActivityConfig(),
-					TransmitPreciseGeo:       getTestActivityConfig(),
-					TransmitUniqueRequestIds: getTestActivityConfig(),
-					TransmitTids:             getTestActivityConfig(),
+					SyncUser:                 getTestActivityConfig(true),
+					FetchBids:                getTestActivityConfig(true),
+					EnrichUserFPD:            getTestActivityConfig(true),
+					ReportAnalytics:          getTestActivityConfig(true),
+					TransmitUserFPD:          getTestActivityConfig(true),
+					TransmitPreciseGeo:       getTestActivityConfig(false),
+					TransmitUniqueRequestIds: getTestActivityConfig(true),
+					TransmitTids:             getTestActivityConfig(true),
 				},
 			},
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivitySyncUser:                 getTestActivityPlan(),
-				ActivityFetchBids:                getTestActivityPlan(),
-				ActivityEnrichUserFPD:            getTestActivityPlan(),
-				ActivityReportAnalytics:          getTestActivityPlan(),
-				ActivityTransmitUserFPD:          getTestActivityPlan(),
-				ActivityTransmitPreciseGeo:       getTestActivityPlan(),
-				ActivityTransmitUniqueRequestIds: getTestActivityPlan(),
-				ActivityTransmitTids:             getTestActivityPlan(),
+				ActivitySyncUser:                 getTestActivityPlan(ActivityAllow),
+				ActivityFetchBids:                getTestActivityPlan(ActivityAllow),
+				ActivityEnrichUserFPD:            getTestActivityPlan(ActivityAllow),
+				ActivityReportAnalytics:          getTestActivityPlan(ActivityAllow),
+				ActivityTransmitUserFPD:          getTestActivityPlan(ActivityAllow),
+				ActivityTransmitPreciseGeo:       getTestActivityPlan(ActivityDeny),
+				ActivityTransmitUniqueRequestIds: getTestActivityPlan(ActivityAllow),
+				ActivityTransmitTids:             getTestActivityPlan(ActivityAllow),
 			}},
 		},
 	}
@@ -103,7 +103,7 @@ func TestActivityControlAllow(t *testing.T) {
 		{
 			name: "activity_not_defined",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivitySyncUser: getTestActivityPlan()}},
+				ActivitySyncUser: getTestActivityPlan(ActivityAllow)}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
@@ -111,7 +111,7 @@ func TestActivityControlAllow(t *testing.T) {
 		{
 			name: "activity_defined_but_not_found_default_returned",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivityFetchBids: getTestActivityPlan()}},
+				ActivityFetchBids: getTestActivityPlan(ActivityAllow)}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderB"},
 			activityResult: true,
@@ -119,7 +119,7 @@ func TestActivityControlAllow(t *testing.T) {
 		{
 			name: "activity_defined_and_allowed",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivityFetchBids: getTestActivityPlan()}},
+				ActivityFetchBids: getTestActivityPlan(ActivityAllow)}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
@@ -135,12 +135,12 @@ func TestActivityControlAllow(t *testing.T) {
 	}
 }
 
-func getTestActivityConfig() config.Activity {
+func getTestActivityConfig(allow bool) config.Activity {
 	return config.Activity{
 		Default: ptrutil.ToPtr(true),
 		Rules: []config.ActivityRule{
 			{
-				Allow: true,
+				Allow: allow,
 				Condition: config.ActivityCondition{
 					ComponentName: []string{"bidderA"},
 					ComponentType: []string{"bidder"},
@@ -150,12 +150,12 @@ func getTestActivityConfig() config.Activity {
 	}
 }
 
-func getTestActivityPlan() ActivityPlan {
+func getTestActivityPlan(result ActivityResult) ActivityPlan {
 	return ActivityPlan{
 		defaultResult: true,
 		rules: []Rule{
 			ConditionRule{
-				result:        ActivityAllow,
+				result:        result,
 				componentName: []string{"bidderA"},
 				componentType: []string{"bidder"},
 			},

--- a/privacy/activitycontrol_test.go
+++ b/privacy/activitycontrol_test.go
@@ -1,7 +1,6 @@
 package privacy
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
@@ -14,136 +13,48 @@ func TestNewActivityControl(t *testing.T) {
 		name            string
 		privacyConf     config.AccountPrivacy
 		activityControl ActivityControl
-		err             error
 	}{
 		{
-			name:            "privacy_config_is_empty",
+			name:            "empty",
 			privacyConf:     config.AccountPrivacy{},
 			activityControl: ActivityControl{plans: nil},
-			err:             nil,
 		},
 		{
-			name: "privacy_config_is_specified_and_correct",
+			name: "specified_and_correct",
 			privacyConf: config.AccountPrivacy{
 				AllowActivities: &config.AllowActivities{
-					SyncUser:                 getDefaultActivityConfig(),
-					FetchBids:                getDefaultActivityConfig(),
-					EnrichUserFPD:            getDefaultActivityConfig(),
-					ReportAnalytics:          getDefaultActivityConfig(),
-					TransmitUserFPD:          getDefaultActivityConfig(),
-					TransmitPreciseGeo:       getDefaultActivityConfig(),
-					TransmitUniqueRequestIds: getDefaultActivityConfig(),
-					TransmitTids:             getDefaultActivityConfig(),
+					SyncUser:                 getTestActivityConfig(),
+					FetchBids:                getTestActivityConfig(),
+					EnrichUserFPD:            getTestActivityConfig(),
+					ReportAnalytics:          getTestActivityConfig(),
+					TransmitUserFPD:          getTestActivityConfig(),
+					TransmitPreciseGeo:       getTestActivityConfig(),
+					TransmitUniqueRequestIds: getTestActivityConfig(),
+					TransmitTids:             getTestActivityConfig(),
 				},
 			},
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivitySyncUser:                 getDefaultActivityPlan(),
-				ActivityFetchBids:                getDefaultActivityPlan(),
-				ActivityEnrichUserFPD:            getDefaultActivityPlan(),
-				ActivityReportAnalytics:          getDefaultActivityPlan(),
-				ActivityTransmitUserFPD:          getDefaultActivityPlan(),
-				ActivityTransmitPreciseGeo:       getDefaultActivityPlan(),
-				ActivityTransmitUniqueRequestIds: getDefaultActivityPlan(),
-				ActivityTransmitTids:             getDefaultActivityPlan(),
+				ActivitySyncUser:                 getTestActivityPlan(),
+				ActivityFetchBids:                getTestActivityPlan(),
+				ActivityEnrichUserFPD:            getTestActivityPlan(),
+				ActivityReportAnalytics:          getTestActivityPlan(),
+				ActivityTransmitUserFPD:          getTestActivityPlan(),
+				ActivityTransmitPreciseGeo:       getTestActivityPlan(),
+				ActivityTransmitUniqueRequestIds: getTestActivityPlan(),
+				ActivityTransmitTids:             getTestActivityPlan(),
 			}},
-			err: nil,
-		},
-		{
-			name: "privacy_config_is_specified_and_SyncUser_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					SyncUser: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_FetchBids_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					FetchBids: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_EnrichUserFPD_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					EnrichUserFPD: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_ReportAnalytics_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					ReportAnalytics: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_TransmitUserFPD_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					TransmitUserFPD: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_TransmitPreciseGeo_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					TransmitPreciseGeo: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_TransmitUniqueRequestIds_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					TransmitUniqueRequestIds: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
-		},
-		{
-			name: "privacy_config_is_specified_and_TransmitTids_is_incorrect",
-			privacyConf: config.AccountPrivacy{
-				AllowActivities: &config.AllowActivities{
-					TransmitTids: getIncorrectActivityConfig(),
-				},
-			},
-			activityControl: ActivityControl{plans: nil},
-			err:             errors.New("unable to parse component: bidder.bidderA.bidderB"),
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			actualAC, actualErr := NewActivityControl(&test.privacyConf)
-			if test.err == nil {
-				assert.Equal(t, test.activityControl, actualAC)
-				assert.NoError(t, actualErr)
-			} else {
-				assert.EqualError(t, actualErr, test.err.Error())
-			}
+			actualAC := NewActivityControl(&test.privacyConf)
+			assert.Equal(t, test.activityControl, actualAC)
 		})
 	}
 }
 
-func TestActivityDefaultToDefaultResult(t *testing.T) {
+func TestCfgToDefaultResult(t *testing.T) {
 	testCases := []struct {
 		name            string
 		activityDefault *bool
@@ -168,14 +79,13 @@ func TestActivityDefaultToDefaultResult(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			actualResult := activityDefaultToDefaultResult(test.activityDefault)
+			actualResult := cfgToDefaultResult(test.activityDefault)
 			assert.Equal(t, test.expectedResult, actualResult)
 		})
 	}
 }
 
-func TestAllowActivityControl(t *testing.T) {
-
+func TestActivityControlAllow(t *testing.T) {
 	testCases := []struct {
 		name            string
 		activityControl ActivityControl
@@ -193,7 +103,7 @@ func TestAllowActivityControl(t *testing.T) {
 		{
 			name: "activity_not_defined",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivitySyncUser: getDefaultActivityPlan()}},
+				ActivitySyncUser: getTestActivityPlan()}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
@@ -201,7 +111,7 @@ func TestAllowActivityControl(t *testing.T) {
 		{
 			name: "activity_defined_but_not_found_default_returned",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivityFetchBids: getDefaultActivityPlan()}},
+				ActivityFetchBids: getTestActivityPlan()}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderB"},
 			activityResult: true,
@@ -209,7 +119,7 @@ func TestAllowActivityControl(t *testing.T) {
 		{
 			name: "activity_defined_and_allowed",
 			activityControl: ActivityControl{plans: map[Activity]ActivityPlan{
-				ActivityFetchBids: getDefaultActivityPlan()}},
+				ActivityFetchBids: getTestActivityPlan()}},
 			activity:       ActivityFetchBids,
 			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: true,
@@ -225,8 +135,7 @@ func TestAllowActivityControl(t *testing.T) {
 	}
 }
 
-// constants
-func getDefaultActivityConfig() config.Activity {
+func getTestActivityConfig() config.Activity {
 	return config.Activity{
 		Default: ptrutil.ToPtr(true),
 		Rules: []config.ActivityRule{
@@ -241,31 +150,14 @@ func getDefaultActivityConfig() config.Activity {
 	}
 }
 
-func getDefaultActivityPlan() ActivityPlan {
+func getTestActivityPlan() ActivityPlan {
 	return ActivityPlan{
 		defaultResult: true,
 		rules: []Rule{
-			ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []Component{
-					{Type: "bidder", Name: "bidderA"},
-				},
+			ConditionRule{
+				result:        ActivityAllow,
+				componentName: []string{"bidderA"},
 				componentType: []string{"bidder"},
-			},
-		},
-	}
-}
-
-func getIncorrectActivityConfig() config.Activity {
-	return config.Activity{
-		Default: ptrutil.ToPtr(true),
-		Rules: []config.ActivityRule{
-			{
-				Allow: true,
-				Condition: config.ActivityCondition{
-					ComponentName: []string{"bidder.bidderA.bidderB"},
-					ComponentType: []string{"bidder"},
-				},
 			},
 		},
 	}

--- a/privacy/component.go
+++ b/privacy/component.go
@@ -1,8 +1,6 @@
 package privacy
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -18,48 +16,10 @@ type Component struct {
 	Name string
 }
 
-func (c Component) Matches(target Component) bool {
-	return strings.EqualFold(c.Type, target.Type) && (c.Name == "*" || strings.EqualFold(c.Name, target.Name))
+func (c Component) MatchesName(v string) bool {
+	return strings.EqualFold(c.Name, v)
 }
 
-var ErrComponentEmpty = errors.New("unable to parse empty component")
-
-func ParseComponent(v string) (Component, error) {
-	if len(v) == 0 {
-		return Component{}, ErrComponentEmpty
-	}
-
-	split := strings.Split(v, ".")
-
-	if len(split) == 2 {
-		if !validComponentType(split[0]) {
-			return Component{}, fmt.Errorf("unable to parse component (invalid type): %s", v)
-		}
-		return Component{
-			Type: split[0],
-			Name: split[1],
-		}, nil
-	}
-
-	if len(split) == 1 {
-		return Component{
-			Type: ComponentTypeBidder,
-			Name: split[0],
-		}, nil
-	}
-
-	return Component{}, fmt.Errorf("unable to parse component: %s", v)
-}
-
-func validComponentType(t string) bool {
-	t = strings.ToLower(t)
-
-	if t == ComponentTypeBidder ||
-		t == ComponentTypeAnalytics ||
-		t == ComponentTypeRealTimeData ||
-		t == ComponentTypeGeneral {
-		return true
-	}
-
-	return false
+func (c Component) MatchesType(v string) bool {
+	return strings.EqualFold(c.Type, v)
 }

--- a/privacy/component_test.go
+++ b/privacy/component_test.go
@@ -1,124 +1,87 @@
 package privacy
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestComponentMatches(t *testing.T) {
+func TestComponentMatchesName(t *testing.T) {
 	testCases := []struct {
 		name   string
 		given  Component
-		target Component
+		target string
 		result bool
 	}{
 		{
-			name:   "full",
+			name:   "match",
 			given:  Component{Type: "a", Name: "b"},
-			target: Component{Type: "a", Name: "b"},
+			target: "b",
 			result: true,
 		},
 		{
-			name:   "name-wildcard",
-			given:  Component{Type: "a", Name: "*"},
-			target: Component{Type: "a", Name: "b"},
+			name:   "wrong-field",
+			given:  Component{Type: "a", Name: "b"},
+			target: "a",
+			result: false,
+		},
+		{
+			name:   "different-value",
+			given:  Component{Type: "a", Name: "b"},
+			target: "foo",
+			result: false,
+		},
+		{
+			name:   "different-case",
+			given:  Component{Type: "a", Name: "b"},
+			target: "B",
 			result: true,
-		},
-		{
-			name:   "different",
-			given:  Component{Type: "a", Name: "b"},
-			target: Component{Type: "foo", Name: "bar"},
-			result: false,
-		},
-		{
-			name:   "different-type",
-			given:  Component{Type: "a", Name: "b"},
-			target: Component{Type: "foo", Name: "b"},
-			result: false,
-		},
-		{
-			name:   "different-name",
-			given:  Component{Type: "a", Name: "b"},
-			target: Component{Type: "a", Name: "foo"},
-			result: false,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.result, test.given.Matches(test.target))
+			assert.Equal(t, test.result, test.given.MatchesName(test.target))
 		})
 	}
 }
 
-func TestParseComponent(t *testing.T) {
+func TestComponentMatchesType(t *testing.T) {
 	testCases := []struct {
-		name          string
-		component     string
-		expected      Component
-		expectedError error
+		name   string
+		given  Component
+		target string
+		result bool
 	}{
 		{
-			name:          "empty",
-			component:     "",
-			expected:      Component{},
-			expectedError: errors.New("unable to parse empty component"),
+			name:   "match",
+			given:  Component{Type: "a", Name: "b"},
+			target: "a",
+			result: true,
 		},
 		{
-			name:          "too-many-parts",
-			component:     "bidder.bidderA.bidderB",
-			expected:      Component{},
-			expectedError: errors.New("unable to parse component: bidder.bidderA.bidderB"),
+			name:   "wrong-field",
+			given:  Component{Type: "a", Name: "b"},
+			target: "b",
+			result: false,
 		},
 		{
-			name:          "type-bidder",
-			component:     "bidder.bidderA",
-			expected:      Component{Type: "bidder", Name: "bidderA"},
-			expectedError: nil,
+			name:   "different-value",
+			given:  Component{Type: "a", Name: "b"},
+			target: "foo",
+			result: false,
 		},
 		{
-			name:          "type-analytics",
-			component:     "analytics.bidderA",
-			expected:      Component{Type: "analytics", Name: "bidderA"},
-			expectedError: nil,
-		},
-		{
-			name:          "type-default",
-			component:     "bidderA",
-			expected:      Component{Type: "bidder", Name: "bidderA"},
-			expectedError: nil,
-		},
-		{
-			name:          "type-rtd",
-			component:     "rtd.test",
-			expected:      Component{Type: "rtd", Name: "test"},
-			expectedError: nil,
-		},
-		{
-			name:          "type-general",
-			component:     "general.test",
-			expected:      Component{Type: "general", Name: "test"},
-			expectedError: nil,
-		},
-		{
-			name:          "type-invalid",
-			component:     "invalid.test",
-			expected:      Component{},
-			expectedError: errors.New("unable to parse component (invalid type): invalid.test"),
+			name:   "different-case",
+			given:  Component{Type: "a", Name: "b"},
+			target: "A",
+			result: true,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			actualSN, actualErr := ParseComponent(test.component)
-			if test.expectedError == nil {
-				assert.Equal(t, test.expected, actualSN)
-				assert.NoError(t, actualErr)
-			} else {
-				assert.EqualError(t, actualErr, test.expectedError.Error())
-			}
+			assert.Equal(t, test.result, test.given.MatchesType(test.target))
 		})
 	}
 }

--- a/privacy/rule.go
+++ b/privacy/rule.go
@@ -1,0 +1,5 @@
+package privacy
+
+type Rule interface {
+	Evaluate(target Component) ActivityResult
+}

--- a/privacy/rule_condition.go
+++ b/privacy/rule_condition.go
@@ -1,9 +1,5 @@
 package privacy
 
-import (
-	"strings"
-)
-
 type ConditionRule struct {
 	result        ActivityResult
 	componentName []string
@@ -45,8 +41,8 @@ func evaluateComponentType(target Component, componentTypes []string) bool {
 	}
 
 	// if there are clauses, at least one needs to match
-	for _, s := range componentTypes {
-		if strings.EqualFold(s, target.Type) {
+	for _, t := range componentTypes {
+		if target.MatchesType(t) {
 			return true
 		}
 	}

--- a/privacy/rule_condition.go
+++ b/privacy/rule_condition.go
@@ -4,17 +4,13 @@ import (
 	"strings"
 )
 
-type Rule interface {
-	Evaluate(target Component) ActivityResult
-}
-
-type ComponentEnforcementRule struct {
+type ConditionRule struct {
 	result        ActivityResult
-	componentName []Component
+	componentName []string
 	componentType []string
 }
 
-func (r ComponentEnforcementRule) Evaluate(target Component) ActivityResult {
+func (r ConditionRule) Evaluate(target Component) ActivityResult {
 	if matched := evaluateComponentName(target, r.componentName); !matched {
 		return ActivityAbstain
 	}
@@ -26,7 +22,7 @@ func (r ComponentEnforcementRule) Evaluate(target Component) ActivityResult {
 	return r.result
 }
 
-func evaluateComponentName(target Component, componentNames []Component) bool {
+func evaluateComponentName(target Component, componentNames []string) bool {
 	// no clauses are considered a match
 	if len(componentNames) == 0 {
 		return true
@@ -34,7 +30,7 @@ func evaluateComponentName(target Component, componentNames []Component) bool {
 
 	// if there are clauses, at least one needs to match
 	for _, n := range componentNames {
-		if n.Matches(target) {
+		if target.MatchesName(n) {
 			return true
 		}
 	}

--- a/privacy/rule_condition_test.go
+++ b/privacy/rule_condition_test.go
@@ -9,17 +9,15 @@ import (
 func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 	testCases := []struct {
 		name           string
-		componentRule  ComponentEnforcementRule
+		componentRule  ConditionRule
 		target         Component
 		activityResult ActivityResult
 	}{
 		{
 			name: "activity_is_allowed",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []Component{
-					{Type: "bidder", Name: "bidderA"},
-				},
+			componentRule: ConditionRule{
+				result:        ActivityAllow,
+				componentName: []string{"bidderA"},
 				componentType: []string{"bidder"},
 			},
 			target:         Component{Type: "bidder", Name: "bidderA"},
@@ -27,11 +25,9 @@ func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 		},
 		{
 			name: "activity_is_not_allowed",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityDeny,
-				componentName: []Component{
-					{Type: "bidder", Name: "bidderA"},
-				},
+			componentRule: ConditionRule{
+				result:        ActivityDeny,
+				componentName: []string{"bidderA"},
 				componentType: []string{"bidder"},
 			},
 			target:         Component{Type: "bidder", Name: "bidderA"},
@@ -39,11 +35,9 @@ func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 		},
 		{
 			name: "abstain_both_clauses_do_not_match",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []Component{
-					{Type: "bidder", Name: "bidderA"},
-				},
+			componentRule: ConditionRule{
+				result:        ActivityAllow,
+				componentName: []string{"bidderA"},
 				componentType: []string{"bidder"},
 			},
 			target:         Component{Type: "bidder", Name: "bidderB"},
@@ -51,18 +45,16 @@ func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 		},
 		{
 			name: "activity_is_not_allowed_componentName_only",
-			componentRule: ComponentEnforcementRule{
-				result: ActivityAllow,
-				componentName: []Component{
-					{Type: "bidder", Name: "bidderA"},
-				},
+			componentRule: ConditionRule{
+				result:        ActivityAllow,
+				componentName: []string{"bidderA"},
 			},
 			target:         Component{Type: "bidder", Name: "bidderA"},
 			activityResult: ActivityAllow,
 		},
 		{
 			name: "activity_is_allowed_componentType_only",
-			componentRule: ComponentEnforcementRule{
+			componentRule: ConditionRule{
 				result:        ActivityAllow,
 				componentType: []string{"bidder"},
 			},
@@ -71,7 +63,7 @@ func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 		},
 		{
 			name: "no-conditions-allow",
-			componentRule: ComponentEnforcementRule{
+			componentRule: ConditionRule{
 				result: ActivityAllow,
 			},
 			target:         Component{Type: "bidder", Name: "bidderA"},
@@ -79,7 +71,7 @@ func TestComponentEnforcementRuleEvaluate(t *testing.T) {
 		},
 		{
 			name: "no-conditions-deny",
-			componentRule: ComponentEnforcementRule{
+			componentRule: ConditionRule{
 				result: ActivityDeny,
 			},
 			target:         Component{Type: "bidder", Name: "bidderA"},


### PR DESCRIPTION
The componentName matching was built for an earlier draft where the format was "scope.name". This PR updates to just "name". This also means parsing an Activity Config can no longer return an error. The code is simplified as a result.