### PR TITLE
CPMStar: add gvlVendorID

### DIFF
--- a/static/bidder-info/cpmstar.yaml
+++ b/static/bidder-info/cpmstar.yaml
@@ -1,6 +1,7 @@
 endpoint: "https://server.cpmstar.com/openrtbbidrq.aspx"
 maintainer:
   email: "prebid@cpmstar.com"
+gvlVendorID: 1317
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
CPMStar Bidder Adapter - Added GVL / TCF Vendor ID to bidder-info