### PR TITLE
Update issue tracking workflow to use actions with node version 20 support

### DIFF
--- a/.github/workflows/issue_prioritization.yml
+++ b/.github/workflows/issue_prioritization.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.PBS_PROJECT_APP_ID }}
           private_key: ${{ secrets.PBS_PROJECT_APP_PEM }}


### PR DESCRIPTION
As per, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 Node 16 has reached its end of life and it is recommended to transition all actions to run on Node 20 by Spring 2024.

Issue tracking workflow makes use of `tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0`.  PR makes changes to use `tibdex/github-app-token@v2.1.0`. Maintainers of tibdex/github-app-token has added support for node version 20 in v2.1.0 of tibdex/github-app-token.