### PR TITLE
Kargo: Add iframe sync option

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -10,6 +10,9 @@ capabilities:
       - video
       - native
 userSync:
+  iframe:
+    url: "https://crb.kargo.com/api/v1/initsyncpbs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
+    userMacro: "$UID"
   redirect:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
     userMacro: "$UID"


### PR DESCRIPTION
Adds iframe sync option to kargo.yaml.

This endpoint will append the specified `r` (RedirectURL) to the list of returned pixels in the iframe. Aside from the appended redirecturl, this list of pixels are the same as from Kargo's prebid js adapter. 
Test url here: `https://crb.kargo.com/api/v1/initsyncpbs?r=https%3A%2F%2Fwww.kargo.com%3Fuid%3D%24UID`