### PR TITLE
Adkernel: Unsecured endpoint url

### DIFF
--- a/adapters/adkernel/adkernel_test.go
+++ b/adapters/adkernel/adkernel_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderAdkernel, config.Adapter{
-		Endpoint: "https://pbs.adksrv.com/hb?zone={{.ZoneID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+		Endpoint: "http://pbs.adksrv.com/hb?zone={{.ZoneID}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
 
 	if buildErr != nil {
 		t.Fatalf("Builder returned unexpected error %v", buildErr)

--- a/adapters/adkernel/adkerneltest/exemplary/multiformat-impression.json
+++ b/adapters/adkernel/adkerneltest/exemplary/multiformat-impression.json
@@ -36,7 +36,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://pbs.adksrv.com/hb?zone=102",
+        "uri": "http://pbs.adksrv.com/hb?zone=102",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernel/adkerneltest/exemplary/single-banner-impression.json
+++ b/adapters/adkernel/adkerneltest/exemplary/single-banner-impression.json
@@ -30,7 +30,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://pbs.adksrv.com/hb?zone=101",
+        "uri": "http://pbs.adksrv.com/hb?zone=101",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/adapters/adkernel/adkerneltest/exemplary/single-video-impression.json
+++ b/adapters/adkernel/adkerneltest/exemplary/single-video-impression.json
@@ -33,7 +33,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://pbs.adksrv.com/hb?zone=102",
+        "uri": "http://pbs.adksrv.com/hb?zone=102",
         "body": {
           "id": "0000000000001",
           "imp": [

--- a/static/bidder-info/adkernel.yaml
+++ b/static/bidder-info/adkernel.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://pbs.adksrv.com/hb?zone={{.ZoneID}}"
+endpoint: "http://pbs.adksrv.com/hb?zone={{.ZoneID}}"
 maintainer:
   email: "prebid-dev@adkernel.com"
 gvlVendorID: 14


### PR DESCRIPTION
Make the endpoint URL unsecured to reduce latency.