### PR TITLE
Sonobi: Added consent macros to the user sync url

### DIFF
--- a/static/bidder-info/sonobi.yaml
+++ b/static/bidder-info/sonobi.yaml
@@ -13,5 +13,5 @@ capabilities:
       - video
 userSync:
   redirect:
-    url: "https://sync.go.sonobi.com/us.gif?loc={{.RedirectURL}}"
+    url: "https://sync.go.sonobi.com/us.gif?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&loc={{.RedirectURL}}"
     userMacro: "[UID]"


### PR DESCRIPTION
Re-opening this to pick the comment thread back up https://github.com/prebid/prebid-server/pull/3283

Pending open question:

Hey @onkarvhanumante, I reviewed this over with the team. The sync urls that fail to redirect is because the gdpr_consent string provided does not define that Sonobi is consented to user snyc. So, the endpoint will not redirect to the &loc query parameter.

Should our user sync endpoint redirect even if the gdpr_consent string doesnt say Sonobi is consented?