### PR TITLE
Fix: increase tmax in flakey modularity test

### DIFF
--- a/endpoints/openrtb2/sample-requests/hooks/auction_bidder_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/auction_bidder_reject.json
@@ -32,7 +32,7 @@
         }
       }
     ],
-    "tmax": 50,
+    "tmax": 500,
     "test": 1,
     "ext": {
       "prebid": {

--- a/endpoints/openrtb2/sample-requests/hooks/auction_bidder_response_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/auction_bidder_response_reject.json
@@ -32,7 +32,7 @@
         }
       }
     ],
-    "tmax": 50,
+    "tmax": 500,
     "test": 1,
     "ext": {
       "prebid": {

--- a/endpoints/openrtb2/sample-requests/hooks/auction_entrypoint_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/auction_entrypoint_reject.json
@@ -28,7 +28,7 @@
         }
       }
     ],
-    "tmax": 50,
+    "tmax": 500,
     "ext": {
       "prebid": {
         "trace": "verbose"

--- a/endpoints/openrtb2/sample-requests/hooks/auction_processed_auction_request_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/auction_processed_auction_request_reject.json
@@ -28,7 +28,7 @@
         }
       }
     ],
-    "tmax": 50,
+    "tmax": 500,
     "ext": {
       "prebid": {
         "trace": "verbose"

--- a/endpoints/openrtb2/sample-requests/hooks/auction_raw_auction_request_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/auction_raw_auction_request_reject.json
@@ -28,7 +28,7 @@
         }
       }
     ],
-    "tmax": 50,
+    "tmax": 500,
     "ext": {
       "prebid": {
         "trace": "verbose"

--- a/endpoints/openrtb2/test_utils.go
+++ b/endpoints/openrtb2/test_utils.go
@@ -1579,7 +1579,7 @@ var entryPointHookUpdate = hooks.HookWrapper[hookstage.Entrypoint]{
 
 			ch := hookstage.ChangeSet[hookstage.EntrypointPayload]{}
 			ch.AddMutation(func(payload hookstage.EntrypointPayload) (hookstage.EntrypointPayload, error) {
-				body, err := jsonpatch.MergePatch(payload.Body, []byte(`{"tmax":50}`))
+				body, err := jsonpatch.MergePatch(payload.Body, []byte(`{"tmax":600}`))
 				if err == nil {
 					payload.Body = body
 				}


### PR DESCRIPTION
The tmax values for the test cases in `endpoints/openrtb2/auction_test.go#TestValidResponseAfterExecutingStages` appear to be too small such that they're causing occasional deadline exceeded errors when attempting to retrieve bids from the mock bidders.