### PR TITLE
copper6: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/copper6.yaml
+++ b/static/bidder-info/copper6.yaml
@@ -2,8 +2,3 @@ aliasOf: adtelligent
 endpoint: "http://ghb.app.copper6.com/pbs/ortb"
 maintainer:
   email: "info@copper6.com"
-userSync:
-  # Copper6 ssp supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - iframe


### PR DESCRIPTION
Enable user sync to inherit from parent adapter