### PR TITLE
Agma: Allow app.bundle to be used as selector for apps

### DIFF
--- a/analytics/agma/README.md
+++ b/analytics/agma/README.md
@@ -12,8 +12,8 @@ analytics:
         # Required: set the accounts you want to track
         accounts:
         - code: "my-code" # Required: provied by agma
-          publisher_id: "123" # Required: Exchange specific publisher_id
-          site_app_id: "openrtb2-site.id-or-app.id" # optional: scope to the publisher with an openrtb2 Site object id or App object id
+          publisher_id: "123" # Required: Exchange specific publisher_id, can be an empty string accounts are not used
+          site_app_id: "openrtb2-site.id-or-app.id-or-app.bundle" # optional: scope to the publisher with an openrtb2 Site object id or App object id/bundle
         # Optional properties (advanced configuration)
         endpoint: 
             url: "https://go.pbs.agma-analytics.de/v1/prebid-server" # Check with agma if your site needs an extra url

--- a/analytics/agma/agma_module.go
+++ b/analytics/agma/agma_module.go
@@ -169,6 +169,10 @@ func (l *AgmaLogger) extractPublisherAndSite(requestWrapper *openrtb_ext.Request
 			publisherId = requestWrapper.App.Publisher.ID
 		}
 		appSiteId = requestWrapper.App.ID
+		if appSiteId == "" {
+			appSiteId = requestWrapper.App.Bundle
+		}
+
 	}
 	return publisherId, appSiteId
 }

--- a/analytics/agma/agma_module_test.go
+++ b/analytics/agma/agma_module_test.go
@@ -188,6 +188,11 @@ func TestShouldTrackEvent(t *testing.T) {
 				PublisherId: "track-me",
 				Code:        "abc",
 			},
+			{
+				PublisherId: "",
+				SiteAppId:   "track-me",
+				Code:        "abc",
+			},
 		},
 	}
 	mockedSender := new(MockedSender)
@@ -283,6 +288,36 @@ func TestShouldTrackEvent(t *testing.T) {
 
 	assert.False(t, shouldTrack)
 	assert.Equal(t, "", code)
+
+	// should allow empty accounts
+	shouldTrack, code = logger.shouldTrackEvent(&openrtb_ext.RequestWrapper{
+		BidRequest: &openrtb2.BidRequest{
+			App: &openrtb2.App{
+				ID: "track-me",
+			},
+			User: &openrtb2.User{
+				Ext: json.RawMessage(`{"consent": "` + agmaConsent + `"}`),
+			},
+		},
+	})
+
+	assert.True(t, shouldTrack)
+	assert.Equal(t, "abc", code)
+
+	// Bundle ID instead of app.id
+	shouldTrack, code = logger.shouldTrackEvent(&openrtb_ext.RequestWrapper{
+		BidRequest: &openrtb2.BidRequest{
+			App: &openrtb2.App{
+				Bundle: "track-me",
+			},
+			User: &openrtb2.User{
+				Ext: json.RawMessage(`{"consent": "` + agmaConsent + `"}`),
+			},
+		},
+	})
+
+	assert.True(t, shouldTrack)
+	assert.Equal(t, "abc", code)
 }
 
 func TestShouldTrackMultipleAccounts(t *testing.T) {


### PR DESCRIPTION
This update enables users of our adapter to use `app.bundle` for selecting an app, in addition to the existing `app.id` option. This enhancement allows configuration when hosting providers share stored requests between apps.


edit: there was an unrelated build fail, I've rebased master and the CI looks fine now