### PR TITLE
update code coverage workflow to use actions with node 20 support

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.5
 
       - name: Checkout pull request branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get adapter directories
         id: get_directories
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -68,7 +68,7 @@ jobs:
           rm -f -r ./*
 
       - name: Checkout coverage-preview branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: coverage-preview
@@ -94,7 +94,7 @@ jobs:
 
       - name: Add coverage summary to pull request
         if: steps.run_coverage.outputs.coverage_dir != '' && steps.commit_coverage.outputs.remote_coverage_preview_dir != ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const utils = require('./.github/workflows/helpers/pull-request-utils.js')


### PR DESCRIPTION
- As of now, warning related to node 16 usage were seen on `prebid/prebid-server` for code coverage workflow.
   <img width="1728" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/f1de1097-42d7-4a72-9503-80d8d967a934">

- As per, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 Node 16 has reached its end of life and it is recommended to transition to use Node 20 by Spring 2024. 

- PR makes changes in code coverage workflow to use actions with node 20 support.

- Tested by running  code coverage workflow on forked repo.
   https://github.com/onkarvhanumante/prebid-server/actions/runs/7811209264
   <img width="1728" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/3b2aa4ba-c46d-4683-9350-65ef9a739d34">
