### PR TITLE
Fix: revert JSON lib used to prepare /bidders/params response

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -92,7 +92,7 @@ func newJsonDirectoryServer(schemaDirectory string, validator openrtb_ext.Bidder
 		data[aliasName] = bidderData
 	}
 
-	response, err := jsonutil.Marshal(data)
+	response, err := json.Marshal(data)
 	if err != nil {
 		glog.Fatalf("Failed to marshal bidder param JSON-schema: %v", err)
 	}


### PR DESCRIPTION
As part of the v2.0.0 release we switched the JSON library from the standard library `encoding/json` to `json-iter` throughout PBS core, however, it had the unintended consequence of changing the response output on the `/bidders/params `endpoint from a compacted single-line response to a formatted multi-line response. This PR reverts that logic so that `encoding/json` is used to marshal the response on that endpoint.

All other endpoints were checked for a similar problem and were not affected. The `/bidders/params` endpoint prepares its response in a different way from all other endpoints by marshaling `map[string]json.RawMessage` while other endpoints build their response by marshaling structs.

There does not appear to be a way to explicitly compact JSON using `json-iter` at this time so going back to the standard library in this instance suffices for now.