### PR TITLE
add 'debug' and 'integration' to sample requests

### DIFF
--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json
@@ -83,6 +83,8 @@
           "name": "video",
           "version": "1.0"
         },
+        "debug": true,
+        "integration": "managed",
         "targeting": {
           "includewinners": false,
           "pricegranularity": {


### PR DESCRIPTION
Description in
[endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json](https://github.com/prebid/prebid-server/blob/master/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json#L2)
 says: "This demonstrates all of the OpenRTB extensions supported by Prebid Server."
This PR adds `ext.prebid.debug` and `ext.prebid.integration`, documented in https://docs.prebid.org/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#prebid-server-ortb2-extension-summary, to the [valid-whole/exemplary/all-ext.json](https://github.com/prebid/prebid-server/blob/master/endpoints/openrtb2/sample-requests/valid-whole/exemplary/all-ext.json) sample request for completeness and illustration.