### PR TITLE
Fix: single bid processing from alternatebiddercode

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -762,6 +762,7 @@ func (e *exchange) getAllBids(
 					} else {
 						adapterBids[bidderName] = seatBid
 					}
+					extraRespInfo.bidsFound = true
 				}
 				// collect fledgeAuctionConfigs separately from bids, as empty seatBids may be discarded
 				extraRespInfo.fledge = collectFledgeFromSeatBid(extraRespInfo.fledge, bidderName, brw.adapter, seatBid)
@@ -769,10 +770,6 @@ func (e *exchange) getAllBids(
 		}
 		//but we need to add all bidders data to adapterExtra to have metrics and other metadata
 		adapterExtra[brw.bidder] = brw.adapterExtra
-
-		if !extraRespInfo.bidsFound && adapterBids[brw.bidder] != nil && len(adapterBids[brw.bidder].Bids) > 0 {
-			extraRespInfo.bidsFound = true
-		}
 	}
 
 	return adapterBids, adapterExtra, extraRespInfo


### PR DESCRIPTION
In alternatebiddercodes feature (https://github.com/prebid/prebid-server/issues/2174) it it possible that prebid-server gets a bid only from alternatebidder and not the primary bidder. Ex. For PubMatic-GroupM setup, PubMatic adapter would return a GroupM bid only.

For the above scenario, 

1. [L769](https://github.com/prebid/prebid-server/blob/v2.0.2/exchange/exchange.go#L769) , extraRespInfo.bidsFound is  set to 'false' because 'brw.bidder' is 'pubmatic' but seatBid.Seat is 'groupm'
2. [L377](https://github.com/prebid/prebid-server/blob/v2.0.2/exchange/exchange.go#L377), anyBidsReturned flag is set to false .
3. if anyBidsReturned=false then Floor-enforcement + category-mapping + deal-support etc are not being applied to the bid-response.Even targetting-keys + event-trackers are missing in the bid.ext

This PR contains the fix for the issue, also to capture such issue I've introduced the unit-test case to cover 'getallbids' function. Currently only addressed the required scenarions in the test function but it can be extended in future as per requirement. 

Refer - [sample_request.txt](https://github.com/prebid/prebid-server/files/13449191/sample_request.txt)
