### PR TITLE
Fix for stored responses and request wrapper

### DIFF
--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -70,7 +70,7 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 
 	allowedBidderRequests = make([]BidderRequest, 0)
 
-	bidderImpWithBidResp := stored_responses.InitStoredBidResponses(req.BidRequest, auctionReq.StoredBidResponses)
+	bidderImpWithBidResp := stored_responses.InitStoredBidResponses(req, auctionReq.StoredBidResponses)
 
 	impsByBidder, err := splitImps(req.BidRequest.Imp)
 	if err != nil {

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -72,6 +72,18 @@ func (rw *RequestWrapper) LenImp() int {
 	return len(rw.Imp)
 }
 
+// SyncImps synchronizes impWrappers with reqWrapper.BidRequest.Imp using the last one as a source of truth
+func (rw *RequestWrapper) SyncImps() {
+	if len(rw.Imp) > 0 {
+		rw.impWrappers = make([]*ImpWrapper, len(rw.Imp))
+		for i := range rw.Imp {
+			rw.impWrappers[i] = &ImpWrapper{Imp: &rw.Imp[i]}
+		}
+	} else {
+		rw.impWrappers = nil
+	}
+}
+
 func (rw *RequestWrapper) GetImp() []*ImpWrapper {
 	if rw.impWrappersAccessed {
 		return rw.impWrappers


### PR DESCRIPTION
In request with stored bid responses we delete impressions where stored bid response is specified. We need to synchronize Impressions array in requestWrapper too and update reqWrapper.ImpWrapper.