### PR TITLE
Triplelift Native: fix panic

### DIFF
--- a/adapters/triplelift_native/triplelift_native.go
+++ b/adapters/triplelift_native/triplelift_native.go
@@ -69,7 +69,6 @@ func processImp(imp *openrtb2.Imp, request *openrtb2.BidRequest) error {
 	} else {
 		imp.TagID = tlext.InvCode
 	}
-
 	// floor is optional
 	if tlext.Floor == nil {
 		return nil

--- a/adapters/triplelift_native/triplelift_native.go
+++ b/adapters/triplelift_native/triplelift_native.go
@@ -50,12 +50,6 @@ func processImp(imp *openrtb2.Imp, request *openrtb2.BidRequest) error {
 	// get the triplelift extension
 	var ext ExtImp
 	var tlext openrtb_ext.ExtImpTriplelift
-	var siteCopy openrtb2.Site
-	var extData ExtImpData
-
-	if request.Site != nil {
-		siteCopy = *request.Site
-	}
 
 	if err := json.Unmarshal(imp.Ext, &ext); err != nil {
 		return err
@@ -70,19 +64,12 @@ func processImp(imp *openrtb2.Imp, request *openrtb2.BidRequest) error {
 		return fmt.Errorf("no inv_code specified")
 	}
 
-	if ext.Data != nil {
-		extData = *ext.Data
-	}
-
-	if extData.TagCode != "" {
-		if siteCopy.Publisher.Domain == "msn.com" {
-			imp.TagID = extData.TagCode
-		} else {
-			imp.TagID = tlext.InvCode
-		}
+	if ext.Data != nil && len(ext.Data.TagCode) > 0 && request.Site != nil && request.Site.Publisher != nil && request.Site.Publisher.Domain == "msn.com" {
+		imp.TagID = ext.Data.TagCode
 	} else {
 		imp.TagID = tlext.InvCode
 	}
+
 	// floor is optional
 	if tlext.Floor == nil {
 		return nil

--- a/adapters/triplelift_native/triplelift_nativetest/supplemental/nil-site-publisher.json
+++ b/adapters/triplelift_native/triplelift_nativetest/supplemental/nil-site-publisher.json
@@ -1,0 +1,31 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "name": "anyname"
+    },
+    "imp": [
+      {
+        "native": {
+          "request": "{\"plcmtcnt\":1,\"plcmttype\":2,\"privacy\":1,\"context\":1,\"contextsubtype\":12,\"eventtrackers\":[{\"event\":1,\"methods\":[1,2]},{\"event\":2,\"methods\":[1]}],\"assets\":[{\"data\":{\"type\":12},\"required\":1},{\"title\":{\"len\":50},\"required\":1},{\"img\":{\"w\":80,\"h\":80,\"type\":1},\"required\":1},{\"img\":{\"w\":1200,\"h\":627,\"type\":3},\"required\":1},{\"data\":{\"type\":3},\"required\":0},{\"data\":{\"len\":100,\"type\":2},\"required\":1},{\"video\":{\"mimes\":[\"video/mpeg\",\"video/mp4\"],\"minduration\":2,\"protocols\":[2,5],\"maxduration\":2,\"ext\":{\"playbackmethod\":[1,2]}},\"required\":1}],\"ver\":\"1.2\"}"
+        },
+        "id": "test-imp-id",
+        "ext": {
+          "bidder": {
+            "inventoryCode": "foo",
+            "floor": 20
+          },
+          "data": {
+            "tag_code": "bar"
+          }
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Unsupported publisher for triplelift_native",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/triplelift_native/triplelift_nativetest/supplemental/nil-site.json
+++ b/adapters/triplelift_native/triplelift_nativetest/supplemental/nil-site.json
@@ -1,0 +1,72 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "publisher": {
+        "id": "foo",
+        "name": "foo",
+        "domain": "msn.com"
+      }
+    },
+    "imp": [
+      {
+        "native": {
+          "request": "{\"plcmtcnt\":1,\"plcmttype\":2,\"privacy\":1,\"context\":1,\"contextsubtype\":12,\"eventtrackers\":[{\"event\":1,\"methods\":[1,2]},{\"event\":2,\"methods\":[1]}],\"assets\":[{\"data\":{\"type\":12},\"required\":1},{\"title\":{\"len\":50},\"required\":1},{\"img\":{\"w\":80,\"h\":80,\"type\":1},\"required\":1},{\"img\":{\"w\":1200,\"h\":627,\"type\":3},\"required\":1},{\"data\":{\"type\":3},\"required\":0},{\"data\":{\"len\":100,\"type\":2},\"required\":1},{\"video\":{\"mimes\":[\"video/mpeg\",\"video/mp4\"],\"minduration\":2,\"protocols\":[2,5],\"maxduration\":2,\"ext\":{\"playbackmethod\":[1,2]}},\"required\":1}],\"ver\":\"1.2\"}"
+        },
+        "id": "test-imp-id",
+        "ext": {
+          "bidder": {
+            "inventoryCode": "anyInventoryCode",
+            "floor": 20
+          },
+          "data": {
+            "tag_code": "bar"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://tlx.3lift.net/s2sn/auction?supplier_id=20",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "native": {
+                "request": "{\"plcmtcnt\":1,\"plcmttype\":2,\"privacy\":1,\"context\":1,\"contextsubtype\":12,\"eventtrackers\":[{\"event\":1,\"methods\":[1,2]},{\"event\":2,\"methods\":[1]}],\"assets\":[{\"data\":{\"type\":12},\"required\":1},{\"title\":{\"len\":50},\"required\":1},{\"img\":{\"w\":80,\"h\":80,\"type\":1},\"required\":1},{\"img\":{\"w\":1200,\"h\":627,\"type\":3},\"required\":1},{\"data\":{\"type\":3},\"required\":0},{\"data\":{\"len\":100,\"type\":2},\"required\":1},{\"video\":{\"mimes\":[\"video/mpeg\",\"video/mp4\"],\"minduration\":2,\"protocols\":[2,5],\"maxduration\":2,\"ext\":{\"playbackmethod\":[1,2]}},\"required\":1}],\"ver\":\"1.2\"}"
+              },
+              "tagid": "anyInventoryCode",
+              "bidfloor": 20,
+              "ext": {
+                "bidder": {
+                  "inventoryCode": "anyInventoryCode",
+                  "floor": 20
+                },
+                "data": {
+                  "tag_code": "bar"
+                }
+              }
+            }
+          ],
+          "app": {
+            "publisher": {
+              "id": "foo",
+              "name": "foo",
+              "domain": "msn.com"
+            }
+          }
+        },
+        "impIDs": [
+          "test-imp-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}


### PR DESCRIPTION
This pull request adds an extra `nil` check to the logic recently added in #3745 as it was triggering panics when a `nil` value of`siteCopy.Publisher` would get dereferenced in line 78 of `adapters/triplelift_native/triplelift_native.go`.
```
73     if ext.Data != nil {
74         extData = *ext.Data
75     }
76
77     if extData.TagCode != "" {
78         if siteCopy.Publisher.Domain == "msn.com" { //<-- PANIC
79             imp.TagID = extData.TagCode
80         } else {
81             imp.TagID = tlext.InvCode
82         }
83     } else {
84         imp.TagID = tlext.InvCode
85     }
adapters/triplelift_native/triplelift_native.go [RO]
```

@Triplelift, we were wondering if:
1. Do you agree with this change?
1. Given that the `imp.TagID` can now come from either `ext.Data.TagCode` or `tlext.InvCode`, do we still want to return error in line 64 or should we remove?
   ```
   57       if err := json.Unmarshal(ext.Bidder, &tlext); err != nil {
   58           return err
   59       }
   60       if imp.Native == nil {
   61           return fmt.Errorf("no native object specified")
   62       }
   63 -     if tlext.InvCode == "" {
   64 -         return fmt.Errorf("no inv_code specified")
   65 -     }
   66  
   67       if ext.Data != nil && len(ext.Data.TagCode) > 0 && request.Site != nil && request.Site.Publisher != nil && request.Site.Publisher.Domain == "msn.com" {
   68           imp.TagID = ext.Data.TagCode
   69       } else {
   70           imp.TagID = tlext.InvCode
   71       }
   72  
   73       // floor is optional
   74       if tlext.Floor == nil {
   75           return nil
   76       }
   adapters/triplelift_native/triplelift_native.go [RO]
   ```

1. If `request.Site` is `nil`, are we interested in using the `App.Publisher.Domain` instead? Function `effectivePubID` downstream makes use of `App.Publisher` values. Should `processImp` use `App.Publisher.Domain` if available?

