### PR TITLE
Adf: Update cookie matching endpoint domain

### DIFF
--- a/static/bidder-info/adf.yaml
+++ b/static/bidder-info/adf.yaml
@@ -23,5 +23,5 @@ capabilities:
       - video
 userSync:
   redirect:
-    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
+    url: "https://c1.adform.net/cookie?redirect_url={{.RedirectURL}}"
     userMacro: "$UID"

--- a/static/bidder-info/adform.yaml
+++ b/static/bidder-info/adform.yaml
@@ -1,5 +1,5 @@
 aliasOf: adf
 userSync:
   redirect:
-    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
+    url: "https://c1.adform.net/cookie?redirect_url={{.RedirectURL}}"
     userMacro: "$UID"


### PR DESCRIPTION
Adform migrates cookie matching to new domain - c1.adform.net
The current one will still be available for some time.