### PR TITLE
Fix goroutine leak in hooks execution group

### DIFF
--- a/hooks/hookexecution/execution.go
+++ b/hooks/hookexecution/execution.go
@@ -67,7 +67,7 @@ func executeGroup[H any, P any](
 ) (GroupOutcome, P, groupModuleContext, *RejectError) {
 	var wg sync.WaitGroup
 	rejected := make(chan struct{})
-	resp := make(chan hookResponse[P])
+	resp := make(chan hookResponse[P], len(group.Hooks))
 
 	for _, hook := range group.Hooks {
 		mCtx := executionCtx.getModuleContext(hook.Module)


### PR DESCRIPTION
This function creates an unbuffered channel
https://github.com/prebid/prebid-server/blob/ec6a45d2b6772b32c04053504a3422c571f9fb06/hooks/hookexecution/execution.go#L70

If hook returns Reject error the `collectHookResponses` aborts reading of the channel
https://github.com/prebid/prebid-server/blob/ec6a45d2b6772b32c04053504a3422c571f9fb06/hooks/hookexecution/execution.go#L138
and this results to dead goroutine in https://github.com/prebid/prebid-server/blob/ec6a45d2b6772b32c04053504a3422c571f9fb06/hooks/hookexecution/execution.go#L76 because the channel is still open and goroutines can still write to this channel.  As this channel is no more read by anyone the writing goroutine will stuck indefinitely awaiting release of the channel

https://github.com/prebid/prebid-server/issues/3754