### PR TITLE
Fix: Release workflow permissions

### DIFF
--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -414,6 +414,7 @@ class userHelper {
     this.owner = input.context.repo.owner
     this.repo = input.context.repo.repo
     this.github = input.github
+    this.user = input.user
   }
 
   /*
@@ -424,7 +425,7 @@ class userHelper {
     const { data } = await this.github.rest.repos.getCollaboratorPermissionLevel({
       owner: this.owner,
       repo: this.repo,
-      username: this.owner,
+      username: this.user,
     })
     return data.permission === writePermission || data.permission === adminPermission
   }

--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -426,7 +426,6 @@ class userHelper {
       repo: this.repo,
       username: this.owner,
     })
-    console.log(JSON.stringify(data))
     return data.permission === writePermission || data.permission === adminPermission
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,6 @@ jobs:
             return hasPermission
     outputs:
       hasWritePermission: ${{ steps.check.outputs.result }}
-  
-  debug-step:
-    name: Debug step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug
-        run: echo ${{ needs.check-permission.outputs.hasWritePermission }}
 
   build-master:
     name: Build master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
   publish-tag:
     name: Publish tag
     needs: build-master
-    if: contains(needs.check-permission.outputs.hasWritePermission, 'true')
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           result-encoding: string
           script: |
             const utils = require('./.github/workflows/helpers/pull-request-utils.js')
-            const helper = utils.userHelper({github, context})
+            const helper = utils.userHelper({github, context, user: '${{ github.actor }}'})
             const hasPermission = await helper.hasWritePermissions()
             return hasPermission
     outputs:


### PR DESCRIPTION
Release workflow has `check user permission` step. To check permission workflow makes call to permission api with repo owner and username as input.

Currently repo owner i.e `prebid` is used as username to check collaborator permission. However, `github.actor` i.e user who runs workflow should be used to check user permission. PR makes changes to use github.actor as username.

Earlier this workflow was tested on fork repository (https://github.com/onkarvhanumante/prebid-server/actions/runs/7842711148). However on fork repository, value for owner and username were same. Therefore this issue was not seen on fork repository.


Tested new changes on fork - https://github.com/onkarvhanumante/prebid-server/actions/runs/7913227266/job/21600444085
<img width="1727" alt="image" src="https://github.com/prebid/prebid-server/assets/24757781/131b6cf7-435d-4517-b50a-4f25d17db783">

