### PR TITLE
Medianet: Add fledge support

### DIFF
--- a/adapters/medianet/medianet.go
+++ b/adapters/medianet/medianet.go
@@ -102,7 +102,9 @@ func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest
 		}
 	}
 
-	bidResponse.FledgeAuctionConfigs = extractFledge(a, bidResp)
+	if fledgeAuctionConfigs, err := extractFledge(a, bidResp); err == nil && fledgeAuctionConfigs != nil {
+		bidResponse.FledgeAuctionConfigs = fledgeAuctionConfigs
+	}
 
 	return bidResponse, errs
 }
@@ -132,12 +134,12 @@ func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType,
 	}
 }
 
-func extractFledge(a *adapter, bidResp openrtb2.BidResponse) []*openrtb_ext.FledgeAuctionConfig {
+func extractFledge(a *adapter, bidResp openrtb2.BidResponse) ([]*openrtb_ext.FledgeAuctionConfig, error) {
 	var fledgeAuctionConfigs []*openrtb_ext.FledgeAuctionConfig
 
 	var bidRespExt medianetRespExt
 	if err := json.Unmarshal(bidResp.Ext, &bidRespExt); err != nil {
-		return nil
+		return nil, err
 	}
 
 	for _, igi := range bidRespExt.Igi {
@@ -154,7 +156,7 @@ func extractFledge(a *adapter, bidResp openrtb2.BidResponse) []*openrtb_ext.Fled
 		}
 	}
 
-	return fledgeAuctionConfigs
+	return fledgeAuctionConfigs, nil
 }
 
 func buildEndpoint(mnetUrl, hostUrl string) string {

--- a/adapters/medianet/medianet.go
+++ b/adapters/medianet/medianet.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prebid/prebid-server/v2/openrtb_ext"
 )
 
-type MedianetAdapter struct {
+type adapter struct {
 	bidderName string
 	endpoint   string
 }
@@ -40,7 +40,7 @@ type medianetRespExt struct {
 	Igi []interestGroupIntent `json:"igi,omitempty"`
 }
 
-func (a *MedianetAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
 	var errs []error
 
 	reqJson, err := json.Marshal(request)
@@ -61,7 +61,7 @@ func (a *MedianetAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 	}}, errs
 }
 
-func (a *MedianetAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
 	var errs []error
 
 	if response.StatusCode == http.StatusNoContent {
@@ -110,7 +110,7 @@ func (a *MedianetAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 // Builder builds a new instance of the Medianet adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
 	url := buildEndpoint(config.Endpoint, config.ExtraAdapterInfo)
-	return &MedianetAdapter{
+	return &adapter{
 		bidderName: string(bidderName),
 		endpoint:   url,
 	}, nil
@@ -132,7 +132,7 @@ func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType,
 	}
 }
 
-func extractFledge(a *MedianetAdapter, bidResp openrtb2.BidResponse) []*openrtb_ext.FledgeAuctionConfig {
+func extractFledge(a *adapter, bidResp openrtb2.BidResponse) []*openrtb_ext.FledgeAuctionConfig {
 	var fledgeAuctionConfigs []*openrtb_ext.FledgeAuctionConfig
 
 	var bidRespExt medianetRespExt

--- a/adapters/medianet/medianettest/exemplary/fledge-no-bid.json
+++ b/adapters/medianet/medianettest/exemplary/fledge-no-bid.json
@@ -1,0 +1,91 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "ae": 1,
+          "bidder": {
+            "cid": "8CUTSTCID",
+            "crid": "999999999"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://example.media.net/rtb/prebid?src=http%3A%2F%2Flocalhost%3A8080%2Fextrnal_url",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "ae": 1,
+                "bidder": {
+                  "cid": "8CUTSTCID",
+                  "crid": "999999999"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs":["1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "1",
+          "cur": "USD",
+          "nbr": 1,
+          "ext": {
+            "igi":[{
+              "igs":[{
+                "impid": "1",
+                "config": {
+                  "key": "value"
+                }
+              }]
+            }]
+          }
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [],
+      "fledgeauctionconfigs": [
+        {
+          "impid": "1",
+          "bidder": "medianet",
+          "config": {
+            "key": "value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/medianet/medianettest/exemplary/fledge.json
+++ b/adapters/medianet/medianettest/exemplary/fledge.json
@@ -1,0 +1,120 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "1",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "ae": 1,
+          "bidder": {
+            "cid": "8CUTSTCID",
+            "crid": "999999999"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://example.media.net/rtb/prebid?src=http%3A%2F%2Flocalhost%3A8080%2Fextrnal_url",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  }
+                ]
+              },
+              "ext": {
+                "ae": 1,
+                "bidder": {
+                  "cid": "8CUTSTCID",
+                  "crid": "999999999"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs":["1"]
+      },
+
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "medianet",
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "1",
+                  "price": 1.50,
+                  "adm": "some-test-ad",
+                  "crid": "test-crid",
+                  "h": 50,
+                  "w": 320
+                }
+              ]
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "igi":[{
+              "igs":[{
+                "impid": "1",
+                "config": {
+                  "key": "value"
+                }
+              }]
+            }]
+          }
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "1",
+            "price": 1.50,
+            "adm": "some-test-ad",
+            "crid": "test-crid",
+            "w": 320,
+            "h": 50
+          },
+          "type": "banner"
+        }
+      ],
+      "fledgeauctionconfigs": [
+        {
+          "impid": "1",
+          "bidder": "medianet",
+          "config": {
+            "key": "value"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add Fledge support for Medianet adapter. The response from bidder for fledge auction config support the ortb format mentioned in the below link.
https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/Protected%20Audience%20Support.md

Previously opened MR that got closed because developer account was removed
https://github.com/prebid/prebid-server/pull/3641