### PR TITLE
Adnuntius: site.ext targeting

### DIFF
--- a/adapters/adnuntius/adnuntius.go
+++ b/adapters/adnuntius/adnuntius.go
@@ -33,6 +33,9 @@ type adnAdunit struct {
 type extDeviceAdnuntius struct {
 	NoCookies bool `json:"noCookies,omitempty"`
 }
+type siteExt struct {
+	Data interface{} `json:"data"`
+}
 
 type Ad struct {
 	Bid struct {
@@ -71,9 +74,10 @@ type adnMetaData struct {
 	Usi string `json:"usi,omitempty"`
 }
 type adnRequest struct {
-	AdUnits  []adnAdunit `json:"adUnits"`
-	MetaData adnMetaData `json:"metaData,omitempty"`
-	Context  string      `json:"context,omitempty"`
+	AdUnits   []adnAdunit `json:"adUnits"`
+	MetaData  adnMetaData `json:"metaData,omitempty"`
+	Context   string      `json:"context,omitempty"`
+	KeyValues interface{} `json:"kv,omitempty"`
 }
 
 type RequestExt struct {
@@ -138,7 +142,6 @@ func makeEndpointUrl(ortbRequest openrtb2.BidRequest, a *adapter, noCookies bool
 		if deviceExt.NoCookies {
 			noCookies = true
 		}
-
 	}
 
 	_, offset := a.time.Now().Zone()
@@ -249,11 +252,31 @@ func (a *adapter) generateRequests(ortbRequest openrtb2.BidRequest) ([]*adapters
 		site = ortbRequest.Site.Page
 	}
 
+	extSite, erro := getSiteExtAsKv(&ortbRequest)
+	if erro != nil {
+		return nil, []error{fmt.Errorf("failed to parse site Ext: %v", err)}
+	}
+
 	for _, networkAdunits := range networkAdunitMap {
 
 		adnuntiusRequest := adnRequest{
-			AdUnits: networkAdunits,
-			Context: site,
+			AdUnits:   networkAdunits,
+			Context:   site,
+			KeyValues: extSite.Data,
+		}
+
+		var extUser openrtb_ext.ExtUser
+		if ortbRequest.User != nil && ortbRequest.User.Ext != nil {
+			if err := json.Unmarshal(ortbRequest.User.Ext, &extUser); err != nil {
+				return nil, []error{fmt.Errorf("failed to parse Ext User: %v", err)}
+			}
+		}
+
+		// Will change when our adserver can accept multiple user IDS
+		if extUser.Eids != nil && len(extUser.Eids) > 0 {
+			if len(extUser.Eids[0].UIDs) > 0 {
+				adnuntiusRequest.MetaData.Usi = extUser.Eids[0].UIDs[0].ID
+			}
 		}
 
 		ortbUser := ortbRequest.User
@@ -308,6 +331,16 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, externalRequest *adapte
 	}
 
 	return bidResponse, nil
+}
+
+func getSiteExtAsKv(request *openrtb2.BidRequest) (siteExt, error) {
+	var extSite siteExt
+	if request.Site != nil && request.Site.Ext != nil {
+		if err := json.Unmarshal(request.Site.Ext, &extSite); err != nil {
+			return extSite, fmt.Errorf("failed to parse ExtSite in Adnuntius: %v", err)
+		}
+	}
+	return extSite, nil
 }
 
 func getGDPR(request *openrtb2.BidRequest) (string, string, error) {

--- a/adapters/adnuntius/adnuntiustest/supplemental/site-ext.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/site-ext.json
@@ -1,0 +1,113 @@
+{
+	"mockBidRequest": {
+		"id": "test-request-id",
+		"user": {
+			"id": "1kjh3429kjh295jkl"
+		},
+		"site": {
+			"ext":{
+				"data" : {
+					"key": ["value"]
+				}
+			}
+		},
+		"imp": [
+			{
+				"id": "test-imp-id",
+				"banner": {
+					"format": [
+						{
+							"w": 300,
+							"h": 250
+						},
+						{
+							"w": 300,
+							"h": 600
+						}
+					]
+				},
+				"ext": {
+					"bidder": {
+						"auId": "123"
+					}
+				}
+			}
+		]
+	},
+	"httpCalls": [
+		{
+			"expectedRequest": {
+				"uri": "http://whatever.url?format=json&tzo=0",
+				"body": {
+					"adUnits": [
+						{
+							"auId": "123",
+							"targetId": "123-test-imp-id",
+							"dimensions": [[300,250],[300,600]]
+						}
+					],
+					"kv": {
+						"key": ["value"]
+					},
+					"metaData": {
+						"usi": "1kjh3429kjh295jkl"
+					},
+					"context": "unknown"
+				}
+			},
+			"mockResponse": {
+				"status": 200,
+				"body": {
+					"adUnits": [
+						{
+							"auId": "0000000000000123",
+							"targetId": "123-test-imp-id",
+							"html": "<ADCODE>",
+							"responseId": "adn-rsp-900646517",
+							"ads": [
+								{
+									"destinationUrls": {
+										"url": "http://www.google.com"
+									},
+									"bid": {
+										"amount": 20.0,
+										"currency": "NOK"
+									},
+									"adId": "adn-id-1559784094",
+									"creativeWidth": "980",
+									"creativeHeight": "240",
+									"creativeId": "jn9hpzvlsf8cpdmm",
+									"lineItemId": "q7y9qm5b0xt9htrv"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	],
+	"expectedBidResponses": [
+		{
+			"bids": [
+				{
+					"bid": {
+						"id": "adn-id-1559784094",
+						"impid": "test-imp-id",
+						"price": 20000,
+						"adm": "<ADCODE>",
+						"adid": "adn-id-1559784094",
+						"adomain": [
+							"google.com"
+						],
+						"cid": "q7y9qm5b0xt9htrv",
+						"crid": "jn9hpzvlsf8cpdmm",
+						"w": 980,
+						"h": 240
+					},
+					"type": "banner"
+				}
+			],
+			"currency": "NOK"
+		}
+	]
+}

--- a/adapters/adnuntius/adnuntiustest/supplemental/user-ext.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/user-ext.json
@@ -1,0 +1,112 @@
+{
+	"mockBidRequest": {
+		"id": "test-request-id",
+		"user": {
+			"ext":{
+				"eids" : [
+					{ 
+						"source": "idProvider", 
+						"uids": [
+							{ "id": "userId", "atype": 1, "ext": { "stype": "ppuid" } }
+						] 
+					}
+				]
+			}
+		},
+		"imp": [
+			{
+				"id": "test-imp-id",
+				"banner": {
+					"format": [
+						{
+							"w": 300,
+							"h": 250
+						},
+						{
+							"w": 300,
+							"h": 600
+						}
+					]
+				},
+				"ext": {
+					"bidder": {
+						"auId": "123"
+					}
+				}
+			}
+		]
+	},
+	"httpCalls": [
+		{
+			"expectedRequest": {
+				"uri": "http://whatever.url?format=json&tzo=0",
+				"body": {
+					"adUnits": [
+						{
+							"auId": "123",
+							"targetId": "123-test-imp-id",
+							"dimensions": [[300,250],[300,600]]
+						}
+					],
+					"metaData": {
+						"usi": "userId"
+					},
+					"context": "unknown"
+				}
+			},
+			"mockResponse": {
+				"status": 200,
+				"body": {
+					"adUnits": [
+						{
+							"auId": "0000000000000123",
+							"targetId": "123-test-imp-id",
+							"html": "<ADCODE>",
+							"responseId": "adn-rsp-900646517",
+							"ads": [
+								{
+									"destinationUrls": {
+										"url": "http://www.google.com"
+									},
+									"bid": {
+										"amount": 20.0,
+										"currency": "NOK"
+									},
+									"adId": "adn-id-1559784094",
+									"creativeWidth": "980",
+									"creativeHeight": "240",
+									"creativeId": "jn9hpzvlsf8cpdmm",
+									"lineItemId": "q7y9qm5b0xt9htrv"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	],
+	"expectedBidResponses": [
+		{
+			"bids": [
+				{
+					"bid": {
+						"id": "adn-id-1559784094",
+						"impid": "test-imp-id",
+						"price": 20000,
+						"adm": "<ADCODE>",
+						"adid": "adn-id-1559784094",
+						"adomain": [
+							"google.com"
+						],
+						"cid": "q7y9qm5b0xt9htrv",
+						"crid": "jn9hpzvlsf8cpdmm",
+						"w": 980,
+						"h": 240
+					},
+					"type": "banner"
+				}
+			],
+			"currency": "NOK"
+		}
+	]
+}


### PR DESCRIPTION
This PR is meant to allow Adnuntius to do targeting on site Ext and also pick the first external ID from EIDs until we allow for multiple IDs in our adserver.