### PR TITLE
Add log lines in release workflow

### DIFF
--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -426,7 +426,8 @@ class userHelper {
       repo: this.repo,
       username: this.owner,
     })
-    return data.permission === adminPermission || data.permission === writePermission
+    console.log(JSON.stringify(data))
+    return data.permission === writePermission || data.permission === adminPermission
   }
 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
             return hasPermission
     outputs:
       hasWritePermission: ${{ steps.check.outputs.result }}
+  
+  debug-step:
+    name: Debug step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug
+        run: echo ${{ needs.check-permission.outputs.hasWritePermission }}
 
   build-master:
     name: Build master


### PR DESCRIPTION
As of now release workflow gets aborted at `check permission` step.  Refer https://github.com/prebid/prebid-server/actions/runs/7911722094. PR adds log lines to help debug why the workflow is getting aborted.

Tested changes on fork - https://github.com/onkarvhanumante/prebid-server/actions/runs/7911745638