### PR TITLE
freewheel-ssp: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/freewheel-ssp.yaml
+++ b/static/bidder-info/freewheel-ssp.yaml
@@ -1,5 +1,1 @@
 aliasOf: freewheelssp
-userSync:
-  iframe:
-    url: "https://ads.stickyadstv.com/pbs-user-sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
-    userMacro: "{viewerid}"


### PR DESCRIPTION
enable user sync to inherit from parent adapter