### PR TITLE
Modules: Add bidder response to raw bidder response stage payload

### DIFF
--- a/hooks/hookexecution/executor.go
+++ b/hooks/hookexecution/executor.go
@@ -229,10 +229,10 @@ func (e *hookExecutor) ExecuteRawBidderResponseStage(response *adapters.BidderRe
 
 	stageName := hooks.StageRawBidderResponse.String()
 	executionCtx := e.newContext(stageName)
-	payload := hookstage.RawBidderResponsePayload{Bids: response.Bids, Bidder: bidder}
+	payload := hookstage.RawBidderResponsePayload{BidderResponse: response, Bidder: bidder}
 
 	outcome, payload, contexts, reject := executeStage(executionCtx, plan, payload, handler, e.metricEngine)
-	response.Bids = payload.Bids
+	response = payload.BidderResponse
 	outcome.Entity = entity(bidder)
 	outcome.Stage = stageName
 

--- a/hooks/hookexecution/mocks_test.go
+++ b/hooks/hookexecution/mocks_test.go
@@ -151,7 +151,7 @@ func (e mockTimeoutHook) HandleRawBidderResponseHook(_ context.Context, _ hookst
 	time.Sleep(20 * time.Millisecond)
 	c := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
 	c.AddMutation(func(payload hookstage.RawBidderResponsePayload) (hookstage.RawBidderResponsePayload, error) {
-		payload.Bids[0].BidMeta = &openrtb_ext.ExtBidPrebidMeta{AdapterCode: "new-code"}
+		payload.BidderResponse.Bids[0].BidMeta = &openrtb_ext.ExtBidPrebidMeta{AdapterCode: "new-code"}
 		return payload, nil
 	}, hookstage.MutationUpdate, "bidderResponse", "bidMeta.AdapterCode")
 
@@ -351,7 +351,7 @@ func (e mockUpdateBidderResponseHook) HandleRawBidderResponseHook(_ context.Cont
 	c := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
 	c.AddMutation(
 		func(payload hookstage.RawBidderResponsePayload) (hookstage.RawBidderResponsePayload, error) {
-			payload.Bids[0].DealPriority = 10
+			payload.BidderResponse.Bids[0].DealPriority = 10
 			return payload, nil
 		}, hookstage.MutationUpdate, "bidderResponse", "bid.deal-priority",
 	)

--- a/hooks/hookstage/rawbidderresponse.go
+++ b/hooks/hookstage/rawbidderresponse.go
@@ -25,6 +25,7 @@ type RawBidderResponse interface {
 // objects representing bids returned by a particular bidder.
 // Hooks are allowed to modify bids using mutations.
 type RawBidderResponsePayload struct {
-	Bids   []*adapters.TypedBid
-	Bidder string
+	// Bids           []*adapters.TypedBid
+	BidderResponse *adapters.BidderResponse
+	Bidder         string
 }

--- a/hooks/hookstage/rawbidderresponse.go
+++ b/hooks/hookstage/rawbidderresponse.go
@@ -21,11 +21,9 @@ type RawBidderResponse interface {
 	) (HookResult[RawBidderResponsePayload], error)
 }
 
-// RawBidderResponsePayload consists of a list of adapters.TypedBid
-// objects representing bids returned by a particular bidder.
-// Hooks are allowed to modify bids using mutations.
+// RawBidderResponsePayload consists of a bidder response returned by a particular bidder.
+// Hooks are allowed to modify bidder response using mutations.
 type RawBidderResponsePayload struct {
-	// Bids           []*adapters.TypedBid
 	BidderResponse *adapters.BidderResponse
 	Bidder         string
 }

--- a/hooks/hookstage/rawbidderresponse_mutations.go
+++ b/hooks/hookstage/rawbidderresponse_mutations.go
@@ -33,7 +33,7 @@ func (c ChangeSetBids[T]) Update(bids []*adapters.TypedBid) {
 	c.changeSetRawBidderResponse.changeSet.AddMutation(func(p T) (T, error) {
 		bidderPayload, err := c.changeSetRawBidderResponse.castPayload(p)
 		if err == nil {
-			bidderPayload.Bids = bids
+			bidderPayload.BidderResponse.Bids = bids
 		}
 		if payload, ok := any(bidderPayload).(T); ok {
 			return payload, nil

--- a/hooks/hookstage/rawbidderresponse_mutations.go
+++ b/hooks/hookstage/rawbidderresponse_mutations.go
@@ -29,7 +29,8 @@ type ChangeSetBids[T any] struct {
 	changeSetRawBidderResponse ChangeSetRawBidderResponse[T]
 }
 
-func (c ChangeSetBids[T]) Update(bids []*adapters.TypedBid) {
+// UpdateBids updates the list of bids present in bidder-response using mutations.
+func (c ChangeSetBids[T]) UpdateBids(bids []*adapters.TypedBid) {
 	c.changeSetRawBidderResponse.changeSet.AddMutation(func(p T) (T, error) {
 		bidderPayload, err := c.changeSetRawBidderResponse.castPayload(p)
 		if err == nil {

--- a/modules/prebid/ortb2blocking/hook_raw_bidder_response.go
+++ b/modules/prebid/ortb2blocking/hook_raw_bidder_response.go
@@ -78,7 +78,7 @@ func handleRawBidderResponseHook(
 
 	changeSet := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
 	if len(payload.BidderResponse.Bids) != len(allowedBids) {
-		changeSet.RawBidderResponse().Bids().Update(allowedBids)
+		changeSet.RawBidderResponse().Bids().UpdateBids(allowedBids)
 		result.ChangeSet = changeSet
 	}
 

--- a/modules/prebid/ortb2blocking/hook_raw_bidder_response.go
+++ b/modules/prebid/ortb2blocking/hook_raw_bidder_response.go
@@ -34,7 +34,7 @@ func handleRawBidderResponseHook(
 
 	// allowedBids will store all bids that have passed the attribute check
 	allowedBids := make([]*adapters.TypedBid, 0)
-	for _, bid := range payload.Bids {
+	for _, bid := range payload.BidderResponse.Bids {
 
 		failedChecksData := make(map[string]interface{})
 		bidMediaTypes := mediaTypesFromBid(bid)
@@ -77,7 +77,7 @@ func handleRawBidderResponseHook(
 	}
 
 	changeSet := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
-	if len(payload.Bids) != len(allowedBids) {
+	if len(payload.BidderResponse.Bids) != len(allowedBids) {
 		changeSet.RawBidderResponse().Bids().Update(allowedBids)
 		result.ChangeSet = changeSet
 	}

--- a/modules/prebid/ortb2blocking/module_test.go
+++ b/modules/prebid/ortb2blocking/module_test.go
@@ -614,11 +614,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 	}{
 		{
 			description: "Payload not changed when empty account config and empty module contexts are provided. Analytic tags have successful records",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ADomain: []string{"foo"}, ImpID: impID1},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ADomain: []string{"foo"}, ImpID: impID1},
+					},
+				}},
+			},
 			expectedBids: []*adapters.TypedBid{
 				{
 					Bid: &openrtb2.Bid{ADomain: []string{"foo"}, ImpID: impID1},
@@ -643,9 +645,11 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Catch error if wrong data has been passed from previous hook. Payload not changed",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ADomain: []string{"foo"}, ImpID: impID1},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ADomain: []string{"foo"}, ImpID: impID1},
+					},
 				},
 			}},
 			expectedBids: []*adapters.TypedBid{
@@ -658,14 +662,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by badv attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -701,14 +707,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid not blocked because blocking conditions for current bidder do not exist. Payload not updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -742,14 +750,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid not blocked because enforce blocking is disabled by account config. Payload not updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": false}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -783,14 +793,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid not blocked because enforce blocking overridden for given bidder. Payload not updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true, "action_overrides": {"enforce_blocks": [{"conditions": {"bidders": ["appnexus"]}, "override": false}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -824,14 +836,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by badv attribute check (block unknown attributes). Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true, "block_unknown_adomain": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -867,14 +881,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid not blocked because block unknown overridden for given bidder. Payload not updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true, "block_unknown_adomain": true, "action_overrides": {"block_unknown_adomain": [{"conditions": {"bidders": ["appnexus"]}, "override": false}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -908,14 +924,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid not blocked due to deal exception. Payload not updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1, DealID: "acceptDealID"},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, ImpID: impID1, DealID: "acceptDealID"},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", ADomain: []string{"good_domain"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true, "action_overrides": {"allowed_adomain_for_deals": [{"conditions": {"deal_ids": ["acceptDealID"]}, "override": ["forbidden_domain"]}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -949,11 +967,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing enforce blocks overrides for badv attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"badv": {"enforce_blocks": true, "action_overrides": {"enforce_blocks": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -974,11 +994,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing block unknown domains overrides for badv attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"badv": {"enforce_blocks": true, "action_overrides": {"block_unknown_adomain": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -999,11 +1021,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if deal_ids not defined in config override conditions for badv attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, DealID: "acceptDealID"},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", ADomain: []string{"forbidden_domain"}, DealID: "acceptDealID"},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"badv": {"enforce_blocks": true, "action_overrides": {"allowed_adomain_for_deals": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1024,14 +1048,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by bcat attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", Cat: []string{"moto"}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", Cat: []string{"moto"}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"bcat":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1067,11 +1093,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing enforce blocks overrides for bcat attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"bcat": {"enforce_blocks": true, "action_overrides": {"enforce_blocks": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1092,11 +1120,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing block unknown domains overrides for bcat attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"bcat": {"enforce_blocks": true, "action_overrides": {"block_unknown_adv_cat": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1117,11 +1147,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if deal_ids not defined in config override conditions for bcat attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1, DealID: "acceptDealID"},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Cat: []string{"fishing"}, ImpID: impID1, DealID: "acceptDealID"},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"bcat": {"enforce_blocks": true, "action_overrides": {"allowed_adv_cat_for_deals": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1142,14 +1174,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by cattax attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", CatTax: 1, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", CatTax: 2, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", CatTax: 1, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", CatTax: 2, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"bcat":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1185,14 +1219,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by cattax attribute check (the default value used if no blocking attribute passed). Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", CatTax: 1, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", CatTax: 2, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", CatTax: 1, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", CatTax: 2, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"bcat":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1227,14 +1263,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by bapp attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", Bundle: "allowed_bundle", ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", Bundle: "allowed_bundle", ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"bapp":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1270,11 +1308,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing enforce blocks overrides for bapp attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"bapp": {"enforce_blocks": true, "action_overrides": {"enforce_blocks": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1295,11 +1335,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if deal_ids not defined in config override conditions for bapp attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1, DealID: "acceptDealID"},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Bundle: "forbidden_bundle", ImpID: impID1, DealID: "acceptDealID"},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"bapp": {"enforce_blocks": true, "action_overrides": {"allowed_app_for_deals": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1320,14 +1362,16 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by battr attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1},
-				},
-				{
-					Bid: &openrtb2.Bid{ID: "2", Attr: []adcom1.CreativeAttribute{2}, ImpID: impID2},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1},
+					},
+					{
+						Bid: &openrtb2.Bid{ID: "2", Attr: []adcom1.CreativeAttribute{2}, ImpID: impID2},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"battr":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1363,11 +1407,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if there is an issue processing enforce blocks overrides for battr attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"battr": {"enforce_blocks": true, "action_overrides": {"enforce_blocks": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1388,11 +1434,13 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Expect error if deal_ids not defined in config override conditions for battr attribute. Analytics should have error status tag",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1, DealID: "acceptDealID"},
-				},
-			}},
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{ID: "1", Attr: []adcom1.CreativeAttribute{1}, ImpID: impID1, DealID: "acceptDealID"},
+					},
+				}},
+			},
 			config: json.RawMessage(`{"attributes": {"battr": {"enforce_blocks": true, "action_overrides": {"allowed_banner_attr_for_deals": [{"conditions": {}}]}}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1413,30 +1461,32 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 		},
 		{
 			description: "Bid blocked by multiple attribute check. Payload updated. Analytic tags successfully collected",
-			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, Bids: []*adapters.TypedBid{
-				{
-					Bid: &openrtb2.Bid{
-						ID:      "1",
-						ADomain: []string{"forbidden_domain"},
-						Cat:     []string{"fishing"},
-						CatTax:  1,
-						Bundle:  "forbidden_bundle",
-						Attr:    []adcom1.CreativeAttribute{1},
-						ImpID:   impID1,
+			payload: hookstage.RawBidderResponsePayload{Bidder: bidder, BidderResponse: &adapters.BidderResponse{
+				Bids: []*adapters.TypedBid{
+					{
+						Bid: &openrtb2.Bid{
+							ID:      "1",
+							ADomain: []string{"forbidden_domain"},
+							Cat:     []string{"fishing"},
+							CatTax:  1,
+							Bundle:  "forbidden_bundle",
+							Attr:    []adcom1.CreativeAttribute{1},
+							ImpID:   impID1,
+						},
 					},
-				},
-				{
-					Bid: &openrtb2.Bid{
-						ID:      "2",
-						ADomain: []string{"allowed_domain"},
-						Cat:     []string{"moto"},
-						CatTax:  2,
-						Bundle:  "allowed_bundle",
-						Attr:    []adcom1.CreativeAttribute{2},
-						ImpID:   impID2,
+					{
+						Bid: &openrtb2.Bid{
+							ID:      "2",
+							ADomain: []string{"allowed_domain"},
+							Cat:     []string{"moto"},
+							CatTax:  2,
+							Bundle:  "allowed_bundle",
+							Attr:    []adcom1.CreativeAttribute{2},
+							ImpID:   impID2,
+						},
 					},
-				},
-			}},
+				}},
+			},
 			config: json.RawMessage(`{"attributes":{"badv":{"enforce_blocks": true}, "bcat":{"enforce_blocks": true}, "cattax":{"enforce_blocks": true}, "bapp":{"enforce_blocks": true}, "battr":{"enforce_blocks": true}}}`),
 			expectedBids: []*adapters.TypedBid{
 				{
@@ -1514,7 +1564,7 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 				assert.NoError(t, err)
 				test.payload = newPayload
 			}
-			assert.Equal(t, test.expectedBids, test.payload.Bids, "Invalid Bids returned after executing RawBidderResponse hook.")
+			assert.Equal(t, test.expectedBids, test.payload.BidderResponse.Bids, "Invalid Bids returned after executing RawBidderResponse hook.")
 
 			// reset ChangeSet not to break hookResult assertion, we validated ChangeSet separately
 			hookResult.ChangeSet = hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}


### PR DESCRIPTION
Currently, there is no way to determine the currency of the bids returned in the bidder-response during the raw_bidder_response_stage.
There are several use cases where it is important to know the currency of the bidder-response at this stage.
This PR addresses the issue by introducing the bidder-response itself, rather than just bidder-response.Bids, at this stage.