### PR TITLE
Vidazoo: Update bidder info for GPP support

### DIFF
--- a/static/bidder-info/vidazoo.yaml
+++ b/static/bidder-info/vidazoo.yaml
@@ -14,5 +14,7 @@ capabilities:
       - video
 userSync:
   iframe:
-    url: https://sync.cootlogix.com/api/user/html/pbs_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}
+    url: https://sync.cootlogix.com/api/user/html/pbs_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}
     userMacro: ${userId}
+openrtb:
+  gpp_supported: true


### PR DESCRIPTION
Extended the user sync URL to include GPP parameters.