### PR TITLE
record tmax timeout error in adapter error metric

### DIFF
--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -14,6 +14,7 @@ const (
 	NoConversionRateErrorCode
 	MalformedAcctErrorCode
 	ModuleRejectionErrorCode
+	TmaxTimeoutErrorCode
 )
 
 // Defines numeric codes for well-known warnings.

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -20,6 +20,25 @@ func (err *Timeout) Severity() Severity {
 	return SeverityFatal
 }
 
+// TmaxTimeout should be used to flag that remaining tmax duration is not enough to get response from bidder
+//
+// TmaxTimeout will not be written to the app log, since it's not an actionable item for the Prebid Server hosts.
+type TmaxTimeout struct {
+	Message string
+}
+
+func (err *TmaxTimeout) Error() string {
+	return err.Message
+}
+
+func (err *TmaxTimeout) Code() int {
+	return TmaxTimeoutErrorCode
+}
+
+func (err *TmaxTimeout) Severity() Severity {
+	return SeverityFatal
+}
+
 // BadInput should be used when returning errors which are caused by bad input.
 // It should _not_ be used if the error is a server-side issue (e.g. failed to send the external request).
 //

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -88,8 +88,6 @@ const (
 	Gzip string = "GZIP"
 )
 
-var errTmaxTimeout = errors.New("exceeded tmax duration")
-
 // AdaptBidder converts an adapters.Bidder into an exchange.AdaptedBidder.
 //
 // The name refers to the "Adapter" architecture pattern, and should not be confused with a Prebid "Adapter"
@@ -551,7 +549,7 @@ func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.Re
 			bidder.me.RecordTMaxTimeout()
 			return &httpCallInfo{
 				request: req,
-				err:     errTmaxTimeout,
+				err:     &errortypes.TmaxTimeout{Message: "exceeded tmax duration"},
 			}
 		}
 	}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -3221,7 +3221,7 @@ func TestDoRequestImplWithTmax(t *testing.T) {
 			ctxDeadline:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			description:     "returns-tmax-timeout-error",
 			tmaxAdjustments: &TmaxAdjustmentsPreprocessed{IsEnforced: true, PBSResponsePreparationDuration: 100, BidderNetworkLatencyBuffer: 10, BidderResponseDurationMin: 5000},
-			assertFn:        func(err error) { assert.Equal(t, errTmaxTimeout, err) },
+			assertFn:        func(err error) { assert.Equal(t, &errortypes.TmaxTimeout{Message: "exceeded tmax duration"}, err) },
 		},
 		{
 			ctxDeadline:     time.Now().Add(5 * time.Second),
@@ -3296,7 +3296,7 @@ func TestDoRequestImplWithTmaxTimeout(t *testing.T) {
 			ctxDeadline:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			description:     "returns-tmax-timeout-error",
 			tmaxAdjustments: &TmaxAdjustmentsPreprocessed{IsEnforced: true, PBSResponsePreparationDuration: 100, BidderNetworkLatencyBuffer: 10, BidderResponseDurationMin: 5000},
-			assertFn:        func(err error) { assert.Equal(t, errTmaxTimeout, err) },
+			assertFn:        func(err error) { assert.Equal(t, &errortypes.TmaxTimeout{Message: "exceeded tmax duration"}, err) },
 		},
 	}
 	for _, test := range tests {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -844,6 +844,8 @@ func errorsToMetric(errs []error) map[metrics.AdapterError]struct{} {
 			ret[metrics.AdapterErrorFailedToRequestBids] = s
 		case errortypes.AlternateBidderCodeWarningCode:
 			ret[metrics.AdapterErrorValidation] = s
+		case errortypes.TmaxTimeoutErrorCode:
+			ret[metrics.AdapterErrorTmaxTimeout] = s
 		default:
 			ret[metrics.AdapterErrorUnknown] = s
 		}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -267,6 +267,7 @@ const (
 	AdapterErrorTimeout             AdapterError = "timeout"
 	AdapterErrorFailedToRequestBids AdapterError = "failedtorequestbid"
 	AdapterErrorValidation          AdapterError = "validation"
+	AdapterErrorTmaxTimeout         AdapterError = "tmaxtimeout"
 	AdapterErrorUnknown             AdapterError = "unknown_error"
 )
 


### PR DESCRIPTION
We have a [bidderRequest loop](https://github.com/prebid/prebid-server/blob/2e056bfbc071292361b6c399ed8176ff369babc3/exchange/exchange.go#L675), which goes through each bidder request. Inside this loop, PBS sends a request to the bidder server and handles the bidder's response or any errors that may occur.

Within this loop, we gather all errors related to bidders using [errorsToMetric()](https://github.com/prebid/prebid-server/blob/2e056bfbc071292361b6c399ed8176ff369babc3/exchange/exchange.go#L719) and then record these errors into `AdapterErrors` metric using [RecordAdapterRequest()](https://github.com/prebid/prebid-server/blob/2e056bfbc071292361b6c399ed8176ff369babc3/exchange/exchange.go#L687-L689)

PR makes changes to handle tmax timeout error. This means that if a tmax timeout error occurs then it should be included and recorded in the `AdapterErrors` metric as well.