### PR TITLE
Fix: flakey deal tier test

### DIFF
--- a/openrtb_ext/deal_tier_test.go
+++ b/openrtb_ext/deal_tier_test.go
@@ -17,93 +17,100 @@ func TestReadDealTiersFromImp(t *testing.T) {
 		expectedErrorType error
 	}{
 		{
-			description:    "Nil",
+			description:    "nil",
 			impExt:         nil,
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "None",
+			description:    "none",
 			impExt:         json.RawMessage(``),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "Empty Object",
+			description:    "empty_object",
 			impExt:         json.RawMessage(`{}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext - no prebid but with other params",
+			description:    "imp.ext_no_prebid_but_with_other_params",
 			impExt:         json.RawMessage(`{"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}, "tid": "1234"}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext.prebid - nil",
+			description:    "imp.ext.prebid_nil",
 			impExt:         json.RawMessage(`{"prebid": null}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext.prebid - empty",
+			description:    "imp.ext.prebid_empty",
 			impExt:         json.RawMessage(`{"prebid": {}}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext.prebid - no bidder but with other params",
+			description:    "imp.ext.prebid_no bidder but with other params",
 			impExt:         json.RawMessage(`{"prebid": {"supportdeals": true}}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - one",
+			description:    "imp.ext.prebid.bidder_one",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - one but it's not found in the Adapter Bidder list",
+			description:    "imp.ext.prebid.bidder_one_but_not_found_in_the_adapter_bidder_list",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"unknown": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - one but case is different from the Adapter Bidder list",
+			description:    "imp.ext.prebid.bidder_one_but_case_is_different_from_the_adapter_bidder_list",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"APpNExUS": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - one with other params",
+			description:    "imp.ext.prebid.bidder_one_with_other_params",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}, "supportdeals": true}, "tid": "1234"}`),
 			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - multiple",
+			description:    "imp.ext.prebid.bidder_multiple",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "appnexusPrefix"}, "placementId": 12345}, "rubicon": {"dealTier": {"minDealTier": 8, "prefix": "rubiconPrefix"}, "placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "appnexusPrefix", MinDealTier: 5}, BidderRubicon: {Prefix: "rubiconPrefix", MinDealTier: 8}},
 		},
 		{
-			description:    "imp.ext.prebid.bidder - same bidder listed twice but with different case the last one prevails",
-			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 100, "prefix": "appnexusPrefix"}, "placementId": 12345},"APpNExUS": {"dealTier": {"minDealTier": 5, "prefix": "APpNExUSPrefix"}, "placementId": 12345}}}}`),
-			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "APpNExUSPrefix", MinDealTier: 5}},
-		},
-		{
-			description:    "imp.ext.prebid.bidder - one without deal tier",
+			description:    "imp.ext.prebid.bidder_one_without_deal_tier",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{},
 		},
 		{
-			description:       "imp.ext.prebid.bidder - error",
+			description:       "imp.ext.prebid.bidder_error",
 			impExt:            json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": "wrong type", "placementId": 12345}}}}`),
 			expectedErrorType: &errortypes.FailedToUnmarshal{},
 		},
 	}
 
 	for _, test := range testCases {
-		imp := openrtb2.Imp{Ext: test.impExt}
+		t.Run(test.description, func(t *testing.T) {
 
+			imp := openrtb2.Imp{Ext: test.impExt}
+			result, err := ReadDealTiersFromImp(imp)
+
+			assert.Equal(t, test.expectedResult, result)
+
+			if test.expectedErrorType != nil {
+				assert.IsType(t, test.expectedErrorType, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("imp.ext.prebid.bidder_dedupe", func(t *testing.T) {
+		impExt := json.RawMessage(`{"prebid": {"bidder": {"APPNEXUS": {"dealTier": {"minDealTier": 100}},"APpNExUS": {"dealTier": {"minDealTier": 5}}}}}`)
+		imp := openrtb2.Imp{Ext: impExt}
 		result, err := ReadDealTiersFromImp(imp)
 
-		assert.Equal(t, test.expectedResult, result, test.description+":result")
-
-		if test.expectedErrorType != nil {
-			assert.IsType(t, test.expectedErrorType, err)
-		} else {
-			assert.NoError(t, err, test.description+":error")
-		}
-	}
+		assert.Len(t, result, 1)
+		assert.NotNil(t, result["appnexus"])
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
We're seeing occasional test suite failures related to the deal tier test `TestReadDealTiersFromImp`. The test case with description `imp.ext.prebid.bidder - same bidder listed twice but with different case the last one prevails` sometimes fails. This test case was recently added as part of the adapter name case insensitive initiative. The problem traces back to the fact that the function under test, `ReadDealTiersFromImp`, attempts to unmarshal `imp.ext.prebid.bidder` into type `map[string]struct` and then iterates over the map, normalizing each bidder name and ultimately selecting the deal tier information for the last occurrence of a given normalized bidder name. However, a map does not guarantee order so the order in which the keys are read from the map when iterating over it is unpredictable, which means we can't be sure which bidder name casing will be the last one encountered and ultimately selected.

The team discussed and determined that the unpredictable behavior is acceptable for this edge case so we should just update the test to ensure deduping occurs rather than verifying the details of the selected deal tier.