### PR TITLE
Fix loading of default bid adjustments for "account_defaults"

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -498,6 +498,20 @@ account_defaults:
           period_sec: 2000
           max_age_sec: 6000
           max_schema_dims: 10
+    bidadjustments:
+        mediatype:
+            '*':
+                '*':
+                    '*':
+                        - adjtype: multiplier
+                          value: 1.01
+                          currency: USD
+            video-instream:
+                bidder:
+                    deal_id:
+                        - adjtype: cpm
+                          value: 1.02
+                          currency: EUR
     privacy:
         ipv6:
             anon_keep_bits: 50
@@ -751,7 +765,23 @@ func TestFullConfig(t *testing.T) {
 		9:  &expectedTCF2.Purpose9,
 		10: &expectedTCF2.Purpose10,
 	}
+
+	expectedBidAdjustments := &openrtb_ext.ExtRequestPrebidBidAdjustments{
+		MediaType: openrtb_ext.MediaType{
+			WildCard: map[openrtb_ext.BidderName]openrtb_ext.AdjustmentsByDealID{
+				"*": {
+					"*": []openrtb_ext.Adjustment{{Type: "multiplier", Value: 1.01, Currency: "USD"}},
+				},
+			},
+			VideoInstream: map[openrtb_ext.BidderName]openrtb_ext.AdjustmentsByDealID{
+				"bidder": {
+					"deal_id": []openrtb_ext.Adjustment{{Type: "cpm", Value: 1.02, Currency: "EUR"}},
+				},
+			},
+		},
+	}
 	assert.Equal(t, expectedTCF2, cfg.GDPR.TCF2, "gdpr.tcf2")
+	assert.Equal(t, expectedBidAdjustments, cfg.AccountDefaults.BidAdjustments)
 
 	cmpStrings(t, "currency_converter.fetch_url", "https://currency.prebid.org", cfg.CurrencyConverter.FetchURL)
 	cmpInts(t, "currency_converter.fetch_interval_seconds", 1800, cfg.CurrencyConverter.FetchIntervalSeconds)

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -3177,7 +3177,7 @@ func TestCleanOpenRTBRequestsBidAdjustment(t *testing.T) {
 			}},
 		},
 		{
-			description:        "bidAjustement Not provided",
+			description:        "bidAdjustment Not provided",
 			gdprAccountEnabled: &falseValue,
 			gdprHostEnabled:    true,
 			gdpr:               "1",

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -164,7 +164,7 @@ type ExtRequestPrebidCacheVAST struct {
 
 // ExtRequestPrebidBidAdjustments defines the contract for bidrequest.ext.prebid.bidadjustments
 type ExtRequestPrebidBidAdjustments struct {
-	MediaType MediaType `json:"mediatype,omitempty"`
+	MediaType MediaType `mapstructure:"mediatype" json:"mediatype,omitempty"`
 }
 
 // AdjustmentsByDealID maps a dealID to a slice of bid adjustments
@@ -173,19 +173,19 @@ type AdjustmentsByDealID map[string][]Adjustment
 // MediaType defines contract for bidrequest.ext.prebid.bidadjustments.mediatype
 // BidderName will map to a DealID that will map to a slice of bid adjustments
 type MediaType struct {
-	Banner         map[BidderName]AdjustmentsByDealID `json:"banner,omitempty"`
-	VideoInstream  map[BidderName]AdjustmentsByDealID `json:"video-instream,omitempty"`
-	VideoOutstream map[BidderName]AdjustmentsByDealID `json:"video-outstream,omitempty"`
-	Audio          map[BidderName]AdjustmentsByDealID `json:"audio,omitempty"`
-	Native         map[BidderName]AdjustmentsByDealID `json:"native,omitempty"`
-	WildCard       map[BidderName]AdjustmentsByDealID `json:"*,omitempty"`
+	Banner         map[BidderName]AdjustmentsByDealID `mapstructure:"banner" json:"banner,omitempty"`
+	VideoInstream  map[BidderName]AdjustmentsByDealID `mapstructure:"video-instream" json:"video-instream,omitempty"`
+	VideoOutstream map[BidderName]AdjustmentsByDealID `mapstructure:"video-outstream" json:"video-outstream,omitempty"`
+	Audio          map[BidderName]AdjustmentsByDealID `mapstructure:"audio" json:"audio,omitempty"`
+	Native         map[BidderName]AdjustmentsByDealID `mapstructure:"native" json:"native,omitempty"`
+	WildCard       map[BidderName]AdjustmentsByDealID `mapstructure:"*" json:"*,omitempty"`
 }
 
 // Adjustment defines the object that will be present in the slice of bid adjustments found from MediaType map
 type Adjustment struct {
-	Type     string  `json:"adjtype,omitempty"`
-	Value    float64 `json:"value,omitempty"`
-	Currency string  `json:"currency,omitempty"`
+	Type     string  `mapstructure:"adjtype" json:"adjtype,omitempty"`
+	Value    float64 `mapstructure:"value" json:"value,omitempty"`
+	Currency string  `mapstructure:"currency" json:"currency,omitempty"`
 }
 
 // ExtRequestTargeting defines the contract for bidrequest.ext.prebid.targeting


### PR DESCRIPTION
I'd like to have some bid adjustment rules for all accounts but due to missing `mapstructure` structure tags Viper doesn't load wildcard fields. https://github.com/spf13/viper/blob/master/TROUBLESHOOTING.md#unmarshaling-doesnt-work
```
account_defaults:
  bidadjustments:
    mediatype:
      '*':     # media type
        '*':   # bidder name
          '*': # deal id
            - adjtype: multiplier
              value: 1.03
              currency: USD
```