### PR TITLE
Retrieve bid type from bid.ext.mediatype in Yieldmo bid response

### DIFF
--- a/adapters/yieldmo/yieldmo.go
+++ b/adapters/yieldmo/yieldmo.go
@@ -30,6 +30,10 @@ type Ext struct {
 	Gpid        string `json:"gpid,omitempty"`
 }
 
+type ExtBid struct {
+	MediaType string `json:"mediatype,omitempty"`
+}
+
 func (a *YieldmoAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
 	var errs []error
 	var adapterRequests []*adapters.RequestData
@@ -138,14 +142,18 @@ func (a *YieldmoAdapter) MakeBids(internalRequest *openrtb2.BidRequest, external
 
 	for _, sb := range bidResp.SeatBid {
 		for i := range sb.Bid {
+			bidType, err := getMediaTypeForImp(sb.Bid[i])
+			if err != nil {
+				continue
+			}
+
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
 				Bid:     &sb.Bid[i],
-				BidType: getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp),
+				BidType: bidType,
 			})
 		}
 	}
 	return bidResponse, nil
-
 }
 
 // Builder builds a new instance of the Yieldmo adapter for the given bidder with the given config.
@@ -156,12 +164,12 @@ func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server co
 	return bidder, nil
 }
 
-func getMediaTypeForImp(impId string, imps []openrtb2.Imp) openrtb_ext.BidType {
-	//default to video unless banner exists in impression
-	for _, imp := range imps {
-		if imp.ID == impId && imp.Banner != nil {
-			return openrtb_ext.BidTypeBanner
-		}
+// Retrieve the media type corresponding to the bid from the bid.ext object
+func getMediaTypeForImp(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	var bidExt ExtBid
+	if err := json.Unmarshal(bid.Ext, &bidExt); err != nil {
+		return "", &errortypes.BadInput{Message: err.Error()}
 	}
-	return openrtb_ext.BidTypeVideo
+
+	return openrtb_ext.ParseBidType(bidExt.MediaType)
 }

--- a/adapters/yieldmo/yieldmotest/exemplary/app-banner.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/app-banner.json
@@ -65,7 +65,11 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "h": 250,
-                  "w": 300
+                  "w": 300,
+                  "ext":
+                  {
+                    "mediatype": "banner"
+                  }
                 }
               ]
             }
@@ -87,7 +91,11 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 300,
-            "h": 250
+            "h": 250,
+            "ext":
+            {
+              "mediatype": "banner"
+            }
           },
           "type": "banner"
         }

--- a/adapters/yieldmo/yieldmotest/exemplary/app_video.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/app_video.json
@@ -63,7 +63,11 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "h": 250,
-                  "w": 300
+                  "w": 300,
+                  "ext":
+                  {
+                    "mediatype": "video"
+                  }
                 }
               ]
             }
@@ -85,7 +89,11 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 300,
-            "h": 250
+            "h": 250,
+            "ext":
+            {
+              "mediatype": "video"
+            }
           },
           "type": "video"
         }

--- a/adapters/yieldmo/yieldmotest/exemplary/simple-banner.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/simple-banner.json
@@ -65,7 +65,11 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "h": 250,
-                  "w": 300
+                  "w": 300,
+                  "ext":
+                    {
+                      "mediatype": "banner"
+                    }
                 }
               ]
             }
@@ -87,7 +91,11 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 300,
-            "h": 250
+            "h": 250,
+            "ext":
+            {
+              "mediatype": "banner"
+            }
           },
           "type": "banner"
         }

--- a/adapters/yieldmo/yieldmotest/exemplary/simple_video.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/simple_video.json
@@ -63,7 +63,11 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "h": 250,
-                  "w": 300
+                  "w": 300,
+                  "ext":
+                  {
+                    "mediatype": "video"
+                  }
                 }
               ]
             }
@@ -85,7 +89,11 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 300,
-            "h": 250
+            "h": 250,
+            "ext":
+            {
+              "mediatype": "video"
+            }
           },
           "type": "video"
         }

--- a/adapters/yieldmo/yieldmotest/exemplary/with_gpid.json
+++ b/adapters/yieldmo/yieldmotest/exemplary/with_gpid.json
@@ -73,7 +73,11 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "h": 250,
-                  "w": 300
+                  "w": 300,
+                  "ext":
+                  {
+                    "mediatype": "banner"
+                  }
                 }
               ]
             }
@@ -95,7 +99,11 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 300,
-            "h": 250
+            "h": 250,
+            "ext":
+            {
+              "mediatype": "banner"
+            }
           },
           "type": "banner"
         }


### PR DESCRIPTION
For **Yieldmo** bidder, **Bid.ext** now includes a field called **mediatype** which represents the bid type. This PR includes the changes necessary to retrieve this new field and pass it upstream as the bid type.