### PR TITLE
Remove Config Backwards Compatibility: File System Stored Requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1069,7 +1069,6 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.ReadInConfig()
 
 	// Migrate config settings to maintain compatibility with old configs
-	migrateConfig(v)
 	migrateConfigPurposeOneTreatment(v)
 	migrateConfigSpecialFeature1(v)
 	migrateConfigTCF2PurposeFlags(v)
@@ -1132,19 +1131,6 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 
 	for bidderName := range bidderInfos {
 		setBidderDefaults(v, strings.ToLower(bidderName))
-	}
-}
-
-func migrateConfig(v *viper.Viper) {
-	// if stored_requests.filesystem is not a map in conf file as expected from defaults,
-	// means we have old-style settings; migrate them to new filesystem map to avoid breaking viper
-	if _, ok := v.Get("stored_requests.filesystem").(map[string]interface{}); !ok {
-		glog.Warning("stored_requests.filesystem should be changed to stored_requests.filesystem.enabled")
-		glog.Warning("stored_requests.directorypath should be changed to stored_requests.filesystem.directorypath")
-		m := v.GetStringMap("stored_requests.filesystem")
-		m["enabled"] = v.GetBool("stored_requests.filesystem")
-		m["directorypath"] = v.GetString("stored_requests.directorypath")
-		v.Set("stored_requests.filesystem", m)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -492,12 +492,6 @@ tmax_adjustments:
   pbs_response_preparation_duration_ms: 100
 `)
 
-var oldStoredRequestsConfig = []byte(`
-stored_requests:
-  filesystem: true
-  directorypath: "/somepath"
-`)
-
 func cmpStrings(t *testing.T, key, expected, actual string) {
 	t.Helper()
 	assert.Equal(t, expected, actual, "%s: %s != %s", key, expected, actual)
@@ -818,36 +812,15 @@ func TestValidateConfig(t *testing.T) {
 	assert.Nil(t, err, "OpenRTB filesystem config should work. %v", err)
 }
 
-func TestMigrateConfig(t *testing.T) {
-	v := viper.New()
-	SetupViper(v, "", bidderInfos)
-	v.Set("gdpr.default_value", "0")
-	v.SetConfigType("yaml")
-	v.ReadConfig(bytes.NewBuffer(oldStoredRequestsConfig))
-	migrateConfig(v)
-	cfg, err := New(v, bidderInfos, mockNormalizeBidderName)
-	assert.NoError(t, err, "Setting up config should work but it doesn't")
-	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
-	cmpStrings(t, "stored_requests.filesystem.path", "/somepath", cfg.StoredRequests.Files.Path)
-}
-
 func TestMigrateConfigFromEnv(t *testing.T) {
-	if oldval, ok := os.LookupEnv("PBS_STORED_REQUESTS_FILESYSTEM"); ok {
-		defer os.Setenv("PBS_STORED_REQUESTS_FILESYSTEM", oldval)
-	} else {
-		defer os.Unsetenv("PBS_STORED_REQUESTS_FILESYSTEM")
-	}
-
 	if oldval, ok := os.LookupEnv("PBS_ADAPTERS_BIDDER1_ENDPOINT"); ok {
 		defer os.Setenv("PBS_ADAPTERS_BIDDER1_ENDPOINT", oldval)
 	} else {
 		defer os.Unsetenv("PBS_ADAPTERS_BIDDER1_ENDPOINT")
 	}
 
-	os.Setenv("PBS_STORED_REQUESTS_FILESYSTEM", "true")
 	os.Setenv("PBS_ADAPTERS_BIDDER1_ENDPOINT", "http://bidder1_override.com")
 	cfg, _ := newDefaultConfig(t)
-	cmpBools(t, "stored_requests.filesystem.enabled", true, cfg.StoredRequests.Files.Enabled)
 	cmpStrings(t, "adapters.bidder1.endpoint", "http://bidder1_override.com", cfg.BidderInfos["bidder1"].Endpoint)
 }
 


### PR DESCRIPTION
The upcoming 2.0 release will remove backwards compatibility for deprecated host and account configuration options. This PR removes support for the following host options:
`stored_requests.filesystem`
`stored_requests.directorypath`

Instead, hosts should use the following respectively:
`stored_requests.filesystem.enabled`
`stored_requests.filesystem.path`