### PR TITLE
Fix: use file system bidder info config as base (option 2)

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -22,13 +22,13 @@ type BidderInfos map[string]BidderInfo
 // BidderInfo specifies all configuration for a bidder except for enabled status, endpoint, and extra information.
 type BidderInfo struct {
 	AliasOf          string `yaml:"aliasOf" mapstructure:"aliasOf"`
-	Disabled         bool   `yaml:"disabled" mapstructure:"disabled"`
+	Disabled         *bool  `yaml:"disabled" mapstructure:"disabled"`
 	Endpoint         string `yaml:"endpoint" mapstructure:"endpoint"`
 	ExtraAdapterInfo string `yaml:"extra_info" mapstructure:"extra_info"`
 
 	Maintainer              *MaintainerInfo   `yaml:"maintainer" mapstructure:"maintainer"`
 	Capabilities            *CapabilitiesInfo `yaml:"capabilities" mapstructure:"capabilities"`
-	ModifyingVastXmlAllowed bool              `yaml:"modifyingVastXmlAllowed" mapstructure:"modifyingVastXmlAllowed"`
+	ModifyingVastXmlAllowed *bool             `yaml:"modifyingVastXmlAllowed" mapstructure:"modifyingVastXmlAllowed"`
 	Debug                   *DebugInfo        `yaml:"debug" mapstructure:"debug"`
 	GVLVendorID             uint16            `yaml:"gvlVendorID" mapstructure:"gvlVendorID"`
 
@@ -184,7 +184,11 @@ type SyncerEndpoint struct {
 }
 
 func (bi BidderInfo) IsEnabled() bool {
-	return !bi.Disabled
+	return bi.Disabled != nil && !*bi.Disabled
+}
+
+func (bi BidderInfo) IsModifyingVastXmlAllowed() bool {
+	return bi.ModifyingVastXmlAllowed != nil && *bi.ModifyingVastXmlAllowed
 }
 
 type InfoReader interface {
@@ -608,11 +612,11 @@ func applyBidderInfoConfigOverrides(configBidderInfos BidderInfos, fsBidderInfos
 		if configBidderInfo.AppSecret != "" {
 			mergedBidderInfo.AppSecret = configBidderInfo.AppSecret
 		}
-		if configBidderInfo.Disabled == true {
-			mergedBidderInfo.Disabled = true
+		if configBidderInfo.Disabled != nil {
+			mergedBidderInfo.Disabled = configBidderInfo.Disabled
 		}
-		if configBidderInfo.ModifyingVastXmlAllowed == true {
-			mergedBidderInfo.ModifyingVastXmlAllowed = true
+		if configBidderInfo.ModifyingVastXmlAllowed != nil {
+			mergedBidderInfo.ModifyingVastXmlAllowed = configBidderInfo.ModifyingVastXmlAllowed
 		}
 		if configBidderInfo.Experiment.AdsCert.Enabled == true {
 			mergedBidderInfo.Experiment.AdsCert.Enabled = true

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -83,7 +83,6 @@ func TestLoadBidderInfoFromDisk(t *testing.T) {
 
 	expected := BidderInfos{
 		bidder: {
-			Disabled: false,
 			Maintainer: &MaintainerInfo{
 				Email: "some-email@domain.com",
 			},
@@ -121,6 +120,9 @@ func TestLoadBidderInfoFromDisk(t *testing.T) {
 }
 
 func TestProcessBidderInfo(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	testCases := []struct {
 		description         string
 		bidderInfos         map[string][]byte
@@ -189,7 +191,7 @@ func TestProcessBidderInfo(t *testing.T) {
 					Debug: &DebugInfo{
 						Allow: true,
 					},
-					Disabled:            false,
+					Disabled:            &falseValue,
 					Endpoint:            "https://endpoint.com",
 					EndpointCompression: "GZIP",
 					Experiment: BidderInfoExperiment{
@@ -202,7 +204,7 @@ func TestProcessBidderInfo(t *testing.T) {
 					Maintainer: &MaintainerInfo{
 						Email: "some-email@domain.com",
 					},
-					ModifyingVastXmlAllowed: true,
+					ModifyingVastXmlAllowed: &trueValue,
 					OpenRTB: &OpenRTBInfo{
 						GPPSupported: true,
 						Version:      "2.6",
@@ -240,7 +242,7 @@ func TestProcessBidderInfo(t *testing.T) {
 					Debug: &DebugInfo{
 						Allow: true,
 					},
-					Disabled:            false,
+					Disabled:            &falseValue,
 					Endpoint:            "https://endpoint.com",
 					EndpointCompression: "GZIP",
 					Experiment: BidderInfoExperiment{
@@ -253,7 +255,7 @@ func TestProcessBidderInfo(t *testing.T) {
 					Maintainer: &MaintainerInfo{
 						Email: "some-email@domain.com",
 					},
-					ModifyingVastXmlAllowed: true,
+					ModifyingVastXmlAllowed: &trueValue,
 					OpenRTB: &OpenRTBInfo{
 						GPPSupported: true,
 						Version:      "2.6",
@@ -284,6 +286,9 @@ func TestProcessBidderInfo(t *testing.T) {
 }
 
 func TestProcessAliasBidderInfo(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	parentWithSyncerKey := BidderInfo{
 		AppSecret: "app-secret",
 		Capabilities: &CapabilitiesInfo{
@@ -297,7 +302,7 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 		Debug: &DebugInfo{
 			Allow: true,
 		},
-		Disabled:            false,
+		Disabled:            &falseValue,
 		Endpoint:            "https://endpoint.com",
 		EndpointCompression: "GZIP",
 		Experiment: BidderInfoExperiment{
@@ -310,7 +315,7 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 		Maintainer: &MaintainerInfo{
 			Email: "some-email@domain.com",
 		},
-		ModifyingVastXmlAllowed: true,
+		ModifyingVastXmlAllowed: &trueValue,
 		OpenRTB: &OpenRTBInfo{
 			GPPSupported: true,
 			Version:      "2.6",
@@ -344,7 +349,7 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 		Debug: &DebugInfo{
 			Allow: false,
 		},
-		Disabled:            true,
+		Disabled:            &trueValue,
 		Endpoint:            "https://alias-endpoint.com",
 		EndpointCompression: "DEFAULT",
 		Experiment: BidderInfoExperiment{
@@ -357,7 +362,7 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 		Maintainer: &MaintainerInfo{
 			Email: "alias-email@domain.com",
 		},
-		ModifyingVastXmlAllowed: false,
+		ModifyingVastXmlAllowed: &falseValue,
 		OpenRTB: &OpenRTBInfo{
 			GPPSupported: false,
 			Version:      "2.5",
@@ -452,8 +457,8 @@ func TestProcessAliasBidderInfo(t *testing.T) {
 			description: "all bidder info specified for alias, do not inherit from parent bidder",
 			aliasInfos: map[string]aliasNillableFields{
 				"bidderB": {
-					Disabled:                &aliasBidderInfo.Disabled,
-					ModifyingVastXmlAllowed: &aliasBidderInfo.ModifyingVastXmlAllowed,
+					Disabled:                aliasBidderInfo.Disabled,
+					ModifyingVastXmlAllowed: aliasBidderInfo.ModifyingVastXmlAllowed,
 					Experiment:              &aliasBidderInfo.Experiment,
 					XAPI:                    &aliasBidderInfo.XAPI,
 				},
@@ -519,11 +524,14 @@ func mockNormalizeBidderName(name string) (openrtb_ext.BidderName, bool) {
 }
 
 func TestToGVLVendorIDMap(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	givenBidderInfos := BidderInfos{
-		"bidderA": BidderInfo{Disabled: false, GVLVendorID: 0},
-		"bidderB": BidderInfo{Disabled: false, GVLVendorID: 100},
-		"bidderC": BidderInfo{Disabled: true, GVLVendorID: 0},
-		"bidderD": BidderInfo{Disabled: true, GVLVendorID: 200},
+		"bidderA": BidderInfo{Disabled: &falseValue, GVLVendorID: 0},
+		"bidderB": BidderInfo{Disabled: &falseValue, GVLVendorID: 100},
+		"bidderC": BidderInfo{Disabled: &trueValue, GVLVendorID: 0},
+		"bidderD": BidderInfo{Disabled: &trueValue, GVLVendorID: 200},
 	}
 
 	expectedGVLVendorIDMap := map[openrtb_ext.BidderName]uint16{
@@ -1696,6 +1704,9 @@ func TestApplyBidderInfoConfigOverridesInvalid(t *testing.T) {
 }
 
 func TestReadFullYamlBidderConfig(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	bidder := "bidderA"
 	bidderInf := BidderInfo{}
 
@@ -1722,7 +1733,7 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 					MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner},
 				},
 			},
-			ModifyingVastXmlAllowed: true,
+			ModifyingVastXmlAllowed: &trueValue,
 			Debug: &DebugInfo{
 				Allow: true,
 			},
@@ -1736,7 +1747,7 @@ func TestReadFullYamlBidderConfig(t *testing.T) {
 				GPPSupported: true,
 				Version:      "2.6",
 			},
-			Disabled:         false,
+			Disabled:         &falseValue,
 			ExtraAdapterInfo: "extra-info",
 			AppSecret:        "app-secret",
 			PlatformID:       "123",

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -1649,6 +1649,18 @@ func TestApplyBidderInfoConfigOverrides(t *testing.T) {
 			givenConfigBidderInfos: BidderInfos{"a": {EndpointCompression: "LZ77", Syncer: &Syncer{Key: "override"}}},
 			expectedBidderInfos:    BidderInfos{"a": {EndpointCompression: "LZ77", Syncer: &Syncer{Key: "override"}}},
 		},
+		{
+			description:            "Don't override AliasOf",
+			givenFsBidderInfos:     BidderInfos{"a": {AliasOf: "Alias1"}},
+			givenConfigBidderInfos: BidderInfos{"a": {}},
+			expectedBidderInfos:    BidderInfos{"a": {AliasOf: "Alias1"}},
+		},
+		{
+			description:            "Attempt override AliasOf but ignored",
+			givenFsBidderInfos:     BidderInfos{"a": {AliasOf: "Alias1"}},
+			givenConfigBidderInfos: BidderInfos{"a": {AliasOf: "Alias2"}},
+			expectedBidderInfos:    BidderInfos{"a": {AliasOf: "Alias1"}},
+		},
 	}
 	for _, test := range testCases {
 		bidderInfos, resultErr := applyBidderInfoConfigOverrides(test.givenConfigBidderInfos, test.givenFsBidderInfos, mockNormalizeBidderName)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -841,6 +841,8 @@ func TestUserSyncFromEnv(t *testing.T) {
 }
 
 func TestBidderInfoFromEnv(t *testing.T) {
+	trueValue := true
+
 	// setup env vars for testing
 	if oldval, ok := os.LookupEnv("PBS_ADAPTERS_BIDDER1_DISABLED"); ok {
 		defer os.Setenv("PBS_ADAPTERS_BIDDER1_DISABLED", oldval)
@@ -908,7 +910,7 @@ func TestBidderInfoFromEnv(t *testing.T) {
 
 	cfg, _ := newDefaultConfig(t)
 
-	assert.Equal(t, true, cfg.BidderInfos["bidder1"].Disabled)
+	assert.Equal(t, &trueValue, cfg.BidderInfos["bidder1"].Disabled)
 	assert.Equal(t, "http://some.url/override", cfg.BidderInfos["bidder1"].Endpoint)
 	assert.Equal(t, `{"extrainfo": true}`, cfg.BidderInfos["bidder1"].ExtraAdapterInfo)
 

--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -276,7 +276,7 @@ func isAllowVastForBidder(bidder string, bidderInfos *config.BidderInfos, allowU
 	if normalizedBidder, ok := normalizeBidderName(bidder); ok {
 		if b, ok := (*bidderInfos)[normalizedBidder.String()]; bidderInfos != nil && ok {
 			// check if bidder is enabled
-			return b.IsEnabled() && b.ModifyingVastXmlAllowed
+			return b.IsEnabled() && b.IsModifyingVastXmlAllowed()
 		}
 	}
 

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -366,6 +366,9 @@ func TestShouldTolerateAccountNotFound(t *testing.T) {
 }
 
 func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastNotAllowed(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	// mock pbs cache client
 	mockCacheClient := &vtrackMockCacheClient{
 		Fail:  false,
@@ -389,12 +392,12 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastNotAllowe
 	// bidder info
 	bidderInfos := make(config.BidderInfos)
 	bidderInfos["bidder"] = config.BidderInfo{
-		Disabled:                false,
-		ModifyingVastXmlAllowed: false,
+		Disabled:                &falseValue,
+		ModifyingVastXmlAllowed: &falseValue,
 	}
 	bidderInfos["updatable_bidder"] = config.BidderInfo{
-		Disabled:                false,
-		ModifyingVastXmlAllowed: true,
+		Disabled:                &falseValue,
+		ModifyingVastXmlAllowed: &trueValue,
 	}
 
 	// prepare
@@ -430,6 +433,9 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastNotAllowe
 }
 
 func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastAllowed(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	// mock pbs cache client
 	mockCacheClient := &vtrackMockCacheClient{
 		Fail:  false,
@@ -453,12 +459,12 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastAllowed(t
 	// bidder info
 	bidderInfos := make(config.BidderInfos)
 	bidderInfos["bidder"] = config.BidderInfo{
-		Disabled:                false,
-		ModifyingVastXmlAllowed: true,
+		Disabled:                &falseValue,
+		ModifyingVastXmlAllowed: &trueValue,
 	}
 	bidderInfos["updatable_bidder"] = config.BidderInfo{
-		Disabled:                false,
-		ModifyingVastXmlAllowed: true,
+		Disabled:                &falseValue,
+		ModifyingVastXmlAllowed: &trueValue,
 	}
 
 	// prepare
@@ -500,6 +506,9 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableBiddersWhenBidderVastAllowed(t
 }
 
 func TestShouldSendToCacheExpectedPutsAndUpdatableCaseSensitiveBiddersWhenBidderVastAllowed(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	// mock pbs cache client
 	mockCacheClient := &vtrackMockCacheClient{
 		Fail:  false,
@@ -523,8 +532,8 @@ func TestShouldSendToCacheExpectedPutsAndUpdatableCaseSensitiveBiddersWhenBidder
 	// bidder info
 	bidderInfos := make(config.BidderInfos)
 	bidderInfos["appnexus"] = config.BidderInfo{
-		Disabled:                false,
-		ModifyingVastXmlAllowed: true,
+		Disabled:                &falseValue,
+		ModifyingVastXmlAllowed: &trueValue,
 	}
 
 	d, err := getVTrackRequestData(true, true)

--- a/endpoints/info/bidders_detail_test.go
+++ b/endpoints/info/bidders_detail_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 func TestPrepareBiddersDetailResponse(t *testing.T) {
-	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
+	falseValue := false
+
+	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
 	bidderAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"}}`)
 
-	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
+	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
 	bidderBResponse := []byte(`{"status":"ACTIVE","usesHttps":false,"maintainer":{"email":"bidderB"}}`)
 
 	allResponseBidderA := bytes.Buffer{}
@@ -83,11 +85,11 @@ func TestMapDetails(t *testing.T) {
 	trueValue := true
 	falseValue := false
 
-	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
+	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
 	bidderADetail := bidderDetail{Status: "ACTIVE", UsesHTTPS: &trueValue, Maintainer: &maintainer{Email: "bidderA"}}
 	aliasADetail := bidderDetail{Status: "ACTIVE", UsesHTTPS: &trueValue, Maintainer: &maintainer{Email: "bidderA"}, AliasOf: "a"}
 
-	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
+	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
 	bidderBDetail := bidderDetail{Status: "ACTIVE", UsesHTTPS: &falseValue, Maintainer: &maintainer{Email: "bidderB"}}
 	aliasBDetail := bidderDetail{Status: "ACTIVE", UsesHTTPS: &falseValue, Maintainer: &maintainer{Email: "bidderB"}, AliasOf: "b"}
 
@@ -219,7 +221,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Enabled - All Values Present",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "http://anyEndpoint",
-				Disabled: false,
+				Disabled: &falseValue,
 				Maintainer: &config.MaintainerInfo{
 					Email: "foo@bar.com",
 				},
@@ -247,7 +249,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Disabled - All Values Present",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "http://anyEndpoint",
-				Disabled: true,
+				Disabled: &trueValue,
 				Maintainer: &config.MaintainerInfo{
 					Email: "foo@bar.com",
 				},
@@ -270,7 +272,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Enabled - No Values Present",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "http://amyEndpoint",
-				Disabled: false,
+				Disabled: &falseValue,
 			},
 			expected: bidderDetail{
 				Status:    "ACTIVE",
@@ -281,7 +283,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Enabled - Protocol - HTTP",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "http://amyEndpoint",
-				Disabled: false,
+				Disabled: &falseValue,
 			},
 			expected: bidderDetail{
 				Status:    "ACTIVE",
@@ -292,7 +294,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Enabled - Protocol - HTTPS",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "https://amyEndpoint",
-				Disabled: false,
+				Disabled: &falseValue,
 			},
 			expected: bidderDetail{
 				Status:    "ACTIVE",
@@ -302,7 +304,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 		{
 			description: "Enabled - Protocol - HTTPS - Case Insensitive",
 			givenBidderInfo: config.BidderInfo{
-				Disabled: false,
+				Disabled: &falseValue,
 				Endpoint: "https://amyEndpoint",
 			},
 			expected: bidderDetail{
@@ -314,7 +316,7 @@ func TestMapDetailFromConfig(t *testing.T) {
 			description: "Enabled - Protocol - Unknown",
 			givenBidderInfo: config.BidderInfo{
 				Endpoint: "endpointWithoutProtocol",
-				Disabled: false,
+				Disabled: &falseValue,
 			},
 			expected: bidderDetail{
 				Status:    "ACTIVE",
@@ -364,11 +366,13 @@ func TestMapMediaTypes(t *testing.T) {
 }
 
 func TestBiddersDetailHandler(t *testing.T) {
-	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
+	falseValue := false
+
+	bidderAInfo := config.BidderInfo{Endpoint: "https://secureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderA"}}
 	bidderAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"}}`)
 	aliasAResponse := []byte(`{"status":"ACTIVE","usesHttps":true,"maintainer":{"email":"bidderA"},"aliasOf":"appnexus"}`)
 
-	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: false, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
+	bidderBInfo := config.BidderInfo{Endpoint: "http://unsecureEndpoint.com", Disabled: &falseValue, Maintainer: &config.MaintainerInfo{Email: "bidderB"}}
 	bidderBResponse := []byte(`{"status":"ACTIVE","usesHttps":false,"maintainer":{"email":"bidderB"}}`)
 
 	allResponse := bytes.Buffer{}

--- a/endpoints/info/bidders_test.go
+++ b/endpoints/info/bidders_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 func TestPrepareBiddersResponseAll(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
-		enabledCore   = config.BidderInfo{Disabled: false}
-		enabledAlias  = config.BidderInfo{Disabled: false, AliasOf: "something"}
-		disabledCore  = config.BidderInfo{Disabled: true}
-		disabledAlias = config.BidderInfo{Disabled: true, AliasOf: "something"}
+		enabledCore   = config.BidderInfo{Disabled: &falseValue}
+		enabledAlias  = config.BidderInfo{Disabled: &falseValue, AliasOf: "something"}
+		disabledCore  = config.BidderInfo{Disabled: &trueValue}
+		disabledAlias = config.BidderInfo{Disabled: &trueValue, AliasOf: "something"}
 	)
 
 	testCases := []struct {
@@ -108,11 +111,14 @@ func TestPrepareBiddersResponseAll(t *testing.T) {
 }
 
 func TestPrepareBiddersResponseAllBaseOnly(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
-		enabledCore   = config.BidderInfo{Disabled: false}
-		enabledAlias  = config.BidderInfo{Disabled: false, AliasOf: "something"}
-		disabledCore  = config.BidderInfo{Disabled: true}
-		disabledAlias = config.BidderInfo{Disabled: true, AliasOf: "something"}
+		enabledCore   = config.BidderInfo{Disabled: &falseValue}
+		enabledAlias  = config.BidderInfo{Disabled: &falseValue, AliasOf: "something"}
+		disabledCore  = config.BidderInfo{Disabled: &trueValue}
+		disabledAlias = config.BidderInfo{Disabled: &trueValue, AliasOf: "something"}
 	)
 
 	testCases := []struct {
@@ -167,11 +173,14 @@ func TestPrepareBiddersResponseAllBaseOnly(t *testing.T) {
 }
 
 func TestPrepareBiddersResponseEnabledOnly(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
-		enabledCore   = config.BidderInfo{Disabled: false}
-		enabledAlias  = config.BidderInfo{Disabled: false, AliasOf: "something"}
-		disabledCore  = config.BidderInfo{Disabled: true}
-		disabledAlias = config.BidderInfo{Disabled: true, AliasOf: "something"}
+		enabledCore   = config.BidderInfo{Disabled: &falseValue}
+		enabledAlias  = config.BidderInfo{Disabled: &falseValue, AliasOf: "something"}
+		disabledCore  = config.BidderInfo{Disabled: &trueValue}
+		disabledAlias = config.BidderInfo{Disabled: &trueValue, AliasOf: "something"}
 	)
 
 	testCases := []struct {
@@ -264,11 +273,14 @@ func TestPrepareBiddersResponseEnabledOnly(t *testing.T) {
 }
 
 func TestPrepareBiddersResponseEnabledOnlyBaseOnly(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
-		enabledCore   = config.BidderInfo{Disabled: false}
-		enabledAlias  = config.BidderInfo{Disabled: false, AliasOf: "something"}
-		disabledCore  = config.BidderInfo{Disabled: true}
-		disabledAlias = config.BidderInfo{Disabled: true, AliasOf: "something"}
+		enabledCore   = config.BidderInfo{Disabled: &falseValue}
+		enabledAlias  = config.BidderInfo{Disabled: &falseValue, AliasOf: "something"}
+		disabledCore  = config.BidderInfo{Disabled: &trueValue}
+		disabledAlias = config.BidderInfo{Disabled: &trueValue, AliasOf: "something"}
 	)
 
 	testCases := []struct {
@@ -328,11 +340,14 @@ func TestPrepareBiddersResponseEnabledOnlyBaseOnly(t *testing.T) {
 }
 
 func TestBiddersHandler(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
-		enabledCore   = config.BidderInfo{Disabled: false}
-		enabledAlias  = config.BidderInfo{Disabled: false, AliasOf: "something"}
-		disabledCore  = config.BidderInfo{Disabled: true}
-		disabledAlias = config.BidderInfo{Disabled: true, AliasOf: "something"}
+		enabledCore   = config.BidderInfo{Disabled: &falseValue}
+		enabledAlias  = config.BidderInfo{Disabled: &falseValue, AliasOf: "something"}
+		disabledCore  = config.BidderInfo{Disabled: &trueValue}
+		disabledAlias = config.BidderInfo{Disabled: &trueValue, AliasOf: "something"}
 	)
 
 	bidders := config.BidderInfos{"a": enabledCore, "b": enabledAlias, "c": disabledCore, "d": disabledAlias}

--- a/endpoints/openrtb2/test_utils.go
+++ b/endpoints/openrtb2/test_utils.go
@@ -1093,7 +1093,7 @@ func getBidderInfos(disabledAdapters []string, biddersNames []openrtb_ext.Bidder
 
 func newBidderInfo(isDisabled bool) config.BidderInfo {
 	return config.BidderInfo{
-		Disabled: isDisabled,
+		Disabled: &isDisabled,
 	}
 }
 

--- a/exchange/adapter_util.go
+++ b/exchange/adapter_util.go
@@ -129,7 +129,7 @@ func mergeRemovedAndDisabledBidderWarningMessages(removed map[string]string, inf
 	disabledBidders := removed
 
 	for name, info := range infos {
-		if info.Disabled {
+		if !info.IsEnabled() {
 			msg := fmt.Sprintf(`Bidder "%s" has been disabled on this instance of Prebid Server. Please work with the PBS host to enable this bidder again.`, name)
 			disabledBidders[name] = msg
 		}

--- a/exchange/adapter_util_test.go
+++ b/exchange/adapter_util_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
-	infoEnabled  = config.BidderInfo{Disabled: false}
-	infoDisabled = config.BidderInfo{Disabled: true}
+	falseValue   = false
+	trueValue    = true
+	infoEnabled  = config.BidderInfo{Disabled: &falseValue}
+	infoDisabled = config.BidderInfo{Disabled: &trueValue}
 )
 
 func TestBuildAdapters(t *testing.T) {
@@ -165,6 +167,8 @@ func TestBuildBidders(t *testing.T) {
 }
 
 func TestSetAliasBuilder(t *testing.T) {
+	falseValue := false
+
 	rubiconBidder := fakeBidder{"b"}
 	ixBidder := fakeBidder{"ix"}
 	rubiconBuilder := fakeBuilder{rubiconBidder, nil}.Builder
@@ -180,21 +184,21 @@ func TestSetAliasBuilder(t *testing.T) {
 	}{
 		{
 			description:      "Success - Alias builder",
-			bidderInfo:       config.BidderInfo{Disabled: false, AliasOf: "rubicon"},
+			bidderInfo:       config.BidderInfo{Disabled: &falseValue, AliasOf: "rubicon"},
 			bidderName:       openrtb_ext.BidderName("appnexus"),
 			builders:         map[openrtb_ext.BidderName]adapters.Builder{openrtb_ext.BidderRubicon: rubiconBuilder},
 			expectedBuilders: map[openrtb_ext.BidderName]adapters.Builder{openrtb_ext.BidderRubicon: rubiconBuilder, openrtb_ext.BidderAppnexus: rubiconBuilder},
 		},
 		{
 			description:   "Failure - Invalid parent bidder builder",
-			bidderInfo:    config.BidderInfo{Disabled: false, AliasOf: "rubicon"},
+			bidderInfo:    config.BidderInfo{Disabled: &falseValue, AliasOf: "rubicon"},
 			bidderName:    openrtb_ext.BidderName("appnexus"),
 			builders:      map[openrtb_ext.BidderName]adapters.Builder{openrtb_ext.BidderIx: ixBuilder},
 			expectedError: errors.New("rubicon: parent builder not registered"),
 		},
 		{
 			description:   "Failure - Invalid parent for alias",
-			bidderInfo:    config.BidderInfo{Disabled: false, AliasOf: "unknown"},
+			bidderInfo:    config.BidderInfo{Disabled: &falseValue, AliasOf: "unknown"},
 			bidderName:    openrtb_ext.BidderName("appnexus"),
 			builders:      map[openrtb_ext.BidderName]adapters.Builder{openrtb_ext.BidderIx: ixBuilder},
 			expectedError: errors.New("unknown parent bidder: unknown for alias: appnexus"),

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2307,8 +2307,9 @@ func TestRequestBidsWithAdsCertsSigner(t *testing.T) {
 }
 
 func wrapWithBidderInfo(bidder adapters.Bidder) adapters.Bidder {
+	falseValue := false
 	bidderInfo := config.BidderInfo{
-		Disabled: false,
+		Disabled: &falseValue,
 		Capabilities: &config.CapabilitiesInfo{
 			App: &config.PlatformInfo{
 				MediaTypes: []openrtb_ext.BidType{openrtb_ext.BidTypeBanner},

--- a/exchange/events.go
+++ b/exchange/events.go
@@ -60,7 +60,7 @@ func (ev *eventTracking) modifyBidsForEvents(seatBids map[openrtb_ext.BidderName
 
 // isModifyingVASTXMLAllowed returns true if this bidder config allows modifying VAST XML for event tracking
 func (ev *eventTracking) isModifyingVASTXMLAllowed(bidderName string) bool {
-	return ev.bidderInfos[bidderName].ModifyingVastXmlAllowed && ev.isEventAllowed()
+	return ev.bidderInfos[bidderName].IsModifyingVastXmlAllowed() && ev.isEventAllowed()
 }
 
 // modifyBidVAST injects event Impression url if needed, otherwise returns original VAST string

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2557,7 +2557,7 @@ func newExchangeForTests(t *testing.T, filename string, expectations map[string]
 				expectations:  map[string]*bidderRequest{string(bidderName): spec.ExpectedRequest},
 				mockResponses: map[string]bidderResponse{string(bidderName): spec.MockResponse},
 			}
-			bidderInfos[string(bidderName)] = config.BidderInfo{ModifyingVastXmlAllowed: spec.ModifyingVastXmlAllowed}
+			bidderInfos[string(bidderName)] = config.BidderInfo{ModifyingVastXmlAllowed: &spec.ModifyingVastXmlAllowed}
 		}
 	}
 

--- a/usersync/syncersbuilder.go
+++ b/usersync/syncersbuilder.go
@@ -80,7 +80,7 @@ func BuildSyncers(hostConfig *config.Configuration, bidderInfos config.BidderInf
 }
 
 func shouldCreateSyncer(cfg config.BidderInfo) bool {
-	if cfg.Disabled {
+	if !cfg.IsEnabled() {
 		return false
 	}
 

--- a/usersync/syncersbuilder_test.go
+++ b/usersync/syncersbuilder_test.go
@@ -19,18 +19,21 @@ func TestSyncerBuildError(t *testing.T) {
 }
 
 func TestBuildSyncers(t *testing.T) {
+	falseValue := false
+	trueValue := true
+
 	var (
 		hostConfig              = config.Configuration{ExternalURL: "http://host.com", UserSync: config.UserSync{RedirectURL: "{{.ExternalURL}}/{{.SyncerKey}}/host"}}
 		iframeConfig            = &config.SyncerEndpoint{URL: "https://bidder.com/iframe?redirect={{.RedirectURL}}"}
 		iframeConfigError       = &config.SyncerEndpoint{URL: "https://bidder.com/iframe?redirect={{xRedirectURL}}"} // Error caused by invalid macro
-		infoKeyAPopulated       = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfig}}
-		infoKeyADisabled        = config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfig}}
-		infoKeyAEmpty           = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "a"}}
-		infoKeyAError           = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfigError}}
-		infoKeyASupportsOnly    = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Supports: []string{"iframe"}}}
-		infoKeyBPopulated       = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "b", IFrame: iframeConfig}}
-		infoKeyBEmpty           = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "b"}}
-		infoKeyMissingPopulated = config.BidderInfo{Disabled: false, Syncer: &config.Syncer{IFrame: iframeConfig}}
+		infoKeyAPopulated       = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfig}}
+		infoKeyADisabled        = config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfig}}
+		infoKeyAEmpty           = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "a"}}
+		infoKeyAError           = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "a", IFrame: iframeConfigError}}
+		infoKeyASupportsOnly    = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Supports: []string{"iframe"}}}
+		infoKeyBPopulated       = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "b", IFrame: iframeConfig}}
+		infoKeyBEmpty           = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "b"}}
+		infoKeyMissingPopulated = config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{IFrame: iframeConfig}}
 	)
 
 	// NOTE: The hostConfig includes the syncer key in the RedirectURL to distinguish between the syncer keys
@@ -178,6 +181,8 @@ func TestBuildSyncers(t *testing.T) {
 }
 
 func TestShouldCreateSyncer(t *testing.T) {
+	falseValue := false
+	trueValue := true
 	var (
 		anySupports = []string{"iframe"}
 		anyEndpoint = &config.SyncerEndpoint{}
@@ -191,82 +196,82 @@ func TestShouldCreateSyncer(t *testing.T) {
 	}{
 		{
 			description: "Enabled, No Syncer",
-			given:       config.BidderInfo{Disabled: false, Syncer: nil},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: nil},
 			expected:    false,
 		},
 		{
 			description: "Enabled, Syncer",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "anyKey"}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "anyKey"}},
 			expected:    true,
 		},
 		{
 			description: "Enabled, Syncer - Fully Loaded",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
 			expected:    true,
 		},
 		{
 			description: "Enabled, Syncer - Only Key",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "anyKey"}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Key: "anyKey"}},
 			expected:    true,
 		},
 		{
 			description: "Enabled, Syncer - Only Supports",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Supports: anySupports}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Supports: anySupports}},
 			expected:    false,
 		},
 		{
 			description: "Enabled, Syncer - Only IFrame",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{IFrame: anyEndpoint}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{IFrame: anyEndpoint}},
 			expected:    true,
 		},
 		{
 			description: "Enabled, Syncer - Only Redirect",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Redirect: anyEndpoint}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{Redirect: anyEndpoint}},
 			expected:    true,
 		},
 		{
 			description: "Enabled, Syncer - Only SupportCORS",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: &falseValue, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
 			expected:    true,
 		},
 		{
 			description: "Disabled, No Syncer",
-			given:       config.BidderInfo{Disabled: true, Syncer: nil},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: nil},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "anyKey"}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Key: "anyKey"}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Fully Loaded",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Only Key",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "anyKey"}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Key: "anyKey"}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Only Supports",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Supports: anySupports}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Supports: anySupports}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Only IFrame",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{IFrame: anyEndpoint}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{IFrame: anyEndpoint}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Only Redirect",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Redirect: anyEndpoint}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{Redirect: anyEndpoint}},
 			expected:    false,
 		},
 		{
 			description: "Disabled, Syncer - Only SupportCORS",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: &trueValue, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
 			expected:    false,
 		},
 	}


### PR DESCRIPTION
This is one way we can fix the bidder info config override logic issue. This involves changing the `Disabled` and `ModifyingVastXMLAllowed` bools to bool pointers.