### PR TITLE
make NormalizeBidderName to do faster lookup

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -239,6 +239,7 @@ func SetAliasBidderName(aliasBidderName string, parentBidderName BidderName) err
 	aliasBidder := BidderName(aliasBidderName)
 	coreBidderNames = append(coreBidderNames, aliasBidder)
 	aliasBidderToParent[aliasBidder] = parentBidderName
+	bidderNameLookup[strings.ToLower(aliasBidderName)] = aliasBidder
 	return nil
 }
 
@@ -564,11 +565,11 @@ var bidderNameLookup = func() map[string]BidderName {
 		lookup[bidderNameLower] = name
 	}
 	return lookup
-}
+}()
 
 func NormalizeBidderName(name string) (BidderName, bool) {
 	nameLower := strings.ToLower(name)
-	bidderName, exists := bidderNameLookup()[nameLower]
+	bidderName, exists := bidderNameLookup[nameLower]
 	return bidderName, exists
 }
 

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -148,6 +149,7 @@ func TestSetAliasBidderName(t *testing.T) {
 		} else {
 			assert.Contains(t, CoreBidderNames(), BidderName(test.aliasBidderName))
 			assert.Contains(t, aliasBidderToParent, BidderName(test.aliasBidderName))
+			assert.Contains(t, bidderNameLookup, strings.ToLower(test.aliasBidderName))
 		}
 	}
 


### PR DESCRIPTION
Now - normalizeBidderName function is being used in the auction flow so we need to make sure that it does faster lookups.
This PR makes changes to not call `bidderNameLookup` function on every normalizeBidderName. Instead, `bidderNameLookup` now returns static map instead of function and that will be used to do lookups. 
To handle alias cases - map is being updated while calling `SetAliasBidderName` function.