### PR TITLE
ORTB 2.6: Temporarily remove down convert and make test suite pass

### DIFF
--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
@@ -74,9 +74,7 @@
       }
     ],
     "regs": {
-      "ext": {
-        "us_privacy": "1YYY"
-      }
+      "us_privacy": "1YYY"
     },
     "ext": {
       "prebid": {

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
@@ -74,14 +74,10 @@
       }
     ],
     "regs": {
-      "ext": {
-        "gdpr": 1
-      }
+      "gdpr": 1
     },
     "user": {
-      "ext": {
-        "consent": "CPdECS0PdECS0ACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"
-      }
+      "consent": "CPdECS0PdECS0ACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"
     },
     "ext": {
       "prebid": {

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
@@ -79,9 +79,7 @@
       }
     ],
     "regs": {
-      "ext": {
-        "gdpr": 1
-      }
+      "gdpr": 1
     },
     "ext": {
       "prebid": {

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
@@ -74,14 +74,10 @@
       }
     ],
     "regs": {
-      "ext": {
-        "gdpr": 1
-      }
+      "gdpr": 1
     },
     "user": {
-      "ext": {
-        "consent": "CPdECS0PdECS0ACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"
-      }
+      "consent": "CPdECS0PdECS0ACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"
     },
     "ext": {
       "prebid": {

--- a/exchange/exchangetest/ccpa-featureflag-on.json
+++ b/exchange/exchangetest/ccpa-featureflag-on.json
@@ -57,9 +57,7 @@
                         }
                     ],
                     "regs": {
-                        "ext": {
-                            "us_privacy": "1-Y-"
-                        }
+                        "us_privacy": "1-Y-"
                     },
                     "user": {}
                 }

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -1,7 +1,6 @@
 package exchange
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -158,9 +157,16 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 	bidderRequests = make([]BidderRequest, 0, len(impsByBidder))
 
 	for bidder, imps := range impsByBidder {
-		reqWrapperCopy := req.Clone() //TODO: check if it is cloning stuff that we don't need to clone
-		reqCopy := *req.BidRequest
-		reqCopy.Imp = imps
+		reqWrapperCopy := req.Clone()
+		bidRequestCopy := *req.BidRequest
+		reqWrapperCopy.BidRequest = &bidRequestCopy
+		impWrappers := make([]*openrtb_ext.ImpWrapper, 0)
+		for _, imp := range imps {
+			impCopy := imp
+			impWrapper := openrtb_ext.ImpWrapper{Imp: &impCopy}
+			impWrappers = append(impWrappers, &impWrapper)
+		}
+		reqWrapperCopy.SetImp(impWrappers)
 
 		coreBidder, isRequestAlias := resolveBidder(bidder, requestAliases)
 
@@ -168,26 +174,26 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		sChainWriter.Write(reqWrapperCopy, bidder)
 
 		// generate bidder-specific request ext
-		reqCopy.Ext, err = buildRequestExtForBidder(bidder, req.BidRequest.Ext, requestExt, bidderParamsInReqExt, auctionReq.Account.AlternateBidderCodes)
+		err = buildRequestExtForBidder(bidder, reqWrapperCopy, bidderParamsInReqExt, auctionReq.Account.AlternateBidderCodes)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
 
 		// eid scrubbing
-		if err := removeUnpermissionedEids(&reqCopy, bidder, requestExt); err != nil {
+		if err := removeUnpermissionedEids(reqWrapperCopy.BidRequest, bidder, requestExt); err != nil {
 			errs = append(errs, fmt.Errorf("unable to enforce request.ext.prebid.data.eidpermissions because %v", err))
 			continue
 		}
 
 		// apply bid adjustments
 		if auctionReq.Account.PriceFloors.IsAdjustForBidAdjustmentEnabled() {
-			applyBidAdjustmentToFloor(&reqCopy, bidder, bidAdjustmentFactors)
+			applyBidAdjustmentToFloor(reqWrapperCopy, bidder, bidAdjustmentFactors)
 		}
 
 		// prepare user
 		syncerKey := rs.bidderToSyncerKey[string(coreBidder)]
-		hadSync := prepareUser(&reqCopy, bidder, syncerKey, lowerCaseExplicitBuyerUIDs, auctionReq.UserSyncs)
+		hadSync := prepareUser(reqWrapperCopy.BidRequest, bidder, syncerKey, lowerCaseExplicitBuyerUIDs, auctionReq.UserSyncs)
 
 		auctionPermissions := gdprPerms.AuctionActivitiesAllowed(ctx, coreBidder, openrtb_ext.BidderName(bidder))
 
@@ -197,33 +203,33 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		}
 
 		// fpd
-		applyFPD(auctionReq.FirstPartyData, coreBidder, openrtb_ext.BidderName(bidder), isRequestAlias, &reqCopy)
+		applyFPD(auctionReq.FirstPartyData, coreBidder, openrtb_ext.BidderName(bidder), isRequestAlias, reqWrapperCopy.BidRequest)
 
 		// privacy scrubbing
-		if err := rs.applyPrivacy(&reqCopy, coreBidder, bidder, auctionReq, auctionPermissions, ccpaEnforcer, lmt, coppa); err != nil {
+		if err := rs.applyPrivacy(reqWrapperCopy, coreBidder, bidder, auctionReq, auctionPermissions, ccpaEnforcer, lmt, coppa); err != nil {
 			errs = append(errs, err)
 			continue
 		}
 
 		// GPP downgrade: always downgrade unless we can confirm GPP is supported
 		if shouldSetLegacyPrivacy(rs.bidderInfo, string(coreBidder)) {
-			setLegacyGDPRFromGPP(&reqCopy, gpp)
-			setLegacyUSPFromGPP(&reqCopy, gpp)
+			setLegacyGDPRFromGPP(reqWrapperCopy.BidRequest, gpp)
+			setLegacyUSPFromGPP(reqWrapperCopy.BidRequest, gpp)
 		}
 
-		//TODO: could make bidderImpWithBidResp[openrtb_ext.BidderName(bidder)]
+		// remove imps with stored responses so they aren't sent to the bidder
 		if impResponses, ok := bidderImpWithBidResp[openrtb_ext.BidderName(bidder)]; ok {
-			removeImpsWithStoredResponses(&reqCopy, impResponses)
+			removeImpsWithStoredResponses(reqWrapperCopy, impResponses)
 		}
 
 		// down convert
-		info, ok := rs.bidderInfo[bidder]
-		if !ok || info.OpenRTB == nil || info.OpenRTB.Version != "2.6" {
-			if err := openrtb_ext.ConvertDownTo25(reqWrapperCopy); err != nil {
-				errs = append(errs, err)
-				continue
-			}
-		}
+		// info, ok := rs.bidderInfo[bidder]
+		// if !ok || info.OpenRTB == nil || info.OpenRTB.Version != "2.6" {
+		// 	if err := openrtb_ext.ConvertDownTo25(reqWrapperCopy); err != nil {
+		// 		errs = append(errs, err)
+		// 		continue
+		// 	}
+		// }
 
 		// sync wrapper
 		if err := reqWrapperCopy.RebuildRequest(); err != nil {
@@ -240,7 +246,7 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		} else {
 			bidderLabels.CookieFlag = metrics.CookieFlagYes
 		}
-		if len(reqCopy.Imp) > 0 {
+		if len(reqWrapperCopy.Imp) > 0 {
 			bidderLabels.Source = auctionReq.LegacyLabels.Source
 			bidderLabels.RType = auctionReq.LegacyLabels.RType
 			bidderLabels.PubID = auctionReq.LegacyLabels.PubID
@@ -251,7 +257,7 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		bidderRequest := BidderRequest{
 			BidderName:            openrtb_ext.BidderName(bidder),
 			BidderCoreName:        coreBidder,
-			BidRequest:            &reqCopy,
+			BidRequest:            reqWrapperCopy.BidRequest,
 			IsRequestAlias:        isRequestAlias,
 			BidderStoredResponses: bidderImpWithBidResp[openrtb_ext.BidderName(bidder)],
 			ImpReplaceImpId:       auctionReq.BidderImpReplaceImpID[bidder],
@@ -264,19 +270,23 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 }
 
 // removeImpsWithStoredResponses deletes imps with stored bid resp
-func removeImpsWithStoredResponses(req *openrtb2.BidRequest, impBidResponses map[string]json.RawMessage) {
-	imps := req.Imp
-	req.Imp = nil //to indicate this bidder doesn't have real requests
+func removeImpsWithStoredResponses(req *openrtb_ext.RequestWrapper, impBidResponses map[string]json.RawMessage) {
+	if len(impBidResponses) == 0 {
+		return
+	}
+
+	var updatedImps []*openrtb_ext.ImpWrapper
+	imps := req.GetImp()
 	for _, imp := range imps {
 		if _, ok := impBidResponses[imp.ID]; !ok {
 			//add real imp back to request
-			req.Imp = append(req.Imp, imp)
+			updatedImps = append(updatedImps, imp)
 		}
 	}
+	req.SetImp(updatedImps)
 }
 
-// PreloadExts...
-// TODO: move elsewhere, perhaps into openrtb_ext package?
+// PreloadExts ensures all exts have been unmarshalled into wrapper ext objects
 func PreloadExts(req *openrtb_ext.RequestWrapper) error {
 	if req == nil {
 		return nil
@@ -322,13 +332,12 @@ func (rs *requestSplitter) isBidderBlockedByPrivacy(r *openrtb_ext.RequestWrappe
 	return false
 }
 
-func (rs *requestSplitter) applyPrivacy(bidRequest *openrtb2.BidRequest, coreBidderName openrtb_ext.BidderName, bidderName string, auctionReq AuctionRequest, auctionPermissions gdpr.AuctionPermissions, ccpaEnforcer privacy.PolicyEnforcer, lmt bool, coppa bool) error {
+func (rs *requestSplitter) applyPrivacy(reqWrapper *openrtb_ext.RequestWrapper, coreBidderName openrtb_ext.BidderName, bidderName string, auctionReq AuctionRequest, auctionPermissions gdpr.AuctionPermissions, ccpaEnforcer privacy.PolicyEnforcer, lmt bool, coppa bool) error {
 	scope := privacy.Component{Type: privacy.ComponentTypeBidder, Name: bidderName}
 	ipConf := privacy.IPConf{IPV6: auctionReq.Account.Privacy.IPv6Config, IPV4: auctionReq.Account.Privacy.IPv4Config}
 
-	reqWrapper := &openrtb_ext.RequestWrapper{
-		BidRequest: ortb.CloneBidRequestPartial(bidRequest),
-	}
+	bidRequest := ortb.CloneBidRequestPartial(reqWrapper.BidRequest)
+	reqWrapper.BidRequest = bidRequest
 
 	passIDActivityAllowed := auctionReq.Activities.Allow(privacy.ActivityTransmitUserFPD, scope, privacy.NewRequestFromBidRequest(*reqWrapper))
 	buyerUIDSet := reqWrapper.User != nil && reqWrapper.User.BuyerUID != ""
@@ -376,7 +385,7 @@ func (rs *requestSplitter) applyPrivacy(bidRequest *openrtb2.BidRequest, coreBid
 		return err
 	}
 
-	*bidRequest = *reqWrapper.BidRequest
+	// *bidRequest = *reqWrapper.BidRequest
 	return nil
 }
 
@@ -450,67 +459,44 @@ func ExtractReqExtBidderParamsMap(bidRequest *openrtb2.BidRequest) (map[string]j
 	return bidderParams, nil
 }
 
-func buildRequestExtForBidder(bidder string, requestExt json.RawMessage, requestExtParsed *openrtb_ext.ExtRequest, bidderParamsInReqExt map[string]json.RawMessage, cfgABC *openrtb_ext.ExtAlternateBidderCodes) (json.RawMessage, error) {
-	// Resolve alternatebiddercode for current bidder
+func buildRequestExtForBidder(bidder string, req *openrtb_ext.RequestWrapper, reqExtBidderParams map[string]json.RawMessage, cfgABC *openrtb_ext.ExtAlternateBidderCodes) error {
+	reqExt, err := req.GetRequestExt()
+	if err != nil {
+		return err
+	}
+	prebid := reqExt.GetPrebid()
+
+	// Resolve alternatebiddercode
 	var reqABC *openrtb_ext.ExtAlternateBidderCodes
-	if len(requestExt) != 0 && requestExtParsed != nil && requestExtParsed.Prebid.AlternateBidderCodes != nil {
-		reqABC = requestExtParsed.Prebid.AlternateBidderCodes
+	if prebid != nil && prebid.AlternateBidderCodes != nil {
+		reqABC = prebid.AlternateBidderCodes
 	}
 	alternateBidderCodes := buildRequestExtAlternateBidderCodes(bidder, cfgABC, reqABC)
 
-	if (len(requestExt) == 0 || requestExtParsed == nil) && alternateBidderCodes == nil {
-		return nil, nil
-	}
-
-	// Resolve Bidder Params
-	var bidderParams json.RawMessage
-	if bidderParamsInReqExt != nil {
-		bidderParams = bidderParamsInReqExt[bidder]
-	}
-
-	// Copy Allowed Fields
-	// Per: https://docs.prebid.org/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#prebid-server-ortb2-extension-summary
-	prebid := openrtb_ext.ExtRequestPrebid{
-		BidderParams:         bidderParams,
-		AlternateBidderCodes: alternateBidderCodes,
-	}
-
-	if requestExtParsed != nil {
-		prebid.Channel = requestExtParsed.Prebid.Channel
-		prebid.CurrencyConversions = requestExtParsed.Prebid.CurrencyConversions
-		prebid.Debug = requestExtParsed.Prebid.Debug
-		prebid.Integration = requestExtParsed.Prebid.Integration
-		prebid.MultiBid = buildRequestExtMultiBid(bidder, requestExtParsed.Prebid.MultiBid, alternateBidderCodes)
-		prebid.Sdk = requestExtParsed.Prebid.Sdk
-		prebid.Server = requestExtParsed.Prebid.Server
-	}
-
-	// Marshal New Prebid Object
-	prebidJson, err := jsonutil.Marshal(prebid)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse Existing Ext
-	extMap := make(map[string]json.RawMessage)
-	if len(requestExt) != 0 {
-		if err := jsonutil.Unmarshal(requestExt, &extMap); err != nil {
-			return nil, err
+	var prebidNew openrtb_ext.ExtRequestPrebid
+	if prebid == nil {
+		prebidNew = openrtb_ext.ExtRequestPrebid{
+			BidderParams:         reqExtBidderParams[bidder],
+			AlternateBidderCodes: alternateBidderCodes,
+		}
+	} else {
+		// Copy Allowed Fields
+		// Per: https://docs.prebid.org/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#prebid-server-ortb2-extension-summary
+		prebidNew = openrtb_ext.ExtRequestPrebid{
+			BidderParams:         reqExtBidderParams[bidder],
+			AlternateBidderCodes: alternateBidderCodes,
+			Channel:              prebid.Channel,
+			CurrencyConversions:  prebid.CurrencyConversions,
+			Debug:                prebid.Debug,
+			Integration:          prebid.Integration,
+			MultiBid:             buildRequestExtMultiBid(bidder, prebid.MultiBid, alternateBidderCodes),
+			Sdk:                  prebid.Sdk,
+			Server:               prebid.Server,
 		}
 	}
 
-	// Update Ext With Prebid Json
-	if bytes.Equal(prebidJson, []byte(`{}`)) {
-		delete(extMap, "prebid")
-	} else {
-		extMap["prebid"] = prebidJson
-	}
-
-	if len(extMap) > 0 {
-		return jsonutil.Marshal(extMap)
-	} else {
-		return nil, nil
-	}
+	reqExt.SetPrebid(&prebidNew)
+	return nil
 }
 
 func buildRequestExtAlternateBidderCodes(bidder string, accABC *openrtb_ext.ExtAlternateBidderCodes, reqABC *openrtb_ext.ExtAlternateBidderCodes) *openrtb_ext.ExtAlternateBidderCodes {
@@ -1147,7 +1133,7 @@ func getPrebidMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
 	}
 }
 
-func applyBidAdjustmentToFloor(req *openrtb2.BidRequest, bidder string, adjustmentFactors map[string]float64) {
+func applyBidAdjustmentToFloor(req *openrtb_ext.RequestWrapper, bidder string, adjustmentFactors map[string]float64) {
 	if len(adjustmentFactors) == 0 {
 		return
 	}
@@ -1158,9 +1144,12 @@ func applyBidAdjustmentToFloor(req *openrtb2.BidRequest, bidder string, adjustme
 	}
 
 	if bidAdjustment != 1.0 {
-		for index, imp := range req.Imp {
-			imp.BidFloor = imp.BidFloor / bidAdjustment
-			req.Imp[index] = imp
+		impWrappers := req.GetImp()
+		for ind, imp := range impWrappers {
+			impCopy := *imp.Imp
+			impCopy.BidFloor = impCopy.BidFloor / bidAdjustment
+			impWrappers[ind].Imp = &impCopy
 		}
+		req.SetImp(impWrappers)
 	}
 }

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -2590,145 +2590,146 @@ func TestBuildRequestExtForBidder(t *testing.T) {
 	)
 
 	testCases := []struct {
-		description          string
+		name                 string
 		requestExt           json.RawMessage
 		bidderParams         map[string]json.RawMessage
 		alternateBidderCodes *openrtb_ext.ExtAlternateBidderCodes
 		expectedJson         json.RawMessage
 	}{
 		{
-			description:          "Nil",
+			name:                 "Nil",
 			bidderParams:         nil,
 			requestExt:           nil,
 			alternateBidderCodes: nil,
 			expectedJson:         nil,
 		},
 		{
-			description:          "Empty",
+			name:                 "Empty",
 			bidderParams:         nil,
 			alternateBidderCodes: nil,
 			requestExt:           json.RawMessage(`{}`),
 			expectedJson:         nil,
 		},
 		{
-			description:  "Prebid - Allowed Fields Only",
+			name:         "Prebid - Allowed Fields Only",
 			bidderParams: nil,
 			requestExt:   json.RawMessage(`{"prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}}}`),
 			expectedJson: json.RawMessage(`{"prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}}}`),
 		},
 		{
-			description:  "Prebid - Allowed Fields + Bidder Params",
+			name:         "Prebid - Allowed Fields + Bidder Params",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}}}`),
 			expectedJson: json.RawMessage(`{"prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}, "bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Other",
+			name:         "Other",
 			bidderParams: nil,
 			requestExt:   json.RawMessage(`{"other":"foo"}`),
 			expectedJson: json.RawMessage(`{"other":"foo"}`),
 		},
 		{
-			description:  "Prebid + Other + Bider Params",
+			name:         "Prebid + Other + Bider Params",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true}, "server": {"externalurl": "url", "gvlid": 1, "datacenter": "2"}, "sdk": {"renderers": [{"name": "r1"}]}, "bidderparams":"bar"}}`),
 		},
 		{
-			description:          "Prebid + AlternateBidderCodes in pbs config but current bidder not in AlternateBidderCodes config",
+			name:                 "Prebid + AlternateBidderCodes in pbs config but current bidder not in AlternateBidderCodes config",
 			bidderParams:         map[string]json.RawMessage{bidder: bidderParams},
 			alternateBidderCodes: &openrtb_ext.ExtAlternateBidderCodes{Enabled: true, Bidders: map[string]openrtb_ext.ExtAdapterAlternateBidderCodes{"bar": {Enabled: true, AllowedBidderCodes: []string{"*"}}}},
 			requestExt:           json.RawMessage(`{"other":"foo"}`),
 			expectedJson:         json.RawMessage(`{"other":"foo","prebid":{"alternatebiddercodes":{"enabled":true,"bidders":null},"bidderparams":"bar"}}`),
 		},
 		{
-			description:          "Prebid + AlternateBidderCodes in request",
+			name:                 "Prebid + AlternateBidderCodes in request",
 			bidderParams:         map[string]json.RawMessage{bidder: bidderParams},
 			alternateBidderCodes: &openrtb_ext.ExtAlternateBidderCodes{},
 			requestExt:           json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]},"bar":{"enabled":true,"allowedbiddercodes":["ix"]}}}}}`),
 			expectedJson:         json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]}}},"bidderparams":"bar"}}`),
 		},
 		{
-			description:          "Prebid + AlternateBidderCodes in request but current bidder not in AlternateBidderCodes config",
+			name:                 "Prebid + AlternateBidderCodes in request but current bidder not in AlternateBidderCodes config",
 			bidderParams:         map[string]json.RawMessage{bidder: bidderParams},
 			alternateBidderCodes: &openrtb_ext.ExtAlternateBidderCodes{},
 			requestExt:           json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"bar":{"enabled":true,"allowedbiddercodes":["ix"]}}}}}`),
 			expectedJson:         json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":null},"bidderparams":"bar"}}`),
 		},
 		{
-			description:          "Prebid + AlternateBidderCodes in both pbs config and in the request",
+			name:                 "Prebid + AlternateBidderCodes in both pbs config and in the request",
 			bidderParams:         map[string]json.RawMessage{bidder: bidderParams},
 			alternateBidderCodes: &openrtb_ext.ExtAlternateBidderCodes{Enabled: true, Bidders: map[string]openrtb_ext.ExtAdapterAlternateBidderCodes{"foo": {Enabled: true, AllowedBidderCodes: []string{"*"}}}},
 			requestExt:           json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]},"bar":{"enabled":true,"allowedbiddercodes":["ix"]}}}}}`),
 			expectedJson:         json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]}}},"bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Prebid + Other + Bider Params + MultiBid.Bidder",
+			name:         "Prebid + Other + Bider Params + MultiBid.Bidder",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidder":"foo","maxbids":2,"targetbiddercodeprefix":"fmb"},{"bidders":["appnexus","groupm"],"maxbids":2}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidder":"foo","maxbids":2,"targetbiddercodeprefix":"fmb"}],"bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Prebid + Other + Bider Params + MultiBid.Bidders",
+			name:         "Prebid + Other + Bider Params + MultiBid.Bidders",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidder":"pubmatic","maxbids":3,"targetbiddercodeprefix":"pubM"},{"bidders":["foo","groupm"],"maxbids":4}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidders":["foo"],"maxbids":4}],"bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Prebid + Other + Bider Params + MultiBid (foo not in MultiBid)",
+			name:         "Prebid + Other + Bider Params + MultiBid (foo not in MultiBid)",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidder":"foo2","maxbids":2,"targetbiddercodeprefix":"fmb"},{"bidders":["appnexus","groupm"],"maxbids":2}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Prebid + Other + Bider Params + MultiBid (foo not in MultiBid)",
+			name:         "Prebid + Other + Bider Params + MultiBid (foo not in MultiBid)",
 			bidderParams: map[string]json.RawMessage{bidder: bidderParams},
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"multibid":[{"bidder":"foo2","maxbids":2,"targetbiddercodeprefix":"fmb"},{"bidders":["appnexus","groupm"],"maxbids":2}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"bidderparams":"bar"}}`),
 		},
 		{
-			description:  "Prebid + AlternateBidderCodes.MultiBid.Bidder",
+			name:         "Prebid + AlternateBidderCodes.MultiBid.Bidder",
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["pubmatic"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidder":"foo2","maxbids":4,"targetbiddercodeprefix":"fmb2"},{"bidder":"pubmatic","maxbids":5,"targetbiddercodeprefix":"pm"}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["pubmatic"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidder":"pubmatic","maxbids":5,"targetbiddercodeprefix":"pm"}]}}`),
 		},
 		{
-			description:  "Prebid + AlternateBidderCodes.MultiBid.Bidders",
+			name:         "Prebid + AlternateBidderCodes.MultiBid.Bidders",
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["pubmatic"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidders":["pubmatic","groupm"],"maxbids":4}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["pubmatic"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidders":["pubmatic"],"maxbids":4}]}}`),
 		},
 		{
-			description:  "Prebid + AlternateBidderCodes.MultiBid.Bidder with *",
+			name:         "Prebid + AlternateBidderCodes.MultiBid.Bidder with *",
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["*"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidder":"foo2","maxbids":4,"targetbiddercodeprefix":"fmb2"},{"bidder":"pubmatic","maxbids":5,"targetbiddercodeprefix":"pm"}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["*"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidder":"foo2","maxbids":4,"targetbiddercodeprefix":"fmb2"},{"bidder":"pubmatic","maxbids":5,"targetbiddercodeprefix":"pm"}]}}`),
 		},
 		{
-			description:  "Prebid + AlternateBidderCodes.MultiBid.Bidders with *",
+			name:         "Prebid + AlternateBidderCodes.MultiBid.Bidders with *",
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["*"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidders":["pubmatic","groupm"],"maxbids":4}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["*"]}}},"multibid":[{"bidder":"foo","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidders":["pubmatic"],"maxbids":4},{"bidders":["groupm"],"maxbids":4}]}}`),
 		},
 		{
-			description:  "Prebid + AlternateBidderCodes + MultiBid",
+			name:         "Prebid + AlternateBidderCodes + MultiBid",
 			requestExt:   json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]}}},"multibid":[{"bidder":"foo3","maxbids":3,"targetbiddercodeprefix":"fmb"},{"bidders":["pubmatic","groupm"],"maxbids":4}]}}`),
 			expectedJson: json.RawMessage(`{"other":"foo","prebid":{"integration":"a","channel":{"name":"b","version":"c"},"debug":true,"currency":{"rates":{"FOO":{"BAR":42}},"usepbsrates":true},"alternatebiddercodes":{"enabled":true,"bidders":{"foo":{"enabled":true,"allowedbiddercodes":["foo2"]}}}}}`),
 		},
 	}
 
 	for _, test := range testCases {
-		requestExtParsed := &openrtb_ext.ExtRequest{}
-		if test.requestExt != nil {
-			err := jsonutil.UnmarshalValid(test.requestExt, requestExtParsed)
-			if !assert.NoError(t, err, test.description+":parse_ext") {
-				continue
+		t.Run(test.name, func(t *testing.T) {
+			req := openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					Ext: test.requestExt,
+				},
 			}
-		}
+			err := buildRequestExtForBidder(bidder, &req, test.bidderParams, test.alternateBidderCodes)
+			assert.NoError(t, req.RebuildRequest())
+			assert.NoError(t, err)
 
-		actualJson, actualErr := buildRequestExtForBidder(bidder, test.requestExt, requestExtParsed, test.bidderParams, test.alternateBidderCodes)
-		if len(test.expectedJson) > 0 {
-			assert.JSONEq(t, string(test.expectedJson), string(actualJson), test.description+":json")
-		} else {
-			assert.Equal(t, test.expectedJson, actualJson, test.description+":json")
-		}
-		assert.NoError(t, actualErr, test.description+":err")
+			if len(test.expectedJson) > 0 {
+				assert.JSONEq(t, string(test.expectedJson), string(req.Ext))
+			} else {
+				assert.Equal(t, test.expectedJson, req.Ext)
+			}
+		})
 	}
 }
 
@@ -2736,28 +2737,37 @@ func TestBuildRequestExtForBidder_RequestExtParsedNil(t *testing.T) {
 	var (
 		bidder               = "foo"
 		requestExt           = json.RawMessage(`{}`)
-		requestExtParsed     *openrtb_ext.ExtRequest
 		bidderParams         map[string]json.RawMessage
 		alternateBidderCodes *openrtb_ext.ExtAlternateBidderCodes
 	)
 
-	actualJson, actualErr := buildRequestExtForBidder(bidder, requestExt, requestExtParsed, bidderParams, alternateBidderCodes)
-	assert.Nil(t, actualJson)
-	assert.NoError(t, actualErr)
+	req := openrtb_ext.RequestWrapper{
+		BidRequest: &openrtb2.BidRequest{
+			Ext: requestExt,
+		},
+	}
+	err := buildRequestExtForBidder(bidder, &req, bidderParams, alternateBidderCodes)
+	assert.NoError(t, req.RebuildRequest())
+	assert.Nil(t, req.Ext)
+	assert.NoError(t, err)
 }
 
 func TestBuildRequestExtForBidder_RequestExtMalformed(t *testing.T) {
 	var (
 		bidder               = "foo"
 		requestExt           = json.RawMessage(`malformed`)
-		requestExtParsed     = &openrtb_ext.ExtRequest{}
 		bidderParams         map[string]json.RawMessage
 		alternateBidderCodes *openrtb_ext.ExtAlternateBidderCodes
 	)
 
-	actualJson, actualErr := buildRequestExtForBidder(bidder, requestExt, requestExtParsed, bidderParams, alternateBidderCodes)
-	assert.Equal(t, json.RawMessage(nil), actualJson)
-	assert.EqualError(t, actualErr, "expect { or n, but found m")
+	req := openrtb_ext.RequestWrapper{
+		BidRequest: &openrtb2.BidRequest{
+			Ext: requestExt,
+		},
+	}
+	err := buildRequestExtForBidder(bidder, &req, bidderParams, alternateBidderCodes)
+	assert.NoError(t, req.RebuildRequest())
+	assert.EqualError(t, err, "expect { or n, but found m")
 }
 
 // newAdapterAliasBidRequest builds a BidRequest with aliases
@@ -5033,7 +5043,7 @@ func getTransmitTIDActivityConfig(componentName string, allow bool) config.Accou
 
 func TestApplyBidAdjustmentToFloor(t *testing.T) {
 	type args struct {
-		bidRequest           *openrtb2.BidRequest
+		bidRequestWrapper    *openrtb_ext.RequestWrapper
 		bidderName           string
 		bidAdjustmentFactors map[string]float64
 	}
@@ -5045,8 +5055,10 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 		{
 			name: "bid_adjustment_factor_is_nil",
 			args: args{
-				bidRequest: &openrtb2.BidRequest{
-					Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+				bidRequestWrapper: &openrtb_ext.RequestWrapper{
+					BidRequest: &openrtb2.BidRequest{
+						Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+					},
 				},
 				bidderName:           "appnexus",
 				bidAdjustmentFactors: nil,
@@ -5058,8 +5070,10 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 		{
 			name: "bid_adjustment_factor_is_empty",
 			args: args{
-				bidRequest: &openrtb2.BidRequest{
-					Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+				bidRequestWrapper: &openrtb_ext.RequestWrapper{
+					BidRequest: &openrtb2.BidRequest{
+						Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+					},
 				},
 				bidderName:           "appnexus",
 				bidAdjustmentFactors: map[string]float64{},
@@ -5071,8 +5085,10 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 		{
 			name: "bid_adjustment_factor_not_present",
 			args: args{
-				bidRequest: &openrtb2.BidRequest{
-					Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+				bidRequestWrapper: &openrtb_ext.RequestWrapper{
+					BidRequest: &openrtb2.BidRequest{
+						Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+					},
 				},
 				bidderName:           "appnexus",
 				bidAdjustmentFactors: map[string]float64{"pubmatic": 1.0},
@@ -5084,8 +5100,10 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 		{
 			name: "bid_adjustment_factor_present",
 			args: args{
-				bidRequest: &openrtb2.BidRequest{
-					Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+				bidRequestWrapper: &openrtb_ext.RequestWrapper{
+					BidRequest: &openrtb2.BidRequest{
+						Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+					},
 				},
 				bidderName:           "appnexus",
 				bidAdjustmentFactors: map[string]float64{"pubmatic": 1.0, "appnexus": 0.75},
@@ -5097,8 +5115,10 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 		{
 			name: "bid_adjustment_factor_present_and_zero",
 			args: args{
-				bidRequest: &openrtb2.BidRequest{
-					Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+				bidRequestWrapper: &openrtb_ext.RequestWrapper{
+					BidRequest: &openrtb2.BidRequest{
+						Imp: []openrtb2.Imp{{BidFloor: 100}, {BidFloor: 150}},
+					},
 				},
 				bidderName:           "appnexus",
 				bidAdjustmentFactors: map[string]float64{"pubmatic": 1.0, "appnexus": 0.0},
@@ -5110,8 +5130,9 @@ func TestApplyBidAdjustmentToFloor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			applyBidAdjustmentToFloor(tt.args.bidRequest, tt.args.bidderName, tt.args.bidAdjustmentFactors)
-			assert.Equal(t, tt.expectedBidRequest, tt.args.bidRequest, tt.name)
+			applyBidAdjustmentToFloor(tt.args.bidRequestWrapper, tt.args.bidderName, tt.args.bidAdjustmentFactors)
+			assert.NoError(t, tt.args.bidRequestWrapper.RebuildRequest())
+			assert.Equal(t, tt.expectedBidRequest, tt.args.bidRequestWrapper.BidRequest, tt.name)
 		})
 	}
 }
@@ -5338,15 +5359,19 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 	bidRespId1 := json.RawMessage(`{"id": "resp_id1"}`)
 	testCases := []struct {
 		description        string
-		reqIn              *openrtb2.BidRequest
+		req                *openrtb_ext.RequestWrapper
 		storedBidResponses map[string]json.RawMessage
 		expectedImps       []openrtb2.Imp
 	}{
 		{
 			description: "request with imps and stored bid response for this imp",
-			reqIn: &openrtb2.BidRequest{Imp: []openrtb2.Imp{
-				{ID: "imp-id1"},
-			}},
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					Imp: []openrtb2.Imp{
+						{ID: "imp-id1"},
+					},
+				},
+			},
 			storedBidResponses: map[string]json.RawMessage{
 				"imp-id1": bidRespId1,
 			},
@@ -5354,10 +5379,14 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 		},
 		{
 			description: "request with imps and stored bid response for one of these imp",
-			reqIn: &openrtb2.BidRequest{Imp: []openrtb2.Imp{
-				{ID: "imp-id1"},
-				{ID: "imp-id2"},
-			}},
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					Imp: []openrtb2.Imp{
+						{ID: "imp-id1"},
+						{ID: "imp-id2"},
+					},
+				},
+			},
 			storedBidResponses: map[string]json.RawMessage{
 				"imp-id1": bidRespId1,
 			},
@@ -5369,10 +5398,14 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 		},
 		{
 			description: "request with imps and stored bid response for both of these imp",
-			reqIn: &openrtb2.BidRequest{Imp: []openrtb2.Imp{
-				{ID: "imp-id1"},
-				{ID: "imp-id2"},
-			}},
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					Imp: []openrtb2.Imp{
+						{ID: "imp-id1"},
+						{ID: "imp-id2"},
+					},
+				},
+			},
 			storedBidResponses: map[string]json.RawMessage{
 				"imp-id1": bidRespId1,
 				"imp-id2": bidRespId1,
@@ -5381,10 +5414,14 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 		},
 		{
 			description: "request with imps and no stored bid responses",
-			reqIn: &openrtb2.BidRequest{Imp: []openrtb2.Imp{
-				{ID: "imp-id1"},
-				{ID: "imp-id2"},
-			}},
+			req: &openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					Imp: []openrtb2.Imp{
+						{ID: "imp-id1"},
+						{ID: "imp-id2"},
+					},
+				},
+			},
 			storedBidResponses: nil,
 
 			expectedImps: []openrtb2.Imp{
@@ -5394,8 +5431,9 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		request := testCase.reqIn
+		request := testCase.req
 		removeImpsWithStoredResponses(request, testCase.storedBidResponses)
+		assert.NoError(t, request.RebuildRequest())
 		assert.Equal(t, testCase.expectedImps, request.Imp, "incorrect Impressions for testCase %s", testCase.description)
 	}
 }

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -239,6 +239,7 @@ func (rw *RequestWrapper) rebuildImp() error {
 			return err
 		}
 		rw.Imp[i] = *rw.impWrappers[i].Imp
+		rw.impWrappers[i].Imp = &rw.Imp[i]
 	}
 
 	return nil
@@ -392,6 +393,8 @@ func (rw *RequestWrapper) rebuildSourceExt() error {
 	return nil
 }
 
+// Clone clones the request wrapper exts and the imp wrappers
+// the cloned imp wrappers are pointing to the bid request imps
 func (rw *RequestWrapper) Clone() *RequestWrapper {
 	if rw == nil {
 		return nil
@@ -402,6 +405,26 @@ func (rw *RequestWrapper) Clone() *RequestWrapper {
 		newImpWrappers[i] = iw.Clone()
 	}
 	clone.impWrappers = newImpWrappers
+	clone.userExt = rw.userExt.Clone()
+	clone.deviceExt = rw.deviceExt.Clone()
+	clone.requestExt = rw.requestExt.Clone()
+	clone.appExt = rw.appExt.Clone()
+	clone.regExt = rw.regExt.Clone()
+	clone.siteExt = rw.siteExt.Clone()
+	clone.doohExt = rw.doohExt.Clone()
+	clone.sourceExt = rw.sourceExt.Clone()
+
+	return &clone
+}
+
+func (rw *RequestWrapper) CloneAndClearImpWrappers() *RequestWrapper {
+	if rw == nil {
+		return nil
+	}
+	rw.impWrappersAccessed = false
+
+	clone := *rw
+	clone.impWrappers = nil
 	clone.userExt = rw.userExt.Clone()
 	clone.deviceExt = rw.deviceExt.Clone()
 	clone.requestExt = rw.requestExt.Clone()

--- a/openrtb_ext/request_wrapper_test.go
+++ b/openrtb_ext/request_wrapper_test.go
@@ -198,6 +198,7 @@ func TestRebuildImp(t *testing.T) {
 		request           openrtb2.BidRequest
 		requestImpWrapper []*ImpWrapper
 		expectedRequest   openrtb2.BidRequest
+		expectedAccessed  bool
 		expectedError     string
 	}{
 		{
@@ -217,11 +218,13 @@ func TestRebuildImp(t *testing.T) {
 			request:           openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "1"}}},
 			requestImpWrapper: []*ImpWrapper{{Imp: &openrtb2.Imp{ID: "2"}, impExt: &ImpExt{prebid: prebid, prebidDirty: true}}},
 			expectedRequest:   openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "2", Ext: prebidJson}}},
+			expectedAccessed:  true,
 		},
 		{
 			description:       "One - Accessed - Error",
 			request:           openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "1"}}},
 			requestImpWrapper: []*ImpWrapper{{Imp: nil, impExt: &ImpExt{}}},
+			expectedAccessed:  true,
 			expectedError:     "ImpWrapper RebuildImp called on a nil Imp",
 		},
 		{
@@ -229,6 +232,7 @@ func TestRebuildImp(t *testing.T) {
 			request:           openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "1"}, {ID: "2"}}},
 			requestImpWrapper: []*ImpWrapper{{Imp: &openrtb2.Imp{ID: "1"}, impExt: &ImpExt{}}, {Imp: &openrtb2.Imp{ID: "2"}, impExt: &ImpExt{prebid: prebid, prebidDirty: true}}},
 			expectedRequest:   openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "1"}, {ID: "2", Ext: prebidJson}}},
+			expectedAccessed:  true,
 		},
 	}
 
@@ -246,6 +250,20 @@ func TestRebuildImp(t *testing.T) {
 		} else {
 			assert.NoError(t, err, test.description)
 			assert.Equal(t, test.expectedRequest, *w.BidRequest, test.description)
+		}
+
+		if test.expectedAccessed && test.expectedError == "" {
+			bidRequestImps := make(map[string]*openrtb2.Imp, 0)
+			for i, v := range w.Imp {
+				bidRequestImps[v.ID] = &w.Imp[i]
+			}
+			wrapperImps := make(map[string]*openrtb2.Imp, 0)
+			for i, v := range w.impWrappers {
+				wrapperImps[v.ID] = w.impWrappers[i].Imp
+			}
+			for k := range bidRequestImps {
+				assert.Same(t, bidRequestImps[k], wrapperImps[k], test.description)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR does the following:
- temporarily removes the 2.5 down convert logic
- pushes the request wrapper down into `buildRequestExtForBidder`, `applyBidAdjustmentToFloor`, `applyPrivacy`, `removeImpsWithStoredResponses`
- pushes the wrapper's bid request instead of a copy of the wrapper's bid request down into remaining functions in the `CleanOpenRTBRequests` loop (which will eventually be updated to receive the wrapper instead in future PRs)
~~- always makes modifications to the imps of a bidder's request wrapper copy using the imp wrapper~~
- fixed imp wrapper bug so that the request wrapper bid request imps point to the same object as the imp wrapper imps when calling the request wrapper `RebuildRequest` function
- makes the test suite pass