### PR TITLE
Fix go vet 'composite literals with unkeyed fields'

### DIFF
--- a/adapters/adoppler/adoppler.go
+++ b/adapters/adoppler/adoppler.go
@@ -65,7 +65,7 @@ func (ads *AdopplerAdapter) MakeRequests(
 	for _, imp := range req.Imp {
 		ext, err := unmarshalExt(imp.Ext)
 		if err != nil {
-			errs = append(errs, &errortypes.BadInput{err.Error()})
+			errs = append(errs, &errortypes.BadInput{Message: err.Error()})
 			continue
 		}
 
@@ -83,7 +83,7 @@ func (ads *AdopplerAdapter) MakeRequests(
 		if err != nil {
 			e := fmt.Sprintf("Unable to build bid URI: %s",
 				err.Error())
-			errs = append(errs, &errortypes.BadInput{e})
+			errs = append(errs, &errortypes.BadInput{Message: e})
 			continue
 		}
 		data := &adapters.RequestData{
@@ -110,11 +110,11 @@ func (ads *AdopplerAdapter) MakeBids(
 		return nil, nil
 	}
 	if resp.StatusCode == http.StatusBadRequest {
-		return nil, []error{&errortypes.BadInput{"bad request"}}
+		return nil, []error{&errortypes.BadInput{Message: "bad request"}}
 	}
 	if resp.StatusCode != http.StatusOK {
 		err := &errortypes.BadServerResponse{
-			fmt.Sprintf("unexpected status: %d", resp.StatusCode),
+			Message: fmt.Sprintf("unexpected status: %d", resp.StatusCode),
 		}
 		return nil, []error{err}
 	}
@@ -123,7 +123,7 @@ func (ads *AdopplerAdapter) MakeBids(
 	err := json.Unmarshal(resp.Body, &bidResp)
 	if err != nil {
 		err := &errortypes.BadServerResponse{
-			fmt.Sprintf("invalid body: %s", err.Error()),
+			Message: fmt.Sprintf("invalid body: %s", err.Error()),
 		}
 		return nil, []error{err}
 	}
@@ -132,7 +132,7 @@ func (ads *AdopplerAdapter) MakeBids(
 	for _, imp := range intReq.Imp {
 		if _, ok := impTypes[imp.ID]; ok {
 			return nil, []error{&errortypes.BadInput{
-				fmt.Sprintf("duplicate $.imp.id %s", imp.ID),
+				Message: fmt.Sprintf("duplicate $.imp.id %s", imp.ID),
 			}}
 		}
 		if imp.Banner != nil {
@@ -145,7 +145,7 @@ func (ads *AdopplerAdapter) MakeBids(
 			impTypes[imp.ID] = openrtb_ext.BidTypeNative
 		} else {
 			return nil, []error{&errortypes.BadInput{
-				"one of $.imp.banner, $.imp.video, $.imp.audio and $.imp.native field required",
+				Message: "one of $.imp.banner, $.imp.video, $.imp.audio and $.imp.native field required",
 			}}
 		}
 	}
@@ -156,7 +156,7 @@ func (ads *AdopplerAdapter) MakeBids(
 			tp, ok := impTypes[bid.ImpID]
 			if !ok {
 				err := &errortypes.BadServerResponse{
-					fmt.Sprintf("unknown impid: %s", bid.ImpID),
+					Message: fmt.Sprintf("unknown impid: %s", bid.ImpID),
 				}
 				return nil, []error{err}
 			}
@@ -165,11 +165,11 @@ func (ads *AdopplerAdapter) MakeBids(
 			if tp == openrtb_ext.BidTypeVideo {
 				adsExt, err := unmarshalAdsExt(bid.Ext)
 				if err != nil {
-					return nil, []error{&errortypes.BadServerResponse{err.Error()}}
+					return nil, []error{&errortypes.BadServerResponse{Message: err.Error()}}
 				}
 				if adsExt == nil || adsExt.Video == nil {
 					return nil, []error{&errortypes.BadServerResponse{
-						"$.seatbid.bid.ext.ads.video required",
+						Message: "$.seatbid.bid.ext.ads.video required",
 					}}
 				}
 				bidVideo = &openrtb_ext.ExtBidPrebidVideo{

--- a/adapters/adquery/adquery.go
+++ b/adapters/adquery/adquery.go
@@ -41,7 +41,7 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRe
 	for _, imp := range request.Imp {
 		ext, err := parseExt(imp.Ext)
 		if err != nil {
-			errs = append(errs, &errortypes.BadInput{err.Error()})
+			errs = append(errs, &errortypes.BadInput{Message: err.Error()})
 			continue
 		}
 


### PR DESCRIPTION
Fix go vet 'composite literals with unkeyed fields' issue by applying `gopls fix -a -w <file.go>`. Follow-up on https://github.com/prebid/prebid-server/pull/3507. Part of the fix for prebid#3481.

Reference: golang/go#53062