### PR TITLE
Fix: Set bid meta adaptercode to adapter name

### DIFF
--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -72,8 +72,12 @@ func TestJsonSampleRequests(t *testing.T) {
 			"invalid-native",
 		},
 		{
-			"Makes sure we handle (default) aliased bidders properly",
+			"Makes sure we handle aliased bidders properly",
 			"aliased",
+		},
+		{
+			"Makes sure we handle alternate bidder codes properly",
+			"alternate-bidder-code",
 		},
 		{
 			"Asserts we return 500s on requests referencing accounts with malformed configs.",

--- a/endpoints/openrtb2/sample-requests/aliased/default-request-alias.json
+++ b/endpoints/openrtb2/sample-requests/aliased/default-request-alias.json
@@ -35,7 +35,17 @@
           {
             "id": "appnexus-bid",
             "impid": "my-imp-id",
-            "price": 0
+            "price": 0,
+            "ext": {
+              "origbidcpm": 0,
+              "origbidcur": "USD",
+              "prebid": {
+                "meta": {
+                  "adaptercode": "appnexus"
+                },
+                "type": "banner"
+              }
+            }
           }
         ],
        "seat": "alias1"

--- a/endpoints/openrtb2/sample-requests/aliased/hard-alias.json
+++ b/endpoints/openrtb2/sample-requests/aliased/hard-alias.json
@@ -1,0 +1,62 @@
+{
+  "description": "Imp extension references valid bidder alias of adf defined in the adform bidder infos config yaml file.",
+  "config": {
+    "mockBidders": [
+      {
+        "bidderName": "adform",
+        "currency": "USD",
+        "price": 2
+      }
+    ]
+  },
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "site": {
+      "page": "test.somepage.com"
+    },
+    "imp": [
+      {
+        "id": "my-imp-id",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ]
+        },
+        "ext": {
+          "adform": {
+            "mid": "123"
+          }
+        }
+      }
+    ]
+  },
+  "expectedBidResponse": {
+    "id":"some-request-id",
+    "bidid":"test bid id",
+    "cur": "USD",
+    "nbr":0,
+    "seatbid": [
+      {
+        "bid": [
+          {
+            "id": "adform-bid",
+            "impid": "my-imp-id",
+            "price": 2,
+            "ext": {
+              "origbidcpm": 2,
+              "origbidcur": "USD",
+              "prebid": {
+                "meta": {
+                  "adaptercode": "adform"
+                },
+                "type": "banner"
+              }
+            }
+          }
+        ],
+       "seat": "adform"
+      }
+    ]
+  },
+  "expectedReturnCode": 200
+}

--- a/endpoints/openrtb2/sample-requests/aliased/request-alias.json
+++ b/endpoints/openrtb2/sample-requests/aliased/request-alias.json
@@ -1,0 +1,64 @@
+{
+    "description": "Imp extension references valid bidder alias of appnexus defined in the request ext.prebid.aliases field.",
+    "config": {
+      
+    },
+    "mockBidRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com"
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": [
+              "video/mp4"
+            ]
+          },
+          "ext": {
+            "alias1": {
+              "placementId": 12883451
+            }
+          }
+        }
+      ],
+      "ext": {
+        "prebid": {
+          "aliases": {
+            "alias1": "appnexus"
+          }
+        }
+      }
+    },
+    "expectedBidResponse": {
+      "id":"some-request-id",
+      "bidid":"test bid id",
+      "cur": "USD",
+      "nbr":0,
+      "seatbid": [
+        {
+          "bid": [
+            {
+              "id": "appnexus-bid",
+              "impid": "my-imp-id",
+              "price": 0,
+              "ext": {
+                "origbidcpm": 0,
+                "origbidcur": "USD",
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "banner"
+                }
+              }
+            }
+          ],
+         "seat": "alias1"
+        }
+      ]
+    },
+    "expectedReturnCode": 200
+  }
+  

--- a/endpoints/openrtb2/sample-requests/aliased/request-alias.json
+++ b/endpoints/openrtb2/sample-requests/aliased/request-alias.json
@@ -1,8 +1,5 @@
 {
     "description": "Imp extension references valid bidder alias of appnexus defined in the request ext.prebid.aliases field.",
-    "config": {
-      
-    },
     "mockBidRequest": {
       "id": "some-request-id",
       "site": {

--- a/endpoints/openrtb2/sample-requests/alternate-bidder-code/alternate-bidder-code.json
+++ b/endpoints/openrtb2/sample-requests/alternate-bidder-code/alternate-bidder-code.json
@@ -1,0 +1,67 @@
+{
+    "description": "Imp extension doesn't come with valid bidder name but does come with valid bidder alias as defined in the mockAliases list.",
+    "config": {
+      "mockBidders": [
+        {
+          "bidderName": "appnexus",
+          "currency": "USD",
+          "price": 2,
+          "seat": "groupm"
+        }
+      ]
+    },
+    "mockBidRequest": {
+      "id": "some-request-id",
+      "site": {
+        "page": "test.somepage.com",
+        "publisher": {
+            "id": "alternate_bidder_code_acct"
+          }
+      },
+      "imp": [
+        {
+          "id": "my-imp-id",
+          "video": {
+            "mimes": [
+              "video/mp4"
+            ]
+          },
+          "ext": {
+            "appnexus": {
+              "placementId": 12883451
+            }
+          }
+        }
+      ]
+    },
+    "expectedBidResponse": {
+      "id":"some-request-id",
+      "bidid":"test bid id",
+      "cur": "USD",
+      "nbr":0,
+      "seatbid": [
+        {
+          "bid": [
+            {
+              "id": "appnexus-bid",
+              "impid": "my-imp-id",
+              "price": 2,
+              "ext": {
+                "origbidcpm": 2,
+                "origbidcur": "USD",
+                "prebid": {
+                  "meta": {
+                    "adaptercode": "appnexus"
+                  },
+                  "type": "banner"
+                }
+              }
+            }
+          ],
+         "seat": "groupm"
+        }
+      ]
+    },
+    "expectedReturnCode": 200
+  }
+  

--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/simple.json
@@ -47,7 +47,17 @@
           {
             "id": "appnexus-bid",
             "impid": "some-impression-id",
-            "price": 0
+            "price": 0,
+            "ext": {
+              "origbidcpm": 0,
+              "origbidcur": "USD",
+              "prebid": {
+                "meta": {
+                  "adaptercode": "appnexus"
+                },
+                "type": "banner"
+              }
+            }
           }
         ],
         "seat": "appnexus"

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -387,6 +387,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 							DealPriority:   bidResponse.Bids[i].DealPriority,
 							OriginalBidCPM: originalBidCpm,
 							OriginalBidCur: bidResponse.Currency,
+							AdapterCode:    bidderRequest.BidderCoreName,
 						})
 						seatBidMap[bidderName].Currency = currencyAfterAdjustments
 					}

--- a/exchange/entities/entities.go
+++ b/exchange/entities/entities.go
@@ -50,4 +50,5 @@ type PbsOrtbBid struct {
 	OriginalBidCPM    float64
 	OriginalBidCur    string
 	TargetBidderCode  string
+	AdapterCode       openrtb_ext.BidderName
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -1317,7 +1317,7 @@ func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCrea
 			}
 		}
 
-		if bidExtJSON, err := makeBidExtJSON(bid.Bid.Ext, bidExtPrebid, impExtInfoMap, bid.Bid.ImpID, bid.OriginalBidCPM, bid.OriginalBidCur, adapter); err != nil {
+		if bidExtJSON, err := makeBidExtJSON(bid.Bid.Ext, bidExtPrebid, impExtInfoMap, bid.Bid.ImpID, bid.OriginalBidCPM, bid.OriginalBidCur, bid.AdapterCode); err != nil {
 			errs = append(errs, err)
 		} else {
 			result = append(result, *bid.Bid)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1638,7 +1638,7 @@ func TestBidResponseCurrency(t *testing.T) {
 					Price: 9.517803,
 					W:     300,
 					H:     250,
-					Ext:   json.RawMessage(`{"origbidcpm":9.517803,"prebid":{"meta":{"adaptercode":"appnexus"},"type":"banner"}}`),
+					Ext:   json.RawMessage(`{"origbidcpm":9.517803,"prebid":{"meta":{},"type":"banner"}}`),
 				},
 			},
 		},
@@ -1768,7 +1768,7 @@ func TestBidResponseImpExtInfo(t *testing.T) {
 		H:     250,
 		Ext:   nil,
 	}
-	aPbsOrtbBidArr := []*entities.PbsOrtbBid{{Bid: sampleBid, BidType: openrtb_ext.BidTypeVideo}}
+	aPbsOrtbBidArr := []*entities.PbsOrtbBid{{Bid: sampleBid, BidType: openrtb_ext.BidTypeVideo, AdapterCode: openrtb_ext.BidderAppnexus}}
 
 	adapterBids := map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
 		openrtb_ext.BidderName("appnexus"): {
@@ -4144,7 +4144,7 @@ func TestStoredAuctionResponses(t *testing.T) {
 		SeatBid: []openrtb2.SeatBid{
 			{
 				Bid: []openrtb2.Bid{
-					{ID: "bid_id", ImpID: "impression-id", Ext: json.RawMessage(`{"origbidcpm":0,"prebid":{"meta":{"adaptercode":"appnexus"},"type":"video"}}`)},
+					{ID: "bid_id", ImpID: "impression-id", Ext: json.RawMessage(`{"origbidcpm":0,"prebid":{"meta":{},"type":"video"}}`)},
 				},
 				Seat: "appnexus",
 			},
@@ -5231,6 +5231,7 @@ func TestGetAllBids(t *testing.T) {
 									ID: "1",
 								},
 								OriginalBidCur: "USD",
+								AdapterCode:    openrtb_ext.BidderPubmatic,
 							},
 						},
 						Currency:  "USD",
@@ -5299,6 +5300,7 @@ func TestGetAllBids(t *testing.T) {
 									ID: "1",
 								},
 								OriginalBidCur: "USD",
+								AdapterCode:    openrtb_ext.BidderPubmatic,
 							},
 						},
 						Currency:  "USD",
@@ -5312,6 +5314,7 @@ func TestGetAllBids(t *testing.T) {
 									ID: "2",
 								},
 								OriginalBidCur: "USD",
+								AdapterCode:    openrtb_ext.BidderPubmatic,
 							},
 						},
 						Currency:  "USD",
@@ -5379,6 +5382,7 @@ func TestGetAllBids(t *testing.T) {
 									ID: "2",
 								},
 								OriginalBidCur: "USD",
+								AdapterCode:    openrtb_ext.BidderPubmatic,
 							},
 						},
 						Currency:  "USD",

--- a/exchange/exchangetest/alternate-bidder-codes.json
+++ b/exchange/exchangetest/alternate-bidder-codes.json
@@ -95,9 +95,7 @@
                   "price": 0.71
                 },
                 "bidType": "video",
-                "bidMeta": {
-                  "adaptercode": "pubmatic"
-                }
+                "bidMeta": {}
               }
             ],
             "seat": "pubmatic"
@@ -111,9 +109,7 @@
                   "price": 0.51
                 },
                 "bidType": "video",
-                "bidMeta": {
-                  "adaptercode": "pubmatic"
-                }
+                "bidMeta": {}
               }
             ],
             "seat": "groupm"
@@ -164,9 +160,7 @@
                   "price": 0.3
                 },
                 "bidType": "banner",
-                "bidMeta": {
-                  "adaptercode": "appnexus"
-                }
+                "bidMeta": {}
               }
             ],
             "seat": "appnexus"
@@ -181,7 +175,6 @@
                 },
                 "bidType": "banner",
                 "bidMeta": {
-                  "adaptercode": "appnexus"
                 }
               }
             ],
@@ -205,9 +198,7 @@
               "ext": {
                 "origbidcpm": 0.51,
                 "prebid": {
-                  "meta": {
-                    "adaptercode": "groupm"
-                  },
+                  "meta": {},
                   "type": "video"
                 }
               }
@@ -220,7 +211,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "groupm"
                   },
                   "type": "banner"
                 }
@@ -239,7 +229,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pubmatic"
                   },
                   "type": "video"
                 }
@@ -258,7 +247,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner"
                 }

--- a/exchange/exchangetest/append-bidder-names.json
+++ b/exchange/exchangetest/append-bidder-names.json
@@ -138,7 +138,6 @@
                                 "prebid": {
                                     "type": "video",
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "targeting": {
                                         "hb_bidder": "appnexus",
@@ -166,7 +165,6 @@
                                 "origbidcpm": 0.6,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "targeting": {
                                         "hb_bidder": "appnexus",

--- a/exchange/exchangetest/bid-consolidation-test.json
+++ b/exchange/exchangetest/bid-consolidation-test.json
@@ -128,7 +128,6 @@
                 "origbidcpm": 0.4,
                 "prebid": {
                   "meta": {
-                    "adaptercode":"rubicon"
                   },
                   "type": "video"
                 }
@@ -150,7 +149,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode":"appnexus"
                   },
                   "type": "video"
                 }
@@ -167,7 +165,6 @@
                 "origbidcpm": 0.6,
                 "prebid": {
                   "meta": {
-                    "adaptercode":"appnexus"
                   },
                   "type": "video"
                 }

--- a/exchange/exchangetest/bid-ext-prebid-collision.json
+++ b/exchange/exchangetest/bid-ext-prebid-collision.json
@@ -100,7 +100,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/bid-ext.json
+++ b/exchange/exchangetest/bid-ext.json
@@ -97,7 +97,6 @@
                                 "someField": "someValue",
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/bid_response_validation_enforce_one_bid_rejected.json
+++ b/exchange/exchangetest/bid_response_validation_enforce_one_bid_rejected.json
@@ -174,7 +174,6 @@
                                 "origbidcpm": 0.4,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"rubicon"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/bid_response_validation_warn_creative.json
+++ b/exchange/exchangetest/bid_response_validation_warn_creative.json
@@ -170,7 +170,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "type": "banner"
                                 }
@@ -192,7 +191,6 @@
                                 "origbidcpm": 0.4,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"rubicon"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/bid_response_validation_warn_secure.json
+++ b/exchange/exchangetest/bid_response_validation_warn_secure.json
@@ -173,7 +173,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"appnexus"
                                     },
                                     "type": "banner"
                                 }
@@ -196,7 +195,6 @@
                                 "origbidcpm": 0.4,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode":"rubicon"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/debuglog_disabled.json
+++ b/exchange/exchangetest/debuglog_disabled.json
@@ -146,7 +146,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -175,7 +174,6 @@
                 "origbidcpm": 0.6,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targeting": {
                     "hb_bidder": "appnexus",

--- a/exchange/exchangetest/debuglog_enabled.json
+++ b/exchange/exchangetest/debuglog_enabled.json
@@ -148,7 +148,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -177,7 +176,6 @@
                 "origbidcpm": 0.6,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targeting": {
                     "hb_bidder": "appnexus",

--- a/exchange/exchangetest/dsa-default-ignored.json
+++ b/exchange/exchangetest/dsa-default-ignored.json
@@ -126,7 +126,6 @@
                         "origbidcpm": 0.3,
                         "prebid": {
                             "meta": {
-                                "adaptercode": "appnexus"
                             },
                             "type": "video"
                         },

--- a/exchange/exchangetest/dsa-default.json
+++ b/exchange/exchangetest/dsa-default.json
@@ -182,7 +182,6 @@
                         "origbidcpm": 0.3,
                         "prebid": {
                             "meta": {
-                                "adaptercode": "appnexus"
                             },
                             "type": "video"
                         },

--- a/exchange/exchangetest/dsa-not-required.json
+++ b/exchange/exchangetest/dsa-not-required.json
@@ -122,7 +122,6 @@
                         "origbidcpm": 0.3,
                         "prebid": {
                             "meta": {
-                                "adaptercode": "appnexus"
                             },
                             "type": "video"
                         }

--- a/exchange/exchangetest/dsa-required.json
+++ b/exchange/exchangetest/dsa-required.json
@@ -195,7 +195,6 @@
                         "origbidcpm": 0.3,
                         "prebid": {
                             "meta": {
-                                "adaptercode": "appnexus"
                             },
                             "type": "video"
                         },

--- a/exchange/exchangetest/eidpermissions-allowed-alias.json
+++ b/exchange/exchangetest/eidpermissions-allowed-alias.json
@@ -136,7 +136,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "foo"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/eidpermissions-allowed-case-insensitive.json
+++ b/exchange/exchangetest/eidpermissions-allowed-case-insensitive.json
@@ -133,7 +133,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/eidpermissions-allowed.json
+++ b/exchange/exchangetest/eidpermissions-allowed.json
@@ -133,7 +133,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/eidpermissions-denied.json
+++ b/exchange/exchangetest/eidpermissions-denied.json
@@ -120,7 +120,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/events-bid-account-off-request-off.json
+++ b/exchange/exchangetest/events-bid-account-off-request-off.json
@@ -80,7 +80,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner"
                 }
@@ -97,7 +96,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner"
                 }

--- a/exchange/exchangetest/events-bid-account-off-request-on.json
+++ b/exchange/exchangetest/events-bid-account-off-request-on.json
@@ -83,7 +83,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner",
                   "events": {
@@ -104,7 +103,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner",
                   "events": {

--- a/exchange/exchangetest/events-bid-account-on-request-off.json
+++ b/exchange/exchangetest/events-bid-account-on-request-off.json
@@ -82,7 +82,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner",
                   "events": {
@@ -103,7 +102,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner",
                   "events": {

--- a/exchange/exchangetest/events-vast-account-off-request-off.json
+++ b/exchange/exchangetest/events-vast-account-off-request-off.json
@@ -126,7 +126,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video"
                 }
@@ -149,7 +148,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -175,7 +173,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }

--- a/exchange/exchangetest/events-vast-account-off-request-on.json
+++ b/exchange/exchangetest/events-vast-account-off-request-on.json
@@ -132,7 +132,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "bidid": "bid-audienceNetwork-1",
                   "type": "video"
@@ -157,7 +156,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "bidid": "bid-appnexus-1",
                   "type": "video",
@@ -185,7 +183,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "bidid": "bid-appnexus-2",
                   "type": "video"

--- a/exchange/exchangetest/events-vast-account-on-request-off.json
+++ b/exchange/exchangetest/events-vast-account-on-request-off.json
@@ -127,7 +127,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video"
                 }
@@ -151,7 +150,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -178,7 +176,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }

--- a/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
+++ b/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
@@ -81,7 +81,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pmbidder"
                 }
               },
               {
@@ -95,7 +94,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pmbidder"
                 }
               },
               {
@@ -109,7 +107,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pmbidder"
                 }
               }
             ],
@@ -128,7 +125,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pmbidder"
                 }
               }
             ],
@@ -156,7 +152,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pmbidder"
                   },
                   "type": "video",
                   "targeting": {
@@ -185,7 +180,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "groupm"
                   },
                   "type": "video",
                   "targeting": {
@@ -214,7 +208,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "groupm"
                   },
                   "type": "video"
                 }
@@ -231,7 +224,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "groupm"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/extra-bids.json
+++ b/exchange/exchangetest/extra-bids.json
@@ -146,7 +146,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -160,7 +159,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -174,7 +172,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             }
                         ],
@@ -193,7 +190,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             }
                         ],
@@ -262,7 +258,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -281,7 +276,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -309,7 +303,6 @@
                                 "origbidcpm": 0.51,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "groupm"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -333,7 +326,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "groupm"
                                     },
                                     "type": "banner"
                                 }
@@ -355,7 +347,6 @@
                                 "origbidcpm": 0.71,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -384,7 +375,6 @@
                                 "origbidcpm": 0.21,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video"
                                 }
@@ -401,7 +391,6 @@
                                 "origbidcpm": 0.61,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -435,7 +424,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner",
                                     "targeting": {

--- a/exchange/exchangetest/firstpartydata-amp-imp-ext-one-prebid-bidder.json
+++ b/exchange/exchangetest/firstpartydata-amp-imp-ext-one-prebid-bidder.json
@@ -122,7 +122,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-multiple-prebid-bidders.json
@@ -189,7 +189,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }
@@ -211,7 +210,6 @@
                                 "origbidcpm": 0.4,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "rubicon"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
+++ b/exchange/exchangetest/firstpartydata-imp-ext-one-prebid-bidder.json
@@ -122,7 +122,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/fledge-with-bids.json
+++ b/exchange/exchangetest/fledge-with-bids.json
@@ -115,7 +115,6 @@
                                 "someField": "someValue",
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "openx"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/floors_enforcement.json
+++ b/exchange/exchangetest/floors_enforcement.json
@@ -137,7 +137,6 @@
                   "origbidcpm": 12,
                   "prebid": {
                     "meta": {
-                      "adaptercode": "appnexus"
                     },
                     "floors": {
                       "floorCurrency": "USD",

--- a/exchange/exchangetest/generate-bid-id-error.json
+++ b/exchange/exchangetest/generate-bid-id-error.json
@@ -110,7 +110,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/generate-bid-id-many.json
+++ b/exchange/exchangetest/generate-bid-id-many.json
@@ -98,7 +98,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "bidid": "bid-appnexus-1",
                   "type": "video"
@@ -119,7 +118,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "bidid": "bid-appnexus-2",
                   "type": "video"

--- a/exchange/exchangetest/generate-bid-id-one.json
+++ b/exchange/exchangetest/generate-bid-id-one.json
@@ -81,7 +81,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "bidid": "bid-appnexus-1",
                   "type": "video"

--- a/exchange/exchangetest/include-brand-category.json
+++ b/exchange/exchangetest/include-brand-category.json
@@ -135,7 +135,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -164,7 +163,6 @@
                 "origbidcpm": 0.6,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targeting": {
                     "hb_bidder": "appnexus",

--- a/exchange/exchangetest/mediatypepricegranularity-banner-video-native.json
+++ b/exchange/exchangetest/mediatypepricegranularity-banner-video-native.json
@@ -197,7 +197,6 @@
                                 "origbidcpm": 15,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner",
                                     "targeting": {
@@ -227,7 +226,6 @@
                                 "origbidcpm": 18,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "targeting": {
                                         "hb_bidder": "appnexus",
@@ -262,7 +260,6 @@
                                 "origbidcpm": 29,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "targeting": {
                                         "hb_bidder": "appnexus",

--- a/exchange/exchangetest/mediatypepricegranularity-native.json
+++ b/exchange/exchangetest/mediatypepricegranularity-native.json
@@ -165,7 +165,6 @@
                                 "origbidcpm": 24,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "native",
                                     "targeting": {
@@ -195,7 +194,6 @@
                                 "origbidcpm": 29,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "targeting": {
                                         "hb_bidder": "appnexus",

--- a/exchange/exchangetest/multi-bid-default-bid-limit.json
+++ b/exchange/exchangetest/multi-bid-default-bid-limit.json
@@ -267,7 +267,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             },
                             {
@@ -295,7 +294,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             },
                             {
@@ -323,7 +321,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -471,7 +468,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "rubicon"
                                 }
                             },
                             {
@@ -498,7 +494,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "rubicon"
                                 }
                             },
                             {
@@ -525,7 +520,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "rubicon"
                                 }
                             }
                         ],
@@ -552,7 +546,6 @@
                             "ext": {
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "rubicon"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -593,7 +586,6 @@
                             "ext": {
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "rubicon"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -638,7 +630,6 @@
                             "ext": {
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -674,7 +665,6 @@
                             "ext": {
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 },

--- a/exchange/exchangetest/multi-bids-error.json
+++ b/exchange/exchangetest/multi-bids-error.json
@@ -180,7 +180,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -194,7 +193,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -208,7 +206,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -222,7 +219,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             }
                         ],
@@ -283,7 +279,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             },
                             {
@@ -297,7 +292,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -325,7 +319,6 @@
                                 "origbidcpm": 0.71,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -355,7 +348,6 @@
                                 "origbidcpm": 0.21,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -380,7 +372,6 @@
                                 "origbidcpm": 0.61,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -410,7 +401,6 @@
                                 "origbidcpm": 0.51,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -440,7 +430,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner",
                                     "targeting": {
@@ -464,7 +453,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/multi-bids-mixed-case.json
+++ b/exchange/exchangetest/multi-bids-mixed-case.json
@@ -146,7 +146,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pubmatic"
                 }
               },
               {
@@ -160,7 +159,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pubmatic"
                 }
               },
               {
@@ -174,7 +172,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pubmatic"
                 }
               },
               {
@@ -188,7 +185,6 @@
                 },
                 "bidType": "video",
                 "bidMeta": {
-                  "adaptercode": "pubmatic"
                 }
               }
             ],
@@ -261,7 +257,6 @@
                 },
                 "bidType": "banner",
                 "bidMeta": {
-                  "adaptercode": "appnexus"
                 }
               },
               {
@@ -275,7 +270,6 @@
                 },
                 "bidType": "banner",
                 "bidMeta": {
-                  "adaptercode": "appnexus"
                 }
               }
             ],
@@ -303,7 +297,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pubmatic"
                   },
                   "type": "video",
                   "targeting": {
@@ -333,7 +326,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pubmatic"
                   },
                   "type": "video"
                 }
@@ -350,7 +342,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pubmatic"
                   },
                   "type": "video",
                   "targeting": {
@@ -380,7 +371,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "pubmatic"
                   },
                   "type": "video",
                   "targeting": {
@@ -410,7 +400,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targetbiddercode": "appnexus",
                   "type": "banner",
@@ -435,7 +424,6 @@
                 "origbidcpm": 0.3,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner"
                 }

--- a/exchange/exchangetest/multi-bids-with-extra-bids.json
+++ b/exchange/exchangetest/multi-bids-with-extra-bids.json
@@ -174,7 +174,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -188,7 +187,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -202,7 +200,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -216,7 +213,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             }
                         ],
@@ -293,7 +289,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             },
                             {
@@ -307,7 +302,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -335,7 +329,6 @@
                                 "origbidcpm": 0.71,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -365,7 +358,6 @@
                                 "origbidcpm": 0.21,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video"
                                 }
@@ -382,7 +374,6 @@
                                 "origbidcpm": 0.61,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -412,7 +403,6 @@
                                 "origbidcpm": 0.51,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -442,7 +432,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "targetbiddercode": "appnexus",
                                     "type": "banner",
@@ -467,7 +456,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/multi-bids.json
+++ b/exchange/exchangetest/multi-bids.json
@@ -146,7 +146,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -160,7 +159,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -174,7 +172,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             },
                             {
@@ -188,7 +185,6 @@
                                 },
                                 "bidType": "video",
                                 "bidMeta": {
-                                    "adaptercode": "pubmatic"
                                 }
                             }
                         ],
@@ -261,7 +257,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             },
                             {
@@ -275,7 +270,6 @@
                                 },
                                 "bidType": "banner",
                                 "bidMeta": {
-                                    "adaptercode": "appnexus"
                                 }
                             }
                         ],
@@ -303,7 +297,6 @@
                                 "origbidcpm": 0.71,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -333,7 +326,6 @@
                                 "origbidcpm": 0.21,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video"
                                 }
@@ -350,7 +342,6 @@
                                 "origbidcpm": 0.61,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -380,7 +371,6 @@
                                 "origbidcpm": 0.51,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "pubmatic"
                                     },
                                     "type": "video",
                                     "targeting": {
@@ -410,7 +400,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "targetbiddercode": "appnexus",
                                     "type": "banner",
@@ -435,7 +424,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "banner"
                                 }

--- a/exchange/exchangetest/passthrough_imp_only.json
+++ b/exchange/exchangetest/passthrough_imp_only.json
@@ -145,7 +145,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video",
                                     "passthrough": {
@@ -166,7 +165,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/passthrough_root_and_imp.json
+++ b/exchange/exchangetest/passthrough_root_and_imp.json
@@ -107,7 +107,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video",
                                     "passthrough": {

--- a/exchange/exchangetest/passthrough_root_only.json
+++ b/exchange/exchangetest/passthrough_root_only.json
@@ -102,7 +102,6 @@
                             "ext": {
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 },

--- a/exchange/exchangetest/request-ext-prebid-filtering.json
+++ b/exchange/exchangetest/request-ext-prebid-filtering.json
@@ -175,7 +175,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/request-imp-ext-prebid-filtering.json
+++ b/exchange/exchangetest/request-imp-ext-prebid-filtering.json
@@ -125,7 +125,6 @@
                                 "origbidcpm": 0.3,
                                 "prebid": {
                                     "meta": {
-                                        "adaptercode": "appnexus"
                                     },
                                     "type": "video"
                                 }

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -155,7 +155,6 @@
                 "origbidcpm": 12.00,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targeting": {
                     "hb_bidder": "appnexus",

--- a/exchange/exchangetest/request-multi-bidders-one-no-resp.json
+++ b/exchange/exchangetest/request-multi-bidders-one-no-resp.json
@@ -127,7 +127,6 @@
                 "origbidcpm": 12.00,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "targeting": {
                     "hb_bidder": "appnexus",

--- a/exchange/exchangetest/targeting-always-include-deals.json
+++ b/exchange/exchangetest/targeting-always-include-deals.json
@@ -170,7 +170,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video",
                   "targeting": {
@@ -195,7 +194,6 @@
                 "origbidcpm": 0.40,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video"
                 }
@@ -218,7 +216,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -250,7 +247,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }
@@ -268,7 +264,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/targeting-cache-vast-banner.json
+++ b/exchange/exchangetest/targeting-cache-vast-banner.json
@@ -88,7 +88,6 @@
                 "origbidcpm": 0.01,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "banner",
                   "targeting": {

--- a/exchange/exchangetest/targeting-cache-vast.json
+++ b/exchange/exchangetest/targeting-cache-vast.json
@@ -89,7 +89,6 @@
                 "origbidcpm": 0.01,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "cache": {
                     "bids": {

--- a/exchange/exchangetest/targeting-cache-zero.json
+++ b/exchange/exchangetest/targeting-cache-zero.json
@@ -91,7 +91,6 @@
                 "origbidcpm": 0.01,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "cache": {
                     "bids": {

--- a/exchange/exchangetest/targeting-mobile.json
+++ b/exchange/exchangetest/targeting-mobile.json
@@ -153,7 +153,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video",
                   "targeting": {
@@ -183,7 +182,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -214,7 +212,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }
@@ -231,7 +228,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/targeting-no-winners.json
+++ b/exchange/exchangetest/targeting-no-winners.json
@@ -153,7 +153,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video",
                   "targeting": {
@@ -182,7 +181,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -206,7 +204,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }
@@ -223,7 +220,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/targeting-only-winners.json
+++ b/exchange/exchangetest/targeting-only-winners.json
@@ -153,7 +153,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video"
                 }
@@ -175,7 +174,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -199,7 +197,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }
@@ -216,7 +213,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {

--- a/exchange/exchangetest/targeting-with-winners.json
+++ b/exchange/exchangetest/targeting-with-winners.json
@@ -153,7 +153,6 @@
                 "origbidcpm": 0.51,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "audienceNetwork"
                   },
                   "type": "video",
                   "targeting": {
@@ -182,7 +181,6 @@
                 "origbidcpm": 0.71,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {
@@ -211,7 +209,6 @@
                 "origbidcpm": 0.21,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video"
                 }
@@ -228,7 +225,6 @@
                 "origbidcpm": 0.61,
                 "prebid": {
                   "meta": {
-                    "adaptercode": "appnexus"
                   },
                   "type": "video",
                   "targeting": {


### PR DESCRIPTION
This addresses most of #3363. With this fix, `seatbid[].bid[].ext.prebid.meta.adaptercode` will be set to the adapter name in the request alias and alternate bidder code use cases.
In the hard alias case, the adaptercode is still set to the hard alias. This is a larger change that will be addressed in its own PR.

In this PR I also removed all references to `adaptercode` in the exchange JSON tests since they no longer serve a purpose as the exchange tests mock objects that contain the `adaptercode` logic. As such, I made some updates to the auction endpoint tests that allow us to verify the request alias, hard alias and alternate bidder code logic work correctly with respect to the `adaptercode`.