### PR TITLE
Update validate pull request workflows to use node 20 actions

### DIFF
--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -10,12 +10,12 @@ jobs:
     
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.20.5
 
     - name: Checkout Merged Branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
     
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Resolves to empty string for push events and falls back to HEAD.
         ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
- As per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 support for Node version 16 has reached its end of life and it is recommended to transition all actions to run on Node version 20 by Spring 2024.

- The `validate` and `validate-merge` workflow uses `actions/setup-go@v4` and `actions/checkout@v3` actions.  These actions have dependency on Node version 16.

- PR updates both workflows, to use `setup-go` action of version 5 and the `checkout` action of version 4. These updated versions use Node version 20.
