### PR TITLE
Fix: Module template & builder produces duplicate map keys

### DIFF
--- a/modules/generator/builder.tmpl
+++ b/modules/generator/builder.tmpl
@@ -1,20 +1,21 @@
 package modules
-
-{{if .}}
 import (
-    {{- range .}}
-    {{.Vendor}}{{.Module | Title}} "github.com/prebid/prebid-server/v2/modules/{{.Vendor}}/{{.Module}}"
+{{- range $vendor, $modules := .}}
+    {{- range $module := $modules}}
+        {{$vendor}}{{$module | Title}} "github.com/prebid/prebid-server/v2/modules/{{$vendor}}/{{$module}}"
     {{- end}}
+{{- end}}
 )
-{{end}}
 
 // builders returns mapping between module name and its builder
 // vendor and module names are chosen based on the module directory name
 func builders() ModuleBuilders {
     return ModuleBuilders{
-        {{- range .}}
-        "{{.Vendor}}": {
-            "{{.Module}}": {{.Vendor}}{{.Module | Title}}.Builder,
+        {{- range $vendor, $modules := .}}
+        "{{$vendor}}": {
+            {{- range $module := $modules}}
+            "{{$module}}": {{$vendor}}{{$module | Title}}.Builder,
+            {{- end}}
         },
         {{- end}}
     }


### PR DESCRIPTION
I have several modules organized in this way
```
modules/
├── vendor1
│   ├── module1
│   ├── module2
│   └── module3
├── generator
├── moduledeps
└── prebid
    └── ortb2blocking
```
But `make build-modules` produces a generated file with duplicate keys in map

```
func builders() ModuleBuilders {
	return ModuleBuilders{
		"vendor1": {
			"module1": vendor1Module1.Builder,
		},
		"vendor1": {
			"module2": vendor1Module2.Builder,
		},
		"vendor1": {
			"module3": vendor1Module3.Builder,
		},
		"prebid": {
			"ortb2blocking": prebidOrtb2blocking.Builder,
		},
	}
}
```

With the fix:
```
func builders() ModuleBuilders {
	return ModuleBuilders{
		"vendor1": {
			"module1":   vendor1Module1.Builder,
			"module2":   vendor1Module2.Builder,
			"module3":   vendor1Module3.Builder,
		},
		"prebid": {
			"ortb2blocking": prebidOrtb2blocking.Builder,
		},
	}
}
```