### PR TITLE
Update release workflow to support major version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,18 @@ jobs:
 
           nextTag=''
           releaseType=${{ inputs.releaseType }}
-          if [ $releaseType == "minor" ]; then
-            # increment minor version and reset patch version
-            nextTag=$(echo "${currentTag}" | awk -F. '{OFS="."; $2+=1; $3=0; print $0}')
+          if [ $releaseType == "major" ]; then
+              # PBS-GO skipped the v1.0.0 major release - https://github.com/prebid/prebid-server/issues/3068
+              # If the current tag is v0.x.x, the script sets the next release tag to v2.0.0
+              # Otherwise, the script increments the major version by 1 and sets the minor and patch versions to zero
+              # For example, v2.x.x will be incremented to v3.0.0
+              major=$(echo "${currentTag}" | awk -F. '{gsub(/^v/, "", $1); if($1 == 0) $1=2; else $1+=1; print $1}')
+              nextTag="v${major}.0.0"
+          elif [ $releaseType == "minor" ]; then
+              # Increment minor version and reset patch version
+              nextTag=$(echo "${currentTag}" | awk -F. '{OFS="."; $2+=1; $3=0; print $0}')
           else
-            # increment patch version
+            # Increment patch version
             nextTag=$(echo "${currentTag}" | awk -F. '{OFS="."; $3+=1; print $0}')
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ on:
       releaseType:
         type: choice
         options:
+          - major
           - minor
           - patch
         default: minor
         required: true
-        description: 'minor: v0.X.0, patch: v0.0.X'
+        description: 'major: vX.0.0, minor: v0.X.0, patch: v0.0.X'
       debug:
         type: boolean
         default: true


### PR DESCRIPTION
### Description:
- PR updates release workflow to support major version release
- PBS-GO skipped the v1.0.0 major release - https://github.com/prebid/prebid-server/issues/3068
     - If the current tag is v0.x.x, the script sets the next release tag to v2.0.0
     - Otherwise, the script increments the major version by 1 and sets the minor and patch versions to zero. For example, v2.x.x will be incremented to v3.0.0

### Testing:
  ```
  Tested on fork repo - https://github.com/onkarvhanumante/prebid-server/actions/workflows/release.yml
  ```
Major:
    ![major](https://github.com/prebid/prebid-server/assets/24757781/dce5a421-e1e5-469a-b98a-3c2d3fe68ff3)
Minor:
    ![minor](https://github.com/prebid/prebid-server/assets/24757781/8815055d-296b-4042-af1d-0d8638391f7e)
Patch:
    ![patch](https://github.com/prebid/prebid-server/assets/24757781/96c25fed-28ea-4a73-bfb0-2a6b7e2dcf12)


Docker images were built based on release type
![Screenshot 2023-10-18 170955](https://github.com/prebid/prebid-server/assets/24757781/2250703e-0382-46d2-afdd-0d68e0b2d064)

