### PR TITLE
yahooAdvertising: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/yahooAdvertising.yaml
+++ b/static/bidder-info/yahooAdvertising.yaml
@@ -1,6 +1,1 @@
 aliasOf: yahooAds
-userSync:
-  # yahooAdvertising supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - redirect


### PR DESCRIPTION
Enable user sync to inherit from parent adapter