### PR TITLE
update code semgrep workflow to use  actions with node 20 support

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
@@ -17,7 +17,7 @@ jobs:
 
       - name: Calculate diff
         id: calculate_diff
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -52,7 +52,7 @@ jobs:
       - name: Add pull request comment
         id: add_pull_request_comment
         if: contains(steps.should_run_semgrep.outputs.hasChanges, 'true')
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string


### PR DESCRIPTION
- As of now, warning related to node 16 usage were seen on `prebid/prebid-server` for semgrep workflow.
  <img width="1728" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/6db0ca31-18ab-492e-932e-5b96af47b1a2">

- As per, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 Node 16 has reached its end of life and it is recommended to transition to use Node 20 by Spring 2024. 

- PR makes changes in code coverage workflow to use actions with node 20 support.

- Tested by running  semgrep workflow on forked repo.
   https://github.com/onkarvhanumante/prebid-server/actions/runs/7813702768
   <img width="1728" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/cd22b2bb-0d86-4618-8c01-48b222289786">

   