### PR TITLE
make case insensitive comparison in auction request

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1510,12 +1510,12 @@ func (deps *endpointDeps) validateImpExt(imp *openrtb_ext.ImpWrapper, aliases ma
 	errL := []error{}
 
 	for bidder, ext := range prebid.Bidder {
-		coreBidder := bidder
+		coreBidder, _ := openrtb_ext.NormalizeBidderName(bidder)
 		if tmp, isAlias := aliases[bidder]; isAlias {
-			coreBidder = tmp
+			coreBidder = openrtb_ext.BidderName(tmp)
 		}
 
-		if coreBidderNormalized, isValid := deps.bidderMap[coreBidder]; isValid {
+		if coreBidderNormalized, isValid := deps.bidderMap[coreBidder.String()]; isValid {
 			if err := deps.paramsValidator.Validate(coreBidderNormalized, ext); err != nil {
 				return []error{fmt.Errorf("request.imp[%d].ext.prebid.bidder.%s failed validation.\n%v", impIndex, bidder, err)}
 			}

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1575,18 +1575,21 @@ func (deps *endpointDeps) parseBidExt(req *openrtb_ext.RequestWrapper) error {
 }
 
 func (deps *endpointDeps) validateAliases(aliases map[string]string) error {
-	for alias, coreBidder := range aliases {
-		if _, isCoreBidderDisabled := deps.disabledBidders[coreBidder]; isCoreBidderDisabled {
-			return fmt.Errorf("request.ext.prebid.aliases.%s refers to disabled bidder: %s", alias, coreBidder)
+	for alias, bidderName := range aliases {
+		normalisedBidderName, _ := openrtb_ext.NormalizeBidderName(bidderName)
+		coreBidderName := normalisedBidderName.String()
+		if _, isCoreBidderDisabled := deps.disabledBidders[coreBidderName]; isCoreBidderDisabled {
+			return fmt.Errorf("request.ext.prebid.aliases.%s refers to disabled bidder: %s", alias, bidderName)
 		}
 
-		if _, isCoreBidder := deps.bidderMap[coreBidder]; !isCoreBidder {
-			return fmt.Errorf("request.ext.prebid.aliases.%s refers to unknown bidder: %s", alias, coreBidder)
+		if _, isCoreBidder := deps.bidderMap[coreBidderName]; !isCoreBidder {
+			return fmt.Errorf("request.ext.prebid.aliases.%s refers to unknown bidder: %s", alias, bidderName)
 		}
 
-		if alias == coreBidder {
+		if alias == coreBidderName {
 			return fmt.Errorf("request.ext.prebid.aliases.%s defines a no-op alias. Choose a different alias, or remove this entry.", alias)
 		}
+		aliases[alias] = coreBidderName
 	}
 	return nil
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -2833,19 +2833,21 @@ func TestValidateImpExt(t *testing.T) {
 
 	for _, group := range testGroups {
 		for _, test := range group.testCases {
-			imp := &openrtb2.Imp{Ext: test.impExt}
-			impWrapper := &openrtb_ext.ImpWrapper{Imp: imp}
+			t.Run(test.description, func(t *testing.T) {
+				imp := &openrtb2.Imp{Ext: test.impExt}
+				impWrapper := &openrtb_ext.ImpWrapper{Imp: imp}
 
-			errs := deps.validateImpExt(impWrapper, nil, 0, false, nil)
+				errs := deps.validateImpExt(impWrapper, nil, 0, false, nil)
 
-			assert.NoError(t, impWrapper.RebuildImp(), test.description+":rebuild_imp")
+				assert.NoError(t, impWrapper.RebuildImp(), test.description+":rebuild_imp")
 
-			if len(test.expectedImpExt) > 0 {
-				assert.JSONEq(t, test.expectedImpExt, string(imp.Ext), "imp.ext JSON does not match expected. Test: %s. %s\n", group.description, test.description)
-			} else {
-				assert.Empty(t, imp.Ext, "imp.ext expected to be empty but was: %s. Test: %s. %s\n", string(imp.Ext), group.description, test.description)
-			}
-			assert.Equal(t, test.expectedErrs, errs, "errs slice does not match expected. Test: %s. %s\n", group.description, test.description)
+				if len(test.expectedImpExt) > 0 {
+					assert.JSONEq(t, test.expectedImpExt, string(imp.Ext), "imp.ext JSON does not match expected. Test: %s. %s\n", group.description, test.description)
+				} else {
+					assert.Empty(t, imp.Ext, "imp.ext expected to be empty but was: %s. Test: %s. %s\n", string(imp.Ext), group.description, test.description)
+				}
+				assert.Equal(t, test.expectedErrs, errs, "errs slice does not match expected. Test: %s. %s\n", group.description, test.description)
+			})
 		}
 	}
 }

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext-case-insensitive.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext-case-insensitive.json
@@ -1,5 +1,5 @@
 {
-  "description": "This demonstrates all of the OpenRTB extensions supported by Prebid Server. Very few requests will need all of these at once.",
+  "description": "This demonstrates all extension in case insensitive.",
   "config": {
     "mockBidders": [
       {
@@ -69,7 +69,7 @@
     "ext": {
       "prebid": {
         "aliases": {
-          "districtm": "appnexus"
+          "districtm": "Appnexus"
         },
         "bidadjustmentfactors": {
           "appnexus": 1.01,

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json
@@ -2,8 +2,16 @@
   "description": "This demonstrates all of the OpenRTB extensions supported by Prebid Server. Very few requests will need all of these at once.",
   "config": {
     "mockBidders": [
-      {"bidderName": "appnexus", "currency": "USD", "price": 1.00},
-      {"bidderName": "rubicon", "currency": "USD", "price": 1.00}
+      {
+        "bidderName": "appnexus",
+        "currency": "USD",
+        "price": 1.00
+      },
+      {
+        "bidderName": "rubicon",
+        "currency": "USD",
+        "price": 1.00
+      }
     ]
   },
   "mockBidRequest": {
@@ -61,7 +69,7 @@
     "ext": {
       "prebid": {
         "aliases": {
-          "districtm": "appnexus"
+          "districtm": "Appnexus"
         },
         "bidadjustmentfactors": {
           "appnexus": 1.01,
@@ -91,42 +99,42 @@
     }
   },
   "expectedBidResponse": {
-      "id":"some-request-id",
-      "seatbid": [
-        {
-          "bid": [
-            {
-              "id": "appnexus-bid",
-              "impid": "some-impression-id",
-              "price": 1.01
-            }
-          ],
-          "seat": "appnexus"
-        },
-        {
-          "bid": [
-            {
-              "id": "appnexus-bid",
-              "impid": "some-impression-id",
-              "price": 0.98
-            }
-          ],
-          "seat": "districtm"
-        },
-        {
-          "bid": [
-            {
-              "id": "rubicon-bid",
-              "impid": "some-impression-id",
-              "price": 0.99
-            }
-          ],
-          "seat": "rubicon"
-        }
-      ],
-      "bidid":"test bid id",
-      "cur":"USD",
-      "nbr":0
+    "id": "some-request-id",
+    "seatbid": [
+      {
+        "bid": [
+          {
+            "id": "appnexus-bid",
+            "impid": "some-impression-id",
+            "price": 1.01
+          }
+        ],
+        "seat": "appnexus"
+      },
+      {
+        "bid": [
+          {
+            "id": "appnexus-bid",
+            "impid": "some-impression-id",
+            "price": 0.98
+          }
+        ],
+        "seat": "districtm"
+      },
+      {
+        "bid": [
+          {
+            "id": "rubicon-bid",
+            "impid": "some-impression-id",
+            "price": 0.99
+          }
+        ],
+        "seat": "rubicon"
+      }
+    ],
+    "bidid": "test bid id",
+    "cur": "USD",
+    "nbr": 0
   },
   "expectedReturnCode": 200
 }

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple-case-insensitive.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple-case-insensitive.json
@@ -1,0 +1,61 @@
+{
+    "description": "Simple request - bidder case insensitive",
+    "config": {
+        "mockBidders": [
+            {
+                "bidderName": "appnexus",
+                "currency": "USD",
+                "price": 0.00
+            }
+        ]
+    },
+    "mockBidRequest": {
+        "id": "some-request-id",
+        "site": {
+            "page": "prebid.org"
+        },
+        "imp": [
+            {
+                "id": "some-impression-id",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        },
+                        {
+                            "w": 300,
+                            "h": 600
+                        }
+                    ]
+                },
+                "ext": {
+                    "Appnexus": {
+                        "placementId": 12883451
+                    }
+                }
+            }
+        ],
+        "tmax": 500,
+        "ext": {}
+    },
+    "expectedBidResponse": {
+        "id": "some-request-id",
+        "seatbid": [
+            {
+                "bid": [
+                    {
+                        "id": "appnexus-bid",
+                        "impid": "some-impression-id",
+                        "price": 0
+                    }
+                ],
+                "seat": "Appnexus"
+            }
+        ],
+        "bidid": "test bid id",
+        "cur": "USD",
+        "nbr": 0
+    },
+    "expectedReturnCode": 200
+}

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
@@ -2,7 +2,11 @@
   "description": "Simple request",
   "config": {
     "mockBidders": [
-      {"bidderName": "appnexus", "currency": "USD", "price": 0.00}
+      {
+        "bidderName": "appnexus",
+        "currency": "USD",
+        "price": 0.00
+      }
     ]
   },
   "mockBidRequest": {
@@ -26,7 +30,7 @@
           ]
         },
         "ext": {
-          "appnexus": {
+          "Appnexus": {
             "placementId": 12883451
           }
         }
@@ -36,22 +40,22 @@
     "ext": {}
   },
   "expectedBidResponse": {
-      "id":"some-request-id",
-      "seatbid": [
-        {
-          "bid": [
-            {
-              "id": "appnexus-bid",
-              "impid": "some-impression-id",
-              "price": 0
-            }
-          ],
-          "seat": "appnexus"
-        }
-      ],
-      "bidid":"test bid id",
-      "cur":"USD",
-      "nbr":0
+    "id": "some-request-id",
+    "seatbid": [
+      {
+        "bid": [
+          {
+            "id": "appnexus-bid",
+            "impid": "some-impression-id",
+            "price": 0
+          }
+        ],
+        "seat": "Appnexus"
+      }
+    ],
+    "bidid": "test bid id",
+    "cur": "USD",
+    "nbr": 0
   },
   "expectedReturnCode": 200
 }

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
@@ -30,7 +30,7 @@
           ]
         },
         "ext": {
-          "Appnexus": {
+          "appnexus": {
             "placementId": 12883451
           }
         }
@@ -50,7 +50,7 @@
             "price": 0
           }
         ],
-        "seat": "Appnexus"
+        "seat": "appnexus"
       }
     ],
     "bidid": "test bid id",

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -769,7 +769,7 @@ func TestAdapterCurrency(t *testing.T) {
 		categoriesFetcher: nilCategoryFetcher{},
 		bidIDGenerator:    &mockBidIDGenerator{false, false},
 		adapterMap: map[openrtb_ext.BidderName]AdaptedBidder{
-			openrtb_ext.BidderName("foo"): AdaptBidder(mockBidder, nil, &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderName("foo"), nil, ""),
+			openrtb_ext.BidderName("appnexus"): AdaptBidder(mockBidder, nil, &config.Configuration{}, &metricsConfig.NilMetricsEngine{}, openrtb_ext.BidderName("appnexus"), nil, ""),
 		},
 	}
 	e.requestSplitter = requestSplitter{
@@ -783,7 +783,7 @@ func TestAdapterCurrency(t *testing.T) {
 		Imp: []openrtb2.Imp{{
 			ID:     "some-impression-id",
 			Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}, {W: 300, H: 600}}},
-			Ext:    json.RawMessage(`{"prebid":{"bidder":{"foo":{"placementId":1}}}}`),
+			Ext:    json.RawMessage(`{"prebid":{"bidder":{"appnexus":{"placementId":1}}}}`),
 		}},
 		Site: &openrtb2.Site{
 			Page: "prebid.org",
@@ -805,7 +805,7 @@ func TestAdapterCurrency(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "some-request-id", response.ID, "Response ID")
 	assert.Empty(t, response.SeatBid, "Response Bids")
-	assert.Contains(t, string(response.Ext), `"errors":{"foo":[{"code":5,"message":"The adapter failed to generate any bid requests, but also failed to generate an error explaining why"}]}`, "Response Ext")
+	assert.Contains(t, string(response.Ext), `"errors":{"appnexus":[{"code":5,"message":"The adapter failed to generate any bid requests, but also failed to generate an error explaining why"}]}`, "Response Ext")
 
 	// Test Currency Converter Properly Passed To Adapter
 	if assert.NotNil(t, mockBidder.lastExtraRequestInfo, "Currency Conversion Argument") {

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -761,10 +761,11 @@ func setUserExtWithCopy(request *openrtb2.BidRequest, userExtJSON json.RawMessag
 
 // resolveBidder returns the known BidderName associated with bidder, if bidder is an alias. If it's not an alias, the bidder is returned.
 func resolveBidder(bidder string, aliases map[string]string) openrtb_ext.BidderName {
+	normalisedBidderName, _ := openrtb_ext.NormalizeBidderName(bidder)
 	if coreBidder, ok := aliases[bidder]; ok {
 		return openrtb_ext.BidderName(coreBidder)
 	}
-	return openrtb_ext.BidderName(bidder)
+	return normalisedBidderName
 }
 
 // parseAliases parses the aliases from the BidRequest


### PR DESCRIPTION
We need to make case insensitive comparison in the request while in the response we should return the same bidder name(with whatever case) from the request.
By doing case insensitive comparison in the request, we are not making any changes in our current auction flow. Our current auction flow will work the same way as it is today.



