### PR TITLE
IX: save/restore global var in test

### DIFF
--- a/adapters/ix/ix.go
+++ b/adapters/ix/ix.go
@@ -95,7 +95,7 @@ func (a *IxAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters
 
 	setPublisherId(&requestCopy, uniqueSiteIDs, ixDiag)
 
-	err := setIxDiagIntoExtRequest(&requestCopy, ixDiag)
+	err := setIxDiagIntoExtRequest(&requestCopy, ixDiag, version.Ver)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -392,7 +392,17 @@ func marshalJsonWithoutUnicode(v interface{}) (string, error) {
 	return strings.TrimSuffix(sb.String(), "\n"), nil
 }
 
-func setIxDiagIntoExtRequest(request *openrtb2.BidRequest, ixDiag *IxDiag) error {
+// extractVersionWithoutCommitHash takes a version string like '0.23.1-g4ee257d8' and returns
+// the prefix without the commit hash: '0.23.1' -
+// the substring preceding the first hyphen.
+func extractVersionWithoutCommitHash(ver string) string {
+	if strings.Contains(ver, "-") {
+		return ver[:strings.Index(ver, "-")]
+	}
+	return ver // if no hyphen, return the original string
+}
+
+func setIxDiagIntoExtRequest(request *openrtb2.BidRequest, ixDiag *IxDiag, ver string) error {
 	extRequest := &ExtRequest{}
 	if request.Ext != nil {
 		if err := json.Unmarshal(request.Ext, &extRequest); err != nil {
@@ -404,10 +414,8 @@ func setIxDiagIntoExtRequest(request *openrtb2.BidRequest, ixDiag *IxDiag) error
 		ixDiag.PbjsV = extRequest.Prebid.Channel.Version
 	}
 	// Slice commit hash out of version
-	if strings.Contains(version.Ver, "-") {
-		ixDiag.PbsV = version.Ver[:strings.Index(version.Ver, "-")]
-	} else if version.Ver != "" {
-		ixDiag.PbsV = version.Ver
+	if ver != "" {
+		ixDiag.PbsV = extractVersionWithoutCommitHash(ver)
 	}
 
 	// Only set request.ext if ixDiag is not empty

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prebid/prebid-server/v2/config"
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
 	"github.com/prebid/prebid-server/v2/util/ptrutil"
-	"github.com/prebid/prebid-server/v2/version"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/openrtb/v20/adcom1"
@@ -152,6 +151,34 @@ func TestIxMakeRequestWithGppString(t *testing.T) {
 	assert.Equal(t, req.Regs.GPP, testGppString)
 }
 
+func TestExtractVersionWithoutCommitHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{
+			name:     "empty version",
+			version:  "",
+			expected: "",
+		},
+		{
+			name:     "version with commit hash",
+			version:  "1.880-abcdef",
+			expected: "1.880",
+		},
+		{
+			name:     "version without commit hash",
+			version:  "1.23.4",
+			expected: "1.23.4",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, extractVersionWithoutCommitHash(test.version))
+		})
+	}
+}
 func TestBuildIxDiag(t *testing.T) {
 	testCases := []struct {
 		description     string
@@ -253,12 +280,8 @@ func TestBuildIxDiag(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			// save and later restore the value of the global variable to avoid side-effecting other tests
-			oldVersionVer := version.Ver
-			defer func() { version.Ver = oldVersionVer }()
-			version.Ver = test.pbsVersion
 			ixDiag := &IxDiag{}
-			err := setIxDiagIntoExtRequest(test.request, ixDiag)
+			err := setIxDiagIntoExtRequest(test.request, ixDiag, test.pbsVersion)
 			if test.expectError {
 				assert.NotNil(t, err)
 			} else {

--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -253,6 +253,9 @@ func TestBuildIxDiag(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
+			// save and later restore the value of the global variable to avoid side-effecting other tests
+			oldVersionVer := version.Ver
+			defer func() { version.Ver = oldVersionVer }()
 			version.Ver = test.pbsVersion
 			ixDiag := &IxDiag{}
 			err := setIxDiagIntoExtRequest(test.request, ixDiag)


### PR DESCRIPTION
Currently running `go test -v [github.com/prebid/prebid-server/v2/adapters/ix](http://github.com/prebid/prebid-server/v2/adapters/ix) -count=2 -run 'TestJsonSamples|TestBuildIxDiag/Base_Test'` - that is, running each of the tests twice - produces errors due to mutating the global variable:
https://gist.github.com/dmitris/4e0ab9f24d4ba57537be448ed97a80c2
I think being able to execute tests multiple times is valuable to find the state mutation in the code under test or the tests themselves.
PR fixes the test failure.  The fix is based on what @radubarbos has done in the internal version of the code. 