### PR TITLE
pass bidder name to adapter's makebid()

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -121,6 +121,8 @@ type RequestData struct {
 	Uri     string
 	Body    []byte
 	Headers http.Header
+
+	BidderName openrtb_ext.BidderName `json:"-"`
 }
 
 // ExtImpBidder can be used by Bidders to unmarshal any request.imp[i].ext.

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -250,6 +250,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 
 		if httpInfo.err == nil {
 			extraRespInfo.respProcessingStartTime = time.Now()
+			httpInfo.request.BidderName = bidderRequest.BidderName
 			bidResponse, moreErrs := bidder.Bidder.MakeBids(bidderRequest.BidRequest, httpInfo.request, httpInfo.response)
 			errs = append(errs, moreErrs...)
 


### PR DESCRIPTION
`adapters.Builder()` is called once and is limited to data available during startup. adapter and bidder value can be different for a `adapter.MakeBid()` and there is no provision to identify the calling bidder name (ex. alias).

Ex. is `pubmatic2` an alias could the calling `MakeBids()`

Hence, raising this PR to pass the caller bidder name to `MakeBid()` function so that adapter can identify the bidder.