### PR TITLE
Flipp: abide by privacy concerns when using flippExt userKey

### DIFF
--- a/adapters/flipp/flipp.go
+++ b/adapters/flipp/flipp.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/gofrs/uuid"
 	"github.com/prebid/go-gdpr/consentconstants"
 	"github.com/prebid/go-gdpr/vendorconsent"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/v2/adapters"
 	"github.com/prebid/prebid-server/v2/config"
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
+	"github.com/prebid/prebid-server/v2/util/uuidutil"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 	defaultCurrency = "USD"
 )
 
-var uuidGenerator UUIDGenerator
+var uuidGenerator uuidutil.UUIDGenerator
 
 var (
 	count    int64 = 1
@@ -37,17 +37,9 @@ type adapter struct {
 	endpoint string
 }
 
-type UUIDGenerator struct {
-	Generate func() (uuid.UUID, error)
-}
-
-func Generate() (uuid.UUID, error) {
-	return uuid.NewV4()
-}
-
 // Builder builds a new instance of the Flipp adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
-	uuidGenerator.Generate = Generate
+	uuidGenerator = uuidutil.UUIDRandomGenerator{}
 	bidder := &adapter{
 		endpoint: config.Endpoint,
 	}
@@ -145,7 +137,7 @@ func (a *adapter) processImp(request *openrtb2.BidRequest, imp openrtb2.Imp) (*a
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate user uuid. %v", err)
 		}
-		userKey = uid.String()
+		userKey = uid
 	}
 
 	keywordsArray := strings.Split(request.Site.Keywords, ",")

--- a/adapters/flipp/flipp.go
+++ b/adapters/flipp/flipp.go
@@ -250,7 +250,7 @@ func paramsUserKeyPermitted(request *openrtb2.BidRequest) bool {
 			fmt.Printf("%v", err)
 			return true
 		}
-		if tcModel.CoreString.PurposesConsent[4] && !tcModel.IsPurposeAllowed(4) {
+		if !tcModel.IsPurposeAllowed(4) {
 			return false
 		}
 	}

--- a/adapters/flipp/flipp_test.go
+++ b/adapters/flipp/flipp_test.go
@@ -3,10 +3,7 @@ package flipp
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/SirDataFR/iabtcfv2"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/v2/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v2/config"
@@ -15,6 +12,7 @@ import (
 )
 
 func TestJsonSamples(t *testing.T) {
+	NewUUIDGenerator(true)
 	bidder, buildErr := Builder(openrtb_ext.BidderFlipp, config.Adapter{
 		Endpoint: "http://example.com/pserver"},
 		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
@@ -41,43 +39,12 @@ func TestParamsUserKeyPermitted(t *testing.T) {
 	t.Run("The Global Privacy Control is set", func(t *testing.T) {
 		request := &openrtb2.BidRequest{
 			Regs: &openrtb2.Regs{
-				GDPR: ptr.Int8(1),
+				GDPR: openrtb2.Int8Ptr(1),
 			},
 		}
 		result := paramsUserKeyPermitted(request)
 		assert.New(t)
 		assert.False(t, result, "param user key not permitted because Global Privacy Control is set")
-	})
-	t.Run("TCF purpose 4 is in scope and doesn't have consent", func(t *testing.T) {
-		tcData := &iabtcfv2.TCData{
-			CoreString: &iabtcfv2.CoreString{
-				PublisherCC:       "test",
-				Version:           2,
-				Created:           time.Now(),
-				LastUpdated:       time.Now(),
-				CmpId:             92,
-				CmpVersion:        1,
-				ConsentScreen:     1,
-				ConsentLanguage:   "EN",
-				VendorListVersion: 32,
-				TcfPolicyVersion:  2,
-				PurposesConsent: map[int]bool{
-					1: true,
-					2: true,
-					3: true,
-				},
-			},
-		}
-		segmentValue := tcData.CoreString.Encode()
-		user := &openrtb2.User{
-			Consent: segmentValue,
-		}
-		request := &openrtb2.BidRequest{
-			User: user,
-		}
-		result := paramsUserKeyPermitted(request)
-		assert.New(t)
-		assert.False(t, result, "param user key not permitted because TCF purpose 4 is in scope and doesn't have consent")
 	})
 	t.Run("The Prebid transmitEids activity is disallowed", func(t *testing.T) {
 		extData := struct {

--- a/adapters/flipp/flipp_test.go
+++ b/adapters/flipp/flipp_test.go
@@ -1,11 +1,17 @@
 package flipp
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/SirDataFR/iabtcfv2"
+	"github.com/aws/smithy-go/ptr"
+	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/v2/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v2/config"
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonSamples(t *testing.T) {
@@ -18,4 +24,77 @@ func TestJsonSamples(t *testing.T) {
 	}
 
 	adapterstest.RunJSONBidderTest(t, "flipptest", bidder)
+}
+
+func TestParamsUserKeyPermitted(t *testing.T) {
+
+	t.Run("Coppa is in effect", func(t *testing.T) {
+		request := &openrtb2.BidRequest{
+			Regs: &openrtb2.Regs{
+				COPPA: 1,
+			},
+		}
+		result := paramsUserKeyPermitted(request)
+		assert.New(t)
+		assert.False(t, result, "param user key not permitted because coppa is in effect")
+	})
+	t.Run("The Global Privacy Control is set", func(t *testing.T) {
+		request := &openrtb2.BidRequest{
+			Regs: &openrtb2.Regs{
+				GDPR: ptr.Int8(1),
+			},
+		}
+		result := paramsUserKeyPermitted(request)
+		assert.New(t)
+		assert.False(t, result, "param user key not permitted because Global Privacy Control is set")
+	})
+	t.Run("TCF purpose 4 is in scope and doesn't have consent", func(t *testing.T) {
+		tcData := &iabtcfv2.TCData{
+			CoreString: &iabtcfv2.CoreString{
+				PublisherCC:       "test",
+				Version:           2,
+				Created:           time.Now(),
+				LastUpdated:       time.Now(),
+				CmpId:             92,
+				CmpVersion:        1,
+				ConsentScreen:     1,
+				ConsentLanguage:   "EN",
+				VendorListVersion: 32,
+				TcfPolicyVersion:  2,
+				PurposesConsent: map[int]bool{
+					1: true,
+					2: true,
+					3: true,
+				},
+			},
+		}
+		segmentValue := tcData.CoreString.Encode()
+		user := &openrtb2.User{
+			Consent: segmentValue,
+		}
+		request := &openrtb2.BidRequest{
+			User: user,
+		}
+		result := paramsUserKeyPermitted(request)
+		assert.New(t)
+		assert.False(t, result, "param user key not permitted because TCF purpose 4 is in scope and doesn't have consent")
+	})
+	t.Run("The Prebid transmitEids activity is disallowed", func(t *testing.T) {
+		extData := struct {
+			TransmitEids bool `json:"transmitEids"`
+		}{
+			TransmitEids: false,
+		}
+		ext, err := json.Marshal(extData)
+		if err != nil {
+			t.Fatalf("failed to marshal ext data: %v", err)
+		}
+		request := &openrtb2.BidRequest{
+			Ext: ext,
+		}
+
+		result := paramsUserKeyPermitted(request)
+		assert.New(t)
+		assert.False(t, result, "param user key not permitted because Prebid transmitEids activity is disallowed")
+	})
 }

--- a/adapters/flipp/flipp_test.go
+++ b/adapters/flipp/flipp_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/v2/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v2/config"
@@ -14,15 +13,17 @@ import (
 
 const fakeUuid = "30470a14-2949-4110-abce-b62d57304ad5"
 
-func GenerateFakeUUID() (uuid.UUID, error) {
-	return uuid.FromStringOrNil(fakeUuid), nil
+type TestUUIDGenerator struct{}
+
+func (TestUUIDGenerator) Generate() (string, error) {
+	return fakeUuid, nil
 }
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderFlipp, config.Adapter{
 		Endpoint: "http://example.com/pserver"},
 		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-	uuidGenerator.Generate = GenerateFakeUUID
+	uuidGenerator = TestUUIDGenerator{}
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/flipp/flipp_test.go
+++ b/adapters/flipp/flipp_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/prebid-server/v2/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v2/config"
@@ -11,11 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const fakeUuid = "30470a14-2949-4110-abce-b62d57304ad5"
+
+func GenerateFakeUUID() (uuid.UUID, error) {
+	return uuid.FromStringOrNil(fakeUuid), nil
+}
+
 func TestJsonSamples(t *testing.T) {
-	NewUUIDGenerator(true)
 	bidder, buildErr := Builder(openrtb_ext.BidderFlipp, config.Adapter{
 		Endpoint: "http://example.com/pserver"},
 		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	uuidGenerator.Generate = GenerateFakeUUID
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/flipp/flipptest/exemplary/simple-banner-native-param-transmit-eids.json
+++ b/adapters/flipp/flipptest/exemplary/simple-banner-native-param-transmit-eids.json
@@ -10,7 +10,9 @@
             "page": "http://www.example.com/test?flipp-content-code=publisher-test"
         },
         "user": {
-            "consent": "CP0xeHPP0xeHPBcABBENAgCAAPAAAAAAAGcgAAAAAAAA"
+        },
+        "ext": {
+            "transmitEids": false
         },
         "regs": {
             "coppa": 0,
@@ -82,7 +84,7 @@
                     ],
                     "url":"http://www.example.com/test?flipp-content-code=publisher-test",
                     "user":{
-                       "key":"abc123"
+                       "key":"30470a14-2949-4110-abce-b62d57304ad5"
                     }
                 }
             },

--- a/adapters/flipp/flipptest/exemplary/simple-banner-native-param-user-coppa.json
+++ b/adapters/flipp/flipptest/exemplary/simple-banner-native-param-user-coppa.json
@@ -9,12 +9,10 @@
             "id": "1243066",
             "page": "http://www.example.com/test?flipp-content-code=publisher-test"
         },
-        "user": {
-            "consent": "CP0xeHPP0xeHPBcABBENAgCAAPAAAAAAAGcgAAAAAAAA"
-        },
         "regs": {
-            "coppa": 0,
-            "gdpr": 0
+            "coppa": 1
+        },
+        "user": {
         },
         "imp": [
             {
@@ -82,7 +80,7 @@
                     ],
                     "url":"http://www.example.com/test?flipp-content-code=publisher-test",
                     "user":{
-                       "key":"abc123"
+                       "key":"30470a14-2949-4110-abce-b62d57304ad5"
                     }
                 }
             },

--- a/adapters/flipp/flipptest/exemplary/simple-banner-native-param-user-gdpr.json
+++ b/adapters/flipp/flipptest/exemplary/simple-banner-native-param-user-gdpr.json
@@ -10,11 +10,9 @@
             "page": "http://www.example.com/test?flipp-content-code=publisher-test"
         },
         "user": {
-            "consent": "CP0xeHPP0xeHPBcABBENAgCAAPAAAAAAAGcgAAAAAAAA"
         },
         "regs": {
-            "coppa": 0,
-            "gdpr": 0
+            "gdpr": 1
         },
         "imp": [
             {
@@ -82,7 +80,7 @@
                     ],
                     "url":"http://www.example.com/test?flipp-content-code=publisher-test",
                     "user":{
-                       "key":"abc123"
+                       "key":"30470a14-2949-4110-abce-b62d57304ad5"
                     }
                 }
             },

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 
 require (
 	github.com/SirDataFR/iabtcfv2 v1.2.0 // indirect
+	github.com/aws/smithy-go v1.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 )
 
 require (
+	github.com/SirDataFR/iabtcfv2 v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang/glog v1.0.0
-	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/copystructure v1.2.0
@@ -47,6 +46,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang/glog v1.0.0
+	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/copystructure v1.2.0
@@ -39,8 +40,6 @@ require (
 )
 
 require (
-	github.com/SirDataFR/iabtcfv2 v1.2.0 // indirect
-	github.com/aws/smithy-go v1.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -48,7 +47,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/IABTechLab/adscert v0.34.0/go.mod h1:pCLd3Up1kfTrH6kYFUGGeavxIc1f6Tvv
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/SirDataFR/iabtcfv2 v1.2.0 h1:IMVoOYqoAdZanTHDznjyM1Yf7P9P8orviFM9ESfXxpU=
+github.com/SirDataFR/iabtcfv2 v1.2.0/go.mod h1:wBEfrSz6AcFCRtxRSGPj8XB4Ut4ntjkM32zV4V/byTk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/IABTechLab/adscert v0.34.0/go.mod h1:pCLd3Up1kfTrH6kYFUGGeavxIc1f6Tvv
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/SirDataFR/iabtcfv2 v1.2.0 h1:IMVoOYqoAdZanTHDznjyM1Yf7P9P8orviFM9ESfXxpU=
-github.com/SirDataFR/iabtcfv2 v1.2.0/go.mod h1:wBEfrSz6AcFCRtxRSGPj8XB4Ut4ntjkM32zV4V/byTk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -75,8 +73,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.36.29/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/smithy-go v1.15.0 h1:PS/durmlzvAFpQHDs4wi4sNNP9ExsqZh6IlfdHXgKK8=
-github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -214,7 +210,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.36.29/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/smithy-go v1.15.0 h1:PS/durmlzvAFpQHDs4wi4sNNP9ExsqZh6IlfdHXgKK8=
+github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -212,6 +214,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=


### PR DESCRIPTION
Based on the discussion here https://github.com/prebid/prebid.github.io/pull/4551#discussion_r1222097913, we will not use userKey from Flipp bidder params if any of the following conditions are true:

- COPPA is in effect
- The Global Privacy Control is set
- TCF purpose 4 is in scope and doesn't have consent
- The Prebid "transmitEids" activity is disallowed