### PR TITLE
ADF: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/adform.yaml
+++ b/static/bidder-info/adform.yaml
@@ -1,5 +1,1 @@
 aliasOf: adf
-userSync:
-  redirect:
-    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
-    userMacro: "$UID"


### PR DESCRIPTION
Enable user sync to inherit from parent adapter