### PR TITLE
Support case insensitive bidder name in storedbidresponse

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -2486,7 +2486,12 @@ func validateStoredBidRespAndImpExtBidders(bidderExts map[string]json.RawMessage
 		}
 
 		for bidderName := range bidResponses {
-			if _, present := bidderExts[bidderName]; !present {
+			bidder := bidderName
+			normalizedCoreBidder, ok := openrtb_ext.NormalizeBidderName(bidder)
+			if ok {
+				bidder = normalizedCoreBidder.String()
+			}
+			if _, present := bidderExts[bidder]; !present {
 				return generateStoredBidResponseValidationError(impId)
 			}
 		}

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/imp-with-stored-bid-resp-insensitive-bidder-name.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/imp-with-stored-bid-resp-insensitive-bidder-name.json
@@ -1,0 +1,39 @@
+{
+  "description": "request with impression with stored bid response with sensitive bidder name",
+  "mockBidRequest": {
+    "id": "request-with-stored-resp",
+    "site": {
+      "page": "test.somepage.com"
+    },
+    "imp": [
+      {
+        "id": "imp-id3",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "appnexus": {
+            "placementId": 12883451
+          },
+          "prebid": {
+            "storedbidresponse": [
+              {
+                "bidder": "APPNEXUS",
+                "id": "bidResponseId3"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "user": {
+      "yob": 1989
+    }
+  },
+  "expectedReturnCode": 200
+}

--- a/stored_responses/stored_responses.go
+++ b/stored_responses/stored_responses.go
@@ -97,8 +97,13 @@ func extractStoredResponsesIds(impInfo []ImpExtPrebidData,
 				if len(bidderResp.ID) == 0 || len(bidderResp.Bidder) == 0 {
 					return nil, nil, nil, nil, fmt.Errorf("request.imp[%d] has ext.prebid.storedbidresponse specified, but \"id\" or/and \"bidder\" fields are missing ", index)
 				}
+				bidderName := bidderResp.Bidder
+				normalizedCoreBidder, ok := openrtb_ext.NormalizeBidderName(bidderResp.Bidder)
+				if ok {
+					bidderName = normalizedCoreBidder.String()
+				}
 				//check if bidder is valid/exists
-				if _, isValid := bidderMap[bidderResp.Bidder]; !isValid {
+				if _, isValid := bidderMap[bidderName]; !isValid {
 					return nil, nil, nil, nil, fmt.Errorf("request.imp[impId: %s].ext.prebid.bidder contains unknown bidder: %s. Did you forget an alias in request.ext.prebid.aliases?", impId, bidderResp.Bidder)
 				}
 				// bidder is unique per one bid stored response


### PR DESCRIPTION
PR makes changes to support case insensitive bidder names in `ext.prebid.storedbidresponse.bidder`

As shown below bidder name appnexus is known name to PBS. But APPNEXUS is unknown. Prior to PR changes PBS would have error out with unknown APPNEXUS bidder name messgae. PR has implemented insensitive bidder name comparison in ext.prebid.storedbidresponse.bidder

```
        "ext": {
          "appnexus": {
            "placementId": 12883451
          },
          "prebid": {
            "storedbidresponse": [
              {
                "bidder": "APPNEXUS",
                "id": "bidResponseId3"
              }
            ]
          }
        }

```
partially resolves https://github.com/prebid/prebid-server/issues/2400