### PR TITLE
Fix semgrep issue with dgryski Go ruleset

### DIFF
--- a/util/jsonutil/merge.go
+++ b/util/jsonutil/merge.go
@@ -31,12 +31,12 @@ func init() {
 // Fields of type json.RawMessage are merged rather than replaced.
 func MergeClone(v any, data json.RawMessage) error {
 	err := jsonConfigMergeClone.Unmarshal(data, v)
-	if err != nil {
-		return &errortypes.FailedToUnmarshal{
-			Message: tryExtractErrorMessage(err),
-		}
+	if err == nil {
+		return nil
 	}
-	return err
+	return &errortypes.FailedToUnmarshal{
+		Message: tryExtractErrorMessage(err),
+	}
 }
 
 type mergeCloneExtension struct {


### PR DESCRIPTION
PR fixes the semgrep issue with the [dgryski ruleset](https://github.com/dgryski/semgrep-go), rule https://github.com/dgryski/semgrep-go/blob/master/returnnil.yml by restructuring the error handling: return `nil` if the `err` from `jsonConfigMergeClone.Unmarshal`, otherwise make the return value as now.

```sh
┌────────────────┐
│ 1 Code Finding │
└────────────────┘

    util/jsonutil/merge.go
   ❯❯❱ Users.dsavints.gh.dgryski.semgrep-go.return-nil
          return nil instead of nil value

           34┆ if err != nil {
           35┆   return &errortypes.FailedToUnmarshal{
           36┆           Message: tryExtractErrorMessage(err),
           37┆   }
           38┆ }
           39┆ return err
```