### PR TITLE
InfluxDB metrics : bidder name should be in lowercase

### DIFF
--- a/metrics/config/metrics_test.go
+++ b/metrics/config/metrics_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,13 +169,14 @@ func TestMultiMetricsEngine(t *testing.T) {
 	VerifyMetrics(t, "Request", goEngine.RequestStatuses[metrics.ReqTypeORTB2Web][metrics.RequestStatusOK].Count(), 5)
 	VerifyMetrics(t, "ImpMeter", goEngine.ImpMeter.Count(), 8)
 	VerifyMetrics(t, "NoCookieMeter", goEngine.NoCookieMeter.Count(), 0)
-	VerifyMetrics(t, "AdapterMetrics.Pubmatic.GotBidsMeter", goEngine.AdapterMetrics[openrtb_ext.BidderPubmatic].GotBidsMeter.Count(), 5)
-	VerifyMetrics(t, "AdapterMetrics.Pubmatic.NoBidMeter", goEngine.AdapterMetrics[openrtb_ext.BidderPubmatic].NoBidMeter.Count(), 0)
+
+	VerifyMetrics(t, "AdapterMetrics.pubmatic.GotBidsMeter", goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderPubmatic))].GotBidsMeter.Count(), 5)
+	VerifyMetrics(t, "AdapterMetrics.pubmatic.NoBidMeter", goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderPubmatic))].NoBidMeter.Count(), 0)
 	for _, err := range metrics.AdapterErrors() {
-		VerifyMetrics(t, "AdapterMetrics.Pubmatic.Request.ErrorMeter."+string(err), goEngine.AdapterMetrics[openrtb_ext.BidderPubmatic].ErrorMeters[err].Count(), 0)
+		VerifyMetrics(t, "AdapterMetrics.pubmatic.Request.ErrorMeter."+string(err), goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderPubmatic))].ErrorMeters[err].Count(), 0)
 	}
-	VerifyMetrics(t, "AdapterMetrics.AppNexus.GotBidsMeter", goEngine.AdapterMetrics[openrtb_ext.BidderAppnexus].GotBidsMeter.Count(), 0)
-	VerifyMetrics(t, "AdapterMetrics.AppNexus.NoBidMeter", goEngine.AdapterMetrics[openrtb_ext.BidderAppnexus].NoBidMeter.Count(), 5)
+	VerifyMetrics(t, "AdapterMetrics.appnexus.GotBidsMeter", goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderAppnexus))].GotBidsMeter.Count(), 0)
+	VerifyMetrics(t, "AdapterMetrics.appnexus.NoBidMeter", goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderAppnexus))].NoBidMeter.Count(), 5)
 
 	VerifyMetrics(t, "RecordRequestQueueTime.Video.Rejected", goEngine.RequestsQueueTimer[metrics.ReqTypeVideo][false].Count(), 1)
 	VerifyMetrics(t, "RecordRequestQueueTime.Video.Accepted", goEngine.RequestsQueueTimer[metrics.ReqTypeVideo][true].Count(), 0)
@@ -186,7 +188,7 @@ func TestMultiMetricsEngine(t *testing.T) {
 	VerifyMetrics(t, "StoredImpCache.Hit", goEngine.StoredImpCacheMeter[metrics.CacheHit].Count(), 5)
 	VerifyMetrics(t, "AccountCache.Hit", goEngine.AccountCacheMeter[metrics.CacheHit].Count(), 6)
 
-	VerifyMetrics(t, "AdapterMetrics.AppNexus.GDPRRequestBlocked", goEngine.AdapterMetrics[openrtb_ext.BidderAppnexus].GDPRRequestBlocked.Count(), 1)
+	VerifyMetrics(t, "AdapterMetrics.appNexus.GDPRRequestBlocked", goEngine.AdapterMetrics[strings.ToLower(string(openrtb_ext.BidderAppnexus))].GDPRRequestBlocked.Count(), 1)
 
 	// verify that each module has its own metric recorded
 	for module, stages := range modulesStages {

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -273,11 +274,11 @@ func getModuleNames(moduleStageNames map[string][]string) []string {
 // mode metrics. The code would allways try to record the metrics, but effectively noop if we are
 // using a blank meter/timer.
 func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, disableAccountMetrics config.DisabledMetrics, syncerKeys []string, moduleStageNames map[string][]string) *Metrics {
-	exchangesStr := []string{}
+	lowerCaseExchanges := []string{}
 	for _, exchange := range exchanges {
-		exchangesStr = append(exchangesStr, string(exchange))
+		lowerCaseExchanges = append(lowerCaseExchanges, strings.ToLower(string(exchange)))
 	}
-	newMetrics := NewBlankMetrics(registry, exchangesStr, disableAccountMetrics, moduleStageNames)
+	newMetrics := NewBlankMetrics(registry, lowerCaseExchanges, disableAccountMetrics, moduleStageNames)
 	newMetrics.ConnectionCounter = metrics.GetOrRegisterCounter("active_connections", registry)
 	newMetrics.TMaxTimeoutCounter = metrics.GetOrRegisterCounter("tmax_timeout", registry)
 	newMetrics.ConnectionAcceptErrorMeter = metrics.GetOrRegisterMeter("connection_accept_errors", registry)
@@ -336,7 +337,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 		}
 	}
 
-	for _, a := range exchangesStr {
+	for _, a := range lowerCaseExchanges {
 		registerAdapterMetrics(registry, "adapter", string(a), newMetrics.AdapterMetrics[a])
 	}
 

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -925,13 +925,14 @@ func (me *Metrics) RecordRequestPrivacy(privacy PrivacyLabels) {
 }
 
 func (me *Metrics) RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName) {
+	adapterStr := string(adapterName)
 	if me.MetricsDisabled.AdapterGDPRRequestBlocked {
 		return
 	}
 
-	am, ok := me.AdapterMetrics[string(adapterName)]
+	am, ok := me.AdapterMetrics[strings.ToLower(adapterStr)]
 	if !ok {
-		glog.Errorf("Trying to log adapter GDPR request blocked metric for %s: adapter not found", string(adapterName))
+		glog.Errorf("Trying to log adapter GDPR request blocked metric for %s: adapter not found", adapterStr)
 		return
 	}
 

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -997,9 +997,10 @@ func (me *Metrics) RecordBidValidationSecureMarkupError(adapter openrtb_ext.Bidd
 }
 
 func (me *Metrics) RecordBidValidationSecureMarkupWarn(adapter openrtb_ext.BidderName, pubID string) {
-	am, ok := me.AdapterMetrics[string(adapter)]
+	adapterStr := string(adapter)
+	am, ok := me.AdapterMetrics[strings.ToLower(adapterStr)]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	am.BidValidationSecureMarkupWarnMeter.Mark(1)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -952,9 +952,10 @@ func (me *Metrics) RecordAdsCertSignTime(adsCertSignTime time.Duration) {
 }
 
 func (me *Metrics) RecordBidValidationCreativeSizeError(adapter openrtb_ext.BidderName, pubID string) {
-	am, ok := me.AdapterMetrics[string(adapter)]
+	adapterStr := string(adapter)
+	am, ok := me.AdapterMetrics[strings.ToLower(adapterStr)]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	am.BidValidationCreativeSizeErrorMeter.Mark(1)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -757,16 +757,18 @@ func (me *Metrics) RecordBidderServerResponseTime(bidderServerResponseTime time.
 // RecordAdapterBidReceived implements a part of the MetricsEngine interface.
 // This tracks how many bids from each Bidder use `adm` vs. `nurl.
 func (me *Metrics) RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool) {
-	am, ok := me.AdapterMetrics[string(labels.Adapter)]
+	adapterStr := string(labels.Adapter)
+	lowerCaseAdapterName := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowerCaseAdapterName]
 	if !ok {
-		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", string(labels.Adapter))
+		glog.Errorf("Trying to run adapter bid metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 
 	// Adapter metrics
 	am.BidsReceivedMeter.Mark(1)
 	// Account-Adapter metrics
-	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[string(labels.Adapter)]; ok {
+	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[lowerCaseAdapterName]; ok {
 		aam.BidsReceivedMeter.Mark(1)
 	}
 

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -982,9 +982,10 @@ func (me *Metrics) RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.Bidde
 }
 
 func (me *Metrics) RecordBidValidationSecureMarkupError(adapter openrtb_ext.BidderName, pubID string) {
-	am, ok := me.AdapterMetrics[string(adapter)]
+	adapterStr := string(adapter)
+	am, ok := me.AdapterMetrics[strings.ToLower(adapterStr)]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	am.BidValidationSecureMarkupErrorMeter.Mark(1)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -676,9 +676,11 @@ func (me *Metrics) RecordStoredDataError(labels StoredDataLabels) {
 
 // RecordAdapterPanic implements a part of the MetricsEngine interface
 func (me *Metrics) RecordAdapterPanic(labels AdapterLabels) {
-	am, ok := me.AdapterMetrics[string(labels.Adapter)]
+	adapterStr := string(labels.Adapter)
+	lowerCasedAdapterName := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowerCasedAdapterName]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(labels.Adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	am.PanicMeter.Mark(1)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -802,7 +802,9 @@ func (me *Metrics) RecordAdapterPrice(labels AdapterLabels, cpm float64) {
 
 // RecordAdapterTime implements a part of the MetricsEngine interface. Records the adapter response time
 func (me *Metrics) RecordAdapterTime(labels AdapterLabels, length time.Duration) {
-	am, ok := me.AdapterMetrics[string(labels.Adapter)]
+	adapterStr := string(labels.Adapter)
+	lowercaseAdapter := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowercaseAdapter]
 	if !ok {
 		glog.Errorf("Trying to run adapter latency metrics on %s: adapter metrics not found", string(labels.Adapter))
 		return
@@ -810,7 +812,7 @@ func (me *Metrics) RecordAdapterTime(labels AdapterLabels, length time.Duration)
 	// Adapter metrics
 	am.RequestTimer.Update(length)
 	// Account-Adapter metrics
-	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[string(labels.Adapter)]; ok {
+	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[lowercaseAdapter]; ok {
 		aam.RequestTimer.Update(length)
 	}
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -677,8 +677,8 @@ func (me *Metrics) RecordStoredDataError(labels StoredDataLabels) {
 // RecordAdapterPanic implements a part of the MetricsEngine interface
 func (me *Metrics) RecordAdapterPanic(labels AdapterLabels) {
 	adapterStr := string(labels.Adapter)
-	lowerCasedAdapterName := strings.ToLower(adapterStr)
-	am, ok := me.AdapterMetrics[lowerCasedAdapterName]
+	lowerCaseAdapterName := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowerCaseAdapterName]
 	if !ok {
 		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
@@ -729,8 +729,8 @@ func (me *Metrics) RecordAdapterConnections(adapterName openrtb_ext.BidderName,
 	if me.MetricsDisabled.AdapterConnectionMetrics {
 		return
 	}
-	lowerCasedAdapterName := strings.ToLower(string(adapterName))
-	am, ok := me.AdapterMetrics[lowerCasedAdapterName]
+	lowerCaseAdapterName := strings.ToLower(string(adapterName))
+	am, ok := me.AdapterMetrics[lowerCaseAdapterName]
 	if !ok {
 		glog.Errorf("Trying to log adapter connection metrics for %s: adapter not found", string(adapterName))
 		return

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -688,13 +688,15 @@ func (me *Metrics) RecordAdapterPanic(labels AdapterLabels) {
 
 // RecordAdapterRequest implements a part of the MetricsEngine interface
 func (me *Metrics) RecordAdapterRequest(labels AdapterLabels) {
-	am, ok := me.AdapterMetrics[string(labels.Adapter)]
+	adapterStr := string(labels.Adapter)
+	lowerCaseAdapter := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowerCaseAdapter]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(labels.Adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 
-	aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[string(labels.Adapter)]
+	aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[lowerCaseAdapter]
 	switch labels.AdapterBids {
 	case AdapterBidNone:
 		am.NoBidMeter.Mark(1)

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -725,8 +725,8 @@ func (me *Metrics) RecordAdapterConnections(adapterName openrtb_ext.BidderName,
 	if me.MetricsDisabled.AdapterConnectionMetrics {
 		return
 	}
-
-	am, ok := me.AdapterMetrics[string(adapterName)]
+	lowerCasedAdapterName := strings.ToLower(string(adapterName))
+	am, ok := me.AdapterMetrics[lowerCasedAdapterName]
 	if !ok {
 		glog.Errorf("Trying to log adapter connection metrics for %s: adapter not found", string(adapterName))
 		return

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -785,15 +785,17 @@ func (me *Metrics) RecordAdapterBidReceived(labels AdapterLabels, bidType openrt
 
 // RecordAdapterPrice implements a part of the MetricsEngine interface. Generates a histogram of winning bid prices
 func (me *Metrics) RecordAdapterPrice(labels AdapterLabels, cpm float64) {
-	am, ok := me.AdapterMetrics[string(labels.Adapter)]
+	adapterStr := string(labels.Adapter)
+	lowercaseAdapter := strings.ToLower(adapterStr)
+	am, ok := me.AdapterMetrics[lowercaseAdapter]
 	if !ok {
-		glog.Errorf("Trying to run adapter price metrics on %s: adapter metrics not found", string(labels.Adapter))
+		glog.Errorf("Trying to run adapter price metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	// Adapter metrics
 	am.PriceHistogram.Update(int64(cpm))
 	// Account-Adapter metrics
-	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[string(labels.Adapter)]; ok {
+	if aam, ok := me.getAccountMetrics(labels.PubID).adapterMetrics[lowercaseAdapter]; ok {
 		aam.PriceHistogram.Update(int64(cpm))
 	}
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -967,9 +967,10 @@ func (me *Metrics) RecordBidValidationCreativeSizeError(adapter openrtb_ext.Bidd
 }
 
 func (me *Metrics) RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.BidderName, pubID string) {
-	am, ok := me.AdapterMetrics[string(adapter)]
+	adapterStr := string(adapter)
+	am, ok := me.AdapterMetrics[strings.ToLower(adapterStr)]
 	if !ok {
-		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", string(adapter))
+		glog.Errorf("Trying to run adapter metrics on %s: adapter metrics not found", adapterStr)
 		return
 	}
 	am.BidValidationCreativeSizeWarnMeter.Mark(1)

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -1162,3 +1162,15 @@ func TestRecordAdapterPrice(t *testing.T) {
 	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
 	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
 }
+
+func TestRecordAdapterTime(t *testing.T) {
+	registry := metrics.NewRegistry()
+	syncerKeys := []string{"foo"}
+	adapter := "AnyName"
+	lowerCasedAdapterName := "anyname"
+	pubID := "pub1"
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter), openrtb_ext.BidderAppnexus, openrtb_ext.BidderName("Adapter2")}, config.DisabledMetrics{}, syncerKeys, nil)
+	m.RecordAdapterTime(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter), PubID: pubID}, 1000)
+	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].RequestTimer.Max(), int64(1000))
+	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCasedAdapterName].RequestTimer.Max(), int64(1000))
+}

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -791,6 +791,7 @@ func TestRecordRequestPrivacy(t *testing.T) {
 func TestRecordAdapterGDPRRequestBlocked(t *testing.T) {
 	var fakeBidder openrtb_ext.BidderName = "fooAdvertising"
 	adapter := "AnyName"
+	lowerCaseAdapterName := "anyname"
 
 	tests := []struct {
 		description     string
@@ -823,7 +824,7 @@ func TestRecordAdapterGDPRRequestBlocked(t *testing.T) {
 
 		m.RecordAdapterGDPRRequestBlocked(tt.adapterName)
 
-		assert.Equal(t, tt.expectedCount, m.AdapterMetrics[adapter].GDPRRequestBlocked.Count(), tt.description)
+		assert.Equal(t, tt.expectedCount, m.AdapterMetrics[lowerCaseAdapterName].GDPRRequestBlocked.Count(), tt.description)
 	}
 }
 

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -1150,3 +1150,15 @@ func TestRecordAdapterPanic(t *testing.T) {
 	m.RecordAdapterPanic(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter)})
 	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PanicMeter.Count(), int64(1))
 }
+
+func TestRecordAdapterPrice(t *testing.T) {
+	registry := metrics.NewRegistry()
+	syncerKeys := []string{"foo"}
+	adapter := "AnyName"
+	lowerCasedAdapterName := "anyname"
+	pubID := "pub1"
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter), openrtb_ext.BidderAppnexus}, config.DisabledMetrics{}, syncerKeys, nil)
+	m.RecordAdapterPrice(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter), PubID: pubID}, 1000)
+	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
+	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
+}

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -361,6 +361,7 @@ func TestRecordBidValidationSecureMarkup(t *testing.T) {
 		},
 	}
 	adapter := "AnyName"
+	lowerCaseAdapter := "anyname"
 	for _, test := range testCases {
 		registry := metrics.NewRegistry()
 		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter)}, test.givenDisabledMetrics, nil, nil)
@@ -369,7 +370,7 @@ func TestRecordBidValidationSecureMarkup(t *testing.T) {
 		m.RecordBidValidationSecureMarkupWarn(openrtb_ext.BidderName(adapter), test.givenPubID)
 		am := m.getAccountMetrics(test.givenPubID)
 
-		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationSecureMarkupErrorMeter.Count())
+		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationSecureMarkupErrorMeter.Count())
 		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationSecureMarkupWarnMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationSecureMarkupMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationSecureMarkupWarnMeter.Count())

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -317,6 +317,7 @@ func TestRecordBidValidationCreativeSize(t *testing.T) {
 		},
 	}
 	adapter := "AnyName"
+	lowerCaseAdapter := "anyname"
 	for _, test := range testCases {
 		registry := metrics.NewRegistry()
 		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter)}, test.givenDisabledMetrics, nil, nil)
@@ -325,7 +326,7 @@ func TestRecordBidValidationCreativeSize(t *testing.T) {
 		m.RecordBidValidationCreativeSizeWarn(openrtb_ext.BidderName(adapter), test.givenPubID)
 		am := m.getAccountMetrics(test.givenPubID)
 
-		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationCreativeSizeErrorMeter.Count())
+		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationCreativeSizeErrorMeter.Count())
 		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationCreativeSizeWarnMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationCreativeSizeMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationCreativeSizeWarnMeter.Count())

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -1139,3 +1139,12 @@ func VerifyMetrics(t *testing.T, name string, expected int64, actual int64) {
 		t.Errorf("Error in metric %s: expected %d, got %d.", name, expected, actual)
 	}
 }
+
+func TestRecordAdapterPanic(t *testing.T) {
+	registry := metrics.NewRegistry()
+	adapter := "AnyName"
+	lowerCasedAdapterName := "anyname"
+	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter)}, config.DisabledMetrics{AccountAdapterDetails: true, AccountModulesMetrics: true}, nil, map[string][]string{"foobar": {"entry", "raw"}})
+	m.RecordAdapterPanic(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter)})
+	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PanicMeter.Count(), int64(1))
+}

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -22,8 +22,8 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "no_cookie_requests", m.NoCookieMeter)
 	ensureContains(t, registry, "request_time", m.RequestTimer)
 	ensureContains(t, registry, "amp_no_cookie_requests", m.AmpNoCookieMeter)
-	ensureContainsAdapterMetrics(t, registry, "adapter.Adapter1", m.AdapterMetrics["Adapter1"])
-	ensureContainsAdapterMetrics(t, registry, "adapter.Adapter2", m.AdapterMetrics["Adapter2"])
+	ensureContainsAdapterMetrics(t, registry, "adapter.adapter1", m.AdapterMetrics["adapter1"])
+	ensureContainsAdapterMetrics(t, registry, "adapter.adapter2", m.AdapterMetrics["adapter2"])
 	ensureContains(t, registry, "cookie_sync_requests", m.CookieSyncMeter)
 	ensureContains(t, registry, "cookie_sync_requests.ok", m.CookieSyncStatusMeter[CookieSyncOK])
 	ensureContains(t, registry, "cookie_sync_requests.bad_request", m.CookieSyncStatusMeter[CookieSyncBadRequest])
@@ -95,20 +95,21 @@ func TestNewMetrics(t *testing.T) {
 
 func TestRecordBidType(t *testing.T) {
 	registry := metrics.NewRegistry()
-	adapterName := "AnyName"
+	adapterName := "FOO"
+	lowerCaseAdapterName := "foo"
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapterName)}, config.DisabledMetrics{}, nil, nil)
 
 	m.RecordAdapterBidReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderName(adapterName),
 	}, openrtb_ext.BidTypeBanner, true)
-	VerifyMetrics(t, "Appnexus Banner Adm Bids", m.AdapterMetrics[adapterName].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
-	VerifyMetrics(t, "Appnexus Banner Nurl Bids", m.AdapterMetrics[adapterName].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
+	VerifyMetrics(t, "foo Banner Adm Bids", m.AdapterMetrics[lowerCaseAdapterName].MarkupMetrics[openrtb_ext.BidTypeBanner].AdmMeter.Count(), 1)
+	VerifyMetrics(t, "foo Banner Nurl Bids", m.AdapterMetrics[lowerCaseAdapterName].MarkupMetrics[openrtb_ext.BidTypeBanner].NurlMeter.Count(), 0)
 
 	m.RecordAdapterBidReceived(AdapterLabels{
 		Adapter: openrtb_ext.BidderName(adapterName),
 	}, openrtb_ext.BidTypeVideo, false)
-	VerifyMetrics(t, "Appnexus Video Adm Bids", m.AdapterMetrics[adapterName].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)
-	VerifyMetrics(t, "Appnexus Video Nurl Bids", m.AdapterMetrics[adapterName].MarkupMetrics[openrtb_ext.BidTypeVideo].NurlMeter.Count(), 1)
+	VerifyMetrics(t, "foo Video Adm Bids", m.AdapterMetrics[lowerCaseAdapterName].MarkupMetrics[openrtb_ext.BidTypeVideo].AdmMeter.Count(), 0)
+	VerifyMetrics(t, "foo Video Nurl Bids", m.AdapterMetrics[lowerCaseAdapterName].MarkupMetrics[openrtb_ext.BidTypeVideo].NurlMeter.Count(), 1)
 }
 
 func ensureContains(t *testing.T, registry metrics.Registry, name string, metric interface{}) {
@@ -200,6 +201,7 @@ func TestRecordBidTypeDisabledConfig(t *testing.T) {
 		},
 	}
 	adapter := "AnyName"
+	lowerCaseAdapter := "anyname"
 	for _, test := range testCases {
 		registry := metrics.NewRegistry()
 
@@ -209,8 +211,8 @@ func TestRecordBidTypeDisabledConfig(t *testing.T) {
 			Adapter: openrtb_ext.BidderName(adapter),
 			PubID:   test.PubID,
 		}, test.BidType, test.hasAdm)
-		assert.Equal(t, test.ExpectedAdmMeterCount, m.AdapterMetrics[adapter].MarkupMetrics[test.BidType].AdmMeter.Count(), "AnyName Banner Adm Bids")
-		assert.Equal(t, test.ExpectedNurlMeterCount, m.AdapterMetrics[adapter].MarkupMetrics[test.BidType].NurlMeter.Count(), "AnyName Banner Nurl Bids")
+		assert.Equal(t, test.ExpectedAdmMeterCount, m.AdapterMetrics[lowerCaseAdapter].MarkupMetrics[test.BidType].AdmMeter.Count(), "AnyName Banner Adm Bids")
+		assert.Equal(t, test.ExpectedNurlMeterCount, m.AdapterMetrics[lowerCaseAdapter].MarkupMetrics[test.BidType].NurlMeter.Count(), "AnyName Banner Nurl Bids")
 
 		if test.DisabledMetrics.AccountAdapterDetails {
 			assert.Len(t, m.accountMetrics[test.PubID].adapterMetrics, 0, "Test failed. Account metrics that contain adapter information are disabled, therefore we expect no entries in m.accountMetrics[accountId].adapterMetrics, we have %d \n", len(m.accountMetrics[test.PubID].adapterMetrics))

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -327,7 +327,7 @@ func TestRecordBidValidationCreativeSize(t *testing.T) {
 		am := m.getAccountMetrics(test.givenPubID)
 
 		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationCreativeSizeErrorMeter.Count())
-		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationCreativeSizeWarnMeter.Count())
+		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationCreativeSizeWarnMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationCreativeSizeMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationCreativeSizeWarnMeter.Count())
 	}

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -371,7 +371,7 @@ func TestRecordBidValidationSecureMarkup(t *testing.T) {
 		am := m.getAccountMetrics(test.givenPubID)
 
 		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationSecureMarkupErrorMeter.Count())
-		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[adapter].BidValidationSecureMarkupWarnMeter.Count())
+		assert.Equal(t, test.expectedAdapterCount, m.AdapterMetrics[lowerCaseAdapter].BidValidationSecureMarkupWarnMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationSecureMarkupMeter.Count())
 		assert.Equal(t, test.expectedAccountCount, am.bidValidationSecureMarkupWarnMeter.Count())
 	}

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -476,6 +476,7 @@ func TestRecordAdapterConnections(t *testing.T) {
 		expectedConnWaitTime     time.Duration
 	}
 	adapter := "AnyName"
+	lowerCaseAdapterName := "anyname"
 	testCases := []struct {
 		description string
 		in          testIn
@@ -560,10 +561,9 @@ func TestRecordAdapterConnections(t *testing.T) {
 		m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter)}, config.DisabledMetrics{AdapterConnectionMetrics: test.in.connMetricsDisabled}, nil, nil)
 
 		m.RecordAdapterConnections(test.in.adapterName, test.in.connWasReused, test.in.connWait)
-
-		assert.Equal(t, test.out.expectedConnReusedCount, m.AdapterMetrics[adapter].ConnReused.Count(), "Test [%d] incorrect number of reused connections to adapter", i)
-		assert.Equal(t, test.out.expectedConnCreatedCount, m.AdapterMetrics[adapter].ConnCreated.Count(), "Test [%d] incorrect number of new connections to adapter created", i)
-		assert.Equal(t, test.out.expectedConnWaitTime.Nanoseconds(), m.AdapterMetrics[adapter].ConnWaitTime.Sum(), "Test [%d] incorrect wait time in connection to adapter", i)
+		assert.Equal(t, test.out.expectedConnReusedCount, m.AdapterMetrics[lowerCaseAdapterName].ConnReused.Count(), "Test [%d] incorrect number of reused connections to adapter", i)
+		assert.Equal(t, test.out.expectedConnCreatedCount, m.AdapterMetrics[lowerCaseAdapterName].ConnCreated.Count(), "Test [%d] incorrect number of new connections to adapter created", i)
+		assert.Equal(t, test.out.expectedConnWaitTime.Nanoseconds(), m.AdapterMetrics[lowerCaseAdapterName].ConnWaitTime.Sum(), "Test [%d] incorrect wait time in connection to adapter", i)
 	}
 }
 

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -1148,34 +1148,34 @@ func VerifyMetrics(t *testing.T, name string, expected int64, actual int64) {
 func TestRecordAdapterPanic(t *testing.T) {
 	registry := metrics.NewRegistry()
 	adapter := "AnyName"
-	lowerCasedAdapterName := "anyname"
+	lowerCaseAdapterName := "anyname"
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter)}, config.DisabledMetrics{AccountAdapterDetails: true, AccountModulesMetrics: true}, nil, map[string][]string{"foobar": {"entry", "raw"}})
 	m.RecordAdapterPanic(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter)})
-	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PanicMeter.Count(), int64(1))
+	assert.Equal(t, m.AdapterMetrics[lowerCaseAdapterName].PanicMeter.Count(), int64(1))
 }
 
 func TestRecordAdapterPrice(t *testing.T) {
 	registry := metrics.NewRegistry()
 	syncerKeys := []string{"foo"}
 	adapter := "AnyName"
-	lowerCasedAdapterName := "anyname"
+	lowerCaseAdapterName := "anyname"
 	pubID := "pub1"
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter), openrtb_ext.BidderAppnexus}, config.DisabledMetrics{}, syncerKeys, nil)
 	m.RecordAdapterPrice(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter), PubID: pubID}, 1000)
-	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
-	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCasedAdapterName].PriceHistogram.Max(), int64(1000))
+	assert.Equal(t, m.AdapterMetrics[lowerCaseAdapterName].PriceHistogram.Max(), int64(1000))
+	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCaseAdapterName].PriceHistogram.Max(), int64(1000))
 }
 
 func TestRecordAdapterTime(t *testing.T) {
 	registry := metrics.NewRegistry()
 	syncerKeys := []string{"foo"}
 	adapter := "AnyName"
-	lowerCasedAdapterName := "anyname"
+	lowerCaseAdapterName := "anyname"
 	pubID := "pub1"
 	m := NewMetrics(registry, []openrtb_ext.BidderName{openrtb_ext.BidderName(adapter), openrtb_ext.BidderAppnexus, openrtb_ext.BidderName("Adapter2")}, config.DisabledMetrics{}, syncerKeys, nil)
 	m.RecordAdapterTime(AdapterLabels{Adapter: openrtb_ext.BidderName(adapter), PubID: pubID}, 1000)
-	assert.Equal(t, m.AdapterMetrics[lowerCasedAdapterName].RequestTimer.Max(), int64(1000))
-	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCasedAdapterName].RequestTimer.Max(), int64(1000))
+	assert.Equal(t, m.AdapterMetrics[lowerCaseAdapterName].RequestTimer.Max(), int64(1000))
+	assert.Equal(t, m.getAccountMetrics(pubID).adapterMetrics[lowerCaseAdapterName].RequestTimer.Max(), int64(1000))
 }
 
 func TestRecordAdapterRequest(t *testing.T) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -282,6 +282,7 @@ func AdapterErrors() []AdapterError {
 		AdapterErrorTimeout,
 		AdapterErrorFailedToRequestBids,
 		AdapterErrorValidation,
+		AdapterErrorTmaxTimeout,
 		AdapterErrorUnknown,
 	}
 }

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -64,7 +64,7 @@ func TestMetricCountGatekeeping(t *testing.T) {
 	// Verify Per-Adapter Cardinality
 	// - This assertion provides a warning for newly added adapter metrics. Threre are 40+ adapters which makes the
 	//   cost of new per-adapter metrics rather expensive. Thought should be given when adding new per-adapter metrics.
-	assert.True(t, perAdapterCardinalityCount <= 29, "Per-Adapter Cardinality count equals %d \n", perAdapterCardinalityCount)
+	assert.True(t, perAdapterCardinalityCount <= 30, "Per-Adapter Cardinality count equals %d \n", perAdapterCardinalityCount)
 }
 
 func TestConnectionMetrics(t *testing.T) {


### PR DESCRIPTION
- As of now, following are the prometheus metrics which have bidder name as label.
  	```
	RecordAdapterRequest(labels AdapterLabels)
	RecordAdapterConnections(adapterName openrtb_ext.BidderName, connWasReused bool, connWaitTime time.Duration)
	RecordAdapterPanic(labels AdapterLabels)
	RecordAdapterBidReceived(labels AdapterLabels, bidType openrtb_ext.BidType, hasAdm bool)
	RecordAdapterPrice(labels AdapterLabels, cpm float64)
	RecordAdapterTime(labels AdapterLabels, length time.Duration)
	RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName)
	RecordBidValidationCreativeSizeError(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationCreativeSizeWarn(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationSecureMarkupError(adapter openrtb_ext.BidderName, account string)
	RecordBidValidationSecureMarkupWarn(adapter openrtb_ext.BidderName, account string)
    ```
- PR implements changes implements changes to make sure above InfluxDB metrics records bidder name in lowercase.
- Also on startup, PBS server preloads InfluxDB metrics with bidder names. For this, [CoreBidderNames](https://github.com/prebid/prebid-server/blob/23bc394e8218bb3f6c860c37bd13c56ea50d3df1/openrtb_ext/bidders.go#L20) are used.
-  For example, `audienceNetwork, seedingAlliance, yahooAds, yahooAdvertising` are the bidders from `CoreBidderNames` that are in camel case. PR implements changes to make sure prometheus metrics for such bidders are preloaded with lower case bidder name.
