### PR TITLE
Remove Extra Buffer from GZIP Compression

### DIFF
--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -3377,11 +3377,11 @@ func TestGetRequestBody(t *testing.T) {
 			if test.endpointCompression == "GZIP" {
 				assert.Equal(t, "gzip", req.Headers.Get("Content-Encoding"))
 
-				decompressedReqBody, err := decompressGzip(requestBody)
+				decompressedReqBody, err := decompressGzip(requestBody.Bytes())
 				assert.NoError(t, err)
 				assert.Equal(t, test.givenReqBody, decompressedReqBody)
 			} else {
-				assert.Equal(t, test.givenReqBody, requestBody)
+				assert.Equal(t, test.givenReqBody, requestBody.Bytes())
 			}
 		})
 	}


### PR DESCRIPTION
Through some comments left in this GZIP [commit](https://github.com/prebid/prebid-server/commit/0c2865730d948b3d14f2527f0c32820c5935aafa#comments), there was a realization that there's unnecessary extra buffer utilized by returning bytes from `getRequestBody()`, and creating a new buffer for `NewRequest()`

So this PR makes updates to remove this extra buffer.
