### PR TITLE
Kargo: Indicate support for OpenRTB 2.6

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -15,4 +15,5 @@ userSync:
     userMacro: "$UID"
 endpointCompression: "GZIP"
 openrtb:
+  version: 2.6
   gpp-supported: true


### PR DESCRIPTION
Indicates support for openrtb 2.6 for Kargo adapter.