### PR TITLE
indicue: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/indicue.yaml
+++ b/static/bidder-info/indicue.yaml
@@ -2,8 +2,3 @@ aliasOf: adtelligent
 endpoint: "http://ghb.console.indicue.com/pbs/ortb"
 maintainer:
   email: "ops@indicue.com"
-userSync:
-  # Indicue ssp supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - iframe


### PR DESCRIPTION
Enable user sync to inherit from parent adapter