### PR TITLE
Support case insensitive bidder name in eidpermissions

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1013,7 +1013,12 @@ func validateBidders(bidders []string, knownBidders map[string]openrtb_ext.Bidde
 				return errors.New(`bidder wildcard "*" mixed with specific bidders`)
 			}
 		} else {
-			_, isCoreBidder := knownBidders[bidder]
+			bidderName := bidder
+			normalizedCoreBidder, ok := openrtb_ext.NormalizeBidderName(bidderName)
+			if ok {
+				bidderName = normalizedCoreBidder.String()
+			}
+			_, isCoreBidder := knownBidders[bidderName]
 			_, isAlias := knownAliases[bidder]
 			if !isCoreBidder && !isAlias {
 				return fmt.Errorf(`unrecognized bidder "%v"`, bidder)

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/eidpermissions-insensitive-bidder-name.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/eidpermissions-insensitive-bidder-name.json
@@ -1,0 +1,109 @@
+{
+    "description": "This demonstrates ext.prebid.data.eidpermissions.bidders with case insensitive bidder names",
+    "config": {
+        "mockBidders": [
+            {
+                "bidderName": "appnexus",
+                "currency": "USD",
+                "price": 1.00
+            },
+            {
+                "bidderName": "rubicon",
+                "currency": "USD",
+                "price": 1.00
+            }
+        ]
+    },
+    "mockBidRequest": {
+        "id": "some-request-id",
+        "site": {
+            "page": "prebid.org"
+        },
+        "user": {
+            "ext": {
+                "consent": "gdpr-consent-string"
+            }
+        },
+        "regs": {
+            "ext": {
+                "gdpr": 1,
+                "us_privacy": "1NYN"
+            }
+        },
+        "imp": [
+            {
+                "id": "some-impression-id",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        },
+                        {
+                            "w": 300,
+                            "h": 600
+                        }
+                    ]
+                },
+                "ext": {
+                    "APPNEXUS": {
+                        "placementId": 12883451
+                    }
+                }
+            }
+        ],
+        "tmax": 500,
+        "ext": {
+            "prebid": {
+                "data": {
+                    "eidpermissions": [
+                        {
+                            "source": "source1",
+                            "bidders": [
+                                "APPNEXUS"
+                            ]
+                        }
+                    ]
+                },
+                "cache": {
+                    "bids": {}
+                },
+                "channel": {
+                    "name": "video",
+                    "version": "1.0"
+                },
+                "targeting": {
+                    "includewinners": false,
+                    "pricegranularity": {
+                        "precision": 2,
+                        "ranges": [
+                            {
+                                "max": 20,
+                                "increment": 0.10
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "expectedBidResponse": {
+        "id": "some-request-id",
+        "seatbid": [
+            {
+                "bid": [
+                    {
+                        "id": "appnexus-bid",
+                        "impid": "some-impression-id",
+                        "price": 1
+                    }
+                ],
+                "seat": "APPNEXUS"
+            }
+        ],
+        "bidid": "test bid id",
+        "cur": "USD",
+        "nbr": 0
+    },
+    "expectedReturnCode": 200
+}


### PR DESCRIPTION
PR makes changes to support case insensitive bidder names in `ext.prebid.data.eidpermissions.bidders`.

As shown below bidder name appnexus is known name to PBS. But APPNEXUS is unknown. Prior to PR changes PBS would have error out with unknown `APPNEXUS` bidder name messgae. PR has implemented insensitive bidder name comparison in `ext.prebid.data.eidpermissions.bidders`



```
        "ext": {
            "prebid": {
                "data": {
                    "eidpermissions": [
                        {
                            "source": "source1",
                            "bidders": [
                                "APPNEXUS" //  sensitive bidder name
                            ]
                        }
                    ]
                }
          }
```

partially resolves https://github.com/prebid/prebid-server/issues/2400