### PR TITLE
Fix function godoc comment

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -45,7 +45,7 @@ type Bidder interface {
 type TimeoutBidder interface {
 	Bidder
 
-	// MakeTimeoutNotice functions much the same as MakeRequests, except it is fed the bidder request that timed out,
+	// MakeTimeoutNotification functions much the same as MakeRequests, except it is fed the bidder request that timed out,
 	// and expects that only one notification "request" will be generated. A use case for multiple timeout notifications
 	// has not been anticipated.
 	//


### PR DESCRIPTION
PR fixes an error in the function comment.  See https://go.dev/doc/comment regarding the documentation standards for the Go code comments.

 The Goland IDE says about the current version:
```
Comment should have the following format 'MakeTimeoutNotification ...' (with an optional leading article) 
 Inspection info: Reports comments that do not start with the name of the exported element.
According to Comment Sentences at github.com/golang, this is a convention to begin a comment with the name of the exported element.
Example:
// represents a request to run a command.
type Request struct {}
The comment starts with the struct description, not with the struct name. To stick to the convention rules, you can apply the Add prefix to comment quick-fix. After the quick-fix is applied, the comment looks as follows:
// Request represents a request to run a command.
type Request struct {} // better
```