### PR TITLE
Fix: Pubstack memory leak

### DIFF
--- a/analytics/pubstack/eventchannel/sender.go
+++ b/analytics/pubstack/eventchannel/sender.go
@@ -27,7 +27,6 @@ func NewHttpSender(client *http.Client, endpoint string) Sender {
 		if err != nil {
 			return err
 		}
-
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {

--- a/analytics/pubstack/eventchannel/sender.go
+++ b/analytics/pubstack/eventchannel/sender.go
@@ -27,7 +27,7 @@ func NewHttpSender(client *http.Client, endpoint string) Sender {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			glog.Errorf("[pubstack] Wrong code received %d instead of %d", resp.StatusCode, http.StatusOK)

--- a/analytics/pubstack/eventchannel/sender.go
+++ b/analytics/pubstack/eventchannel/sender.go
@@ -3,10 +3,11 @@ package eventchannel
 import (
 	"bytes"
 	"fmt"
-	"github.com/golang/glog"
 	"net/http"
 	"net/url"
 	"path"
+
+	"github.com/golang/glog"
 )
 
 type Sender = func(payload []byte) error
@@ -26,6 +27,8 @@ func NewHttpSender(client *http.Client, endpoint string) Sender {
 		if err != nil {
 			return err
 		}
+
+		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			glog.Errorf("[pubstack] Wrong code received %d instead of %d", resp.StatusCode, http.StatusOK)


### PR DESCRIPTION
Memory leak in the HttpSender module of PubStack caused by neglecting to close the response body.