### PR TITLE
make bidderInfo endpoint case insensitive

### DIFF
--- a/endpoints/info/bidders_detail.go
+++ b/endpoints/info/bidders_detail.go
@@ -27,7 +27,11 @@ func NewBiddersDetailEndpoint(bidders config.BidderInfos, aliases map[string]str
 	return func(w http.ResponseWriter, _ *http.Request, ps httprouter.Params) {
 		bidder := ps.ByName("bidderName")
 
-		if response, ok := responses[bidder]; ok {
+		coreBidderName, found := getNormalisedBidderName(bidder, aliases)
+		if !found {
+			w.WriteHeader(http.StatusNotFound)
+		}
+		if response, ok := responses[coreBidderName]; ok {
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write(response); err != nil {
 				glog.Errorf("error writing response to /info/bidders/%s: %v", bidder, err)
@@ -36,6 +40,20 @@ func NewBiddersDetailEndpoint(bidders config.BidderInfos, aliases map[string]str
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}
+}
+
+func getNormalisedBidderName(bidderName string, aliases map[string]string) (string, bool) {
+	if strings.ToLower(bidderName) == "all" {
+		return "all", true
+	}
+	coreBidderName, ok := openrtb_ext.NormalizeBidderName(bidderName)
+	if !ok { //check default aliases if not found in coreBidders
+		if _, isDefaultAlias := aliases[bidderName]; isDefaultAlias {
+			return bidderName, true
+		}
+		return "", false
+	}
+	return coreBidderName.String(), true
 }
 
 func prepareBiddersDetailResponse(bidders config.BidderInfos, aliases map[string]string) (map[string][]byte, error) {

--- a/endpoints/info/bidders_detail_test.go
+++ b/endpoints/info/bidders_detail_test.go
@@ -2,6 +2,7 @@ package info
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -365,22 +366,22 @@ func TestMapMediaTypes(t *testing.T) {
 func TestBiddersDetailHandler(t *testing.T) {
 	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
 	bidderAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"}}`)
-	aliasAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"},"aliasOf":"a"}`)
+	aliasAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"},"aliasOf":"appnexus"}`)
 
 	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
 	bidderBResponse := []byte(`{"status":"ACTIVE","usesHttps":false,"maintainer":{"email":"bidderB"}}`)
 
 	allResponse := bytes.Buffer{}
-	allResponse.WriteString(`{"a":`)
-	allResponse.Write(bidderAResponse)
-	allResponse.WriteString(`,"aAlias":`)
+	allResponse.WriteString(`{"aAlias":`)
 	allResponse.Write(aliasAResponse)
-	allResponse.WriteString(`,"b":`)
+	allResponse.WriteString(`,"appnexus":`)
+	allResponse.Write(bidderAResponse)
+	allResponse.WriteString(`,"rubicon":`)
 	allResponse.Write(bidderBResponse)
 	allResponse.WriteString(`}`)
 
-	bidders := config.BidderInfos{"a": bidderAInfo, "b": bidderBInfo}
-	aliases := map[string]string{"aAlias": "a"}
+	bidders := config.BidderInfos{"appnexus": bidderAInfo, "rubicon": bidderBInfo}
+	aliases := map[string]string{"aAlias": "appnexus"}
 
 	handler := NewBiddersDetailEndpoint(bidders, aliases)
 
@@ -393,20 +394,34 @@ func TestBiddersDetailHandler(t *testing.T) {
 	}{
 		{
 			description:      "Bidder A",
-			givenBidder:      "a",
+			givenBidder:      "appnexus",
 			expectedStatus:   http.StatusOK,
 			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
 			expectedResponse: bidderAResponse,
 		},
 		{
 			description:      "Bidder B",
-			givenBidder:      "b",
+			givenBidder:      "rubicon",
+			expectedStatus:   http.StatusOK,
+			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
+			expectedResponse: bidderBResponse,
+		},
+		{
+			description:      "Bidder B - case insensitive",
+			givenBidder:      "RUBICON",
 			expectedStatus:   http.StatusOK,
 			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
 			expectedResponse: bidderBResponse,
 		},
 		{
 			description:      "Bidder A Alias",
+			givenBidder:      "aAlias",
+			expectedStatus:   http.StatusOK,
+			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
+			expectedResponse: aliasAResponse,
+		},
+		{
+			description:      "Bidder A Alias - case insensitive",
 			givenBidder:      "aAlias",
 			expectedStatus:   http.StatusOK,
 			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
@@ -420,11 +435,11 @@ func TestBiddersDetailHandler(t *testing.T) {
 			expectedResponse: allResponse.Bytes(),
 		},
 		{
-			description:      "All Bidders - Wrong Case",
-			givenBidder:      "ALL",
-			expectedStatus:   http.StatusNotFound,
-			expectedHeaders:  http.Header{},
-			expectedResponse: []byte{},
+			description:      "All Bidders - Case insensitive",
+			givenBidder:      "All",
+			expectedStatus:   http.StatusOK,
+			expectedHeaders:  http.Header{"Content-Type": []string{"application/json"}},
+			expectedResponse: allResponse.Bytes(),
 		},
 		{
 			description:      "Invalid Bidder",
@@ -436,16 +451,19 @@ func TestBiddersDetailHandler(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		responseRecorder := httptest.NewRecorder()
-		handler(responseRecorder, nil, httprouter.Params{{"bidderName", test.givenBidder}})
+		t.Run(test.description, func(t *testing.T) {
+			responseRecorder := httptest.NewRecorder()
+			handler(responseRecorder, nil, httprouter.Params{{"bidderName", test.givenBidder}})
 
-		result := responseRecorder.Result()
-		assert.Equal(t, result.StatusCode, test.expectedStatus, test.description+":statuscode")
+			result := responseRecorder.Result()
+			assert.Equal(t, result.StatusCode, test.expectedStatus, test.description+":statuscode")
 
-		resultBody, _ := io.ReadAll(result.Body)
-		assert.Equal(t, test.expectedResponse, resultBody, test.description+":body")
+			resultBody, _ := io.ReadAll(result.Body)
+			fmt.Println(string(test.expectedResponse))
+			assert.Equal(t, test.expectedResponse, resultBody, test.description+":body")
 
-		resultHeaders := result.Header
-		assert.Equal(t, test.expectedHeaders, resultHeaders, test.description+":headers")
+			resultHeaders := result.Header
+			assert.Equal(t, test.expectedHeaders, resultHeaders, test.description+":headers")
+		})
 	}
 }


### PR DESCRIPTION
This PR makes `/info/bidders/:bidderName` endpoint as case insensitive. Now, we will be able to make the call to this endpoint using `/info/bidders/APPNEXUS` for example.
There is special `all` case that is also handled in this PR.

partially resolves https://github.com/prebid/prebid-server/issues/2400