### PR TITLE
Update trivy check workflow to use node 20 actions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Resolves to empty string for push events and falls back to HEAD.
           ref: ${{ github.event.pull_request.head.sha }}
@@ -29,6 +29,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
           
       - name: Upload Results To GitHub Security Tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
- As of now, warning related to node 16 usage were seen on `prebid/prebid-server` for trivy check workflow.
   <img width="1728" alt="Screenshot 2024-02-07 at 6 26 47 PM" src="https://github.com/prebid/prebid-server/assets/24757781/27806dbe-494e-4d22-8a04-7521c45cffef">

- As per, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 Node 16 has reached its end of life and it is recommended to transition to use Node 20 by Spring 2024. 

- PR makes changes in code trivy check workflow to use actions with node 20 support.

- Tested by running  semgrep workflow on forked repo.
   https://github.com/onkarvhanumante/prebid-server/actions/runs/7815116030
   <img width="1728" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/b32bffd1-ed52-47f4-83c6-f66576696fb9">