### PR TITLE
Dockerfile: enable building cgo dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ WORKDIR /app/prebid-server/
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 ENV GOPROXY="https://proxy.golang.org"
+
+# Installing gcc as cgo uses it to build native code of some modules
 RUN apt-get update && \
     apt-get install -y git gcc && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# CGO must be enabled because some modules depend on native C code
 ENV CGO_ENABLED 1
 COPY ./ ./
 RUN go mod tidy
@@ -30,6 +34,8 @@ RUN chmod a+xr prebid-server
 COPY static static/
 COPY stored_requests/data stored_requests/data
 RUN chmod -R a+r static/ stored_requests/data
+
+# Installing libatomic1 as it is a runtime dependency for some modules
 RUN apt-get update && \
     apt-get install -y ca-certificates mtr libatomic1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 ENV GOPROXY="https://proxy.golang.org"
 RUN apt-get update && \
-    apt-get install -y git && \
+    apt-get install -y git gcc && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED 1
 COPY ./ ./
 RUN go mod tidy
 RUN go mod vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY static static/
 COPY stored_requests/data stored_requests/data
 RUN chmod -R a+r static/ stored_requests/data
 RUN apt-get update && \
-    apt-get install -y ca-certificates mtr && \
+    apt-get install -y ca-certificates mtr libatomic1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN adduser prebid_user
 USER prebid_user

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ or compile a standalone binary using the command:
 ``` bash
 go build .
 ```
+**Note:** if building from source there are a couple dependencies to be aware of: 
+1. *Compile-time*. Some modules ship native code that requires `cgo` (comes with the `go` compiler) being enabled - by default it is and environment variable `CGO_ENABLED=1` do NOT set it to `0`.
+2. *Compile-time*. `cgo` depends on the C-compiler, which usually is `gcc`, but can be changed by setting the value of `CC` env var, f.e. `CC=clang`.  On ubuntu `gcc` can be installed via `sudo apt-get install gcc`. 
+3. *Runtime*. Some modules require `libatomic`.  On ubuntu it is installed by running `sudo apt-get install libatomic1`.  `libatomic1` is a dependency of `gcc`, so if you are building with `gcc` and running on the same machine, it is likely that `libatomic1` is already installed.   
+
 Ensure that you deploy the `/static` directory, as Prebid Server requires those files at startup.
 
 ## Developing


### PR DESCRIPTION
## What?
Enabled cgo and added `apt-get install gcc` into the Dockerfile. 

## Why?
51Degrees is the module that depends on the native C library and uses cgo to transparently compile this dependency.  cgo depends on gcc.  