### PR TITLE
Liftoff: delete seat in Adapter to enable default seat(liftoff) on PSP side

### DIFF
--- a/adapters/liftoff/liftoff.go
+++ b/adapters/liftoff/liftoff.go
@@ -138,7 +138,6 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 			b := &adapters.TypedBid{
 				Bid:     &seatBid.Bid[i],
 				BidType: openrtb_ext.BidTypeVideo,
-				Seat:    openrtb_ext.BidderName(seatBid.Seat),
 			}
 
 			bidResponse.Bids = append(bidResponse.Bids, b)

--- a/adapters/liftoff/liftofftest/exemplary/app_video_instl.json
+++ b/adapters/liftoff/liftofftest/exemplary/app_video_instl.json
@@ -144,8 +144,7 @@
             "w": 300,
             "h": 250
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }

--- a/adapters/liftoff/liftofftest/exemplary/app_video_rewarded.json
+++ b/adapters/liftoff/liftofftest/exemplary/app_video_rewarded.json
@@ -137,8 +137,7 @@
             "w": 300,
             "h": 250
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }

--- a/adapters/liftoff/liftofftest/exemplary/site_video_instl.json
+++ b/adapters/liftoff/liftofftest/exemplary/site_video_instl.json
@@ -143,8 +143,7 @@
             "w": 300,
             "h": 250
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }

--- a/adapters/liftoff/liftofftest/exemplary/site_video_rewarded.json
+++ b/adapters/liftoff/liftofftest/exemplary/site_video_rewarded.json
@@ -136,8 +136,7 @@
             "w": 300,
             "h": 250
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }

--- a/adapters/liftoff/liftofftest/supplemental/appid_placementid_check.json
+++ b/adapters/liftoff/liftofftest/supplemental/appid_placementid_check.json
@@ -137,8 +137,7 @@
             "w": 300,
             "h": 250
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }

--- a/adapters/liftoff/liftofftest/supplemental/liftoff_ext_check.json
+++ b/adapters/liftoff/liftofftest/supplemental/liftoff_ext_check.json
@@ -132,8 +132,7 @@
             "h": 250,
             "w": 300
           },
-          "type": "video",
-          "seat": "seat-id"
+          "type": "video"
         }
       ]
     }


### PR DESCRIPTION
use default bidder name `liftoff` as seat.