### PR TITLE
Fix go vet composite literals with unkeyed fields

### DIFF
--- a/amp/parse.go
+++ b/amp/parse.go
@@ -73,7 +73,7 @@ func ReadPolicy(ampParams Params, pbsConfigGDPREnabled bool) (privacy.PolicyWrit
 			warningMsg = validateTCf2ConsentString(ampParams.Consent)
 		}
 	case ConsentUSPrivacy:
-		rv = ccpa.ConsentWriter{ampParams.Consent}
+		rv = ccpa.ConsentWriter{Consent: ampParams.Consent}
 		if ccpa.ValidateConsent(ampParams.Consent) {
 			if parseGdprApplies(ampParams.GdprApplies) == 1 {
 				// Log warning because AMP request comes with both a valid CCPA string and gdpr_applies set to true
@@ -85,7 +85,7 @@ func ReadPolicy(ampParams Params, pbsConfigGDPREnabled bool) (privacy.PolicyWrit
 		}
 	default:
 		if ccpa.ValidateConsent(ampParams.Consent) {
-			rv = ccpa.ConsentWriter{ampParams.Consent}
+			rv = ccpa.ConsentWriter{Consent: ampParams.Consent}
 			if parseGdprApplies(ampParams.GdprApplies) == 1 {
 				warningMsg = "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string"
 			}

--- a/amp/parse_test.go
+++ b/amp/parse_test.go
@@ -284,7 +284,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "1YYY"},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      nil,
 					},
 				},
@@ -294,7 +294,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "1YYY", GdprApplies: &boolTrue},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
 					},
 				},
@@ -304,8 +304,11 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", &int8One},
-						warning:      nil,
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							RegExtGDPR: &int8One,
+						},
+						warning: nil,
 					},
 				},
 			},
@@ -329,7 +332,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{ConsentType: 101, Consent: "1YYY"},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      nil,
 					},
 				},
@@ -339,7 +342,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{ConsentType: 101, Consent: "1YYY", GdprApplies: &boolTrue},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
 					},
 				},
@@ -349,8 +352,11 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{ConsentType: 101, Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", &int8One},
-						warning:      nil,
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							RegExtGDPR: &int8One,
+						},
+						warning: nil,
 					},
 				},
 			},
@@ -364,48 +370,83 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "INVALID_GDPR", ConsentType: ConsentTCF2, GdprApplies: nil},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"INVALID_GDPR", &int8One},
-						warning:      &errortypes.Warning{Message: "Consent string 'INVALID_GDPR' is not a valid TCF2 consent string.", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "INVALID_GDPR",
+							RegExtGDPR: &int8One,
+						},
+						warning: &errortypes.Warning{
+							Message:     "Consent string 'INVALID_GDPR' is not a valid TCF2 consent string.",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "GDPR consent string is invalid, consent type is TCF2, gdpr_applies is set to true: return a valid GDPR writer and warn about the GDPR string being invalid",
 					in: testInput{
-						ampParams: Params{Consent: "INVALID_GDPR", ConsentType: ConsentTCF2, GdprApplies: &boolFalse},
+						ampParams: Params{
+							Consent:     "INVALID_GDPR",
+							ConsentType: ConsentTCF2,
+							GdprApplies: &boolFalse,
+						},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"INVALID_GDPR", &int8Zero},
-						warning:      &errortypes.Warning{Message: "Consent string 'INVALID_GDPR' is not a valid TCF2 consent string.", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "INVALID_GDPR",
+							RegExtGDPR: &int8Zero,
+						},
+						warning: &errortypes.Warning{
+							Message:     "Consent string 'INVALID_GDPR' is not a valid TCF2 consent string.",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "Valid GDPR consent string, gdpr_applies is set to false, return a valid GDPR writer, no warning",
 					in: testInput{
-						ampParams: Params{Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", ConsentType: ConsentTCF2, GdprApplies: &boolFalse},
+						ampParams: Params{
+							Consent:     "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							ConsentType: ConsentTCF2, GdprApplies: &boolFalse,
+						},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", &int8Zero},
-						warning:      nil,
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							RegExtGDPR: &int8Zero,
+						},
+						warning: nil,
 					},
 				},
 				{
 					desc: "Valid GDPR consent string, gdpr_applies is set to true, return a valid GDPR writer and no warning",
 					in: testInput{
-						ampParams: Params{Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", ConsentType: ConsentTCF2, GdprApplies: &boolTrue},
+						ampParams: Params{
+							Consent:     "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							ConsentType: ConsentTCF2,
+							GdprApplies: &boolTrue,
+						},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", &int8One},
-						warning:      nil,
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							RegExtGDPR: &int8One,
+						},
+						warning: nil,
 					},
 				},
 				{
 					desc: "Valid GDPR consent string, return a valid GDPR writer and no warning",
 					in: testInput{
-						ampParams: Params{Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", ConsentType: ConsentTCF2},
+						ampParams: Params{
+							Consent:     "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							ConsentType: ConsentTCF2,
+						},
 					},
 					expected: expectedResults{
-						policyWriter: gdpr.ConsentWriter{"CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA", &int8One},
-						warning:      nil,
+						policyWriter: gdpr.ConsentWriter{
+							Consent:    "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+							RegExtGDPR: &int8One,
+						},
+						warning: nil,
 					},
 				},
 			},
@@ -419,7 +460,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "XXXX", ConsentType: ConsentUSPrivacy},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"XXXX"},
+						policyWriter: ccpa.ConsentWriter{Consent: "XXXX"},
 						warning:      &errortypes.Warning{Message: "Consent string 'XXXX' is not a valid CCPA consent string.", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
 					},
 				},
@@ -429,7 +470,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy, GdprApplies: &boolTrue},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
 					},
 				},
@@ -439,7 +480,7 @@ func TestPrivacyReader(t *testing.T) {
 						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy},
 					},
 					expected: expectedResults{
-						policyWriter: ccpa.ConsentWriter{"1YYY"},
+						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
 						warning:      nil,
 					},
 				},
@@ -469,19 +510,34 @@ func TestBuildGdprTCF2ConsentWriter(t *testing.T) {
 		expectedWriter gdpr.ConsentWriter
 	}{
 		{
-			desc:           "gdpr_applies not set",
-			inParams:       Params{Consent: consentString},
-			expectedWriter: gdpr.ConsentWriter{consentString, &int8One},
+			desc:     "gdpr_applies not set",
+			inParams: Params{Consent: consentString},
+			expectedWriter: gdpr.ConsentWriter{
+				Consent:    consentString,
+				RegExtGDPR: &int8One,
+			},
 		},
 		{
-			desc:           "gdpr_applies set to false",
-			inParams:       Params{Consent: consentString, GdprApplies: &boolFalse},
-			expectedWriter: gdpr.ConsentWriter{consentString, &int8Zero},
+			desc: "gdpr_applies set to false",
+			inParams: Params{
+				Consent:     consentString,
+				GdprApplies: &boolFalse,
+			},
+			expectedWriter: gdpr.ConsentWriter{
+				Consent:    consentString,
+				RegExtGDPR: &int8Zero,
+			},
 		},
 		{
-			desc:           "gdpr_applies set to true",
-			inParams:       Params{Consent: consentString, GdprApplies: &boolTrue},
-			expectedWriter: gdpr.ConsentWriter{consentString, &int8One},
+			desc: "gdpr_applies set to true",
+			inParams: Params{
+				Consent:     consentString,
+				GdprApplies: &boolTrue,
+			},
+			expectedWriter: gdpr.ConsentWriter{
+				Consent:    consentString,
+				RegExtGDPR: &int8One,
+			},
 		},
 	}
 	for _, tc := range testCases {

--- a/amp/parse_test.go
+++ b/amp/parse_test.go
@@ -354,7 +354,8 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "Unrecognized consent type, valid CCPA consent string and gdpr_applies set to true: expect a CCPA consent writer and a warning",
 					in: testInput{
-						ampParams: Params{ConsentType: 101,
+						ampParams: Params{
+							ConsentType: 101,
 							Consent:     "1YYY",
 							GdprApplies: &boolTrue,
 						},
@@ -502,7 +503,9 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "Valid CCPA consent string, gdpr_applies is set to true: return a valid GDPR writer and warn about the gdpr_applies value.",
 					in: testInput{
-						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy,
+						ampParams: Params{
+							Consent:     "1YYY",
+							ConsentType: ConsentUSPrivacy,
 							GdprApplies: &boolTrue,
 						},
 					},

--- a/amp/parse_test.go
+++ b/amp/parse_test.go
@@ -291,11 +291,17 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "No consent type, valid CCPA consent string and gdpr_applies set to true: expect a CCPA consent writer and a warning",
 					in: testInput{
-						ampParams: Params{Consent: "1YYY", GdprApplies: &boolTrue},
+						ampParams: Params{
+							Consent:     "1YYY",
+							GdprApplies: &boolTrue,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
-						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						warning: &errortypes.Warning{
+							Message:     "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
@@ -319,17 +325,26 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "Unrecognized consent type was specified and invalid consent string provided: expect nil policy writer and a warning",
 					in: testInput{
-						ampParams: Params{ConsentType: 101, Consent: "NOT_CCPA_NOR_GDPR_TCF2"},
+						ampParams: Params{
+							ConsentType: 101,
+							Consent:     "NOT_CCPA_NOR_GDPR_TCF2",
+						},
 					},
 					expected: expectedResults{
 						policyWriter: privacy.NilPolicyWriter{},
-						warning:      &errortypes.Warning{Message: "Consent string 'NOT_CCPA_NOR_GDPR_TCF2' is not recognized as one of the supported formats CCPA or TCF2.", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						warning: &errortypes.Warning{
+							Message:     "Consent string 'NOT_CCPA_NOR_GDPR_TCF2' is not recognized as one of the supported formats CCPA or TCF2.",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "Unrecognized consent type specified but query params come with a valid CCPA consent string: expect a CCPA consent writer and no error nor warning",
 					in: testInput{
-						ampParams: Params{ConsentType: 101, Consent: "1YYY"},
+						ampParams: Params{
+							ConsentType: 101,
+							Consent:     "1YYY",
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
@@ -339,17 +354,26 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "Unrecognized consent type, valid CCPA consent string and gdpr_applies set to true: expect a CCPA consent writer and a warning",
 					in: testInput{
-						ampParams: Params{ConsentType: 101, Consent: "1YYY", GdprApplies: &boolTrue},
+						ampParams: Params{ConsentType: 101,
+							Consent:     "1YYY",
+							GdprApplies: &boolTrue,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
-						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						warning: &errortypes.Warning{
+							Message:     "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "Unrecognized consent type, valid TCF2 consent string and gdpr_applies not set: expect GDPR consent writer and no error nor warning",
 					in: testInput{
-						ampParams: Params{ConsentType: 101, Consent: "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"},
+						ampParams: Params{
+							ConsentType: 101,
+							Consent:     "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
+						},
 					},
 					expected: expectedResults{
 						policyWriter: gdpr.ConsentWriter{
@@ -367,7 +391,11 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "GDPR consent string is invalid, but consent type is TCF2: return a valid GDPR writer and warn about the GDPR string being invalid",
 					in: testInput{
-						ampParams: Params{Consent: "INVALID_GDPR", ConsentType: ConsentTCF2, GdprApplies: nil},
+						ampParams: Params{
+							Consent:     "INVALID_GDPR",
+							ConsentType: ConsentTCF2,
+							GdprApplies: nil,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: gdpr.ConsentWriter{
@@ -405,7 +433,8 @@ func TestPrivacyReader(t *testing.T) {
 					in: testInput{
 						ampParams: Params{
 							Consent:     "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA",
-							ConsentType: ConsentTCF2, GdprApplies: &boolFalse,
+							ConsentType: ConsentTCF2,
+							GdprApplies: &boolFalse,
 						},
 					},
 					expected: expectedResults{
@@ -457,27 +486,41 @@ func TestPrivacyReader(t *testing.T) {
 				{
 					desc: "CCPA consent string is invalid: return a valid writer a warning about the string being invalid",
 					in: testInput{
-						ampParams: Params{Consent: "XXXX", ConsentType: ConsentUSPrivacy},
+						ampParams: Params{
+							Consent:     "XXXX",
+							ConsentType: ConsentUSPrivacy,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "XXXX"},
-						warning:      &errortypes.Warning{Message: "Consent string 'XXXX' is not a valid CCPA consent string.", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						warning: &errortypes.Warning{
+							Message:     "Consent string 'XXXX' is not a valid CCPA consent string.",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "Valid CCPA consent string, gdpr_applies is set to true: return a valid GDPR writer and warn about the gdpr_applies value.",
 					in: testInput{
-						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy, GdprApplies: &boolTrue},
+						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy,
+							GdprApplies: &boolTrue,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},
-						warning:      &errortypes.Warning{Message: "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string", WarningCode: errortypes.InvalidPrivacyConsentWarningCode},
+						warning: &errortypes.Warning{
+							Message:     "AMP request gdpr_applies value was ignored because provided consent string is a CCPA consent string",
+							WarningCode: errortypes.InvalidPrivacyConsentWarningCode,
+						},
 					},
 				},
 				{
 					desc: "Valid CCPA consent string, return a valid GDPR writer and no warning",
 					in: testInput{
-						ampParams: Params{Consent: "1YYY", ConsentType: ConsentUSPrivacy},
+						ampParams: Params{
+							Consent:     "1YYY",
+							ConsentType: ConsentUSPrivacy,
+						},
 					},
 					expected: expectedResults{
 						policyWriter: ccpa.ConsentWriter{Consent: "1YYY"},


### PR DESCRIPTION
Fix go vet 'composite literals with unkeyed fields' issue by applying `gopls fix -a -w <file.go>` and some reformatting the structure initialization to be multiline with multiple fields. Part of the fix for #3481.

Reference: https://github.com/golang/go/issues/53062