### PR TITLE
Remove MarshalJSON on BidderName

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -226,10 +226,6 @@ func SetAliasBidderName(aliasBidderName string, parentBidderName BidderName) err
 	return nil
 }
 
-func (name BidderName) MarshalJSON() ([]byte, error) {
-	return []byte(name), nil
-}
-
 func (name *BidderName) String() string {
 	if name == nil {
 		return ""


### PR DESCRIPTION
The receiver on BidderName returns incorrect string (it should be quoted)
https://github.com/prebid/prebid-server/blob/c49e8eac6289f27db32bb23a7f9803bd46904009/openrtb_ext/bidders.go#L230
As BidderName is just a redefinition string, no need MarshalJSON on this type
```go

func TestBidderName(t *testing.T) {
	_, err := json.Marshal(
		struct {
			Name openrtb_ext.BidderName
		}{Name: openrtb_ext.BidderMedianet})

	if err != nil {
		t.Log(err)
		t.Fail()
	}
}
```

```
=== RUN   TestBidderName
    main_test.go:78: json: error calling MarshalJSON for type openrtb_ext.BidderName: invalid character 'm' looking for beginning of value
--- FAIL: TestBidderName (0.00s)

FAIL
```