### PR TITLE
Adkernel: rxnetwork alias

### DIFF
--- a/static/bidder-info/rxnetwork.yaml
+++ b/static/bidder-info/rxnetwork.yaml
@@ -1,0 +1,2 @@
+aliasOf: adkernel
+gvlVendorID: 14

--- a/static/bidder-info/rxnetwork.yaml
+++ b/static/bidder-info/rxnetwork.yaml
@@ -1,2 +1,1 @@
 aliasOf: adkernel
-gvlVendorID: 14


### PR DESCRIPTION
Added alias for partner network to resolve an issue with multiple connected networks via same adkernel bidder.