### PR TITLE
Yieldmo: Indicate support for ORTB 2.6

### DIFF
--- a/static/bidder-info/yieldmo.yaml
+++ b/static/bidder-info/yieldmo.yaml
@@ -2,6 +2,8 @@ endpoint: "https://ads.yieldmo.com/exchange/prebid-server"
 maintainer:
   email: "prebid@yieldmo.com"
 gvlVendorID: 173
+openrtb:
+  version: 2.6
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Updating Yieldmo's yaml file to indicate that we support ortb 2.6