### PR TITLE
fix adapter code-coverage github action

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -28,9 +28,9 @@ jobs:
           result-encoding: string
           script: |
             const utils = require('./.github/workflows/helpers/pull-request-utils.js')            
-            function directoryExtractor(filepath) {
-              // extract directory name from filepath of the form adapters/<adapter-name>/*.go
-              if (filepath.startsWith("adapters/") && filepath.split("/").length > 2) {
+            function directoryExtractor(filepath, status) {
+              // extract directory name only if file is not removed and file is in adapters directory
+              if (status != "removed" && filepath.startsWith("adapters/") && filepath.split("/").length > 2) {
                 return filepath.split("/")[1]
               }
               return ""
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run coverage tests
         id: run_coverage
-        if: ${{ steps.get_directories.outputs.result }} != ""
+        if: steps.get_directories.outputs.result != ''
         run: |
           directories=$(echo '${{ steps.get_directories.outputs.result }}' | jq -r '.[]')
           go mod download
@@ -74,7 +74,7 @@ jobs:
           repository: prebid/prebid-server
 
       - name: Commit coverage files to coverage-preview branch
-        if: ${{ steps.run_coverage.outputs.coverage_dir }} != ""
+        if: steps.run_coverage.outputs.coverage_dir != ''
         id: commit_coverage
         run: |
           directory=.github/preview/${{ github.run_id }}_$(date +%s)
@@ -88,11 +88,11 @@ jobs:
           echo "remote_coverage_preview_dir=${directory}" >> $GITHUB_OUTPUT
 
       - name: Checkout master branch
-        if: ${{ steps.get_directories.outputs.result }} != ""
+        if: steps.get_directories.outputs.result != ''
         run: git checkout master
 
       - name: Add coverage summary to pull request
-        if: ${{ steps.run_coverage.outputs.coverage_dir }} != "" && ${{ steps.commit_coverage.outputs.remote_coverage_preview_dir }} != ""
+        if: steps.run_coverage.outputs.coverage_dir != '' && steps.commit_coverage.outputs.remote_coverage_preview_dir != ''
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -213,8 +213,8 @@ class diffHelper {
     })
 
     const directories = []
-    for (const { filename } of data) {
-      const directory = directoryExtractor(filename)
+    for (const { filename, status } of data) {
+      const directory = directoryExtractor(filename, status)
       if (directory != "" && !directories.includes(directory)) {
         directories.push(directory)
       }


### PR DESCRIPTION
PR updates code-coverage github action script to execute only if,
- all files all not removed
- file belongs to the 'adapters' directory

Testings:
- all files are removed: https://github.com/onkarvhanumante/prebid-server/pull/9
- adapter code is updated: https://github.com/onkarvhanumante/prebid-server/pull/10

PR changes will resolve failing code coverage test from PRs - https://github.com/prebid/prebid-server/pull/3143 https://github.com/prebid/prebid-server/pull/3142 https://github.com/prebid/prebid-server/pull/3134 https://github.com/prebid/prebid-server/pull/3133 https://github.com/prebid/prebid-server/pull/3132 https://github.com/prebid/prebid-server/pull/3131 https://github.com/prebid/prebid-server/pull/3130 https://github.com/prebid/prebid-server/pull/3129