### PR TITLE
Fix Release workflow 

### DIFF
--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -409,31 +409,8 @@ class coverageHelper {
   }
 }
 
-class userHelper {
-  constructor(input) {
-    this.owner = input.context.repo.owner
-    this.repo = input.context.repo.repo
-    this.github = input.github
-  }
-
-  /*
-    Checks if the user has write permissions for the repository
-    @returns {boolean} - returns true if the user has write permissions, otherwise false
-  */
-  async hasWritePermissions() {
-    const { data } = await this.github.rest.repos.getCollaboratorPermissionLevel({
-      owner: this.owner,
-      repo: this.repo,
-      username: this.owner,
-    })
-    console.log(JSON.stringify(data))
-    return data.permission === writePermission || data.permission === adminPermission
-  }
-}
-
 module.exports = {
   diffHelper: (input) => new diffHelper(input),
   semgrepHelper: (input) => new semgrepHelper(input),
   coverageHelper: (input) => new coverageHelper(input),
-  userHelper: (input) => new userHelper(input),
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,31 +31,30 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.repository }}
           ref: master
-      - name: Check user permission
-        uses: actions/github-script@v7
+     
+      - name: check user permission
         id: check
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
-            const helper = utils.userHelper({github, context})
-            const hasPermission = await helper.hasWritePermissions()
-            return hasPermission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          collaboratorPermission=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/perbid/prebid-server/collaborators/${{ github.actor }}/permission)          
+          user_permission=$(echo $collaboratorPermission | jq '.permission')
+        
+          if [ $user_permission == "\"write\"" ] || [ $user_permission == "\"admin\"" ]; then
+            echo "hasWritePermission=true" >> $GITHUB_OUTPUT
+          else
+          echo "hasWritePermission=false" >> $GITHUB_OUTPUT
+          fi
     outputs:
-      hasWritePermission: ${{ steps.check.outputs.result }}
-  
-  debug-step:
-    name: Debug step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug
-        run: echo ${{ needs.check-permission.outputs.hasWritePermission }}
+      hasWritePermission: ${{ steps.check.outputs.hasWritePermission }}
 
   build-master:
     name: Build master
     needs: check-permission
-    if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
+    if: contains(needs.check-permission.outputs.hasWritePermission, true)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,7 +70,7 @@ jobs:
   publish-tag:
     name: Publish tag
     needs: build-master
-    if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
+    if: contains(needs.check-permission.outputs.hasWritePermission, true)
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
   publish-tag:
     name: Publish tag
     needs: build-master
-    if: contains(needs.check-permission.outputs.hasWritePermission, true)
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
As of now, release workflow uses `actions/github-script` to check if user has `write` permission. However `actions/github-script`  was not returing user permission. Refer https://github.com/prebid/prebid-server/actions/runs/7912092232/job/21597265232 for more details.
<img width="1727" alt="Screenshot 2024-02-15 at 1 33 54 PM" src="https://github.com/prebid/prebid-server/assets/24757781/2a269951-d790-4e3e-8827-173de3e80637">

PR makes changes to replace `github-script` with `gh` cli to check user permission. This simplifies steps needed to check user permission.  Release workflow runs following command to check uf user has `write` permission.

```
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/prebid/prebid-server/collaborators/onkarvhanumante/permission
{
  "permission": "write",
  "user": {
    "login": "onkarvhanumante",
    "id": 24757781,
    "node_id": "MDQ6VXNlcjI0NzU3Nzgx",
     ...
}

```

Tested on fork repository - https://github.com/onkarvhanumante/prebid-server/actions/runs/7912687917