### PR TITLE
Targeting: Add alwaysincludedeals flag

### DIFF
--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -394,7 +394,7 @@ func defTTL(bidType openrtb_ext.BidType, defaultTTLs *config.DefaultTTLs) (ttl i
 type auction struct {
 	// winningBids is a map from imp.id to the highest overall CPM bid in that imp.
 	winningBids map[string]*entities.PbsOrtbBid
-	// allBidsByBidder stores the highest bid on each imp by each bidder.
+	// allBidsByBidder is map from ImpID to another map that maps bidderName to all bids from that bidder.
 	allBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
 	// roundedPrices stores the price strings rounded for each bid according to the price granularity.
 	roundedPrices map[*entities.PbsOrtbBid]string

--- a/exchange/auction.go
+++ b/exchange/auction.go
@@ -108,7 +108,7 @@ func (d *DebugLog) PutDebugLogError(cache prebid_cache_client.Client, timeout in
 
 func newAuction(seatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, numImps int, preferDeals bool) *auction {
 	winningBids := make(map[string]*entities.PbsOrtbBid, numImps)
-	winningBidsByBidder := make(map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid, numImps)
+	allBidsByBidder := make(map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid, numImps)
 
 	for bidderName, seatBid := range seatBids {
 		if seatBid != nil {
@@ -118,10 +118,10 @@ func newAuction(seatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, nu
 					winningBids[bid.Bid.ImpID] = bid
 				}
 
-				if bidMap, ok := winningBidsByBidder[bid.Bid.ImpID]; ok {
+				if bidMap, ok := allBidsByBidder[bid.Bid.ImpID]; ok {
 					bidMap[bidderName] = append(bidMap[bidderName], bid)
 				} else {
-					winningBidsByBidder[bid.Bid.ImpID] = map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+					allBidsByBidder[bid.Bid.ImpID] = map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 						bidderName: {bid},
 					}
 				}
@@ -130,8 +130,8 @@ func newAuction(seatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, nu
 	}
 
 	return &auction{
-		winningBids:         winningBids,
-		winningBidsByBidder: winningBidsByBidder,
+		winningBids:     winningBids,
+		allBidsByBidder: allBidsByBidder,
 	}
 }
 
@@ -151,7 +151,7 @@ func isNewWinningBid(bid, wbid *openrtb2.Bid, preferDeals bool) bool {
 func (a *auction) validateAndUpdateMultiBid(adapterBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, preferDeals bool, accountDefaultBidLimit int) {
 	bidsSnipped := false
 	// sort bids for multibid targeting
-	for _, topBidsPerBidder := range a.winningBidsByBidder {
+	for _, topBidsPerBidder := range a.allBidsByBidder {
 		for bidder, topBids := range topBidsPerBidder {
 			sort.Slice(topBids, func(i, j int) bool {
 				return isNewWinningBid(topBids[i].Bid, topBids[j].Bid, preferDeals)
@@ -187,7 +187,7 @@ func (a *auction) validateAndUpdateMultiBid(adapterBids map[openrtb_ext.BidderNa
 
 func (a *auction) setRoundedPrices(targetingData targetData) {
 	roundedPrices := make(map[*entities.PbsOrtbBid]string, 5*len(a.winningBids))
-	for _, topBidsPerImp := range a.winningBidsByBidder {
+	for _, topBidsPerImp := range a.allBidsByBidder {
 		for _, topBidsPerBidder := range topBidsPerImp {
 			for _, topBid := range topBidsPerBidder {
 				roundedPrices[topBid] = GetPriceBucket(*topBid.Bid, targetingData)
@@ -225,7 +225,7 @@ func (a *auction) doCache(ctx context.Context, cache prebid_cache_client.Client,
 	for _, imp := range bidRequest.Imp {
 		expByImp[imp.ID] = imp.Exp
 	}
-	for impID, topBidsPerImp := range a.winningBidsByBidder {
+	for impID, topBidsPerImp := range a.allBidsByBidder {
 		for bidderName, topBidsPerBidder := range topBidsPerImp {
 			for _, topBid := range topBidsPerBidder {
 				isOverallWinner := a.winningBids[impID] == topBid
@@ -394,8 +394,8 @@ func defTTL(bidType openrtb_ext.BidType, defaultTTLs *config.DefaultTTLs) (ttl i
 type auction struct {
 	// winningBids is a map from imp.id to the highest overall CPM bid in that imp.
 	winningBids map[string]*entities.PbsOrtbBid
-	// winningBidsByBidder stores the highest bid on each imp by each bidder.
-	winningBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
+	// allBidsByBidder stores the highest bid on each imp by each bidder.
+	allBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
 	// roundedPrices stores the price strings rounded for each bid according to the price granularity.
 	roundedPrices map[*entities.PbsOrtbBid]string
 	// cacheIds stores the UUIDs from Prebid Cache for fetching the full bid JSON.

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -191,7 +191,7 @@ func loadCacheSpec(filename string) (*cacheSpec, error) {
 func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 	var bid *entities.PbsOrtbBid
 	winningBidsByImp := make(map[string]*entities.PbsOrtbBid)
-	winningBidsByBidder := make(map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid)
+	allBidsByBidder := make(map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid)
 	roundedPrices := make(map[*entities.PbsOrtbBid]string)
 	bidCategory := make(map[string]string)
 
@@ -210,15 +210,15 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 		}
 
 		// Map this bid if it's the highest we've seen from this bidder so far
-		if bidMap, ok := winningBidsByBidder[bid.Bid.ImpID]; ok {
+		if bidMap, ok := allBidsByBidder[bid.Bid.ImpID]; ok {
 			bidMap[pbsBid.Bidder] = append(bidMap[pbsBid.Bidder], bid)
 		} else {
-			winningBidsByBidder[bid.Bid.ImpID] = map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder[bid.Bid.ImpID] = map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				pbsBid.Bidder: {bid},
 			}
 		}
 
-		for _, topBidsPerBidder := range winningBidsByBidder {
+		for _, topBidsPerBidder := range allBidsByBidder {
 			for _, topBids := range topBidsPerBidder {
 				sort.Slice(topBids, func(i, j int) bool {
 					return isNewWinningBid(topBids[i].Bid, topBids[j].Bid, true)
@@ -263,9 +263,9 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 	}
 
 	testAuction := &auction{
-		winningBids:         winningBidsByImp,
-		winningBidsByBidder: winningBidsByBidder,
-		roundedPrices:       roundedPrices,
+		winningBids:     winningBidsByImp,
+		allBidsByBidder: allBidsByBidder,
+		roundedPrices:   roundedPrices,
 	}
 	evTracking := &eventTracking{
 		accountID:          "TEST_ACC_ID",
@@ -405,7 +405,7 @@ func TestNewAuction(t *testing.T) {
 				winningBids: map[string]*entities.PbsOrtbBid{
 					"imp1": &bid1p230,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p123},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p230},
@@ -433,7 +433,7 @@ func TestNewAuction(t *testing.T) {
 					"imp1": &bid1p230,
 					"imp2": &bid2p144,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p230},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p077},
@@ -462,7 +462,7 @@ func TestNewAuction(t *testing.T) {
 				winningBids: map[string]*entities.PbsOrtbBid{
 					"imp1": &bid1p123,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p123},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p088d},
@@ -486,7 +486,7 @@ func TestNewAuction(t *testing.T) {
 				winningBids: map[string]*entities.PbsOrtbBid{
 					"imp1": &bid1p088d,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p123},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p088d},
@@ -510,7 +510,7 @@ func TestNewAuction(t *testing.T) {
 				winningBids: map[string]*entities.PbsOrtbBid{
 					"imp1": &bid1p166d,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p088d},
@@ -537,7 +537,7 @@ func TestNewAuction(t *testing.T) {
 				winningBids: map[string]*entities.PbsOrtbBid{
 					"imp1": &bid1p166d,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d},
 						"rubicon":  []*entities.PbsOrtbBid{&bid1p088d},
@@ -563,7 +563,7 @@ func TestNewAuction(t *testing.T) {
 					"imp1": &bid1p166d,
 					"imp2": &bid2p166,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d, &bid1p077},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -645,11 +645,11 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 	}
 
 	type fields struct {
-		winningBids         map[string]*entities.PbsOrtbBid
-		winningBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
-		roundedPrices       map[*entities.PbsOrtbBid]string
-		cacheIds            map[*openrtb2.Bid]string
-		vastCacheIds        map[*openrtb2.Bid]string
+		winningBids     map[string]*entities.PbsOrtbBid
+		allBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
+		roundedPrices   map[*entities.PbsOrtbBid]string
+		cacheIds        map[*openrtb2.Bid]string
+		vastCacheIds    map[*openrtb2.Bid]string
 	}
 	type args struct {
 		adapterBids            map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid
@@ -657,8 +657,8 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 		accountDefaultBidLimit int
 	}
 	type want struct {
-		winningBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
-		adapterBids         map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid
+		allBidsByBidder map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid
+		adapterBids     map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid
 	}
 	tests := []struct {
 		description string
@@ -673,7 +673,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 					"imp1": &bid1p166d,
 					"imp2": &bid2p166,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p001, &bid1p166d, &bid1p077},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -697,7 +697,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 				preferDeals:            true,
 			},
 			want: want{
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d, &bid1p077, &bid1p001},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -724,7 +724,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 					"imp1": &bid1p166d,
 					"imp2": &bid2p166,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p001, &bid1p166d, &bid1p077},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -748,7 +748,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 				preferDeals:            true,
 			},
 			want: want{
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d, &bid1p077, &bid1p001},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -775,7 +775,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 					"imp1": &bid1p166d,
 					"imp2": &bid2p166,
 				},
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p001, &bid1p166d, &bid1p077},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -799,7 +799,7 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 				preferDeals:            true,
 			},
 			want: want{
-				winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 					"imp1": {
 						"appnexus": []*entities.PbsOrtbBid{&bid1p166d, &bid1p077},
 						"pubmatic": []*entities.PbsOrtbBid{&bid1p088d, &bid1p123},
@@ -823,14 +823,14 @@ func TestValidateAndUpdateMultiBid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			a := &auction{
-				winningBids:         tt.fields.winningBids,
-				winningBidsByBidder: tt.fields.winningBidsByBidder,
-				roundedPrices:       tt.fields.roundedPrices,
-				cacheIds:            tt.fields.cacheIds,
-				vastCacheIds:        tt.fields.vastCacheIds,
+				winningBids:     tt.fields.winningBids,
+				allBidsByBidder: tt.fields.allBidsByBidder,
+				roundedPrices:   tt.fields.roundedPrices,
+				cacheIds:        tt.fields.cacheIds,
+				vastCacheIds:    tt.fields.vastCacheIds,
 			}
 			a.validateAndUpdateMultiBid(tt.args.adapterBids, tt.args.preferDeals, tt.args.accountDefaultBidLimit)
-			assert.Equal(t, tt.want.winningBidsByBidder, tt.fields.winningBidsByBidder, tt.description)
+			assert.Equal(t, tt.want.allBidsByBidder, tt.fields.allBidsByBidder, tt.description)
 			assert.Equal(t, tt.want.adapterBids, tt.args.adapterBids, tt.description)
 		})
 	}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -574,7 +574,7 @@ func applyDealSupport(bidRequest *openrtb2.BidRequest, auc *auction, bidCategory
 	errs := []error{}
 	impDealMap := getDealTiers(bidRequest)
 
-	for impID, topBidsPerImp := range auc.winningBidsByBidder {
+	for impID, topBidsPerImp := range auc.allBidsByBidder {
 		impDeal := impDealMap[impID]
 		for bidder, topBidsPerBidder := range topBidsPerImp {
 			bidderNormalized, bidderFound := openrtb_ext.NormalizeBidderName(bidder.String())

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2070,9 +2070,6 @@ func TestExchangeJSON(t *testing.T) {
 
 			fileName := "./exchangetest/" + specFile.Name()
 			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
-			if fileName != "./exchangetest/targeting-always-include-deals.json" {
-				continue
-			}
 
 			t.Run(fileDisplayName, func(t *testing.T) {
 				specData, err := loadFile(fileName)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -3536,7 +3536,7 @@ func TestApplyDealSupport(t *testing.T) {
 		}
 
 		auc := &auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"imp_id1": {
 					test.in.bidderName: {&bid},
 				},
@@ -3545,8 +3545,8 @@ func TestApplyDealSupport(t *testing.T) {
 
 		dealErrs := applyDealSupport(bidRequest, auc, bidCategory, nil)
 
-		assert.Equal(t, test.expected.hbPbCatDur, bidCategory[auc.winningBidsByBidder["imp_id1"][test.in.bidderName][0].Bid.ID], test.description)
-		assert.Equal(t, test.expected.dealTierSatisfied, auc.winningBidsByBidder["imp_id1"][test.in.bidderName][0].DealTierSatisfied, "expected.dealTierSatisfied=%v when %v", test.expected.dealTierSatisfied, test.description)
+		assert.Equal(t, test.expected.hbPbCatDur, bidCategory[auc.allBidsByBidder["imp_id1"][test.in.bidderName][0].Bid.ID], test.description)
+		assert.Equal(t, test.expected.dealTierSatisfied, auc.allBidsByBidder["imp_id1"][test.in.bidderName][0].DealTierSatisfied, "expected.dealTierSatisfied=%v when %v", test.expected.dealTierSatisfied, test.description)
 		if len(test.expected.dealErr) > 0 {
 			assert.Containsf(t, dealErrs, errors.New(test.expected.dealErr), "Expected error message not found in deal errors")
 		}
@@ -3587,7 +3587,7 @@ func TestApplyDealSupportMultiBid(t *testing.T) {
 					},
 				},
 				auc: &auction{
-					winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+					allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 						"imp_id1": {
 							openrtb_ext.BidderName("appnexus"): {
 								&entities.PbsOrtbBid{&openrtb2.Bid{ID: "123456"}, nil, "video", map[string]string{}, &openrtb_ext.ExtBidPrebidVideo{}, nil, nil, 5, false, "", 0, "USD", ""},
@@ -3633,7 +3633,7 @@ func TestApplyDealSupportMultiBid(t *testing.T) {
 					},
 				},
 				auc: &auction{
-					winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+					allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 						"imp_id1": {
 							openrtb_ext.BidderName("appnexus"): {
 								&entities.PbsOrtbBid{&openrtb2.Bid{ID: "123456"}, nil, "video", map[string]string{}, &openrtb_ext.ExtBidPrebidVideo{}, nil, nil, 5, false, "", 0, "USD", ""},
@@ -3684,7 +3684,7 @@ func TestApplyDealSupportMultiBid(t *testing.T) {
 					},
 				},
 				auc: &auction{
-					winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+					allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 						"imp_id1": {
 							openrtb_ext.BidderName("appnexus"): {
 								&entities.PbsOrtbBid{&openrtb2.Bid{ID: "123456"}, nil, "video", map[string]string{}, &openrtb_ext.ExtBidPrebidVideo{}, nil, nil, 5, false, "", 0, "USD", ""},
@@ -3723,7 +3723,7 @@ func TestApplyDealSupportMultiBid(t *testing.T) {
 			errs := applyDealSupport(tt.args.bidRequest, tt.args.auc, tt.args.bidCategory, tt.args.multiBid)
 			assert.Equal(t, tt.want.errs, errs)
 
-			for impID, topBidsPerImp := range tt.args.auc.winningBidsByBidder {
+			for impID, topBidsPerImp := range tt.args.auc.allBidsByBidder {
 				for bidder, topBidsPerBidder := range topBidsPerImp {
 					for i, topBid := range topBidsPerBidder {
 						assert.Equal(t, tt.want.expectedHbPbCatDur[impID][bidder.String()][i], tt.args.bidCategory[topBid.Bid.ID], tt.name)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2070,6 +2070,9 @@ func TestExchangeJSON(t *testing.T) {
 
 			fileName := "./exchangetest/" + specFile.Name()
 			fileDisplayName := "exchange/exchangetest/" + specFile.Name()
+			if fileName != "./exchangetest/targeting-always-include-deals.json" {
+				continue
+			}
 
 			t.Run(fileDisplayName, func(t *testing.T) {
 				specData, err := loadFile(fileName)

--- a/exchange/exchangetest/targeting-always-include-deals.json
+++ b/exchange/exchangetest/targeting-always-include-deals.json
@@ -1,0 +1,267 @@
+{
+  "incomingRequest": {
+    "ortbRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": [
+              "video/mp4"
+            ]
+          },
+          "ext": {
+            "prebid": {
+              "bidder": {
+                "appnexus": {
+                  "placementId": 1
+                },
+                "audienceNetwork": {
+                  "placementId": "some-placement"
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "imp-id-2",
+          "video": {
+            "mimes": [
+              "video/mp4"
+            ]
+          },
+          "ext": {
+            "prebid": {
+              "bidder": {
+                "appnexus": {
+                  "placementId": 2
+                },
+                "audienceNetwork": {
+                  "placementId": "some-other-placement"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": false,
+            "alwaysincludedeals": true
+          }
+        }
+      }
+    }
+  },
+  "outgoingRequests": {
+    "appnexus": {
+      "mockResponse": {
+        "pbsSeatBids": [
+          {
+            "pbsBids": [
+              {
+                "ortbBid": {
+                  "id": "winning-bid",
+                  "impid": "my-imp-id",
+                  "price": 0.71,
+                  "w": 200,
+                  "h": 250,
+                  "crid": "creative-1",
+                  "dealid": "deal-1"
+                },
+                "bidType": "video"
+              },
+              {
+                "ortbBid": {
+                  "id": "losing-bid",
+                  "impid": "my-imp-id",
+                  "price": 0.21,
+                  "w": 200,
+                  "h": 250,
+                  "crid": "creative-2",
+                  "dealid": "deal-2"
+                },
+                "bidType": "video"
+              },
+              {
+                "ortbBid": {
+                  "id": "other-bid",
+                  "impid": "imp-id-2",
+                  "price": 0.61,
+                  "w": 300,
+                  "h": 500,
+                  "crid": "creative-3"
+                },
+                "bidType": "video"
+              }
+            ],
+            "seat": "appnexus"
+          }
+        ]
+      }
+    },
+    "audienceNetwork": {
+      "mockResponse": {
+        "pbsSeatBids": [
+          {
+            "pbsBids": [
+              {
+                "ortbBid": {
+                  "id": "contending-bid",
+                  "impid": "my-imp-id",
+                  "price": 0.51,
+                  "w": 200,
+                  "h": 250,
+                  "crid": "creative-4",
+                  "dealid": "deal-4"
+                },
+                "bidType": "video"
+              }
+            ],
+            "seat": "audienceNetwork"
+          }
+        ]
+      }
+    }
+  },
+  "response": {
+    "bids": {
+      "id": "some-request-id",
+      "seatbid": [
+        {
+          "seat": "audienceNetwork",
+          "bid": [
+            {
+              "id": "contending-bid",
+              "impid": "my-imp-id",
+              "price": 0.51,
+              "w": 200,
+              "h": 250,
+              "crid": "creative-4",
+              "dealid": "deal-4",
+              "ext": {
+                "origbidcpm": 0.51,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "audienceNetwork"
+                  },
+                  "type": "video",
+                  "targeting": {
+                    "hb_bidder_audienceNe": "audienceNetwork",
+                    "hb_cache_host_audien": "www.pbcserver.com",
+                    "hb_cache_path_audien": "/pbcache/endpoint",
+                    "hb_deal_audienceNetw": "deal-4",
+                    "hb_pb_audienceNetwor": "0.50",
+                    "hb_size_audienceNetw": "200x250"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "seat": "appnexus",
+          "bid": [
+            {
+              "id": "winning-bid",
+              "impid": "my-imp-id",
+              "price": 0.71,
+              "w": 200,
+              "h": 250,
+              "crid": "creative-1",
+              "dealid": "deal-1",
+              "ext": {
+                "origbidcpm": 0.71,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "video",
+                  "targeting": {
+                    "hb_bidder": "appnexus",
+                    "hb_bidder_appnexus": "appnexus",
+                    "hb_cache_host": "www.pbcserver.com",
+                    "hb_cache_host_appnex": "www.pbcserver.com",
+                    "hb_cache_path": "/pbcache/endpoint",
+                    "hb_cache_path_appnex": "/pbcache/endpoint",
+                    "hb_pb": "0.70",
+                    "hb_pb_appnexus": "0.70",
+                    "hb_deal":"deal-1",
+                    "hb_deal_appnexus":"deal-1",
+                    "hb_size": "200x250",
+                    "hb_size_appnexus": "200x250"
+                  }
+                }
+              }
+            },
+            {
+              "id": "losing-bid",
+              "impid": "my-imp-id",
+              "price": 0.21,
+              "w": 200,
+              "h": 250,
+              "crid": "creative-2",
+              "dealid": "deal-2",
+              "ext": {
+                "origbidcpm": 0.21,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "video"
+                }
+              }
+            },
+            {
+              "id": "other-bid",
+              "impid": "imp-id-2",
+              "price": 0.61,
+              "w": 300,
+              "h": 500,
+              "crid": "creative-3",
+              "dealid": "deal-3",
+              "ext": {
+                "origbidcpm": 0.61,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "video",
+                  "targeting": {
+                    "hb_bidder": "appnexus",
+                    "hb_bidder_appnexus": "appnexus",
+                    "hb_cache_host": "www.pbcserver.com",
+                    "hb_cache_host_appnex": "www.pbcserver.com",
+                    "hb_cache_path": "/pbcache/endpoint",
+                    "hb_cache_path_appnex": "/pbcache/endpoint",
+                    "hb_deal":"deal-3",
+                    "hb_deal_appnexus":"deal-3",
+                    "hb_pb": "0.60",
+                    "hb_pb_appnexus": "0.60",
+                    "hb_size": "300x500",
+                    "hb_size_appnexus": "300x500"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/exchange/exchangetest/targeting-always-include-deals.json
+++ b/exchange/exchangetest/targeting-always-include-deals.json
@@ -105,7 +105,8 @@
                   "price": 0.61,
                   "w": 300,
                   "h": 500,
-                  "crid": "creative-3"
+                  "crid": "creative-3",
+                  "dealid": "deal-3"
                 },
                 "bidType": "video"
               }
@@ -129,6 +130,17 @@
                   "h": 250,
                   "crid": "creative-4",
                   "dealid": "deal-4"
+                },
+                "bidType": "video"
+              },
+              {
+                "ortbBid": {
+                  "id": "losing-bid-aN",
+                  "impid": "imp-id-2",
+                  "price": 0.40,
+                  "w": 200,
+                  "h": 250,
+                  "crid": "creative-5"
                 },
                 "bidType": "video"
               }
@@ -169,6 +181,23 @@
                     "hb_pb_audienceNetwor": "0.50",
                     "hb_size_audienceNetw": "200x250"
                   }
+                }
+              }
+            },
+            {
+              "id": "losing-bid-aN",
+              "impid": "imp-id-2",
+              "price": 0.40,
+              "w": 200,
+              "h": 250,
+              "crid": "creative-5",
+              "ext": {
+                "origbidcpm": 0.40,
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "audienceNetwork"
+                  },
+                  "type": "video"
                 }
               }
             }

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -46,11 +46,9 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 			bidderCodePrefix, maxBids := getMultiBidMeta(multiBidMap, originalBidderName.String())
 
 			for i, topBid := range topBidsPerBidder {
-				fmt.Println("TOP BID")
-				fmt.Println(topBid.Bid.ID)
 				// Limit targeting keys to maxBids (default 1 bid).
 				// And, do not apply targeting for more than 1 bid if bidderCodePrefix is not defined.
-				if i == maxBids || (i == 1 && bidderCodePrefix == "") { //TODO: This may need to be tweaked if alwaysincluddeals is true
+				if i == maxBids || (i == 1 && bidderCodePrefix == "") {
 					break
 				}
 

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -26,10 +26,10 @@ type targetData struct {
 	includeCacheVast          bool
 	includeFormat             bool
 	preferDeals               bool
+	alwaysIncludeDeals        bool
 	// cacheHost and cachePath exist to supply cache host and path as targeting parameters
-	cacheHost          string
-	cachePath          string
-	alwaysIncludeDeals bool
+	cacheHost string
+	cachePath string
 }
 
 // setTargeting writes all the targeting params into the bids.
@@ -46,9 +46,11 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 			bidderCodePrefix, maxBids := getMultiBidMeta(multiBidMap, originalBidderName.String())
 
 			for i, topBid := range topBidsPerBidder {
+				fmt.Println("TOP BID")
+				fmt.Println(topBid.Bid.ID)
 				// Limit targeting keys to maxBids (default 1 bid).
 				// And, do not apply targeting for more than 1 bid if bidderCodePrefix is not defined.
-				if i == maxBids || (i == 1 && bidderCodePrefix == "") {
+				if i == maxBids || (i == 1 && bidderCodePrefix == "") { //TODO: This may need to be tweaked if alwaysincluddeals is true
 					break
 				}
 

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -39,7 +39,7 @@ type targetData struct {
 // it's ok if those stay in the auction. For now, this method implements a very naive cache strategy.
 // In the future, we should implement a more clever retry & backoff strategy to balance the success rate & performance.
 func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMapping map[string]string, truncateTargetAttr *int, multiBidMap map[string]openrtb_ext.ExtMultiBid) {
-	for impId, topBidsPerImp := range auc.winningBidsByBidder {
+	for impId, topBidsPerImp := range auc.allBidsByBidder {
 		overallWinner := auc.winningBids[impId]
 		for originalBidderName, topBidsPerBidder := range topBidsPerImp {
 			targetingBidderCode := originalBidderName

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -27,8 +27,9 @@ type targetData struct {
 	includeFormat             bool
 	preferDeals               bool
 	// cacheHost and cachePath exist to supply cache host and path as targeting parameters
-	cacheHost string
-	cachePath string
+	cacheHost          string
+	cachePath          string
+	alwaysIncludeDeals bool
 }
 
 // setTargeting writes all the targeting params into the bids.
@@ -86,7 +87,9 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 					targData.addKeys(targets, openrtb_ext.HbConstantCachePathKey, targData.cachePath, targetingBidderCode, isOverallWinner, truncateTargetAttr)
 				}
 
-				if deal := topBid.Bid.DealID; len(deal) > 0 {
+				// TODO: Remove Comments
+				// If alwaysincludedeals is true, PBS should generate KVPs for all bids with dealID
+				if deal := topBid.Bid.DealID; len(deal) > 0 && targData.alwaysIncludeDeals {
 					targData.addKeys(targets, openrtb_ext.HbDealIDConstantKey, deal, targetingBidderCode, isOverallWinner, truncateTargetAttr)
 				}
 

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -344,7 +344,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:   true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -379,7 +379,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -421,7 +421,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			alwaysIncludeDeals: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid111,
@@ -471,7 +471,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeFormat:     true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -520,7 +520,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			cachePath:         "cache",
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -573,7 +573,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -603,7 +603,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -645,7 +645,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -687,7 +687,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -729,7 +729,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:   true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -764,7 +764,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:   true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -799,7 +799,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:   true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {{
 						Bid:     bid123,
@@ -836,7 +836,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeFormat:     true,
 		},
 		Auction: auction{
-			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
 					openrtb_ext.BidderAppnexus: {
 						{
@@ -971,7 +971,7 @@ func TestSetTargeting(t *testing.T) {
 		auc.setRoundedPrices(test.TargetData)
 		winningBids := make(map[string]*entities.PbsOrtbBid)
 		// Set winning bids from the auction data
-		for imp, bidsByBidder := range auc.winningBidsByBidder {
+		for imp, bidsByBidder := range auc.allBidsByBidder {
 			for _, bids := range bidsByBidder {
 				for _, bid := range bids {
 					if winningBid, ok := winningBids[imp]; ok {
@@ -992,12 +992,12 @@ func TestSetTargeting(t *testing.T) {
 				for i, expected := range expectedTargets {
 					assert.Equal(t,
 						expected.BidTargets,
-						auc.winningBidsByBidder[imp][bidder][i].BidTargets,
+						auc.allBidsByBidder[imp][bidder][i].BidTargets,
 						"Test: %s\nTargeting failed for bidder %s on imp %s.",
 						test.Description,
 						string(bidder),
 						imp)
-					assert.Equal(t, expected.TargetBidderCode, auc.winningBidsByBidder[imp][bidder][i].TargetBidderCode)
+					assert.Equal(t, expected.TargetBidderCode, auc.allBidsByBidder[imp][bidder][i].TargetBidderCode)
 				}
 			}
 		}

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -319,6 +319,11 @@ var bid2p166 *openrtb2.Bid = &openrtb2.Bid{
 	Price: 1.66,
 }
 
+var bid175 *openrtb2.Bid = &openrtb2.Bid{
+	Price:  1.75,
+	DealID: "mydeal2",
+}
+
 var (
 	truncateTargetAttrValue10       int = 10
 	truncateTargetAttrValue5        int = 5
@@ -402,6 +407,54 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 						BidTargets: map[string]string{
 							"hb_bidder_rubicon": "rubicon",
 							"hb_pb_rubicon":     "0.80",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
+	{
+		Description: "Targeting with alwaysIncludeDeals",
+		TargetData: targetData{
+			priceGranularity:   lookupPriceGranularity("med"),
+			alwaysIncludeDeals: true,
+		},
+		Auction: auction{
+			winningBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid111,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+					openrtb_ext.BidderRubicon: {{
+						Bid:     bid175,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+					openrtb_ext.BidderPubmatic: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder_appnexus": "appnexus",
+							"hb_pb_appnexus":     "1.10",
+							"hb_deal_appnexus":   "mydeal",
+						},
+					},
+				},
+				openrtb_ext.BidderRubicon: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder_rubicon": "rubicon",
+							"hb_pb_rubicon":     "1.70",
+							"hb_deal_rubicon":   "mydeal2",
 						},
 					},
 				},

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -878,6 +878,7 @@ func getExtTargetData(requestExtPrebid *openrtb_ext.ExtRequestPrebid, cacheInstr
 			priceGranularity:          *requestExtPrebid.Targeting.PriceGranularity,
 			mediaTypePriceGranularity: requestExtPrebid.Targeting.MediaTypePriceGranularity,
 			preferDeals:               requestExtPrebid.Targeting.PreferDeals,
+			alwaysIncludeDeals:        requestExtPrebid.Targeting.AlwaysIncludeDeals,
 		}
 	}
 

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -199,6 +199,7 @@ type ExtRequestTargeting struct {
 	DurationRangeSec          []int                     `json:"durationrangesec,omitempty"`
 	PreferDeals               bool                      `json:"preferdeals,omitempty"`
 	AppendBidderNames         bool                      `json:"appendbiddernames,omitempty"`
+	AlwaysIncludeDeals        bool                      `json:"alwaysincludedeals,omitempty"`
 }
 
 type ExtIncludeBrandCategory struct {


### PR DESCRIPTION
Addresses this issue #2214

The goal is to add a new flag on the request at `ext.prebid.targeting.alwaysincludedeals`, that if true: PBS-core would generate targeting key-value pairs for all bids with a dealid. This is independent of which other ext.prebid.targeting flags are present.