### PR TITLE
Pass bidder core name to BidderRequest hook

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -132,7 +132,7 @@ type bidderAdapterConfig struct {
 
 func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestOptions bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, hookExecutor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, extraBidderRespInfo, []error) {
 	request := openrtb_ext.RequestWrapper{BidRequest: bidderRequest.BidRequest}
-	reject := hookExecutor.ExecuteBidderRequestStage(&request, string(bidderRequest.BidderName))
+	reject := hookExecutor.ExecuteBidderRequestStage(&request, string(bidderRequest.BidderName), bidderRequest.BidderCoreName)
 	if reject != nil {
 		return nil, extraBidderRespInfo{}, []error{reject}
 	}

--- a/hooks/hookexecution/executor.go
+++ b/hooks/hookexecution/executor.go
@@ -34,7 +34,7 @@ type StageExecutor interface {
 	ExecuteEntrypointStage(req *http.Request, body []byte) ([]byte, *RejectError)
 	ExecuteRawAuctionStage(body []byte) ([]byte, *RejectError)
 	ExecuteProcessedAuctionStage(req *openrtb_ext.RequestWrapper) error
-	ExecuteBidderRequestStage(req *openrtb_ext.RequestWrapper, bidder string) *RejectError
+	ExecuteBidderRequestStage(req *openrtb_ext.RequestWrapper, bidder string, bidderCoreName openrtb_ext.BidderName) *RejectError
 	ExecuteRawBidderResponseStage(response *adapters.BidderResponse, bidder string) *RejectError
 	ExecuteAllProcessedBidResponsesStage(adapterBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid)
 	ExecuteAuctionResponseStage(response *openrtb2.BidResponse)
@@ -177,7 +177,7 @@ func (e *hookExecutor) ExecuteProcessedAuctionStage(request *openrtb_ext.Request
 	return reject
 }
 
-func (e *hookExecutor) ExecuteBidderRequestStage(req *openrtb_ext.RequestWrapper, bidder string) *RejectError {
+func (e *hookExecutor) ExecuteBidderRequestStage(req *openrtb_ext.RequestWrapper, bidder string, bidderCoreName openrtb_ext.BidderName) *RejectError {
 	plan := e.planBuilder.PlanForBidderRequestStage(e.endpoint, e.account)
 	if len(plan) == 0 {
 		return nil
@@ -194,7 +194,7 @@ func (e *hookExecutor) ExecuteBidderRequestStage(req *openrtb_ext.RequestWrapper
 
 	stageName := hooks.StageBidderRequest.String()
 	executionCtx := e.newContext(stageName)
-	payload := hookstage.BidderRequestPayload{Request: req, Bidder: bidder}
+	payload := hookstage.BidderRequestPayload{Request: req, Bidder: bidder, BidderCoreName: bidderCoreName}
 	outcome, payload, contexts, reject := executeStage(executionCtx, plan, payload, handler, e.metricEngine)
 	outcome.Entity = entity(bidder)
 	outcome.Stage = stageName
@@ -332,7 +332,7 @@ func (executor EmptyHookExecutor) ExecuteProcessedAuctionStage(_ *openrtb_ext.Re
 	return nil
 }
 
-func (executor EmptyHookExecutor) ExecuteBidderRequestStage(_ *openrtb_ext.RequestWrapper, bidder string) *RejectError {
+func (executor EmptyHookExecutor) ExecuteBidderRequestStage(_ *openrtb_ext.RequestWrapper, bidder string, bidderCoreName openrtb_ext.BidderName) *RejectError {
 	return nil
 }
 

--- a/hooks/hookexecution/executor_test.go
+++ b/hooks/hookexecution/executor_test.go
@@ -37,7 +37,7 @@ func TestEmptyHookExecutor(t *testing.T) {
 	entrypointBody, entrypointRejectErr := executor.ExecuteEntrypointStage(req, body)
 	rawAuctionBody, rawAuctionRejectErr := executor.ExecuteRawAuctionStage(body)
 	processedAuctionRejectErr := executor.ExecuteProcessedAuctionStage(&openrtb_ext.RequestWrapper{BidRequest: &openrtb2.BidRequest{}})
-	bidderRequestRejectErr := executor.ExecuteBidderRequestStage(&openrtb_ext.RequestWrapper{BidRequest: bidderRequest}, "bidder-name")
+	bidderRequestRejectErr := executor.ExecuteBidderRequestStage(&openrtb_ext.RequestWrapper{BidRequest: bidderRequest}, "bidder-name", "bidder-core-name")
 	executor.ExecuteAuctionResponseStage(&openrtb2.BidResponse{})
 
 	outcomes := executor.GetOutcomes()
@@ -916,6 +916,7 @@ func TestExecuteProcessedAuctionStage(t *testing.T) {
 
 func TestExecuteBidderRequestStage(t *testing.T) {
 	bidderName := "the-bidder"
+	bidderCoreName := openrtb_ext.BidderName("the-bidder-core-name")
 	foobarModuleCtx := &moduleContexts{ctxs: map[string]hookstage.ModuleContext{"foobar": nil}}
 	account := &config.Account{}
 
@@ -1171,7 +1172,7 @@ func TestExecuteBidderRequestStage(t *testing.T) {
 			exec := NewHookExecutor(test.givenPlanBuilder, EndpointAuction, &metricsConfig.NilMetricsEngine{})
 			exec.SetAccount(test.givenAccount)
 
-			reject := exec.ExecuteBidderRequestStage(&openrtb_ext.RequestWrapper{BidRequest: test.givenBidderRequest}, bidderName)
+			reject := exec.ExecuteBidderRequestStage(&openrtb_ext.RequestWrapper{BidRequest: test.givenBidderRequest}, bidderName, bidderCoreName)
 
 			assert.Equal(t, test.expectedReject, reject, "Unexpected stage reject.")
 			assert.Equal(t, test.expectedBidderRequest, test.givenBidderRequest, "Incorrect bidder request.")

--- a/hooks/hookstage/bidderrequest.go
+++ b/hooks/hookstage/bidderrequest.go
@@ -2,6 +2,7 @@ package hookstage
 
 import (
 	"context"
+
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
 )
 
@@ -24,6 +25,7 @@ type BidderRequest interface {
 // distilled for the particular bidder.
 // Hooks are allowed to modify openrtb2.BidRequest using mutations.
 type BidderRequestPayload struct {
-	Request *openrtb_ext.RequestWrapper
-	Bidder  string
+	Request        *openrtb_ext.RequestWrapper
+	Bidder         string
+	BidderCoreName openrtb_ext.BidderName
 }


### PR DESCRIPTION
This example auction request to "/openrtb2/auction" contains bidders alias.

```javascript
{ 
  "imp": [
        {
            "ext": {
                "prebid": {
                    "bidder": {
                        "rubicon_s2s": {
                            "accountId": 1234,
                            "siteId": 123,
                            "zoneId": 123
                        }
                    }
                }
            }
        }
    ],
 "ext": {
        "prebid": {
            "aliases": {
                "rubicon_s2s": "rubicon"
            }
        }
    }
}
``` 

I wrote a module for BidderRequestHook that needs a real bidder name but PBS passes to the hook a [bidder alias](https://github.com/prebid/prebid-server/blob/71f20302f7436cd2c707b58f0cc237c2f8d56677/exchange/bidder.go#L135) but not the [bidder core name](https://github.com/prebid/prebid-server/blob/71f20302f7436cd2c707b58f0cc237c2f8d56677/exchange/exchange.go#L226)
The resolving of aliases in the hook is inefficient since it is already done upstream in PBS core


