### PR TITLE
Fix Agma Module Shutdown() test

### DIFF
--- a/analytics/agma/agma_module.go
+++ b/analytics/agma/agma_module.go
@@ -124,9 +124,9 @@ func (l *AgmaLogger) isFull() bool {
 
 func (l *AgmaLogger) flush() {
 	l.mux.Lock()
+	defer l.mux.Unlock()
 
 	if l.eventCount == 0 || l.buffer.Len() == 0 {
-		l.mux.Unlock()
 		return
 	}
 
@@ -136,17 +136,13 @@ func (l *AgmaLogger) flush() {
 
 	payload := make([]byte, l.buffer.Len())
 	_, err := l.buffer.Read(payload)
+	defer l.reset()
 	if err != nil {
-		l.reset()
-		l.mux.Unlock()
 		glog.Warning("[AgmaAnalytics] fail to copy the buffer")
 		return
 	}
 
 	go l.sender(payload)
-
-	l.reset()
-	l.mux.Unlock()
 }
 
 func (l *AgmaLogger) reset() {


### PR DESCRIPTION
Test `TestShutdownFlush` sometimes fails the `AssertCalled` check when run in the `validate.sh` script due to a race contidion that the `time.Sleep` call in line 697 is unable to avoid if the goroutine `go l.sender(payload)` inside `flush()` takes longer to get run by golang's goroutine scheduler than the 10 millisecond wait.

This pull request  substites the `time.Sleep` call for a `sync.WaitGroup` approach.
