### PR TITLE
Remove Config Backwards Compatibility: User Sync URL

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -9,10 +9,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/prebid/prebid-server/macros"
 	"github.com/prebid/prebid-server/openrtb_ext"
-	"github.com/prebid/prebid-server/util/sliceutil"
 
 	validator "github.com/asaskevich/govalidator"
 	"gopkg.in/yaml.v3"
@@ -37,9 +35,6 @@ type BidderInfo struct {
 	Syncer *Syncer `yaml:"userSync" mapstructure:"userSync"`
 
 	Experiment BidderInfoExperiment `yaml:"experiment" mapstructure:"experiment"`
-
-	// needed for backwards compatibility
-	UserSyncURL string `yaml:"usersync_url" mapstructure:"usersync_url"`
 
 	// needed for Rubicon
 	XAPI AdapterXAPI `yaml:"xapi" mapstructure:"xapi"`
@@ -324,9 +319,6 @@ func processBidderAliases(aliasNillableFieldsByBidder map[string]aliasNillableFi
 		if aliasBidderInfo.Syncer == nil {
 			aliasBidderInfo.Syncer = parentBidderInfo.Syncer
 		}
-		if aliasBidderInfo.UserSyncURL == "" {
-			aliasBidderInfo.UserSyncURL = parentBidderInfo.UserSyncURL
-		}
 		if alias.Disabled == nil {
 			aliasBidderInfo.Disabled = parentBidderInfo.Disabled
 		}
@@ -607,51 +599,6 @@ func applyBidderInfoConfigOverrides(configBidderInfos BidderInfos, fsBidderInfos
 			}
 			if bidderInfo.EndpointCompression == "" && fsBidderCfg.EndpointCompression != "" {
 				bidderInfo.EndpointCompression = fsBidderCfg.EndpointCompression
-			}
-
-			// validate and try to apply the legacy usersync_url configuration in attempt to provide
-			// an easier upgrade path. be warned, this will break if the bidder adds a second syncer
-			// type and will eventually be removed after we've given hosts enough time to upgrade to
-			// the new config.
-			if bidderInfo.UserSyncURL != "" {
-				if fsBidderCfg.Syncer == nil {
-					return nil, fmt.Errorf("adapters.%s.usersync_url cannot be applied, bidder does not define a user sync", strings.ToLower(bidderName))
-				}
-
-				endpointsCount := 0
-				if bidderInfo.Syncer.IFrame != nil {
-					bidderInfo.Syncer.IFrame.URL = bidderInfo.UserSyncURL
-					endpointsCount++
-				}
-				if bidderInfo.Syncer.Redirect != nil {
-					bidderInfo.Syncer.Redirect.URL = bidderInfo.UserSyncURL
-					endpointsCount++
-				}
-
-				// use Supports as a hint if there are no good defaults provided
-				if endpointsCount == 0 {
-					if sliceutil.ContainsStringIgnoreCase(bidderInfo.Syncer.Supports, "iframe") {
-						bidderInfo.Syncer.IFrame = &SyncerEndpoint{URL: bidderInfo.UserSyncURL}
-						endpointsCount++
-					}
-					if sliceutil.ContainsStringIgnoreCase(bidderInfo.Syncer.Supports, "redirect") {
-						bidderInfo.Syncer.Redirect = &SyncerEndpoint{URL: bidderInfo.UserSyncURL}
-						endpointsCount++
-					}
-				}
-
-				if endpointsCount == 0 {
-					return nil, fmt.Errorf("adapters.%s.usersync_url cannot be applied, bidder does not define user sync endpoints and does not define supported endpoints", strings.ToLower(bidderName))
-				}
-
-				// if the bidder defines both an iframe and redirect endpoint, we can't be sure which config value to
-				// override, and  it wouldn't be both. this is a fatal configuration error.
-				if endpointsCount > 1 {
-					return nil, fmt.Errorf("adapters.%s.usersync_url cannot be applied, bidder defines multiple user sync endpoints or supports multiple endpoints", strings.ToLower(bidderName))
-				}
-
-				// provide a warning that this compatibility layer is temporary
-				glog.Warningf("adapters.%s.usersync_url is deprecated and will be removed in a future version, please update to the latest user sync config values", strings.ToLower(bidderName))
 			}
 
 			fsBidderInfos[string(normalizedBidderName)] = bidderInfo

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testInfoFilesPathValid = "./test/bidder-info-valid"
@@ -50,7 +51,6 @@ disabled: false
 extra_info: extra-info
 app_secret: app-secret
 platform_id: 123
-usersync_url: user-url
 userSync:
   key: foo
   default: iframe
@@ -217,7 +217,6 @@ func TestProcessBidderInfo(t *testing.T) {
 							UserMacro:   "UID",
 						},
 					},
-					UserSyncURL: "user-url",
 					XAPI: AdapterXAPI{
 						Username: "uname",
 						Password: "pwd",
@@ -269,7 +268,6 @@ func TestProcessBidderInfo(t *testing.T) {
 							UserMacro:   "UID",
 						},
 					},
-					UserSyncURL: "user-url",
 					XAPI: AdapterXAPI{
 						Username: "uname",
 						Password: "pwd",
@@ -279,6 +277,7 @@ func TestProcessBidderInfo(t *testing.T) {
 			},
 		},
 	}
+
 	for _, test := range testCases {
 		reader := StubInfoReader{test.bidderInfos}
 		bidderInfos, err := processBidderInfos(reader, mockNormalizeBidderName)
@@ -287,9 +286,7 @@ func TestProcessBidderInfo(t *testing.T) {
 		} else {
 			assert.Equal(t, test.expectedBidderInfos, bidderInfos, "incorrect bidder infos for test case: %s", test.description)
 		}
-
 	}
-
 }
 
 func TestProcessAliasBidderInfo(t *testing.T) {
@@ -334,7 +331,6 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 				UserMacro:   "UID",
 			},
 		},
-		UserSyncURL: "user-url",
 		XAPI: AdapterXAPI{
 			Username: "uname",
 			Password: "pwd",
@@ -382,7 +378,6 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 				UserMacro:   "alias-UID",
 			},
 		},
-		UserSyncURL: "alias-user-url",
 		XAPI: AdapterXAPI{
 			Username: "alias-uname",
 			Password: "alias-pwd",
@@ -1458,78 +1453,15 @@ func TestSyncerEndpointOverride(t *testing.T) {
 }
 
 func TestApplyBidderInfoConfigSyncerOverrides(t *testing.T) {
-	var testCases = []struct {
-		description            string
-		givenFsBidderInfos     BidderInfos
-		givenConfigBidderInfos BidderInfos
-		expectedError          string
-		expectedBidderInfos    BidderInfos
-	}{
-		{
-			description:            "Syncer Override",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{Key: "original"}}},
-			givenConfigBidderInfos: BidderInfos{"a": {Syncer: &Syncer{Key: "override"}}},
-			expectedBidderInfos:    BidderInfos{"a": {Syncer: &Syncer{Key: "override"}}},
-		},
-		{
-			description:            "UserSyncURL Override IFrame",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{IFrame: &SyncerEndpoint{URL: "original"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedBidderInfos:    BidderInfos{"a": {UserSyncURL: "override", Syncer: &Syncer{IFrame: &SyncerEndpoint{URL: "override"}}}},
-		},
-		{
-			description:            "UserSyncURL Supports IFrame",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{Supports: []string{"iframe"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedBidderInfos:    BidderInfos{"a": {UserSyncURL: "override", Syncer: &Syncer{Supports: []string{"iframe"}, IFrame: &SyncerEndpoint{URL: "override"}}}},
-		},
-		{
-			description:            "UserSyncURL Override Redirect",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{Supports: []string{"redirect"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedBidderInfos:    BidderInfos{"a": {UserSyncURL: "override", Syncer: &Syncer{Supports: []string{"redirect"}, Redirect: &SyncerEndpoint{URL: "override"}}}},
-		},
-		{
-			description:            "UserSyncURL Supports Redirect",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{Redirect: &SyncerEndpoint{URL: "original"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedBidderInfos:    BidderInfos{"a": {UserSyncURL: "override", Syncer: &Syncer{Redirect: &SyncerEndpoint{URL: "override"}}}},
-		},
-		{
-			description:            "UserSyncURL Override Syncer Not Defined",
-			givenFsBidderInfos:     BidderInfos{"a": {}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedError:          "adapters.a.usersync_url cannot be applied, bidder does not define a user sync",
-		},
-		{
-			description:            "UserSyncURL Override Syncer Endpoints Not Defined",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedError:          "adapters.a.usersync_url cannot be applied, bidder does not define user sync endpoints and does not define supported endpoints",
-		},
-		{
-			description:            "UserSyncURL Override Ambiguous",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{IFrame: &SyncerEndpoint{URL: "originalIFrame"}, Redirect: &SyncerEndpoint{URL: "originalRedirect"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedError:          "adapters.a.usersync_url cannot be applied, bidder defines multiple user sync endpoints or supports multiple endpoints",
-		},
-		{
-			description:            "UserSyncURL Supports Ambiguous",
-			givenFsBidderInfos:     BidderInfos{"a": {Syncer: &Syncer{Supports: []string{"iframe", "redirect"}}}},
-			givenConfigBidderInfos: BidderInfos{"a": {UserSyncURL: "override"}},
-			expectedError:          "adapters.a.usersync_url cannot be applied, bidder defines multiple user sync endpoints or supports multiple endpoints",
-		},
-	}
+	var (
+		givenFileSystem = BidderInfos{"a": {Syncer: &Syncer{Key: "original"}}}
+		givenConfig     = BidderInfos{"a": {Syncer: &Syncer{Key: "override"}}}
+		expected        = BidderInfos{"a": {Syncer: &Syncer{Key: "override"}}}
+	)
 
-	for _, test := range testCases {
-		bidderInfos, resultErr := applyBidderInfoConfigOverrides(test.givenConfigBidderInfos, test.givenFsBidderInfos, mockNormalizeBidderName)
-		if test.expectedError == "" {
-			assert.NoError(t, resultErr, test.description+":err")
-			assert.Equal(t, test.expectedBidderInfos, bidderInfos, test.description+":result")
-		} else {
-			assert.EqualError(t, resultErr, test.expectedError, test.description+":err")
-		}
-	}
+	result, resultErr := applyBidderInfoConfigOverrides(givenConfig, givenFileSystem, mockNormalizeBidderName)
+	assert.NoError(t, resultErr)
+	assert.Equal(t, expected, result)
 }
 
 func TestApplyBidderInfoConfigOverrides(t *testing.T) {
@@ -1719,10 +1651,12 @@ func TestApplyBidderInfoConfigOverridesInvalid(t *testing.T) {
 func TestReadFullYamlBidderConfig(t *testing.T) {
 	bidder := "bidderA"
 	bidderInf := BidderInfo{}
-	err := yaml.Unmarshal([]byte(fullBidderYAMLConfig), &bidderInf)
-	actualBidderInfo, err := applyBidderInfoConfigOverrides(BidderInfos{bidder: bidderInf}, BidderInfos{bidder: {Syncer: &Syncer{Supports: []string{"iframe"}}}}, mockNormalizeBidderName)
 
-	assert.NoError(t, err, "Error wasn't expected")
+	err := yaml.Unmarshal([]byte(fullBidderYAMLConfig), &bidderInf)
+	require.NoError(t, err)
+
+	actualBidderInfo, err := applyBidderInfoConfigOverrides(BidderInfos{bidder: bidderInf}, BidderInfos{bidder: {Syncer: &Syncer{Supports: []string{"iframe"}}}}, mockNormalizeBidderName)
+	require.NoError(t, err)
 
 	expectedBidderInfo := BidderInfos{
 		bidder: {
@@ -1759,11 +1693,10 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 			ExtraAdapterInfo: "extra-info",
 			AppSecret:        "app-secret",
 			PlatformID:       "123",
-			UserSyncURL:      "user-url",
 			Syncer: &Syncer{
 				Key: "foo",
 				IFrame: &SyncerEndpoint{
-					URL:         "user-url",
+					URL:         "https://foo.com/sync?mode=iframe&r={{.RedirectURL}}",
 					RedirectURL: "https://redirect/setuid/iframe",
 					ExternalURL: "https://iframe.host",
 					UserMacro:   "UID",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,7 +35,6 @@ var bidderInfos = BidderInfos{
 				MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner},
 			},
 		},
-		UserSyncURL: "http://bidder2.com/usersync",
 	},
 }
 


### PR DESCRIPTION
The upcoming Prebid Server 2.0 release will remove backwards compatibility configuration options. This includes the adapter `usersync_url ` config, which used to the the only way to configure a user sync url before we refactored and introduced more granular options. Hosts may have needed to override this value to enable user sync for some bidders.

Instead, please use the `userSync.iframe.url` and or `userSync.redirect.url` config of the new adapter `usersync` config.