### PR TITLE
Optimize GZIP Compression

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -523,6 +523,11 @@ func (bidder *bidderAdapter) doRequest(ctx context.Context, req *adapters.Reques
 
 func (bidder *bidderAdapter) doRequestImpl(ctx context.Context, req *adapters.RequestData, logger util.LogMsg, bidderRequestStartTime time.Time, tmaxAdjustments *TmaxAdjustmentsPreprocessed) *httpCallInfo {
 	var requestBody []byte
+	var gzipWriterPool = sync.Pool{
+		New: func() interface{} {
+			return gzip.NewWriter(nil)
+		},
+	}
 
 	switch strings.ToUpper(bidder.config.EndpointCompression) {
 	case Gzip:
@@ -726,22 +731,6 @@ func prepareStoredResponse(impId string, bidResp json.RawMessage) *httpCallInfo 
 		err: nil,
 	}
 	return respData
-}
-
-var gzipWriterPool = sync.Pool{
-	New: func() interface{} {
-		return gzip.NewWriter(nil)
-	},
-}
-
-func compressToGZIP(requestBody []byte) []byte {
-	var b bytes.Buffer
-	w := gzipWriterPool.Get().(*gzip.Writer) // Utilize Sync Pool
-
-	w.Reset(&b)
-	w.Write([]byte(requestBody))
-	w.Close()
-	return b.Bytes()
 }
 
 func getBidTypeForAdjustments(bidType openrtb_ext.BidType, impID string, imp []openrtb2.Imp) string {

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -754,7 +754,7 @@ func setRequestBody(req *adapters.RequestData, endpointCompression string) ([]by
 		var b bytes.Buffer
 		w := gzipWriterPool.Get().(*gzip.Writer)
 		w.Reset(&b)
-		_, err := w.Write([]byte(requestBody))
+		_, err := w.Write([]byte(req.Body))
 		if err != nil {
 			return nil, err
 		}
@@ -768,7 +768,7 @@ func setRequestBody(req *adapters.RequestData, endpointCompression string) ([]by
 		req.Headers.Set("Content-Encoding", "gzip")
 
 		// Return Writer To Pool
-		gzipWriterPool.Put(w)
+		defer gzipWriterPool.Put(w)
 
 		return requestBody, nil
 	default:

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -3349,7 +3349,7 @@ func TestDoRequestImplWithTmaxTimeout(t *testing.T) {
 	}
 }
 
-func TestSetRequestBody(t *testing.T) {
+func TestGetRequestBody(t *testing.T) {
 	tests := []struct {
 		name                string
 		endpointCompression string
@@ -3370,7 +3370,7 @@ func TestSetRequestBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := &adapters.RequestData{Body: test.givenReqBody, Headers: http.Header{}}
-			requestBody, err := setRequestBody(req, test.endpointCompression)
+			requestBody, err := getRequestBody(req, test.endpointCompression)
 			assert.NoError(t, err)
 
 			if test.endpointCompression == "GZIP" {
@@ -3419,6 +3419,6 @@ func BenchmarkCompressToGZIPOptimized(b *testing.B) {
 	// Run the benchmark
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		setRequestBody(req, "GZIP")
+		getRequestBody(req, "GZIP")
 	}
 }

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -3349,26 +3349,56 @@ func TestDoRequestImplWithTmaxTimeout(t *testing.T) {
 	}
 }
 
-func BenchmarkCompressToGZIPNotOptimized(b *testing.B) {
-	// Setup the mock server
-	respBody := "{\"bid\":false}"
-	respStatus := 200
-	server := httptest.NewServer(mockHandler(respStatus, "getBody", respBody))
-	defer server.Close()
-
-	// Prepare the request data
-	req := &adapters.RequestData{
-		Method:  "POST",
-		Uri:     server.URL,
-		Body:    []byte("{\"key\":\"val\"}"),
-		Headers: http.Header{},
+func TestSetRequestBody(t *testing.T) {
+	tests := []struct {
+		name                string
+		endpointCompression string
+		givenReqBody        []byte
+	}{
+		{
+			name:                "No-Compression",
+			endpointCompression: "",
+			givenReqBody:        []byte("test body"),
+		},
+		{
+			name:                "GZIP-Compression",
+			endpointCompression: "GZIP",
+			givenReqBody:        []byte("test body"),
+		},
 	}
 
-	// Run the benchmark
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		setRequestBodyNotOptimized(req.Body)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &adapters.RequestData{Body: test.givenReqBody, Headers: http.Header{}}
+			requestBody, err := setRequestBody(req, test.endpointCompression)
+			assert.NoError(t, err)
+
+			if test.endpointCompression == "GZIP" {
+				assert.Equal(t, "gzip", req.Headers.Get("Content-Encoding"))
+
+				decompressedReqBody, err := decompressGzip(requestBody)
+				assert.NoError(t, err)
+				assert.Equal(t, test.givenReqBody, decompressedReqBody)
+			} else {
+				assert.Equal(t, test.givenReqBody, requestBody)
+			}
+		})
 	}
+}
+
+func decompressGzip(input []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(input))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	decompressed, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return decompressed, nil
 }
 
 func BenchmarkCompressToGZIPOptimized(b *testing.B) {
@@ -3391,18 +3421,4 @@ func BenchmarkCompressToGZIPOptimized(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		setRequestBody(req, "GZIP")
 	}
-}
-
-func setRequestBodyNotOptimized(requestBody []byte) ([]byte, error) {
-	var b bytes.Buffer
-	w := gzip.NewWriter(&b)
-	_, err := w.Write([]byte(requestBody))
-	if err != nil {
-		return nil, err
-	}
-	err = w.Close()
-	if err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
 }


### PR DESCRIPTION
By utilizing Golang Sync Pools, I was able to optimize the process of GZIP Compression within PBS.

Benchmark tests are added in this PR to test the difference between how GZIP used to be compressed, and the updated version.

Here are the results (After Latest Refactor):

Non-Optimized:
**BenchmarkCompressToGZIPNotOptimized-8**   	   11616	    100384 ns/op	  813992 B/op	      19 allocs/op

Optimized:
**BenchmarkCompressToGZIPOptimized-8**  	   84913	     12657 ns/op	     128 B/op	       3 allocs/op

From left to right, each value represents the following: Operations per Second, Average Time per Operation, Bytes Allocated per Operation, and Allocations per Operations

The optimized version shows significant improvements across the board