### PR TITLE
Cleanup Prometheus Type Conversions

### DIFF
--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -2,28 +2,30 @@ package prometheusmetrics
 
 import (
 	"github.com/prebid/prebid-server/metrics"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[string][]string) {
 	var (
-		setUidStatusValues        = setUidStatusesAsString()
-		adapterErrorValues        = adapterErrorsAsString()
-		adapterValues             = adaptersAsString()
+		adapterErrorValues        = enumAsString(metrics.AdapterErrors())
+		adapterValues             = enumAsString(openrtb_ext.CoreBidderNames())
 		bidTypeValues             = []string{markupDeliveryAdm, markupDeliveryNurl}
 		boolValues                = boolValuesAsString()
-		cacheResultValues         = cacheResultsAsString()
+		cacheResultValues         = enumAsString(metrics.CacheResults())
 		connectionErrorValues     = []string{connectionAcceptError, connectionCloseError}
-		cookieValues              = cookieTypesAsString()
-		cookieSyncStatusValues    = cookieSyncStatusesAsString()
-		overheadTypes             = overheadTypesAsString()
-		requestTypeValues         = requestTypesAsString()
-		requestStatusValues       = requestStatusesAsString()
-		storedDataFetchTypeValues = storedDataFetchTypesAsString()
-		storedDataErrorValues     = storedDataErrorsAsString()
-		syncerRequestStatusValues = syncerRequestStatusesAsString()
-		syncerSetsStatusValues    = syncerSetStatusesAsString()
+		cookieSyncStatusValues    = enumAsString(metrics.CookieSyncStatuses())
+		cookieValues              = enumAsString(metrics.CookieTypes())
+		overheadTypes             = enumAsString(metrics.OverheadTypes())
+		requestStatusValues       = enumAsString(metrics.RequestStatuses())
+		requestTypeValues         = enumAsString(metrics.RequestTypes())
+		setUidStatusValues        = enumAsString(metrics.SetUidStatuses())
 		sourceValues              = []string{sourceRequest}
+		storedDataErrorValues     = enumAsString(metrics.StoredDataErrors())
+		storedDataFetchTypeValues = enumAsString(metrics.StoredDataFetchTypes())
+		syncerRequestStatusValues = enumAsString(metrics.SyncerRequestStatuses())
+		syncerSetsStatusValues    = enumAsString(metrics.SyncerSetUidStatuses())
+		tcfVersionValues          = enumAsString(metrics.TCFVersions())
 	)
 
 	preloadLabelValuesForCounter(m.connectionsError, map[string][]string{
@@ -224,7 +226,7 @@ func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[st
 
 	preloadLabelValuesForCounter(m.privacyTCF, map[string][]string{
 		sourceLabel:  sourceValues,
-		versionLabel: tcfVersionsAsString(),
+		versionLabel: tcfVersionValues,
 	})
 
 	if !m.metricsDisabled.AdapterGDPRRequestBlocked {

--- a/metrics/prometheus/type_conversion.go
+++ b/metrics/prometheus/type_conversion.go
@@ -2,22 +2,9 @@ package prometheusmetrics
 
 import (
 	"strconv"
-
-	"github.com/prebid/prebid-server/metrics"
-	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-func adaptersAsString() []string {
-	values := openrtb_ext.CoreBidderNames()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func adapterErrorsAsString() []string {
-	values := metrics.AdapterErrors()
+func enumAsString[T ~string](values []T) []string {
 	valuesAsString := make([]string, len(values))
 	for i, v := range values {
 		valuesAsString[i] = string(v)
@@ -30,112 +17,4 @@ func boolValuesAsString() []string {
 		strconv.FormatBool(true),
 		strconv.FormatBool(false),
 	}
-}
-
-func cacheResultsAsString() []string {
-	values := metrics.CacheResults()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func cookieTypesAsString() []string {
-	values := metrics.CookieTypes()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func cookieSyncStatusesAsString() []string {
-	values := metrics.CookieSyncStatuses()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func requestStatusesAsString() []string {
-	values := metrics.RequestStatuses()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func syncerRequestStatusesAsString() []string {
-	values := metrics.SyncerRequestStatuses()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func overheadTypesAsString() []string {
-	overheadTypes := metrics.OverheadTypes()
-	overheadTypesAsString := make([]string, len(overheadTypes))
-	for i, ot := range overheadTypes {
-		overheadTypesAsString[i] = ot.String()
-	}
-	return overheadTypesAsString
-}
-
-func syncerSetStatusesAsString() []string {
-	values := metrics.SyncerSetUidStatuses()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func requestTypesAsString() []string {
-	values := metrics.RequestTypes()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func setUidStatusesAsString() []string {
-	values := metrics.SetUidStatuses()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func storedDataFetchTypesAsString() []string {
-	values := metrics.StoredDataFetchTypes()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func storedDataErrorsAsString() []string {
-	values := metrics.StoredDataErrors()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
-}
-
-func tcfVersionsAsString() []string {
-	values := metrics.TCFVersions()
-	valuesAsString := make([]string, len(values))
-	for i, v := range values {
-		valuesAsString[i] = string(v)
-	}
-	return valuesAsString
 }


### PR DESCRIPTION
Use generics to eliminate boilerplate code in Prometheus preload type conversions.