### PR TITLE
Kargo: Update bidder-info

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -16,4 +16,3 @@ userSync:
 endpointCompression: "GZIP"
 openrtb:
   gpp-supported: true
-  multiformat_supported: true

--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -14,3 +14,6 @@ userSync:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
     userMacro: "$UID"
 endpointCompression: "GZIP"
+openrtb:
+  gpp-supported: true
+  multiformat_supported: true


### PR DESCRIPTION
Adds ortb.multiformat_supported and ortb.gpp_supported for Kargo's bidder info