### PR TITLE
janet: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/janet.yaml
+++ b/static/bidder-info/janet.yaml
@@ -2,8 +2,3 @@ aliasOf: adtelligent
 endpoint: "http://ghb.bidder.jmgads.com/pbs/ortb"
 maintainer:
   email: "info@thejmg.com"
-userSync:
-  # JANet supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - iframe


### PR DESCRIPTION
Enable user sync to inherit from parent adapter