### PR TITLE
orbidder: add supportCors to user sync config

### DIFF
--- a/static/bidder-info/orbidder.yaml
+++ b/static/bidder-info/orbidder.yaml
@@ -11,6 +11,7 @@ capabilities:
       - banner
       - native
 userSync:
+  supportCors: true
   redirect:
     url: "https://orbidder.otto.de/pbs-usersync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&redirect={{.RedirectURL}}"
     userMacro: "[ODN_ID]"


### PR DESCRIPTION
Our Endpoint supports HTTP-OPTION requests and CORS handling.
Sorry for overseen this config possibility. 