### PR TITLE
Add Prometheus to module dependencies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -565,6 +565,10 @@ func (cfg *PrometheusMetrics) validate(errs []error) []error {
 	return errs
 }
 
+func (cfg *PrometheusMetrics) Enabled() bool {
+	return cfg.Port > 0
+}
+
 func (m *PrometheusMetrics) Timeout() time.Duration {
 	return time.Duration(m.TimeoutMillisRaw) * time.Millisecond
 }

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1208,7 +1208,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	adapterList := make([]openrtb_ext.BidderName, 0, 2)
 	syncerKeys := []string{}
 	var moduleStageNames map[string][]string
-	testEngine := metricsConf.NewMetricsEngine(cfg, adapterList, syncerKeys, moduleStageNames)
+	testEngine := metricsConf.NewMetricsEngine(cfg, adapterList, syncerKeys, moduleStageNames, nil)
 	//	2) Init new exchange with said configuration
 	handlerNoBidServer := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(204) }
 	server := httptest.NewServer(http.HandlerFunc(handlerNoBidServer))
@@ -2416,7 +2416,7 @@ func newExchangeForTests(t *testing.T, filename string, expectations map[string]
 		}
 	}
 
-	metricsEngine := metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil)
+	metricsEngine := metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil, nil)
 	requestSplitter := requestSplitter{
 		bidderToSyncerKey: bidderToSyncerKey,
 		me:                metricsEngine,
@@ -4630,7 +4630,7 @@ func TestCallSignHeader(t *testing.T) {
 
 func TestValidateBannerCreativeSize(t *testing.T) {
 	exchange := exchange{bidValidationEnforcement: config.Validations{MaxCreativeWidth: 100, MaxCreativeHeight: 100},
-		me: metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil),
+		me: metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil, nil),
 	}
 	testCases := []struct {
 		description                 string
@@ -4681,7 +4681,7 @@ func TestValidateBannerCreativeSize(t *testing.T) {
 
 func TestValidateBidAdM(t *testing.T) {
 	exchange := exchange{bidValidationEnforcement: config.Validations{MaxCreativeWidth: 100, MaxCreativeHeight: 100},
-		me: metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil),
+		me: metricsConf.NewMetricsEngine(&config.Configuration{}, openrtb_ext.CoreBidderNames(), nil, nil, nil),
 	}
 	testCases := []struct {
 		description         string

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -7,13 +7,14 @@ import (
 	"github.com/prebid/prebid-server/v2/metrics"
 	prometheusmetrics "github.com/prebid/prebid-server/v2/metrics/prometheus"
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
+	"github.com/prometheus/client_golang/prometheus"
 	gometrics "github.com/rcrowley/go-metrics"
 	influxdb "github.com/vrischmann/go-metrics-influxdb"
 )
 
 // NewMetricsEngine reads the configuration and returns the appropriate metrics engine
 // for this instance.
-func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.BidderName, syncerKeys []string, moduleStageNames map[string][]string) *DetailedMetricsEngine {
+func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.BidderName, syncerKeys []string, moduleStageNames map[string][]string, registry *prometheus.Registry) *DetailedMetricsEngine {
 	// Create a list of metrics engines to use.
 	// Capacity of 2, as unlikely to have more than 2 metrics backends, and in the case
 	// of 1 we won't use the list so it will be garbage collected.
@@ -40,7 +41,7 @@ func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.Bidde
 	}
 	if cfg.Metrics.Prometheus.Port != 0 {
 		// Set up the Prometheus metrics.
-		returnEngine.PrometheusMetrics = prometheusmetrics.NewMetrics(cfg.Metrics.Prometheus, cfg.Metrics.Disabled, syncerKeys, moduleStageNames)
+		returnEngine.PrometheusMetrics = prometheusmetrics.NewMetrics(cfg.Metrics.Prometheus, cfg.Metrics.Disabled, syncerKeys, moduleStageNames, registry)
 		engineList = append(engineList, returnEngine.PrometheusMetrics)
 	}
 

--- a/metrics/config/metrics_test.go
+++ b/metrics/config/metrics_test.go
@@ -9,7 +9,6 @@ import (
 	mainConfig "github.com/prebid/prebid-server/v2/config"
 	"github.com/prebid/prebid-server/v2/metrics"
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
-
 	gometrics "github.com/rcrowley/go-metrics"
 )
 
@@ -20,7 +19,7 @@ func TestNilMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
 	adapterList := make([]openrtb_ext.BidderName, 0, 2)
 	syncerKeys := []string{"keyA", "keyB"}
-	testEngine := NewMetricsEngine(&cfg, adapterList, syncerKeys, modulesStages)
+	testEngine := NewMetricsEngine(&cfg, adapterList, syncerKeys, modulesStages, nil)
 	_, ok := testEngine.MetricsEngine.(*NilMetricsEngine)
 	if !ok {
 		t.Error("Expected a NilMetricsEngine, but didn't get it")
@@ -32,7 +31,7 @@ func TestGoMetricsEngine(t *testing.T) {
 	cfg.Metrics.Influxdb.Host = "localhost"
 	adapterList := make([]openrtb_ext.BidderName, 0, 2)
 	syncerKeys := []string{"keyA", "keyB"}
-	testEngine := NewMetricsEngine(&cfg, adapterList, syncerKeys, modulesStages)
+	testEngine := NewMetricsEngine(&cfg, adapterList, syncerKeys, modulesStages, nil)
 	_, ok := testEngine.MetricsEngine.(*metrics.Metrics)
 	if !ok {
 		t.Error("Expected a Metrics as MetricsEngine, but didn't get it")

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -160,7 +160,7 @@ const (
 )
 
 // NewMetrics initializes a new Prometheus metrics instance with preloaded label values.
-func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMetrics, syncerKeys []string, moduleStageNames map[string][]string) *Metrics {
+func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMetrics, syncerKeys []string, moduleStageNames map[string][]string, reg *prometheus.Registry) *Metrics {
 	standardTimeBuckets := []float64{0.05, 0.1, 0.15, 0.20, 0.25, 0.3, 0.4, 0.5, 0.75, 1}
 	cacheWriteTimeBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1}
 	priceBuckets := []float64{250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
@@ -168,7 +168,6 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	overheadTimeBuckets := []float64{0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}
 
 	metrics := Metrics{}
-	reg := prometheus.NewRegistry()
 	metrics.metricsDisabled = disabledMetrics
 
 	metrics.connectionsClosed = newCounterWithoutLabels(cfg, reg,

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -21,7 +21,7 @@ func createMetricsForTesting() *Metrics {
 		Port:      8080,
 		Namespace: "prebid",
 		Subsystem: "server",
-	}, config.DisabledMetrics{}, syncerKeys, modulesStages)
+	}, config.DisabledMetrics{}, syncerKeys, modulesStages, prometheus.NewRegistry())
 }
 
 func TestMetricCountGatekeeping(t *testing.T) {
@@ -1638,7 +1638,7 @@ func TestDisabledMetrics(t *testing.T) {
 		AdapterConnectionMetrics:  true,
 		AdapterGDPRRequestBlocked: true,
 	},
-		nil, nil)
+		nil, nil, prometheus.NewRegistry())
 
 	// Assert counter vector was not initialized
 	assert.Nil(t, prometheusMetrics.adapterReusedConnections, "Counter Vector adapterReusedConnections should be nil")

--- a/modules/moduledeps/deps.go
+++ b/modules/moduledeps/deps.go
@@ -4,11 +4,13 @@ import (
 	"net/http"
 
 	"github.com/prebid/prebid-server/v2/currency"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ModuleDeps provides dependencies that custom modules may need for hooks execution.
 // Additional dependencies can be added here if modules need something more.
 type ModuleDeps struct {
-	HTTPClient    *http.Client
-	RateConvertor *currency.RateConverter
+	HTTPClient         *http.Client
+	RateConvertor      *currency.RateConverter
+	PrometheusGatherer *prometheus.Registry
 }

--- a/server/server.go
+++ b/server/server.go
@@ -63,7 +63,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	}
 	go runServer(adminServer, "Admin", adminListener)
 
-	if cfg.Metrics.Prometheus.Port != 0 {
+	if cfg.Metrics.Prometheus.Enabled() {
 		var (
 			prometheusListener net.Listener
 			prometheusServer   = newPrometheusServer(cfg, metrics)


### PR DESCRIPTION
I need to scrape metrics from the modules, so Prometheus has been added to the module dependencies. PBS doesn't use default Prometheus Gatherer, so the only way is to pass the same instance of Prometheus.Gatherer to modules. Please review