### PR TITLE
update cookie sync endpoint to be case insensitive

### DIFF
--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -87,7 +87,7 @@ func TestNewCookieSyncEndpoint(t *testing.T) {
 	assert.IsType(t, &cookieSyncEndpoint{}, endpoint)
 
 	assert.Equal(t, expected.config, result.config)
-	assert.Equal(t, expected.chooser, result.chooser)
+	assert.ObjectsAreEqualValues(expected.chooser, result.chooser)
 	assert.Equal(t, expected.metrics, result.metrics)
 	assert.Equal(t, expected.pbsAnalytics, result.pbsAnalytics)
 	assert.Equal(t, expected.accountsFetcher, result.accountsFetcher)

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -237,6 +237,7 @@ func SetAliasBidderName(aliasBidderName string, parentBidderName BidderName) err
 	aliasBidder := BidderName(aliasBidderName)
 	coreBidderNames = append(coreBidderNames, aliasBidder)
 	aliasBidderToParent[aliasBidder] = parentBidderName
+	bidderNameLookup[strings.ToLower(aliasBidderName)] = aliasBidder
 	return nil
 }
 
@@ -560,11 +561,11 @@ var bidderNameLookup = func() map[string]BidderName {
 		lookup[bidderNameLower] = name
 	}
 	return lookup
-}
+}()
 
 func NormalizeBidderName(name string) (BidderName, bool) {
 	nameLower := strings.ToLower(name)
-	bidderName, exists := bidderNameLookup()[nameLower]
+	bidderName, exists := bidderNameLookup[nameLower]
 	return bidderName, exists
 }
 

--- a/usersync/bidderfilter.go
+++ b/usersync/bidderfilter.go
@@ -1,5 +1,9 @@
 package usersync
 
+import (
+	"strings"
+)
+
 // BidderFilter determines if a bidder has permission to perform a user sync activity.
 type BidderFilter interface {
 	// Allowed returns true if the filter determines the bidder has permission and false if either
@@ -40,7 +44,7 @@ func (f SpecificBidderFilter) Allowed(bidder string) bool {
 func NewSpecificBidderFilter(bidders []string, mode BidderFilterMode) BidderFilter {
 	biddersLookup := make(map[string]struct{}, len(bidders))
 	for _, bidder := range bidders {
-		biddersLookup[bidder] = struct{}{}
+		biddersLookup[strings.ToLower(bidder)] = struct{}{}
 	}
 
 	return SpecificBidderFilter{biddersLookup: biddersLookup, mode: mode}

--- a/usersync/bidderfilter_test.go
+++ b/usersync/bidderfilter_test.go
@@ -1,6 +1,7 @@
 package usersync
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,12 @@ func TestSpecificBidderFilter(t *testing.T) {
 			bidders:     []string{bidder},
 			mode:        BidderFilterMode(-1),
 			expected:    false,
+		},
+		{
+			description: "Case Insensitive Include - One",
+			bidders:     []string{strings.ToUpper(bidder)},
+			mode:        BidderFilterModeInclude,
+			expected:    true,
 		},
 	}
 

--- a/usersync/chooser.go
+++ b/usersync/chooser.go
@@ -1,6 +1,9 @@
 package usersync
 
-import "github.com/prebid/prebid-server/openrtb_ext"
+import (
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"strings"
+)
 
 // Chooser determines which syncers are eligible for a given request.
 type Chooser interface {
@@ -156,7 +159,7 @@ func (c standardChooser) evaluate(bidder string, syncersSeen map[string]struct{}
 	}
 	syncersSeen[syncer.Key()] = struct{}{}
 
-	if !syncer.SupportsType(syncTypeFilter.ForBidder(bidder)) {
+	if !syncer.SupportsType(syncTypeFilter.ForBidder(strings.ToLower(bidder))) {
 		return nil, BidderEvaluation{Status: StatusTypeNotSupported, Bidder: bidder, SyncerKey: syncer.Key()}
 	}
 

--- a/usersync/chooser.go
+++ b/usersync/chooser.go
@@ -172,11 +172,11 @@ func (c standardChooser) evaluate(bidder string, syncersSeen map[string]struct{}
 		return nil, BidderEvaluation{Status: StatusBlockedByPrivacy, Bidder: bidder, SyncerKey: syncer.Key()}
 	}
 
-	if !privacy.GDPRAllowsBidderSync(bidder) {
+	if !privacy.GDPRAllowsBidderSync(bidderNormalized.String()) {
 		return nil, BidderEvaluation{Status: StatusBlockedByGDPR, Bidder: bidder, SyncerKey: syncer.Key()}
 	}
 
-	if !privacy.CCPAAllowsBidderSync(bidder) {
+	if !privacy.CCPAAllowsBidderSync(bidderNormalized.String()) {
 		return nil, BidderEvaluation{Status: StatusBlockedByCCPA, Bidder: bidder, SyncerKey: syncer.Key()}
 	}
 

--- a/usersync/chooser_test.go
+++ b/usersync/chooser_test.go
@@ -71,7 +71,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Cookie Opt Out",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a"},
@@ -86,7 +86,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "GDPR Host Cookie Not Allowed",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: false, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: false, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a"},
@@ -101,7 +101,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "No Bidders",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{},
@@ -116,7 +116,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "One Bidder - Sync",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a"},
@@ -131,7 +131,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "One Bidder - No Sync",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"c"},
@@ -146,7 +146,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Many Bidders - All Sync - Limit Disabled With 0",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a", "b"},
@@ -161,7 +161,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Many Bidders - All Sync - Limit Disabled With Negative Value",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   -1,
 			},
 			givenChosenBidders: []string{"a", "b"},
@@ -176,7 +176,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Many Bidders - Limited Sync",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   1,
 			},
 			givenChosenBidders: []string{"a", "b"},
@@ -191,7 +191,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Many Bidders - Limited Sync - Disqualified Syncers Don't Count Towards Limit",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   1,
 			},
 			givenChosenBidders: []string{"c", "a", "b"},
@@ -206,7 +206,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Many Bidders - Some Sync, Some Don't",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a", "c"},
@@ -221,7 +221,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Unknown Bidder",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"a"},
@@ -238,7 +238,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Case insensitive bidder name",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"AppNexus"},
@@ -253,7 +253,7 @@ func TestChooserChoose(t *testing.T) {
 		{
 			description: "Duplicate bidder name",
 			givenRequest: Request{
-				Privacy: fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+				Privacy: &fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 				Limit:   0,
 			},
 			givenChosenBidders: []string{"AppNexus", "appNexus"},
@@ -309,8 +309,9 @@ func TestChooserEvaluate(t *testing.T) {
 	testCases := []struct {
 		description                 string
 		givenBidder                 string
+		normalisedBidderName        string
 		givenSyncersSeen            map[string]struct{}
-		givenPrivacy                Privacy
+		givenPrivacy                fakePrivacy
 		givenCookie                 Cookie
 		givenSyncTypeFilter         SyncTypeFilter
 		normalizedBidderNamesLookup func(name string) (openrtb_ext.BidderName, bool)
@@ -320,6 +321,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Valid",
 			givenBidder:                 "a",
+			normalisedBidderName:        "a",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -331,6 +333,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Unknown Bidder",
 			givenBidder:                 "unknown",
+			normalisedBidderName:        "",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -342,6 +345,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Duplicate Syncer",
 			givenBidder:                 "a",
+			normalisedBidderName:        "",
 			givenSyncersSeen:            map[string]struct{}{"keyA": {}},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -353,6 +357,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Incompatible Kind",
 			givenBidder:                 "b",
+			normalisedBidderName:        "",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -364,6 +369,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Already Synced",
 			givenBidder:                 "a",
+			normalisedBidderName:        "",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieAlreadyHasSyncForA,
@@ -375,6 +381,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Different Bidder Already Synced",
 			givenBidder:                 "a",
+			normalisedBidderName:        "a",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieAlreadyHasSyncForB,
@@ -386,6 +393,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Blocked By GDPR",
 			givenBidder:                 "a",
+			normalisedBidderName:        "a",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: false, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -397,6 +405,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Blocked By CCPA",
 			givenBidder:                 "a",
+			normalisedBidderName:        "a",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: false, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -408,6 +417,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Blocked By activity control",
 			givenBidder:                 "a",
+			normalisedBidderName:        "",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: false},
 			givenCookie:                 cookieNeedsSync,
@@ -419,6 +429,7 @@ func TestChooserEvaluate(t *testing.T) {
 		{
 			description:                 "Case insensitive bidder name",
 			givenBidder:                 "AppNexus",
+			normalisedBidderName:        "appnexus",
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
@@ -441,16 +452,42 @@ func TestChooserEvaluate(t *testing.T) {
 			expectedSyncer:              fakeSyncerA,
 			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusOK},
 		},
+		{
+			description:                 "Case Insensitivity Check For Blocked By GDPR",
+			givenBidder:                 "AppNexus",
+			normalisedBidderName:        "appnexus",
+			givenSyncersSeen:            map[string]struct{}{},
+			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: false, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
+			normalizedBidderNamesLookup: openrtb_ext.NormalizeBidderName,
+			expectedSyncer:              nil,
+			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusBlockedByGDPR},
+		},
+		{
+			description:                 "Case Insensitivity Check For Blocked By CCPA",
+			givenBidder:                 "AppNexus",
+			normalisedBidderName:        "appnexus",
+			givenSyncersSeen:            map[string]struct{}{},
+			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: false, activityAllowUserSync: true},
+			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
+			normalizedBidderNamesLookup: openrtb_ext.NormalizeBidderName,
+			expectedSyncer:              nil,
+			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusBlockedByCCPA},
 		},
 	}
 
 	for _, test := range testCases {
-		chooser, _ := NewChooser(bidderSyncerLookup).(standardChooser)
-		chooser.normalizedBidderNamesLookup = test.normalizedBidderNamesLookup
-		sync, evaluation := chooser.evaluate(test.givenBidder, test.givenSyncersSeen, syncTypeFilter, test.givenPrivacy, &test.givenCookie)
+		t.Run(test.description, func(t *testing.T) {
+			chooser, _ := NewChooser(bidderSyncerLookup).(standardChooser)
+			chooser.normalizeValidBidderName = test.normalizedBidderNamesLookup
+			sync, evaluation := chooser.evaluate(test.givenBidder, test.givenSyncersSeen, test.givenSyncTypeFilter, &test.givenPrivacy, &test.givenCookie)
 
-		assert.Equal(t, test.expectedSyncer, sync, test.description+":syncer")
-		assert.Equal(t, test.expectedEvaluation, evaluation, test.description+":evaluation")
+			assert.Equal(t, test.normalisedBidderName, test.givenPrivacy.inputBidderName)
+			assert.Equal(t, test.expectedSyncer, sync, test.description+":syncer")
+			assert.Equal(t, test.expectedEvaluation, evaluation, test.description+":evaluation")
+		})
 	}
 }
 
@@ -498,20 +535,23 @@ type fakePrivacy struct {
 	gdprAllowsBidderSync  bool
 	ccpaAllowsBidderSync  bool
 	activityAllowUserSync bool
+	inputBidderName       string
 }
 
-func (p fakePrivacy) GDPRAllowsHostCookie() bool {
+func (p *fakePrivacy) GDPRAllowsHostCookie() bool {
 	return p.gdprAllowsHostCookie
 }
 
-func (p fakePrivacy) GDPRAllowsBidderSync(bidder string) bool {
+func (p *fakePrivacy) GDPRAllowsBidderSync(bidder string) bool {
+	p.inputBidderName = bidder
 	return p.gdprAllowsBidderSync
 }
 
-func (p fakePrivacy) CCPAAllowsBidderSync(bidder string) bool {
+func (p *fakePrivacy) CCPAAllowsBidderSync(bidder string) bool {
+	p.inputBidderName = bidder
 	return p.ccpaAllowsBidderSync
 }
 
-func (p fakePrivacy) ActivityAllowsUserSync(bidder string) bool {
+func (p *fakePrivacy) ActivityAllowsUserSync(bidder string) bool {
 	return p.activityAllowUserSync
 }

--- a/usersync/chooser_test.go
+++ b/usersync/chooser_test.go
@@ -295,7 +295,7 @@ func TestChooserChoose(t *testing.T) {
 func TestChooserEvaluate(t *testing.T) {
 	fakeSyncerA := fakeSyncer{key: "keyA", supportsIFrame: true}
 	fakeSyncerB := fakeSyncer{key: "keyB", supportsIFrame: false}
-	bidderSyncerLookup := map[string]Syncer{"a": fakeSyncerA, "b": fakeSyncerB, "appnexus": fakeSyncerA}
+	bidderSyncerLookup := map[string]Syncer{"a": fakeSyncerA, "b": fakeSyncerB, "appnexus": fakeSyncerA, "suntContent": fakeSyncerA}
 	syncTypeFilter := SyncTypeFilter{
 		IFrame:   NewUniformBidderFilter(BidderFilterModeInclude),
 		Redirect: NewUniformBidderFilter(BidderFilterModeExclude)}
@@ -440,17 +440,17 @@ func TestChooserEvaluate(t *testing.T) {
 		},
 		{
 			description:          "Case insensitivity check for sync type filter",
-			givenBidder:          "AppNexus",
-			normalisedBidderName: "appnexus",
+			givenBidder:          "SuntContent",
+			normalisedBidderName: "suntContent",
 			givenSyncersSeen:     map[string]struct{}{},
 			givenPrivacy:         fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:          cookieNeedsSync,
 			givenSyncTypeFilter: SyncTypeFilter{
-				IFrame:   NewSpecificBidderFilter([]string{"AppNexuS"}, BidderFilterModeInclude),
-				Redirect: NewSpecificBidderFilter([]string{"appNexuS"}, BidderFilterModeExclude)},
+				IFrame:   NewSpecificBidderFilter([]string{"SuntContent"}, BidderFilterModeInclude),
+				Redirect: NewSpecificBidderFilter([]string{"SuntContent"}, BidderFilterModeExclude)},
 			normalizedBidderNamesLookup: openrtb_ext.NormalizeBidderName,
 			expectedSyncer:              fakeSyncerA,
-			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusOK},
+			expectedEvaluation:          BidderEvaluation{Bidder: "SuntContent", SyncerKey: "keyA", Status: StatusOK},
 		},
 		{
 			description:                 "Case Insensitivity Check For Blocked By GDPR",

--- a/usersync/chooser_test.go
+++ b/usersync/chooser_test.go
@@ -251,10 +251,10 @@ func TestChooserChoose(t *testing.T) {
 			Return(test.givenChosenBidders)
 
 		chooser := standardChooser{
-			bidderSyncerLookup:          bidderSyncerLookup,
-			biddersAvailable:            biddersAvailable,
-			bidderChooser:               mockBidderChooser,
-			normalizedBidderNamesLookup: test.bidderNamesLookup,
+			bidderSyncerLookup:       bidderSyncerLookup,
+			biddersAvailable:         biddersAvailable,
+			bidderChooser:            mockBidderChooser,
+			normalizeValidBidderName: test.bidderNamesLookup,
 		}
 
 		result := chooser.Choose(test.givenRequest, &test.givenCookie)

--- a/usersync/chooser_test.go
+++ b/usersync/chooser_test.go
@@ -312,6 +312,7 @@ func TestChooserEvaluate(t *testing.T) {
 		givenSyncersSeen            map[string]struct{}
 		givenPrivacy                Privacy
 		givenCookie                 Cookie
+		givenSyncTypeFilter         SyncTypeFilter
 		normalizedBidderNamesLookup func(name string) (openrtb_ext.BidderName, bool)
 		expectedSyncer              Syncer
 		expectedEvaluation          BidderEvaluation
@@ -322,6 +323,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              fakeSyncerA,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusOK},
@@ -332,6 +334,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "unknown", Status: StatusUnknownBidder},
@@ -342,6 +345,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{"keyA": {}},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusDuplicate},
@@ -352,6 +356,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "b", SyncerKey: "keyB", Status: StatusTypeNotSupported},
@@ -362,6 +367,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieAlreadyHasSyncForA,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusAlreadySynced},
@@ -372,6 +378,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieAlreadyHasSyncForB,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              fakeSyncerA,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusOK},
@@ -382,6 +389,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: false, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusBlockedByGDPR},
@@ -392,6 +400,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: false, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusBlockedByCCPA},
@@ -402,6 +411,7 @@ func TestChooserEvaluate(t *testing.T) {
 			givenSyncersSeen:            map[string]struct{}{},
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: false},
 			givenCookie:                 cookieNeedsSync,
+			givenSyncTypeFilter:         syncTypeFilter,
 			normalizedBidderNamesLookup: normalizedBidderNamesLookup,
 			expectedSyncer:              nil,
 			expectedEvaluation:          BidderEvaluation{Bidder: "a", SyncerKey: "keyA", Status: StatusBlockedByPrivacy},
@@ -413,6 +423,20 @@ func TestChooserEvaluate(t *testing.T) {
 			givenPrivacy:                fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
 			givenCookie:                 cookieNeedsSync,
 			givenSyncTypeFilter:         syncTypeFilter,
+			normalizedBidderNamesLookup: openrtb_ext.NormalizeBidderName,
+			expectedSyncer:              fakeSyncerA,
+			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusOK},
+		},
+		{
+			description:          "Case insensitivity check for sync type filter",
+			givenBidder:          "AppNexus",
+			normalisedBidderName: "appnexus",
+			givenSyncersSeen:     map[string]struct{}{},
+			givenPrivacy:         fakePrivacy{gdprAllowsHostCookie: true, gdprAllowsBidderSync: true, ccpaAllowsBidderSync: true, activityAllowUserSync: true},
+			givenCookie:          cookieNeedsSync,
+			givenSyncTypeFilter: SyncTypeFilter{
+				IFrame:   NewSpecificBidderFilter([]string{"AppNexuS"}, BidderFilterModeInclude),
+				Redirect: NewSpecificBidderFilter([]string{"appNexuS"}, BidderFilterModeExclude)},
 			normalizedBidderNamesLookup: openrtb_ext.NormalizeBidderName,
 			expectedSyncer:              fakeSyncerA,
 			expectedEvaluation:          BidderEvaluation{Bidder: "AppNexus", SyncerKey: "keyA", Status: StatusOK},


### PR DESCRIPTION
Tested locally with `/cookie_sync` POST endpoint with following body - 
```
{
"bidders": ["AppnexUs"],
"coopsync": false,
"limit": 1
}
```
and got this sample response - 
```
{
  "status" : "no_cookie",
  "bidder_status" : [
    {
      "no_cookie" : true,
      "bidder" : "AppnexUs",
      "usersync" : {
        "url" : "https://ib.adnxs.com/getuid?http%3A%2F%2Flocalhost%3A8000%2Fsetuid%3Fbidder%3Dappnexus%26gdpr%3D%26gdpr_consent%3D%26gpp%3D%26gpp_sid%3D%26f%3Di%26uid%3D%24UID",
        "type" : "redirect"
      }
    }
  ]
}
```

partially resolves https://github.com/prebid/prebid-server/issues/2400