### PR TITLE
pgam: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/pgam.yaml
+++ b/static/bidder-info/pgam.yaml
@@ -2,8 +2,4 @@ aliasOf: adtelligent
 endpoint: "http://ghb.pgamssp.com/pbs/ortb"
 maintainer:
   email: "ppatel@pgammedia.com"
-userSync:
-  # PGAM ssp supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - iframe
+


### PR DESCRIPTION
Enable user sync to inherit from parent adapter