### PR TITLE
Sample: fix prebid js loading bug on sample html page

### DIFF
--- a/sample/001_banner/pbjs.html
+++ b/sample/001_banner/pbjs.html
@@ -12,8 +12,8 @@
             border-style: solid;
         }
     </style>
-    <script src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js"></script>
-    <script>
+    <script src="//cdn.jsdelivr.net/npm/prebid.js@latest/dist/not-for-prod/prebid.js" defer></script>
+    <script defer>
 
         var sizes = [
             [300, 250],
@@ -77,7 +77,7 @@
         }
 
     </script>
-    <script>
+    <script defer>
         var pbjs = pbjs || {};
         pbjs.que = pbjs.que || [];
 


### PR DESCRIPTION
There is a bug on sample html page:
![image_2024-07-03_17-01-07](https://github.com/prebid/prebid-server/assets/28010702/8268262a-6c74-4b55-8054-2b9046a4867a)

```
prebid.js:12 
Uncaught TypeError: Cannot read properties of null (reading 'appendChild')
    at U (prebid.js:12:9881)
    at $.processQueue (prebid.js:12:99684)
    at prebid.js:631:11
```

This is caused by `appendChild()` method call (inside pbjs) on a DOM element that doesn't exist yet .

This can be fixed by simply by deferring javascript scripts loading, and that is what i did in this pr.
