### PR TITLE
streamkey: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/streamkey.yaml
+++ b/static/bidder-info/streamkey.yaml
@@ -9,8 +9,3 @@ capabilities:
   site:
     mediaTypes:
       - video
-userSync:
-  # streamkey supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - iframe


### PR DESCRIPTION
Enable user sync to inherit from parent adapter