### PR TITLE
Rubicon adapter: declare support for ORTB 2.6

### DIFF
--- a/static/bidder-info/rubicon.yaml
+++ b/static/bidder-info/rubicon.yaml
@@ -13,6 +13,9 @@ xapi:
 maintainer:
   email: "header-bidding@rubiconproject.com"
 gvlVendorID: 52
+openrtb:
+  version: 2.6
+  gpp-supported: true
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
This was done a while ago in https://github.com/prebid/prebid-server/pull/2536