### PR TITLE
Skip coverage tests if more than two adapters were modified

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -36,8 +36,9 @@ jobs:
               return ""
             }
             const helper = utils.diffHelper({github, context})
-            const files = await helper.getDirectories(directoryExtractor)
-            return files.length == 0 ? "" : JSON.stringify(files);
+            const directories = await helper.getDirectories(directoryExtractor)
+            // run coverage for maximum of 2 directories
+            return (directories.length == 0 || directories.length > 2) ? "" : JSON.stringify(directories)
 
       - name: Run coverage tests
         id: run_coverage


### PR DESCRIPTION
PR updates [adapter-code-coverage.yml](https://github.com/prebid/prebid-server/compare/update-coverage-check?expand=1#diff-c4f0bb987be62acfd3c8b040dee1111ddf7c2bdfeb3c0b3d48c0cafbc9859970) to run coverage tests for max 2 adapter directories


**Test details**

Coverage tests were skipped for https://github.com/onkarvhanumante/prebid-server/pull/11 PR on forked repo 
https://github.com/onkarvhanumante/prebid-server/actions/runs/7628791242/job/20780684209?pr=11

<img width="1685" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/29dcf875-a06f-4812-ad5a-180ba277129b">
