### PR TITLE
Make admin listener configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Configuration struct {
 	UnixSocketName   string      `mapstructure:"unix_socket_name"`
 	Client           HTTPClient  `mapstructure:"http_client"`
 	CacheClient      HTTPClient  `mapstructure:"http_client_cache"`
+	AdminEnabled     bool        `mapstructure:"admin_enabled"`
 	AdminPort        int         `mapstructure:"admin_port"`
 	Compression      Compression `mapstructure:"compression"`
 	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
@@ -857,6 +858,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("port", 8000)
 	v.SetDefault("unix_socket_enable", false)              // boolean which decide if the socket-server will be started.
 	v.SetDefault("unix_socket_name", "prebid-server.sock") // path of the socket's file which must be listened.
+	v.SetDefault("admin_enabled", true)                    // boolean to determine if admin listener will be started.
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("garbage_collector_threshold", 0)
 	v.SetDefault("status_response", "")

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Configuration struct {
 	UnixSocketName   string      `mapstructure:"unix_socket_name"`
 	Client           HTTPClient  `mapstructure:"http_client"`
 	CacheClient      HTTPClient  `mapstructure:"http_client_cache"`
-	AdminEnabled     bool        `mapstructure:"admin_enabled"`
+	Admin            Admin       `mapstructure:"admin"`
 	AdminPort        int         `mapstructure:"admin_port"`
 	Compression      Compression `mapstructure:"compression"`
 	// GarbageCollectorThreshold allocates virtual memory (in bytes) which is not used by PBS but
@@ -103,6 +103,9 @@ type Configuration struct {
 	PriceFloors PriceFloors `mapstructure:"price_floors"`
 }
 
+type Admin struct {
+	Enabled bool `mapstructure:"enabled"`
+}
 type PriceFloors struct {
 	Enabled bool              `mapstructure:"enabled"`
 	Fetcher PriceFloorFetcher `mapstructure:"fetcher"`
@@ -858,8 +861,8 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("port", 8000)
 	v.SetDefault("unix_socket_enable", false)              // boolean which decide if the socket-server will be started.
 	v.SetDefault("unix_socket_name", "prebid-server.sock") // path of the socket's file which must be listened.
-	v.SetDefault("admin_enabled", true)                    // boolean to determine if admin listener will be started.
 	v.SetDefault("admin_port", 6060)
+	v.SetDefault("admin.enabled", true) // boolean to determine if admin listener will be started.
 	v.SetDefault("garbage_collector_threshold", 0)
 	v.SetDefault("status_response", "")
 	v.SetDefault("datacenter", "")

--- a/server/server.go
+++ b/server/server.go
@@ -29,9 +29,6 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	stopPrometheus := make(chan os.Signal)
 	done := make(chan struct{})
 
-	adminServer := newAdminServer(cfg, adminHandler)
-	go shutdownAfterSignals(adminServer, stopAdmin, done)
-
 	if cfg.UnixSocketEnable && len(cfg.UnixSocketName) > 0 { // start the unix_socket server if config enable-it.
 		var (
 			socketListener net.Listener
@@ -56,12 +53,17 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 		go runServer(mainServer, "Main", mainListener)
 	}
 
-	var adminListener net.Listener
-	if adminListener, err = newTCPListener(adminServer.Addr, nil); err != nil {
-		glog.Errorf("Error listening for TCP connections on %s: %v for admin server", adminServer.Addr, err)
-		return
+	if cfg.AdminEnabled {
+		adminServer := newAdminServer(cfg, adminHandler)
+		go shutdownAfterSignals(adminServer, stopAdmin, done)
+
+		var adminListener net.Listener
+		if adminListener, err = newTCPListener(adminServer.Addr, nil); err != nil {
+			glog.Errorf("Error listening for TCP connections on %s: %v for admin server", adminServer.Addr, err)
+			return
+		}
+		go runServer(adminServer, "Admin", adminListener)
 	}
-	go runServer(adminServer, "Admin", adminListener)
 
 	if cfg.Metrics.Prometheus.Port != 0 {
 		var (
@@ -70,7 +72,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 		)
 		go shutdownAfterSignals(prometheusServer, stopPrometheus, done)
 		if prometheusListener, err = newTCPListener(prometheusServer.Addr, nil); err != nil {
-			glog.Errorf("Error listening for TCP connections on %s: %v for prometheus server", adminServer.Addr, err)
+			glog.Errorf("Error listening for TCP connections on %s: %v for prometheus server", prometheusServer.Addr, err)
 			return
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -53,7 +53,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 		go runServer(mainServer, "Main", mainListener)
 	}
 
-	if cfg.AdminEnabled {
+	if cfg.Admin.Enabled {
 		adminServer := newAdminServer(cfg, adminHandler)
 		go shutdownAfterSignals(adminServer, stopAdmin, done)
 


### PR DESCRIPTION
Admin listener is made configurable by adding  an `Admin` sub-object with `Enabled` field. 
`admin.enabled` is enabled by default.
Making it configurable allows a host company to not run the listener on admin port if they desire to do so.