### PR TITLE
Updated FloorsSchemaVersion data type from string to int

### DIFF
--- a/floors/floors_test.go
+++ b/floors/floors_test.go
@@ -91,7 +91,7 @@ func TestEnrichWithPriceFloors(t *testing.T) {
 		expFloorVal       float64
 		expFloorCur       string
 		expPriceFlrLoc    string
-		expSchemaVersion  string
+		expSchemaVersion  int
 	}{
 		{
 			name: "Floors disabled in account config",
@@ -178,7 +178,7 @@ func TestEnrichWithPriceFloors(t *testing.T) {
 						Publisher: &openrtb2.Publisher{Domain: "www.website.com"},
 					},
 					Imp: []openrtb2.Imp{{ID: "1234", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}}},
-					Ext: json.RawMessage(`{"prebid":{"floors":{"floormin":11,"floormincur":"USD","data":{"currency":"USD","floorsschemaversion":"2","modelgroups":[{"modelweight":50,"modelversion":"version2","schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|*|*":11.01,"*|*|www.website1.com":17.01},"default":21},{"modelweight":50,"modelversion":"version11","skiprate":110,"schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|300x250|*":11.01,"*|300x250|www.website1.com":100.01},"default":21}]},"enforcement":{"enforcepbs":true,"floordeals":true},"enabled":true}}}`),
+					Ext: json.RawMessage(`{"prebid":{"floors":{"floormin":11,"floormincur":"USD","data":{"currency":"USD","floorsschemaversion":2,"modelgroups":[{"modelweight":50,"modelversion":"version2","schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|*|*":11.01,"*|*|www.website1.com":17.01},"default":21},{"modelweight":50,"modelversion":"version11","skiprate":110,"schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|300x250|*":11.01,"*|300x250|www.website1.com":100.01},"default":21}]},"enforcement":{"enforcepbs":true,"floordeals":true},"enabled":true}}}`),
 				},
 			},
 			account:          testAccountConfig,
@@ -186,7 +186,7 @@ func TestEnrichWithPriceFloors(t *testing.T) {
 			expFloorVal:      11.01,
 			expFloorCur:      "USD",
 			expPriceFlrLoc:   openrtb_ext.RequestLocation,
-			expSchemaVersion: "2",
+			expSchemaVersion: 2,
 		},
 		{
 			name: "Rule selection with Site object, banner|300x600|www.website.com",
@@ -385,7 +385,7 @@ func TestEnrichWithPriceFloors(t *testing.T) {
 						assert.Equal(t, *requestExt.GetPrebid().Floors.Skipped, tc.Skipped, tc.name)
 					} else {
 						assert.Equal(t, requestExt.GetPrebid().Floors.PriceFloorLocation, tc.expPriceFlrLoc, tc.name)
-						if tc.expSchemaVersion != "" {
+						if tc.expSchemaVersion != 0 {
 							assert.Equal(t, requestExt.GetPrebid().Floors.Data.FloorsSchemaVersion, tc.expSchemaVersion, tc.name)
 						}
 					}

--- a/floors/validate.go
+++ b/floors/validate.go
@@ -55,7 +55,7 @@ func validateFloorRulesAndLowerValidRuleKey(schema openrtb_ext.PriceFloorSchema,
 
 // validateFloorParams validates SchemaVersion, SkipRate and FloorMin
 func validateFloorParams(extFloorRules *openrtb_ext.PriceFloorRules) error {
-	if extFloorRules.Data != nil && extFloorRules.Data.FloorsSchemaVersion > 0 && extFloorRules.Data.FloorsSchemaVersion != 2 {
+	if extFloorRules.Data != nil && extFloorRules.Data.FloorsSchemaVersion != 0 && extFloorRules.Data.FloorsSchemaVersion != 2 {
 		return fmt.Errorf("Invalid FloorsSchemaVersion = '%v', supported version 2", extFloorRules.Data.FloorsSchemaVersion)
 	}
 

--- a/floors/validate.go
+++ b/floors/validate.go
@@ -55,7 +55,7 @@ func validateFloorRulesAndLowerValidRuleKey(schema openrtb_ext.PriceFloorSchema,
 
 // validateFloorParams validates SchemaVersion, SkipRate and FloorMin
 func validateFloorParams(extFloorRules *openrtb_ext.PriceFloorRules) error {
-	if extFloorRules.Data != nil && len(extFloorRules.Data.FloorsSchemaVersion) > 0 && extFloorRules.Data.FloorsSchemaVersion != "2" {
+	if extFloorRules.Data != nil && extFloorRules.Data.FloorsSchemaVersion > 0 && extFloorRules.Data.FloorsSchemaVersion != 2 {
 		return fmt.Errorf("Invalid FloorsSchemaVersion = '%v', supported version 2", extFloorRules.Data.FloorsSchemaVersion)
 	}
 

--- a/floors/validate_test.go
+++ b/floors/validate_test.go
@@ -56,9 +56,9 @@ func TestValidateFloorParams(t *testing.T) {
 			Err:      errors.New("Invalid FloorMin = '-10', value should be >= 0"),
 		},
 		{
-			name: "Invalid FloorSchemaVersion ",
+			name: "Invalid FloorSchemaVersion",
 			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
-				FloorsSchemaVersion: "1",
+				FloorsSchemaVersion: 1,
 				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{
 					ModelVersion: "Version 1",
 
@@ -69,6 +69,19 @@ func TestValidateFloorParams(t *testing.T) {
 					}, Default: 0.01},
 				}}},
 			Err: errors.New("Invalid FloorsSchemaVersion = '1', supported version 2"),
+		},
+		{
+			name: "Valid FloorSchemaVersion",
+			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
+				FloorsSchemaVersion: 2,
+				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{
+					ModelVersion: "Version 1",
+					Schema:       openrtb_ext.PriceFloorSchema{Fields: []string{"mediaType", "size", "domain"}, Delimiter: "|"},
+					Values: map[string]float64{
+						"banner|300x250|www.website.com": 1.01,
+						"banner|300x600|*":               4.01,
+					}, Default: 0.01},
+				}}},
 		},
 	}
 	for _, tc := range tt {

--- a/floors/validate_test.go
+++ b/floors/validate_test.go
@@ -56,13 +56,12 @@ func TestValidateFloorParams(t *testing.T) {
 			Err:      errors.New("Invalid FloorMin = '-10', value should be >= 0"),
 		},
 		{
-			name: "Invalid FloorSchemaVersion",
+			name: "Invalid FloorSchemaVersion 2",
 			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
 				FloorsSchemaVersion: 1,
 				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{
 					ModelVersion: "Version 1",
-
-					Schema: openrtb_ext.PriceFloorSchema{Fields: []string{"mediaType", "size", "domain"}, Delimiter: "|"},
+					Schema:       openrtb_ext.PriceFloorSchema{Fields: []string{"mediaType", "size", "domain"}, Delimiter: "|"},
 					Values: map[string]float64{
 						"banner|300x250|www.website.com": 1.01,
 						"banner|300x600|*":               4.01,
@@ -71,7 +70,34 @@ func TestValidateFloorParams(t *testing.T) {
 			Err: errors.New("Invalid FloorsSchemaVersion = '1', supported version 2"),
 		},
 		{
-			name: "Valid FloorSchemaVersion",
+			name: "Invalid FloorSchemaVersion -2",
+			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
+				FloorsSchemaVersion: -2,
+				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{
+					ModelVersion: "Version 1",
+					Schema:       openrtb_ext.PriceFloorSchema{Fields: []string{"mediaType", "size", "domain"}, Delimiter: "|"},
+					Values: map[string]float64{
+						"banner|300x250|www.website.com": 1.01,
+						"banner|300x600|*":               4.01,
+					}, Default: 0.01},
+				}}},
+			Err: errors.New("Invalid FloorsSchemaVersion = '-2', supported version 2"),
+		},
+		{
+			name: "Valid FloorSchemaVersion 0",
+			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
+				FloorsSchemaVersion: 0,
+				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{
+					ModelVersion: "Version 1",
+					Schema:       openrtb_ext.PriceFloorSchema{Fields: []string{"mediaType", "size", "domain"}, Delimiter: "|"},
+					Values: map[string]float64{
+						"banner|300x250|www.website.com": 1.01,
+						"banner|300x600|*":               4.01,
+					}, Default: 0.01},
+				}}},
+		},
+		{
+			name: "Valid FloorSchemaVersion 2",
 			floorExt: &openrtb_ext.PriceFloorRules{Data: &openrtb_ext.PriceFloorData{
 				FloorsSchemaVersion: 2,
 				ModelGroups: []openrtb_ext.PriceFloorModelGroup{{

--- a/openrtb_ext/floors.go
+++ b/openrtb_ext/floors.go
@@ -84,7 +84,7 @@ type PriceFloorEndpoint struct {
 type PriceFloorData struct {
 	Currency            string                 `json:"currency,omitempty"`
 	SkipRate            int                    `json:"skiprate,omitempty"`
-	FloorsSchemaVersion string                 `json:"floorsschemaversion,omitempty"`
+	FloorsSchemaVersion int                    `json:"floorsschemaversion,omitempty"`
 	ModelTimestamp      int                    `json:"modeltimestamp,omitempty"`
 	ModelGroups         []PriceFloorModelGroup `json:"modelgroups,omitempty"`
 	FloorProvider       string                 `json:"floorprovider,omitempty"`

--- a/openrtb_ext/floors_test.go
+++ b/openrtb_ext/floors_test.go
@@ -327,7 +327,7 @@ func TestFloorRulesDeepCopy(t *testing.T) {
 				Data: &PriceFloorData{
 					Currency:            "INR",
 					SkipRate:            0,
-					FloorsSchemaVersion: "2",
+					FloorsSchemaVersion: 2,
 					ModelTimestamp:      123,
 					ModelGroups: []PriceFloorModelGroup{
 						{
@@ -370,7 +370,7 @@ func TestFloorRulesDeepCopy(t *testing.T) {
 				Data: &PriceFloorData{
 					Currency:            "INR",
 					SkipRate:            0,
-					FloorsSchemaVersion: "2",
+					FloorsSchemaVersion: 2,
 					ModelTimestamp:      123,
 					ModelGroups: []PriceFloorModelGroup{
 						{


### PR DESCRIPTION
Prebid Documentation [https://docs.prebid.org/dev-docs/modules/floors.html#schema-2]  is updated for data type of data.floorsSchemaVersion from string to integer
