### PR TITLE
trustx: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/trustx.yaml
+++ b/static/bidder-info/trustx.yaml
@@ -2,8 +2,5 @@ aliasOf: grid
 maintainer:
   email: "grid-tech@themediagrid.com"
 gvlVendorID: 686
-userSync:
-  redirect:
-    url: "https://x.bidswitch.net/check_uuid/{{.RedirectURL}}?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}"
-    userMacro: "${BSW_UUID}"
+
     


### PR DESCRIPTION
Enable user sync to inherit from parent adapter