### PR TITLE
Update adapter json test framework to validate BidVideo

### DIFF
--- a/adapters/adapterstest/test_json.go
+++ b/adapters/adapterstest/test_json.go
@@ -226,9 +226,10 @@ type expectedBidResponse struct {
 }
 
 type expectedBid struct {
-	Bid  json.RawMessage `json:"bid"`
-	Type string          `json:"type"`
-	Seat string          `json:"seat"`
+	Bid   json.RawMessage `json:"bid"`
+	Type  string          `json:"type"`
+	Seat  string          `json:"seat"`
+	Video json.RawMessage `json:"video,omitempty"`
 }
 
 // ---------------------------------------
@@ -342,6 +343,9 @@ func diffBids(t *testing.T, description string, actual *adapters.TypedBid, expec
 	assert.Equal(t, string(expected.Seat), string(actual.Seat), fmt.Sprintf(`%s.seat "%s" does not match expected "%s."`, description, string(actual.Seat), string(expected.Seat)))
 	assert.Equal(t, string(expected.Type), string(actual.BidType), fmt.Sprintf(`%s.type "%s" does not match expected "%s."`, description, string(actual.BidType), string(expected.Type)))
 	assert.NoError(t, diffOrtbBids(fmt.Sprintf("%s.bid", description), actual.Bid, expected.Bid))
+	if expected.Video != nil {
+		assert.NoError(t, diffBidVideo(fmt.Sprintf("%s.video", description), actual.BidVideo, expected.Video))
+	}
 }
 
 // diffOrtbBids compares the actual Bid made by the adapter to the expectation from the JSON file.
@@ -356,6 +360,15 @@ func diffOrtbBids(description string, actual *openrtb2.Bid, expected json.RawMes
 	}
 
 	return diffJson(description, actualJson, expected)
+}
+
+func diffBidVideo(description string, actual *openrtb_ext.ExtBidPrebidVideo, expected json.RawMessage) error {
+	actualJson, err := json.Marshal(actual)
+	if err != nil {
+		return fmt.Errorf("%s failed to marshal actual Bid Video into JSON. %v", description, err)
+	}
+
+	return diffJson(description, actualJson, []byte(expected))
 }
 
 // diffJson compares two JSON byte arrays for structural equality. It will produce an error if either

--- a/adapters/freewheelssp/freewheelssptest/exemplary/multi-imp.json
+++ b/adapters/freewheelssp/freewheelssptest/exemplary/multi-imp.json
@@ -153,7 +153,8 @@
           },
           "type": "video",
           "video" : {
-            "duration" : 10
+            "duration" : 10,
+            "primary_category": ""
           }
         }
       ]

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -177,7 +177,8 @@
             },
             "type": "video",
             "video" :{
-              "duration" : 5
+              "duration" : 5,
+              "primary_category": ""
             }
           }
         ]

--- a/adapters/yeahmobi/yeahmobitest/exemplary/simple-video.json
+++ b/adapters/yeahmobi/yeahmobitest/exemplary/simple-video.json
@@ -96,7 +96,8 @@
           },
           "type": "video",
           "video": {
-            "duration": 300
+            "duration": 300,
+            "primary_category": ""
           }
         }
       ]

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -74,8 +74,8 @@ type ExtBidPrebidMeta struct {
 
 // ExtBidPrebidVideo defines the contract for bidresponse.seatbid.bid[i].ext.prebid.video
 type ExtBidPrebidVideo struct {
-	Duration        int    `json:"duration,omitempty"`
-	PrimaryCategory string `json:"primary_category,omitempty"`
+	Duration        int    `json:"duration"`
+	PrimaryCategory string `json:"primary_category"`
 }
 
 // ExtBidPrebidEvents defines the contract for bidresponse.seatbid.bid[i].ext.prebid.events

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -74,8 +74,8 @@ type ExtBidPrebidMeta struct {
 
 // ExtBidPrebidVideo defines the contract for bidresponse.seatbid.bid[i].ext.prebid.video
 type ExtBidPrebidVideo struct {
-	Duration        int    `json:"duration"`
-	PrimaryCategory string `json:"primary_category"`
+	Duration        int    `json:"duration,omitempty"`
+	PrimaryCategory string `json:"primary_category,omitempty"`
 }
 
 // ExtBidPrebidEvents defines the contract for bidresponse.seatbid.bid[i].ext.prebid.events


### PR DESCRIPTION
Adapter json test framework appears to ignore the `expectedBid.video` object and so the related tests do not test anything. 

Add `expectedBid.Video` and diff function to validate this part of the adapter response. There are a few tests that only have `video.duration` and no `video.primary_category` and those would fail; we can update the tests or update the `ExtPrebidVideo` structure to make them optional.

Here I update the structure assuming that the tests show the intention, but if that's not desirable we could update the tests instead.

There's a similar issue with exchange tests that I will look to address separately.

Fixes the existing adapter tests including the one added in #3834 so they actually do validate the expected response.