### PR TITLE
Adapter Name Case Insensitive: /vtrack endpoint

### DIFF
--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -272,10 +272,11 @@ func getBiddersAllowingVastUpdate(req *BidCacheRequest, bidderInfos *config.Bidd
 func isAllowVastForBidder(bidder string, bidderInfos *config.BidderInfos, allowUnknownBidder bool, normalizeBidderName normalizeBidderName) bool {
 	//if bidder is active and isModifyingVastXmlAllowed is true
 	// check if bidder is configured
-	normalizedBidder, _ := normalizeBidderName(bidder)
-	if b, ok := (*bidderInfos)[normalizedBidder.String()]; bidderInfos != nil && ok {
-		// check if bidder is enabled
-		return b.IsEnabled() && b.ModifyingVastXmlAllowed
+	if normalizedBidder, ok := normalizeBidderName(bidder); ok {
+		if b, ok := (*bidderInfos)[normalizedBidder.String()]; bidderInfos != nil && ok {
+			// check if bidder is enabled
+			return b.IsEnabled() && b.ModifyingVastXmlAllowed
+		}
 	}
 
 	return allowUnknownBidder

--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/metrics"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/stored_requests"
 )
@@ -27,12 +28,15 @@ const (
 	ImpressionOpenTag    = "<Impression>"
 )
 
+type normalizeBidderName func(name string) (openrtb_ext.BidderName, bool)
+
 type vtrackEndpoint struct {
-	Cfg           *config.Configuration
-	Accounts      stored_requests.AccountFetcher
-	BidderInfos   config.BidderInfos
-	Cache         prebid_cache_client.Client
-	MetricsEngine metrics.MetricsEngine
+	Cfg                 *config.Configuration
+	Accounts            stored_requests.AccountFetcher
+	BidderInfos         config.BidderInfos
+	Cache               prebid_cache_client.Client
+	MetricsEngine       metrics.MetricsEngine
+	normalizeBidderName normalizeBidderName
 }
 
 type BidCacheRequest struct {
@@ -49,11 +53,12 @@ type CacheObject struct {
 
 func NewVTrackEndpoint(cfg *config.Configuration, accounts stored_requests.AccountFetcher, cache prebid_cache_client.Client, bidderInfos config.BidderInfos, me metrics.MetricsEngine) httprouter.Handle {
 	vte := &vtrackEndpoint{
-		Cfg:           cfg,
-		Accounts:      accounts,
-		BidderInfos:   bidderInfos,
-		Cache:         cache,
-		MetricsEngine: me,
+		Cfg:                 cfg,
+		Accounts:            accounts,
+		BidderInfos:         bidderInfos,
+		Cache:               cache,
+		MetricsEngine:       me,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	return vte.Handle

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/stretchr/testify/assert"
@@ -64,10 +65,11 @@ func TestShouldRespondWithBadRequestWhenAccountParameterIsMissing(t *testing.T) 
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -105,10 +107,11 @@ func TestShouldRespondWithBadRequestWhenRequestBodyIsEmpty(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -146,10 +149,11 @@ func TestShouldRespondWithBadRequestWhenRequestBodyIsInvalid(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -190,10 +194,11 @@ func TestShouldRespondWithBadRequestWhenBidIdIsMissing(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -242,10 +247,11 @@ func TestShouldRespondWithBadRequestWhenBidderIsMissing(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -291,10 +297,11 @@ func TestShouldRespondWithInternalServerErrorWhenPbsCacheClientFails(t *testing.
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -340,10 +347,11 @@ func TestShouldTolerateAccountNotFound(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -397,10 +405,11 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastNotAllowe
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: bidderInfos,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         bidderInfos,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -460,10 +469,11 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastAllowed(t
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: bidderInfos,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         bidderInfos,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -515,10 +525,11 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableUnknownBiddersWhenUnknownBidde
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: bidderInfos,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         bidderInfos,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -571,10 +582,11 @@ func TestShouldReturnBadRequestWhenRequestExceedsMaxRequestSize(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: bidderInfos,
-		Cache:       mockCacheClient,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         bidderInfos,
+		Cache:               mockCacheClient,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute
@@ -615,10 +627,11 @@ func TestShouldRespondWithInternalErrorPbsCacheIsNotConfigured(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	e := vtrackEndpoint{
-		Cfg:         cfg,
-		BidderInfos: nil,
-		Cache:       nil,
-		Accounts:    mockAccountsFetcher,
+		Cfg:                 cfg,
+		BidderInfos:         nil,
+		Cache:               nil,
+		Accounts:            mockAccountsFetcher,
+		normalizeBidderName: openrtb_ext.NormalizeBidderName,
 	}
 
 	// execute


### PR DESCRIPTION
- PR makes changes to support case insensitive adapter name in `/vtrack` endpoint. 
- The `/vtrack` endpoint takes adapter name as input. Adapter name from request is looked up on `bidderInfos` to decide whether to include adapter name in vastXML.
- For example, `appnexus` is known adapter name to PBS. PR makes changes to ensure any casing of appnexus i.e `APPNEXUS, ApPnExUs, appNexus` is mapped to PBS known  `appnexus` adapter name.

```
                      {
				Type:       prebid_cache_client.TypeXML,
				BidID:      "bidId1",
				Bidder:     "APPNEXUS", // case sensitive name
				Data:       d,
				TTLSeconds: 3600,
				Timestamp:  1000,
			},
			{
				Type:       prebid_cache_client.TypeXML,
				BidID:      "bidId2",
				Bidder:     "ApPnExUs", // case sensitive name
				Data:       d,
				TTLSeconds: 3600,
				Timestamp:  1000,
			}
```
