### PR TITLE
Support case insensitive bidder name in bidadjustmentfactors

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -964,7 +964,14 @@ func (deps *endpointDeps) validateBidAdjustmentFactors(adjustmentFactors map[str
 		if adjustmentFactor <= 0 {
 			return fmt.Errorf("request.ext.prebid.bidadjustmentfactors.%s must be a positive number. Got %f", bidderToAdjust, adjustmentFactor)
 		}
-		if _, isBidder := deps.bidderMap[bidderToAdjust]; !isBidder {
+
+		bidderName := bidderToAdjust
+		normalizedCoreBidder, ok := openrtb_ext.NormalizeBidderName(bidderToAdjust)
+		if ok {
+			bidderName = normalizedCoreBidder.String()
+		}
+
+		if _, isBidder := deps.bidderMap[bidderName]; !isBidder {
 			if _, isAlias := aliases[bidderToAdjust]; !isAlias {
 				return fmt.Errorf("request.ext.prebid.bidadjustmentfactors.%s is not a known bidder or alias", bidderToAdjust)
 			}

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/bidder-adjustment-factors-case-insensitive.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/bidder-adjustment-factors-case-insensitive.json
@@ -1,0 +1,119 @@
+{
+    "description": "This demonstrates bid adjustment factors with case insensitive bidder names",
+    "config": {
+        "mockBidders": [
+            {
+                "bidderName": "appnexus",
+                "currency": "USD",
+                "price": 1.00
+            },
+            {
+                "bidderName": "rubicon",
+                "currency": "USD",
+                "price": 1.00
+            }
+        ]
+    },
+    "mockBidRequest": {
+        "id": "some-request-id",
+        "site": {
+            "page": "prebid.org"
+        },
+        "user": {
+            "ext": {
+                "consent": "gdpr-consent-string"
+            }
+        },
+        "regs": {
+            "ext": {
+                "gdpr": 1,
+                "us_privacy": "1NYN"
+            }
+        },
+        "imp": [
+            {
+                "id": "some-impression-id",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        },
+                        {
+                            "w": 300,
+                            "h": 600
+                        }
+                    ]
+                },
+                "ext": {
+                    "APPNEXUS": {
+                        "placementId": 12883451
+                    },
+                    "districtm": {
+                        "placementId": 105
+                    }
+                }
+            }
+        ],
+        "tmax": 500,
+        "ext": {
+            "prebid": {
+                "aliases": {
+                    "districtm": "APPNEXUS"
+                },
+                "bidadjustmentfactors": {
+                    "APPNEXUS": 1.01,
+                    "districtm": 0.98
+                },
+                "cache": {
+                    "bids": {}
+                },
+                "channel": {
+                    "name": "video",
+                    "version": "1.0"
+                },
+                "targeting": {
+                    "includewinners": false,
+                    "pricegranularity": {
+                        "precision": 2,
+                        "ranges": [
+                            {
+                                "max": 20,
+                                "increment": 0.10
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "expectedBidResponse": {
+        "id": "some-request-id",
+        "seatbid": [
+            {
+                "bid": [
+                    {
+                        "id": "appnexus-bid",
+                        "impid": "some-impression-id",
+                        "price": 1.01
+                    }
+                ],
+                "seat": "APPNEXUS"
+            },
+            {
+                "bid": [
+                    {
+                        "id": "appnexus-bid",
+                        "impid": "some-impression-id",
+                        "price": 0.98
+                    }
+                ],
+                "seat": "districtm"
+            }
+        ],
+        "bidid": "test bid id",
+        "cur": "USD",
+        "nbr": 0
+    },
+    "expectedReturnCode": 200
+}


### PR DESCRIPTION
PR makes changes to support case insensitive bidder names in adjustment factors. 

As shown below bidder name `appnexus` is known name to PBS. But `APPNEXUS` is unknown. Prior to PR changes PBS would have error out with unknown `APPNEXUS` bidder name messgae.  PR has implemented insensitive bidder name comparison in `bidadjustmentfactors`

```
    {
       "imp": [
            {
               "ext": {
                   "prebid": {
                      "bidder": {
                          "APPNEXUS": { // sensitive appnexus
                          }
                       }
                    }
               }
            }
        ],
        ext: {
          "prebid": {
              "bidadjustmentfactors": {
                   "APPNEXUS": 1 // sensitive appnexus
               }
           }
``` 

partially resolves https://github.com/prebid/prebid-server/issues/2400