### PR TITLE
Bump Go version to 1.22 in dev containers config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go
-			"VARIANT": "1.21",
+			"VARIANT": "1.22",
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go
-			"VARIANT": "1.20",
+			"VARIANT": "1.21",
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that you deploy the `/static` directory, as Prebid Server requires those 
 
 ## Developing
 
-Prebid Server requires [Go](https://go.dev) version 1.21 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
+Prebid Server requires [Go](https://go.dev) version 1.22 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
 
 1. Clone The Repository
 ``` bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that you deploy the `/static` directory, as Prebid Server requires those 
 
 ## Developing
 
-Prebid Server requires [Go](https://go.dev) version 1.22 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
+Prebid Server requires [Go](https://go.dev) version 1.21 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
 
 1. Clone The Repository
 ``` bash


### PR DESCRIPTION
# Context

In the [README](https://github.com/prebid/prebid-server/blob/v2.31.0/README.md?plain=1#L47), it is written that:
> Prebid Server requires Go version 1.21 or newer.

However, in the [Dev Containers configuration](https://github.com/prebid/prebid-server/blob/v2.31.0/.devcontainer/devcontainer.json#L9), Go 1.20 is configured:
> 			"VARIANT": "1.20",


# Consequence

A natural consequence of that is the following compile error is obtained when one opens the project with Dev Containers with Visual Studio Code (tested with VS Code 1.93.1):

> could not import maps (no required module provides package "maps") compiler BrokenImport

# Root Cause Analysis

The package "maps" does not exist in Go 1.20. See https://pkg.go.dev/maps?tab=versions
If there is a table with nothing on it and you ask someone to eat the apple that is on the table, there will be consequences.
(Feedback from the environment)

# Solution

A no-brainer solution is to make the Dev Containers configuration congruent with the README file.
