### PR TITLE
DSA: Use seat nonbid code 300

### DIFF
--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -31,6 +31,7 @@ const (
 	AdServerTargetingWarningCode
 	BidAdjustmentWarningCode
 	FloorBidRejectionWarningCode
+	InvalidBidResponseDSAWarningCode
 )
 
 // Coder provides an error or warning code with severity.

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1247,12 +1247,12 @@ func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCrea
 	for _, bid := range bids {
 		if !dsa.Validate(bidRequest, bid) {
 			RequiredError := openrtb_ext.ExtBidderMessage{
-				Code:    errortypes.BadServerResponseErrorCode,
-				Message: "bidResponse rejected: DSA object missing when required",
+				Code:    errortypes.InvalidBidResponseDSAWarningCode,
+				Message: "bid response rejected: object missing when required",
 			}
 			bidResponseExt.Warnings[adapter] = append(bidResponseExt.Warnings[adapter], RequiredError)
 
-			seatNonBids.addBid(bid, int(ResponseRejectedPrivacy), adapter.String())
+			seatNonBids.addBid(bid, int(ResponseRejectedGeneral), adapter.String())
 			continue // Don't add bid to result
 		}
 		if e.bidValidationEnforcement.BannerCreativeMaxSize == config.ValidationEnforce && bid.BidType == openrtb_ext.BidTypeBanner {

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1248,7 +1248,7 @@ func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCrea
 		if !dsa.Validate(bidRequest, bid) {
 			RequiredError := openrtb_ext.ExtBidderMessage{
 				Code:    errortypes.InvalidBidResponseDSAWarningCode,
-				Message: "bid response rejected: object missing when required",
+				Message: "bid response rejected: DSA object missing when required",
 			}
 			bidResponseExt.Warnings[adapter] = append(bidResponseExt.Warnings[adapter], RequiredError)
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -4765,7 +4765,7 @@ func TestMakeBidWithValidation(t *testing.T) {
 				seatNonBidsMap: map[string][]openrtb_ext.NonBid{
 					"pubmatic": {
 						{
-							StatusCode: 305,
+							StatusCode: 300,
 							Ext: openrtb_ext.NonBidExt{
 								Prebid: openrtb_ext.ExtResponseNonBidPrebid{
 									Bid: openrtb_ext.NonBidObject{},

--- a/exchange/non_bid_reason.go
+++ b/exchange/non_bid_reason.go
@@ -6,9 +6,9 @@ package exchange
 type NonBidReason int
 
 const (
-	NoBidUnknownError                      NonBidReason = 0   // No Bid - General
+	NoBidUnknownError                      NonBidReason = 0 // No Bid - General
+	ResponseRejectedGeneral                NonBidReason = 300
 	ResponseRejectedCategoryMappingInvalid NonBidReason = 303 // Response Rejected - Category Mapping Invalid
-	ResponseRejectedPrivacy                NonBidReason = 305
 	ResponseRejectedCreativeSizeNotAllowed NonBidReason = 351 // Response Rejected - Invalid Creative (Size Not Allowed)
 	ResponseRejectedCreativeNotSecure      NonBidReason = 352 // Response Rejected - Invalid Creative (Not Secure)
 )


### PR DESCRIPTION
Seat nonbid code 305 has not been formally approved yet so we will use 300 until then.
This PR also adds a DSA specific warning code as I don't think the invalid bid response error code makes sense since this is not a server error nor is it a malformed bid response. Instead it is a validation error.