### PR TITLE
Unruly: BidVideo.Duration Support

### DIFF
--- a/adapters/unruly/unruly.go
+++ b/adapters/unruly/unruly.go
@@ -122,10 +122,16 @@ func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest
 			if err != nil {
 				errs = append(errs, err...)
 			} else {
-				bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				bid := adapters.TypedBid{
 					Bid:     &sb.Bid[i],
 					BidType: bidType,
-				})
+				}
+				if bidType == openrtb_ext.BidTypeVideo && sb.Bid[i].Dur > 0 {
+					bid.BidVideo = &openrtb_ext.ExtBidPrebidVideo{
+						Duration: int(sb.Bid[i].Dur),
+					}
+				}
+				bidResponse.Bids = append(bidResponse.Bids, &bid)
 			}
 		}
 	}

--- a/adapters/unruly/unrulytest/exemplary/simple-video.json
+++ b/adapters/unruly/unrulytest/exemplary/simple-video.json
@@ -9,7 +9,7 @@
             "video/mp4"
           ],
           "minduration": 1,
-          "maxduration": 2,
+          "maxduration": 60,
           "protocols": [1,3,5],
           "w": 1020,
           "h": 780,
@@ -41,7 +41,7 @@
                   "video/mp4"
                 ],
                 "minduration": 1,
-                "maxduration": 2,
+                "maxduration": 60,
                 "protocols": [1,3,5],
                 "w": 1020,
                 "h": 780,
@@ -78,7 +78,8 @@
                   "adm": "some-test-ad",
                   "crid": "crid_10",
                   "w": 1024,
-                  "h": 576
+                  "h": 576,
+                  "dur": 30
                 }
               ]
             }
@@ -97,7 +98,8 @@
           "adm": "some-test-ad",
           "crid": "crid_10",
           "w": 1024,
-          "h": 576
+          "h": 576,
+          "dur": 30
         },
         "type": "video"
       }]


### PR DESCRIPTION
Builds the BidVideo.Duration object if video.dur is present.