### PR TITLE
Add formatcheck make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ image:
 # format runs format
 format:
 	./scripts/format.sh -f true
+
+# formatcheck runs format for diagnostics, without modifying the code
+formatcheck:
+	./scripts/format.sh -f false


### PR DESCRIPTION
PR adds the `formatcheck` makefile target to run the `format.sh` script with `-f false` - to check if the Go files are properly formatted and exit with a non-zero error code. Intended for CI usage to enforce `gofmt`
compliance and fail builds on deviations.

Fix #3475.