### PR TITLE
Make the context safe to use for hooks like BidderRequestHook which are called in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prebid/prebid-server/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/hooks/hookexecution/context.go
+++ b/hooks/hookexecution/context.go
@@ -47,6 +47,10 @@ type moduleContexts struct {
 }
 
 func (mc *moduleContexts) put(moduleName string, mCtx hookstage.ModuleContext) {
+	if mCtx == nil {
+		return
+	}
+
 	mc.Lock()
 	defer mc.Unlock()
 

--- a/hooks/hookexecution/context.go
+++ b/hooks/hookexecution/context.go
@@ -57,7 +57,7 @@ func (mc *moduleContexts) put(moduleName string, mCtx hookstage.ModuleContext) {
 	if existingCtx, ok := mc.ctxs[moduleName]; ok && existingCtx != nil {
 		maps.Copy(existingCtx, mCtx)
 	} else {
-		mc.ctxs[moduleName] = mCtx
+		mc.ctxs[moduleName] = maps.Clone(mCtx)
 	}
 }
 

--- a/hooks/hookexecution/context.go
+++ b/hooks/hookexecution/context.go
@@ -1,6 +1,7 @@
 package hookexecution
 
 import (
+	"maps"
 	"sync"
 
 	"github.com/golang/glog"
@@ -51,10 +52,10 @@ func (mc *moduleContexts) put(moduleName string, mCtx hookstage.ModuleContext) {
 
 	newCtx := mCtx
 	if existingCtx, ok := mc.ctxs[moduleName]; ok && existingCtx != nil {
+		newCtx = maps.Clone(existingCtx)
 		for k, v := range mCtx {
-			existingCtx[k] = v
+			newCtx[k] = v
 		}
-		newCtx = existingCtx
 	}
 	mc.ctxs[moduleName] = newCtx
 }

--- a/hooks/hookexecution/context.go
+++ b/hooks/hookexecution/context.go
@@ -56,12 +56,10 @@ func (mc *moduleContexts) put(moduleName string, mCtx hookstage.ModuleContext) {
 
 	newCtx := mCtx
 	if existingCtx, ok := mc.ctxs[moduleName]; ok && existingCtx != nil {
-		newCtx = maps.Clone(existingCtx)
-		for k, v := range mCtx {
-			newCtx[k] = v
-		}
+		maps.Copy(existingCtx, mCtx)
+	} else {
+		mc.ctxs[moduleName] = newCtx
 	}
-	mc.ctxs[moduleName] = newCtx
 }
 
 func (mc *moduleContexts) get(moduleName string) (hookstage.ModuleContext, bool) {
@@ -69,7 +67,7 @@ func (mc *moduleContexts) get(moduleName string) (hookstage.ModuleContext, bool)
 	defer mc.RUnlock()
 	mCtx, ok := mc.ctxs[moduleName]
 
-	return mCtx, ok
+	return maps.Clone(mCtx), ok
 }
 
 type stageModuleContext struct {

--- a/hooks/hookexecution/context.go
+++ b/hooks/hookexecution/context.go
@@ -54,11 +54,10 @@ func (mc *moduleContexts) put(moduleName string, mCtx hookstage.ModuleContext) {
 	mc.Lock()
 	defer mc.Unlock()
 
-	newCtx := mCtx
 	if existingCtx, ok := mc.ctxs[moduleName]; ok && existingCtx != nil {
 		maps.Copy(existingCtx, mCtx)
 	} else {
-		mc.ctxs[moduleName] = newCtx
+		mc.ctxs[moduleName] = mCtx
 	}
 }
 


### PR DESCRIPTION
Because `ModuleContext` is passed by reference to hooks, and because, when hooks timeout, they continue to run, if they are reading the ModuleContext, when a later stage is writing it, you get `fatal error: concurrent map iteration and map write`.

The existing lock does not protect hooks reading the `ModuleContext` which is a reference to the existingCtx.

By making a Clone before merging the existing with the new, this should clear up the problem.