### PR TITLE
yahoossp: enable user sync to inherit from parent adapter

### DIFF
--- a/static/bidder-info/yahoossp.yaml
+++ b/static/bidder-info/yahoossp.yaml
@@ -1,8 +1,3 @@
 aliasOf: yahooAds
 maintainer:
   email: "hb-fe-tech@oath.com"
-userSync:
-  # yahoossp supports user syncing, but requires configuration by the host. contact this
-  # bidder directly at the email address in this file to ask about enabling user sync.
-  supports:
-    - redirect


### PR DESCRIPTION
Enable user sync to inherit from parent adapter