### PR TITLE
Prometheus metrics:  bidder name should be in lowercase

### DIFF
--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -9,7 +9,7 @@ import (
 func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[string][]string) {
 	var (
 		adapterErrorValues        = enumAsString(metrics.AdapterErrors())
-		adapterValues             = enumAsString(openrtb_ext.CoreBidderNames())
+		adapterValues             = enumAsLowerCaseString(openrtb_ext.CoreBidderNames())
 		bidTypeValues             = []string{markupDeliveryAdm, markupDeliveryNurl}
 		boolValues                = boolValuesAsString()
 		cacheResultValues         = enumAsString(metrics.CacheResults())

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -826,7 +826,7 @@ func (m *Metrics) RecordAdapterBidReceived(labels metrics.AdapterLabels, bidType
 	}
 
 	m.adapterBids.With(prometheus.Labels{
-		adapterLabel:        string(labels.Adapter),
+		adapterLabel:        strings.ToLower(string(labels.Adapter)),
 		markupDeliveryLabel: markupDelivery,
 	}).Inc()
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -978,8 +978,9 @@ func (m *Metrics) RecordAdsCertSignTime(adsCertSignTime time.Duration) {
 }
 
 func (m *Metrics) RecordBidValidationCreativeSizeError(adapter openrtb_ext.BidderName, account string) {
+	lowerCasedAdapter := strings.ToLower(string(adapter))
 	m.adapterBidResponseValidationSizeError.With(prometheus.Labels{
-		adapterLabel: string(adapter), successLabel: successLabel,
+		adapterLabel: lowerCasedAdapter, successLabel: successLabel,
 	}).Inc()
 
 	if !m.metricsDisabled.AccountAdapterDetails && account != metrics.PublisherUnknown {
@@ -990,8 +991,9 @@ func (m *Metrics) RecordBidValidationCreativeSizeError(adapter openrtb_ext.Bidde
 }
 
 func (m *Metrics) RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.BidderName, account string) {
+	lowerCasedAdapter := strings.ToLower(string(adapter))
 	m.adapterBidResponseValidationSizeWarn.With(prometheus.Labels{
-		adapterLabel: string(adapter), successLabel: successLabel,
+		adapterLabel: lowerCasedAdapter, successLabel: successLabel,
 	}).Inc()
 
 	if !m.metricsDisabled.AccountAdapterDetails && account != metrics.PublisherUnknown {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -833,7 +833,7 @@ func (m *Metrics) RecordAdapterBidReceived(labels metrics.AdapterLabels, bidType
 
 func (m *Metrics) RecordAdapterPrice(labels metrics.AdapterLabels, cpm float64) {
 	m.adapterPrices.With(prometheus.Labels{
-		adapterLabel: string(labels.Adapter),
+		adapterLabel: strings.ToLower(string(labels.Adapter)),
 	}).Observe(cpm)
 }
 

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -846,7 +846,7 @@ func (m *Metrics) RecordOverheadTime(overhead metrics.OverheadType, duration tim
 func (m *Metrics) RecordAdapterTime(labels metrics.AdapterLabels, length time.Duration) {
 	if len(labels.AdapterErrors) == 0 {
 		m.adapterRequestsTimer.With(prometheus.Labels{
-			adapterLabel: string(labels.Adapter),
+			adapterLabel: strings.ToLower(string(labels.Adapter)),
 		}).Observe(length.Seconds())
 	}
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -781,22 +781,23 @@ func (m *Metrics) RecordAdapterRequest(labels metrics.AdapterLabels) {
 // Keeps track of created and reused connections to adapter bidders and the time from the
 // connection request, to the connection creation, or reuse from the pool across all engines
 func (m *Metrics) RecordAdapterConnections(adapterName openrtb_ext.BidderName, connWasReused bool, connWaitTime time.Duration) {
+	lowerCasedAdapterName := strings.ToLower(string(adapterName))
 	if m.metricsDisabled.AdapterConnectionMetrics {
 		return
 	}
 
 	if connWasReused {
 		m.adapterReusedConnections.With(prometheus.Labels{
-			adapterLabel: string(adapterName),
+			adapterLabel: lowerCasedAdapterName,
 		}).Inc()
 	} else {
 		m.adapterCreatedConnections.With(prometheus.Labels{
-			adapterLabel: string(adapterName),
+			adapterLabel: lowerCasedAdapterName,
 		}).Inc()
 	}
 
 	m.adapterConnectionWaitTime.With(prometheus.Labels{
-		adapterLabel: string(adapterName),
+		adapterLabel: lowerCasedAdapterName,
 	}).Observe(connWaitTime.Seconds())
 }
 

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -958,7 +958,7 @@ func (m *Metrics) RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.Bidder
 	}
 
 	m.adapterGDPRBlockedRequests.With(prometheus.Labels{
-		adapterLabel: string(adapterName),
+		adapterLabel: strings.ToLower(string(adapterName)),
 	}).Inc()
 }
 

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -3,6 +3,7 @@ package prometheusmetrics
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prebid/prebid-server/config"
@@ -762,15 +763,16 @@ func (m *Metrics) RecordStoredDataError(labels metrics.StoredDataLabels) {
 }
 
 func (m *Metrics) RecordAdapterRequest(labels metrics.AdapterLabels) {
+	lowerCasedAdapter := strings.ToLower(string(labels.Adapter))
 	m.adapterRequests.With(prometheus.Labels{
-		adapterLabel: string(labels.Adapter),
+		adapterLabel: lowerCasedAdapter,
 		cookieLabel:  string(labels.CookieFlag),
 		hasBidsLabel: strconv.FormatBool(labels.AdapterBids == metrics.AdapterBidPresent),
 	}).Inc()
 
 	for err := range labels.AdapterErrors {
 		m.adapterErrors.With(prometheus.Labels{
-			adapterLabel:      string(labels.Adapter),
+			adapterLabel:      lowerCasedAdapter,
 			adapterErrorLabel: string(err),
 		}).Inc()
 	}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -1005,7 +1005,7 @@ func (m *Metrics) RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.Bidder
 
 func (m *Metrics) RecordBidValidationSecureMarkupError(adapter openrtb_ext.BidderName, account string) {
 	m.adapterBidResponseSecureMarkupError.With(prometheus.Labels{
-		adapterLabel: string(adapter), successLabel: successLabel,
+		adapterLabel: strings.ToLower(string(adapter)), successLabel: successLabel,
 	}).Inc()
 
 	if !m.metricsDisabled.AccountAdapterDetails && account != metrics.PublisherUnknown {
@@ -1017,7 +1017,7 @@ func (m *Metrics) RecordBidValidationSecureMarkupError(adapter openrtb_ext.Bidde
 
 func (m *Metrics) RecordBidValidationSecureMarkupWarn(adapter openrtb_ext.BidderName, account string) {
 	m.adapterBidResponseSecureMarkupWarn.With(prometheus.Labels{
-		adapterLabel: string(adapter), successLabel: successLabel,
+		adapterLabel: strings.ToLower(string(adapter)), successLabel: successLabel,
 	}).Inc()
 
 	if !m.metricsDisabled.AccountAdapterDetails && account != metrics.PublisherUnknown {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -815,7 +815,7 @@ func (m *Metrics) RecordBidderServerResponseTime(bidderServerResponseTime time.D
 
 func (m *Metrics) RecordAdapterPanic(labels metrics.AdapterLabels) {
 	m.adapterPanics.With(prometheus.Labels{
-		adapterLabel: string(labels.Adapter),
+		adapterLabel: strings.ToLower(string(labels.Adapter)),
 	}).Inc()
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -264,17 +264,19 @@ func TestBidValidationSecureMarkupMetric(t *testing.T) {
 		},
 	}
 
+	adapterName := openrtb_ext.BidderName("AnyName")
+	lowerCasedAdapterName := "anyname"
 	for _, test := range testCases {
 		m := createMetricsForTesting()
 		m.metricsDisabled.AccountAdapterDetails = test.givenAccountAdapterMetricsDisabled
-		m.RecordBidValidationSecureMarkupError(adapterLabel, "acct-id")
-		m.RecordBidValidationSecureMarkupWarn(adapterLabel, "acct-id")
+		m.RecordBidValidationSecureMarkupError(adapterName, "acct-id")
+		m.RecordBidValidationSecureMarkupWarn(adapterName, "acct-id")
 
 		assertCounterVecValue(t, "", "Account Secure Markup Error", m.accountBidResponseSecureMarkupError, test.expectedAccountCount, prometheus.Labels{accountLabel: "acct-id", successLabel: successLabel})
-		assertCounterVecValue(t, "", "Adapter Secure Markup Error", m.adapterBidResponseSecureMarkupError, test.expectedAdapterCount, prometheus.Labels{adapterLabel: adapterLabel, successLabel: successLabel})
+		assertCounterVecValue(t, "", "Adapter Secure Markup Error", m.adapterBidResponseSecureMarkupError, test.expectedAdapterCount, prometheus.Labels{adapterLabel: lowerCasedAdapterName, successLabel: successLabel})
 
 		assertCounterVecValue(t, "", "Account Secure Markup Warn", m.accountBidResponseSecureMarkupWarn, test.expectedAccountCount, prometheus.Labels{accountLabel: "acct-id", successLabel: successLabel})
-		assertCounterVecValue(t, "", "Adapter Secure Markup Warn", m.adapterBidResponseSecureMarkupWarn, test.expectedAdapterCount, prometheus.Labels{adapterLabel: adapterLabel, successLabel: successLabel})
+		assertCounterVecValue(t, "", "Adapter Secure Markup Warn", m.adapterBidResponseSecureMarkupWarn, test.expectedAdapterCount, prometheus.Labels{adapterLabel: lowerCasedAdapterName, successLabel: successLabel})
 	}
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1510,6 +1510,9 @@ func TestRecordBidderServerResponseTime(t *testing.T) {
 }
 
 func TestRecordAdapterConnections(t *testing.T) {
+	adapterName := openrtb_ext.BidderName("Adapter")
+	lowerCasedAdapterName := "adapter"
+
 	type testIn struct {
 		adapterName   openrtb_ext.BidderName
 		connWasReused bool
@@ -1531,7 +1534,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 		{
 			description: "[1] Successful, new connection created, was idle, has connection wait",
 			in: testIn{
-				adapterName:   openrtb_ext.BidderAppnexus,
+				adapterName:   adapterName,
 				connWasReused: false,
 				connWait:      time.Second * 5,
 			},
@@ -1545,7 +1548,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 		{
 			description: "[2] Successful, new connection created, not idle, has connection wait",
 			in: testIn{
-				adapterName:   openrtb_ext.BidderAppnexus,
+				adapterName:   adapterName,
 				connWasReused: false,
 				connWait:      time.Second * 4,
 			},
@@ -1559,7 +1562,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 		{
 			description: "[3] Successful, was reused, was idle, no connection wait",
 			in: testIn{
-				adapterName:   openrtb_ext.BidderAppnexus,
+				adapterName:   adapterName,
 				connWasReused: true,
 			},
 			out: testOut{
@@ -1572,7 +1575,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 		{
 			description: "[4] Successful, was reused, not idle, has connection wait",
 			in: testIn{
-				adapterName:   openrtb_ext.BidderAppnexus,
+				adapterName:   adapterName,
 				connWasReused: true,
 				connWait:      time.Second * 5,
 			},
@@ -1602,7 +1605,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 			"adapter_connection_reused",
 			m.adapterReusedConnections,
 			float64(test.out.expectedConnReusedCount),
-			prometheus.Labels{adapterLabel: string(test.in.adapterName)})
+			prometheus.Labels{adapterLabel: lowerCasedAdapterName})
 
 		// Assert number of new created connections
 		assertCounterVecValue(t,
@@ -1610,10 +1613,10 @@ func TestRecordAdapterConnections(t *testing.T) {
 			"adapter_connection_created",
 			m.adapterCreatedConnections,
 			float64(test.out.expectedConnCreatedCount),
-			prometheus.Labels{adapterLabel: string(test.in.adapterName)})
+			prometheus.Labels{adapterLabel: lowerCasedAdapterName})
 
 		// Assert connection wait time
-		histogram := getHistogramFromHistogramVec(m.adapterConnectionWaitTime, adapterLabel, string(test.in.adapterName))
+		histogram := getHistogramFromHistogramVec(m.adapterConnectionWaitTime, adapterLabel, lowerCasedAdapterName)
 		assert.Equal(t, test.out.expectedConnWaitCount, histogram.GetSampleCount(), assertDesciptions[2])
 		assert.Equal(t, test.out.expectedConnWaitTime, histogram.GetSampleSum(), assertDesciptions[3])
 	}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -825,6 +825,7 @@ func TestAdapterBidReceivedMetric(t *testing.T) {
 func TestRecordAdapterPriceMetric(t *testing.T) {
 	m := createMetricsForTesting()
 	adapterName := "anyName"
+	lowerCasedAdapterName := "anyname"
 	cpm := float64(42)
 
 	m.RecordAdapterPrice(metrics.AdapterLabels{
@@ -833,7 +834,7 @@ func TestRecordAdapterPriceMetric(t *testing.T) {
 
 	expectedCount := uint64(1)
 	expectedSum := cpm
-	result := getHistogramFromHistogramVec(m.adapterPrices, adapterLabel, adapterName)
+	result := getHistogramFromHistogramVec(m.adapterPrices, adapterLabel, lowerCasedAdapterName)
 	assertHistogram(t, "adapterPrices", result, expectedCount, expectedSum)
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -226,18 +226,19 @@ func TestBidValidationCreativeSizeMetric(t *testing.T) {
 			expectedAccountCount:               0,
 		},
 	}
-
+	adapterName := openrtb_ext.BidderName("AnyName")
+	lowerCasedAdapterName := "anyname"
 	for _, test := range testCases {
 		m := createMetricsForTesting()
 		m.metricsDisabled.AccountAdapterDetails = test.givenAccountAdapterMetricsDisabled
-		m.RecordBidValidationCreativeSizeError(adapterLabel, "acct-id")
-		m.RecordBidValidationCreativeSizeWarn(adapterLabel, "acct-id")
+		m.RecordBidValidationCreativeSizeError(adapterName, "acct-id")
+		m.RecordBidValidationCreativeSizeWarn(adapterName, "acct-id")
 
 		assertCounterVecValue(t, "", "account bid validation", m.accountBidResponseValidationSizeError, test.expectedAccountCount, prometheus.Labels{accountLabel: "acct-id", successLabel: successLabel})
-		assertCounterVecValue(t, "", "adapter bid validation", m.adapterBidResponseValidationSizeError, test.expectedAdapterCount, prometheus.Labels{adapterLabel: adapterLabel, successLabel: successLabel})
+		assertCounterVecValue(t, "", "adapter bid validation", m.adapterBidResponseValidationSizeError, test.expectedAdapterCount, prometheus.Labels{adapterLabel: lowerCasedAdapterName, successLabel: successLabel})
 
 		assertCounterVecValue(t, "", "account bid validation", m.accountBidResponseValidationSizeWarn, test.expectedAccountCount, prometheus.Labels{accountLabel: "acct-id", successLabel: successLabel})
-		assertCounterVecValue(t, "", "adapter bid validation", m.adapterBidResponseValidationSizeWarn, test.expectedAdapterCount, prometheus.Labels{adapterLabel: adapterLabel, successLabel: successLabel})
+		assertCounterVecValue(t, "", "adapter bid validation", m.adapterBidResponseValidationSizeWarn, test.expectedAdapterCount, prometheus.Labels{adapterLabel: lowerCasedAdapterName, successLabel: successLabel})
 	}
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1787,8 +1787,9 @@ func assertHistogram(t *testing.T, name string, histogram dto.Histogram, expecte
 
 func TestRecordAdapterGDPRRequestBlocked(t *testing.T) {
 	m := createMetricsForTesting()
-
-	m.RecordAdapterGDPRRequestBlocked(openrtb_ext.BidderAppnexus)
+	adapterName := openrtb_ext.BidderName("AnyName")
+	lowerCasedAdapterName := "anyname"
+	m.RecordAdapterGDPRRequestBlocked(adapterName)
 
 	assertCounterVecValue(t,
 		"Increment adapter GDPR request blocked counter",
@@ -1796,7 +1797,7 @@ func TestRecordAdapterGDPRRequestBlocked(t *testing.T) {
 		m.adapterGDPRBlockedRequests,
 		1,
 		prometheus.Labels{
-			adapterLabel: string(openrtb_ext.BidderAppnexus),
+			adapterLabel: lowerCasedAdapterName,
 		})
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1098,17 +1098,17 @@ func TestAdapterTimeMetric(t *testing.T) {
 
 func TestAdapterPanicMetric(t *testing.T) {
 	m := createMetricsForTesting()
-	adapterName := "anyName"
-
+	adapterName := openrtb_ext.BidderName("anyName")
+	lowerCasedAdapterName := "anyname"
 	m.RecordAdapterPanic(metrics.AdapterLabels{
-		Adapter: openrtb_ext.BidderName(adapterName),
+		Adapter: adapterName,
 	})
 
 	expectedCount := float64(1)
 	assertCounterVecValue(t, "", "adapterPanics", m.adapterPanics,
 		expectedCount,
 		prometheus.Labels{
-			adapterLabel: adapterName,
+			adapterLabel: lowerCasedAdapterName,
 		})
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -980,6 +980,7 @@ func TestAdapterRequestMetrics(t *testing.T) {
 
 func TestAdapterRequestErrorMetrics(t *testing.T) {
 	adapterName := "anyName"
+	lowerCasedAdapterName := "anyname"
 	performTest := func(m *Metrics, adapterErrors map[metrics.AdapterError]struct{}) {
 		labels := metrics.AdapterLabels{
 			Adapter:       openrtb_ext.BidderName(adapterName),
@@ -1036,7 +1037,7 @@ func TestAdapterRequestErrorMetrics(t *testing.T) {
 		processMetrics(m.adapterErrors, func(m dto.Metric) {
 			isMetricForAdapter := false
 			for _, label := range m.GetLabel() {
-				if label.GetName() == adapterLabel && label.GetValue() == adapterName {
+				if label.GetName() == adapterLabel && label.GetValue() == lowerCasedAdapterName {
 					isMetricForAdapter = true
 				}
 			}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1055,6 +1055,7 @@ func TestAdapterRequestErrorMetrics(t *testing.T) {
 
 func TestAdapterTimeMetric(t *testing.T) {
 	adapterName := "anyName"
+	lowerCasedAdapterName := "anyname"
 	performTest := func(m *Metrics, timeInMs float64, adapterErrors map[metrics.AdapterError]struct{}) {
 		m.RecordAdapterTime(metrics.AdapterLabels{
 			Adapter:       openrtb_ext.BidderName(adapterName),
@@ -1093,7 +1094,7 @@ func TestAdapterTimeMetric(t *testing.T) {
 
 		test.testCase(m)
 
-		result := getHistogramFromHistogramVec(m.adapterRequestsTimer, adapterLabel, adapterName)
+		result := getHistogramFromHistogramVec(m.adapterRequestsTimer, adapterLabel, lowerCasedAdapterName)
 		assertHistogram(t, test.description, result, test.expectedCount, test.expectedSum)
 	}
 }

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -768,10 +768,11 @@ func TestRecordStoredDataError(t *testing.T) {
 }
 
 func TestAdapterBidReceivedMetric(t *testing.T) {
-	adapterName := "anyName"
+	adapterName := openrtb_ext.BidderName("anyName")
+	lowerCasedAdapterName := "anyname"
 	performTest := func(m *Metrics, hasAdm bool) {
 		labels := metrics.AdapterLabels{
-			Adapter: openrtb_ext.BidderName(adapterName),
+			Adapter: adapterName,
 		}
 		bidType := openrtb_ext.BidTypeBanner
 		m.RecordAdapterBidReceived(labels, bidType, hasAdm)
@@ -809,13 +810,13 @@ func TestAdapterBidReceivedMetric(t *testing.T) {
 		assertCounterVecValue(t, test.description, "adapterBids[adm]", m.adapterBids,
 			test.expectedAdmCount,
 			prometheus.Labels{
-				adapterLabel:        adapterName,
+				adapterLabel:        lowerCasedAdapterName,
 				markupDeliveryLabel: markupDeliveryAdm,
 			})
 		assertCounterVecValue(t, test.description, "adapterBids[nurl]", m.adapterBids,
 			test.expectedNurlCount,
 			prometheus.Labels{
-				adapterLabel:        adapterName,
+				adapterLabel:        lowerCasedAdapterName,
 				markupDeliveryLabel: markupDeliveryNurl,
 			})
 	}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -838,6 +838,7 @@ func TestRecordAdapterPriceMetric(t *testing.T) {
 
 func TestAdapterRequestMetrics(t *testing.T) {
 	adapterName := "anyName"
+	lowerCasedAdapterName := "anyname"
 	performTest := func(m *Metrics, cookieFlag metrics.CookieFlag, adapterBids metrics.AdapterBid) {
 		labels := metrics.AdapterLabels{
 			Adapter:     openrtb_ext.BidderName(adapterName),
@@ -937,7 +938,7 @@ func TestAdapterRequestMetrics(t *testing.T) {
 		processMetrics(m.adapterRequests, func(m dto.Metric) {
 			isMetricForAdapter := false
 			for _, label := range m.GetLabel() {
-				if label.GetName() == adapterLabel && label.GetValue() == adapterName {
+				if label.GetName() == adapterLabel && label.GetValue() == lowerCasedAdapterName {
 					isMetricForAdapter = true
 				}
 			}
@@ -1509,7 +1510,6 @@ func TestRecordBidderServerResponseTime(t *testing.T) {
 }
 
 func TestRecordAdapterConnections(t *testing.T) {
-
 	type testIn struct {
 		adapterName   openrtb_ext.BidderName
 		connWasReused bool

--- a/metrics/prometheus/type_conversion.go
+++ b/metrics/prometheus/type_conversion.go
@@ -2,12 +2,21 @@ package prometheusmetrics
 
 import (
 	"strconv"
+	"strings"
 )
 
 func enumAsString[T ~string](values []T) []string {
 	valuesAsString := make([]string, len(values))
 	for i, v := range values {
 		valuesAsString[i] = string(v)
+	}
+	return valuesAsString
+}
+
+func enumAsLowerCaseString[T ~string](values []T) []string {
+	valuesAsString := make([]string, len(values))
+	for i, v := range values {
+		valuesAsString[i] = strings.ToLower(string(v))
 	}
 	return valuesAsString
 }


### PR DESCRIPTION
- As of now, following are the prometheus metrics which have bidder name as label
  	```
	RecordAdapterRequest(labels AdapterLabels)
	RecordAdapterConnections(adapterName openrtb_ext.BidderName, connWasReused bool, connWaitTime time.Duration)
	RecordAdapterPanic(labels AdapterLabels)
	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
	RecordAdapterPrice(labels AdapterLabels, cpm float64)
	RecordAdapterTime(labels AdapterLabels, length time.Duration)
	RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName)
	RecordBidValidationCreativeSizeError(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationSecureMarkupError(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationSecureMarkupWarn(adapter openrtb_ext.BidderName, account string)
    ```
    
- PR implements changes implements changes to make sure above promethus metrics records bidder name in lowercase.

- Also on startup, PBS server preloads prometheus with bidder names. For this, [CoreBidderNames](https://github.com/prebid/prebid-server/blob/23bc394e8218bb3f6c860c37bd13c56ea50d3df1/openrtb_ext/bidders.go#L20) are used. 
  - For example, `audienceNetwork, seedingAlliance, yahooAds, yahooAdvertising` are the bidders from CoreBidderNames that are in camel case. PR implements changes to make sure prometheus metrics for such bidders are preloaded with lower case bidder name.
  - Testing:
    - Before this PR change with master branch code, prometheus metrics are preloades with non lower case bidder names
        ```
        adapter_bids{adapter="yahooAds",delivery="adm"} 0
        ...
        adapter_response_validation_size_warn{adapter="yahooAds",success="false"} 0

        adapter_bids{adapter="seedingAlliance",delivery="adm"} 0
        ...
        syncer_sets{status="ok",syncer="seedingAlliance"} 0

        adapter_bids{adapter="audienceNetwork",delivery="adm"} 0
        ...
        adapter_response_validation_size_warn{adapter="audienceNetwork",success="true"} 0

        adapter_bids{adapter="yahooAdvertising",delivery="adm"} 0
         ...
        adapter_response_validation_size_warn{adapter="yahooAdvertising",success="true"} 0
        ```
     -  With PR changes, above metrics are preloaded with lower case bidder names
        ```
        adapter_bids{adapter="audiencenetwork",delivery="adm"} 0
         ...
        adapter_response_validation_size_warn{adapter="audiencenetwork",success="true"} 0

        adapter_bids{adapter="seedingalliance",delivery="adm"} 0
        ...
        syncer_sets{status="ok",syncer="seedingAlliance"} 0

        adapter_bids{adapter="yahooads",delivery="adm"} 0
        ...        
        adapter_response_validation_size_warn{adapter="yahooads",success="true"} 0

        adapter_bids{adapter="yahooadvertising",delivery="adm"} 0
        ... 
        adapter_response_validation_size_warn{adapter="yahooadvertising",success="true"} 0
        ```