### PR TITLE
Restore Hardcoded Alias User Syncs

### DIFF
--- a/static/bidder-info/adform.yaml
+++ b/static/bidder-info/adform.yaml
@@ -1,1 +1,5 @@
 aliasOf: adf
+userSync:
+  redirect:
+    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/quantumdex.yaml
+++ b/static/bidder-info/quantumdex.yaml
@@ -1,1 +1,8 @@
 aliasOf: "apacdex"
+userSync:
+  iframe:
+    url: https://sync.quantumdex.io/usersync/pbs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}
+    userMacro: "[UID]"
+  redirect:
+    url: "https://sync.quantumdex.io/getuid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/valueimpression.yaml
+++ b/static/bidder-info/valueimpression.yaml
@@ -1,1 +1,8 @@
 aliasOf: "apacdex"
+userSync:
+  iframe:
+    url: https://sync.quantumdex.io/usersync/pbs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}
+    userMacro: "[UID]"
+  redirect:
+    url: "https://sync.quantumdex.io/getuid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "[UID]"


### PR DESCRIPTION
Some of the alias migrations removed the user sync section if it's set in the parent. However, this change the syncer key (cookie family in PBS-Java) and has side affects. Reverting this for now and will discuss next steps in the PMC.