### PR TITLE
Update exchange json tests with correct hb_pb_cat_dur 

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -5568,9 +5568,10 @@ type bidderSeatBid struct {
 // bidderBid is basically a subset of entities.PbsOrtbBid from exchange/bidder.go.
 // See the comment on bidderSeatBid for more info.
 type bidderBid struct {
-	Bid  *openrtb2.Bid                 `json:"ortbBid,omitempty"`
-	Type string                        `json:"bidType,omitempty"`
-	Meta *openrtb_ext.ExtBidPrebidMeta `json:"bidMeta,omitempty"`
+	Bid      *openrtb2.Bid                  `json:"ortbBid,omitempty"`
+	Type     string                         `json:"bidType,omitempty"`
+	BidVideo *openrtb_ext.ExtBidPrebidVideo `json:"bidVideo,omitempty"`
+	Meta     *openrtb_ext.ExtBidPrebidMeta  `json:"bidMeta,omitempty"`
 }
 
 type mockIdFetcher map[string]string
@@ -5617,6 +5618,7 @@ func (b *validatingBidder) requestBid(ctx context.Context, bidderRequest BidderR
 						bids[i] = &entities.PbsOrtbBid{
 							OriginalBidCPM: mockSeatBid.Bids[i].Bid.Price,
 							Bid:            mockSeatBid.Bids[i].Bid,
+							BidVideo:       mockSeatBid.Bids[i].BidVideo,
 							BidType:        openrtb_ext.BidType(mockSeatBid.Bids[i].Type),
 							BidMeta:        mockSeatBid.Bids[i].Meta,
 						}

--- a/exchange/exchangetest/append-bidder-names.json
+++ b/exchange/exchangetest/append-bidder-names.json
@@ -148,10 +148,14 @@
                                         "hb_cache_path_appnex": "/pbcache/endpoint",
                                         "hb_pb": "0.20",
                                         "hb_pb_appnexus": "0.20",
-                                        "hb_pb_cat_dur": "0.20_VideoGames_0s_appnexus",
-                                        "hb_pb_cat_dur_appnex": "0.20_VideoGames_0s_appnexus",
+                                        "hb_pb_cat_dur": "0.20_VideoGames_30s_appnexus",
+                                        "hb_pb_cat_dur_appnex": "0.20_VideoGames_30s_appnexus",
                                         "hb_size": "200x250",
                                         "hb_size_appnexus": "200x250"
+                                    },
+                                    "video": {
+                                        "duration": 30,
+                                        "primary_category": ""
                                     }
                                 }
                             }

--- a/exchange/exchangetest/debuglog_disabled.json
+++ b/exchange/exchangetest/debuglog_disabled.json
@@ -157,10 +157,14 @@
                     "hb_cache_path_appnex": "/pbcache/endpoint",
                     "hb_pb": "0.20",
                     "hb_pb_appnexus": "0.20",
-                    "hb_pb_cat_dur": "0.20_VideoGames_0s",
-                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_0s",
+                    "hb_pb_cat_dur": "0.20_VideoGames_30s",
+                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_30s",
                     "hb_size": "200x250",
                     "hb_size_appnexus": "200x250"
+                  },
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
                   }
                 }
               }

--- a/exchange/exchangetest/debuglog_enabled.json
+++ b/exchange/exchangetest/debuglog_enabled.json
@@ -159,10 +159,14 @@
                     "hb_cache_path_appnex": "/pbcache/endpoint",
                     "hb_pb": "0.20",
                     "hb_pb_appnexus": "0.20",
-                    "hb_pb_cat_dur": "0.20_VideoGames_0s",
-                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_0s",
+                    "hb_pb_cat_dur": "0.20_VideoGames_30s",
+                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_30s",
                     "hb_size": "200x250",
                     "hb_size_appnexus": "200x250"
+                  },
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
                   }
                 }
               }

--- a/exchange/exchangetest/generate-bid-id-error.json
+++ b/exchange/exchangetest/generate-bid-id-error.json
@@ -121,10 +121,14 @@
                     "hb_cache_path_appnex": "/pbcache/endpoint",
                     "hb_pb": "0.20",
                     "hb_pb_appnexus": "0.20",
-                    "hb_pb_cat_dur": "0.20_VideoGames_0s_appnexus",
-                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_0s_appnexus",
+                    "hb_pb_cat_dur": "0.20_VideoGames_30s_appnexus",
+                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_30s_appnexus",
                     "hb_size": "200x250",
                     "hb_size_appnexus": "200x250"
+                  },
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
                   }
                 }
               }

--- a/exchange/exchangetest/generate-bid-id-many.json
+++ b/exchange/exchangetest/generate-bid-id-many.json
@@ -67,7 +67,8 @@
                 },
                 "bidType": "video",
                 "bidVideo": {
-                  "duration": 30
+                  "duration": 30,
+                  "PrimaryCategory": ""
                 }
               }
             ],
@@ -100,7 +101,11 @@
                   "meta": {
                   },
                   "bidid": "bid-appnexus-1",
-                  "type": "video"
+                  "type": "video",
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
+                  }
                 }
               }
             },
@@ -120,7 +125,11 @@
                   "meta": {
                   },
                   "bidid": "bid-appnexus-2",
-                  "type": "video"
+                  "type": "video",
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
+                  }
                 }
               }
             }

--- a/exchange/exchangetest/generate-bid-id-one.json
+++ b/exchange/exchangetest/generate-bid-id-one.json
@@ -50,7 +50,8 @@
                 },
                 "bidType": "video",
                 "bidVideo": {
-                  "duration": 30
+                  "duration": 30,
+                  "primary_category": ""
                 }
               }
             ],
@@ -83,7 +84,11 @@
                   "meta": {
                   },
                   "bidid": "bid-appnexus-1",
-                  "type": "video"
+                  "type": "video",
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
+                  }
                 }
               }
             }

--- a/exchange/exchangetest/include-brand-category.json
+++ b/exchange/exchangetest/include-brand-category.json
@@ -146,10 +146,14 @@
                     "hb_cache_path_appnex": "/pbcache/endpoint",
                     "hb_pb": "0.20",
                     "hb_pb_appnexus": "0.20",
-                    "hb_pb_cat_dur": "0.20_VideoGames_0s",
-                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_0s",
+                    "hb_pb_cat_dur": "0.20_VideoGames_30s",
+                    "hb_pb_cat_dur_appnex": "0.20_VideoGames_30s",
                     "hb_size": "200x250",
                     "hb_size_appnexus": "200x250"
+                  },
+                  "video": {
+                    "duration": 30,
+                    "primary_category": ""
                   }
                 }
               }


### PR DESCRIPTION
Some exchange json tests define the `bidVideo` response component but do not actually load it, so they validate `hb_pb_cat_dur` values that are different from what PBS would generate. The difference is that PBS adds `_30s` when that duration is given in `BidVideo`, but the tests use `_0s`.

This change updates `bidderBid` definition so `bidVideo` is deserialized into the mock response as `BidVideo`.
It also updates the json tests with the correct value for `hb_pb_cat_dur`. Alternatively, we could preserve the current values and remove BidVideo from the tests that don't need it.

A solution to the same issue in adapter tests was proposed in #3835 

I am not sure why `BidVideo` is still necessary though. `Bid.Cat[0]` and `Bid.Dur` are available to be passed back in the Bid response, so the [targeting code](https://github.com/prebid/prebid-server/blob/master/exchange/exchange.go#L1011-L1014) could use them instead.