### PR TITLE
Update release workflow to use actions with node 20 support

### DIFF
--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -1,7 +1,9 @@
 const synchronizeEvent = "synchronize",
   openedEvent = "opened",
   completedStatus = "completed",
-  resultSize = 100
+  resultSize = 100,
+  adminPermission = "admin",
+  writePermission = "write"
 
 class diffHelper {
   constructor(input) {
@@ -407,8 +409,30 @@ class coverageHelper {
   }
 }
 
+class userHelper {
+  constructor(input) {
+    this.owner = input.context.repo.owner
+    this.repo = input.context.repo.repo
+    this.github = input.github
+  }
+
+  /*
+    Checks if the user has write permissions for the repository
+    @returns {boolean} - returns true if the user has write permissions, otherwise false
+  */
+  async hasWritePermissions() {
+    const { data } = await this.github.rest.repos.getCollaboratorPermissionLevel({
+      owner: this.owner,
+      repo: this.repo,
+      username: this.owner,
+    })
+    return data.permission === adminPermission || data.permission === writePermission
+  }
+}
+
 module.exports = {
   diffHelper: (input) => new diffHelper(input),
   semgrepHelper: (input) => new semgrepHelper(input),
   coverageHelper: (input) => new coverageHelper(input),
+  userHelper: (input) => new userHelper(input),
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Prebid Server
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Create & publish tag
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Prebid Server
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,25 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ github.repository }}
+          ref: master
       - name: Check user permission
-        uses: actions-cool/check-user-permission@v2.2.0
+        uses: actions/github-script@v7
         id: check
         with:
-          require: 'write'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
+            const helper = utils.userHelper({github, context})
+            const hasPermission = await helper.hasWritePermissions()
+            return hasPermission
     outputs:
-      hasWritePermission: ${{ steps.check.outputs.require-result }}
+      hasWritePermission: ${{ steps.check.outputs.result }}
 
   build-master:
     name: Build master


### PR DESCRIPTION
- As per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 support for Node version 16 has reached its end of life and it is recommended to transition all actions to run on Node version 20 by Spring 2024.

- Currently release workflow  uses  `actions-cool/check-user-permission@v2.2.0` and `actions/checkout@v3` actions. 

- Maintainers of `actions-cool/check-user-permission` haven't added support for Node version 20. Therefore, PR makes changes to replace `actions-cool/check-user-permission@v2.2.0` by `actions/github-script@v7`.  The `actions/github-script@v7` uses Node version 20 and has api to check if user has permission to release. Note that helper method was added in [helpers/pull-request-utils.js](https://github.com/prebid/prebid-server/compare/release-node-20-support?expand=1#diff-23b9920b93515db73122b583c09dfd4abcb9541bd2aa240f62c0b46637ae9e06) to check permission.

- Additionally, PR updates release workflow to use `actions/checkout@v4`.  This new version is based on node version 20.

- Tested on fork repo:
   https://github.com/onkarvhanumante/prebid-server/actions/runs/7842711148
   <img width="1728" alt="Screenshot 2024-02-09 at 4 04 00 PM" src="https://github.com/prebid/prebid-server/assets/24757781/bf1cbb21-8864-440e-8406-6f059dfe0e00">