### PR TITLE
Rubicon: enable endpoint compression

### DIFF
--- a/static/bidder-info/rubicon.yaml
+++ b/static/bidder-info/rubicon.yaml
@@ -1,4 +1,5 @@
 endpoint: "http://exapi-us-east.rubiconproject.com/a/api/exchange.json"
+endpointCompression: GZIP
 disabled: true
 maintainer:
   email: "header-bidding@rubiconproject.com"


### PR DESCRIPTION
The Magnite exchange accepts compressed requests.