### PR TITLE
quantumdex: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/quantumdex.yaml
+++ b/static/bidder-info/quantumdex.yaml
@@ -1,8 +1,2 @@
 aliasOf: "apacdex"
-userSync:
-  iframe:
-    url: https://sync.quantumdex.io/usersync/pbs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}
-    userMacro: "[UID]"
-  redirect:
-    url: "https://sync.quantumdex.io/getuid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
-    userMacro: "[UID]"
+


### PR DESCRIPTION
Enable user sync to inherit from parent adapter