### PR TITLE
yahooAds: Update maintainer email address

### DIFF
--- a/static/bidder-info/yahooAds.yaml
+++ b/static/bidder-info/yahooAds.yaml
@@ -1,6 +1,6 @@
 endpoint: "https://s2shb.ssp.yahoo.com/admax/bid/partners/PBS"
 maintainer:
-  email: "hb-fe-tech@yahooinc.com"
+  email: "prebid-tech-team@yahooinc.com"
 gvlVendorID: 25
 capabilities:
   app:


### PR DESCRIPTION
This pull request updates the maintainer email address to [prebid-tech-team@yahooinc.com](mailto:prebid-tech-team@yahooinc.com).

Details:

Maintainer Email Address: [prebid-tech-team@yahooinc.com](mailto:prebid-tech-team@yahooinc.com)
