### PR TITLE
OpenX: return BidVideo object for hb_pb_cat_dur targeting 

### DIFF
--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -231,12 +231,24 @@ func (a *OpenxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRe
 	for _, sb := range bidResp.SeatBid {
 		for i := range sb.Bid {
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
-				Bid:     &sb.Bid[i],
-				BidType: getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp),
+				Bid:      &sb.Bid[i],
+				BidType:  getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp),
+				BidVideo: getBidVideo(&sb.Bid[i]),
 			})
 		}
 	}
 	return bidResponse, nil
+}
+
+func getBidVideo(bid *openrtb2.Bid) *openrtb_ext.ExtBidPrebidVideo {
+	var primaryCategory string
+	if len(bid.Cat) > 0 {
+		primaryCategory = bid.Cat[0]
+	}
+	return &openrtb_ext.ExtBidPrebidVideo{
+		PrimaryCategory: primaryCategory,
+		Duration:        int(bid.Dur),
+	}
 }
 
 // getMediaTypeForImp figures out which media type this bid is for.

--- a/adapters/openx/openxtest/exemplary/simple-video.json
+++ b/adapters/openx/openxtest/exemplary/simple-video.json
@@ -60,7 +60,10 @@
                 "adm": "some-test-ad",
                 "crid": "crid_10",
                 "w": 1024,
-                "h": 576
+                "h": 576,
+                "cattax": 1,
+                "cat": ["IAB20"],
+                "dur": 30
               }]
             }
           ]
@@ -82,7 +85,14 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 1024,
-            "h": 576
+            "h": 576,
+            "cattax": 1,
+            "cat": ["IAB20"],
+            "dur": 30
+          },
+          "video": {
+            "duration": 30,
+            "primary_category": "IAB20"
           },
           "type": "video"
         }


### PR DESCRIPTION
Add `BidVideo` to adapter response containing the duration and category. They are used by PBS to build the value of `hb_pb_cat_dur` and `hb_pb_cat_dur_openx` targeting keys.
