### PR TITLE
Optimize BuildBidderNameHashSet

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -597,12 +599,20 @@ func BuildBidderStringSlice() []string {
 	return slice
 }
 
+var (
+	bidderNameHashSetOnce sync.Once
+	bidderNameHashSet     map[string]struct{}
+)
+
 func BuildBidderNameHashSet() map[string]struct{} {
-	hashSet := make(map[string]struct{})
-	for _, name := range CoreBidderNames() {
-		hashSet[string(name)] = struct{}{}
-	}
-	return hashSet
+	bidderNameHashSetOnce.Do(func() {
+		bidderNameHashSet = make(map[string]struct{})
+		for _, name := range CoreBidderNames() {
+			bidderNameHashSet[string(name)] = struct{}{}
+		}
+	})
+
+	return maps.Clone(bidderNameHashSet)
 }
 
 // bidderNameLookup is a map of the lower case version of the bidder name to the precise BidderName value.

--- a/openrtb_ext/bidders_test.go
+++ b/openrtb_ext/bidders_test.go
@@ -282,3 +282,29 @@ func TestNewBidderParamsValidator(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkBuildBidderNameHashSet(b *testing.B) {
+	requestAliases := map[string]string{
+		"pubmatic_s2s0":    "pubmatic",
+		"criteo_s2s1":      "criteo",
+		"rubicon_s2s":      "rubicon",
+		"criteo_s2s":       "criteo",
+		"pubmatic_s2s":     "pubmatic",
+		"rise_s2s":         "rise",
+		"appnexus_s2s":     "appnexus",
+		"medianet_s2s":     "medianet",
+		"triplelift_s2s":   "triplelift",
+		"sovrn_s2s":        "sovrn",
+		"unruly_s2s":       "unruly",
+		"onetag_s2s":       "onetag",
+		"ix_s2s":           "ix",
+		"sharethrough_s2s": "sharethrough",
+		"taboola_s2s":      "taboola",
+	}
+	for i := 0; i < b.N; i++ {
+		bidders := BuildBidderNameHashSet()
+		for k := range requestAliases {
+			bidders[k] = struct{}{}
+		}
+	}
+}


### PR DESCRIPTION
Pprof identified big amount of allocations caused by each call to `CoreBidderNames` on each auction request
By storing result of `CoreBidderNames` into a single variable number of allocations reduced 4x

` go test -benchmem -v -bench=Bench ./openrtb_ext/. |prettybench`

Before:
```
BenchmarkBuildBidderNameHashSet
PASS
benchmark                             iter      time/iter   bytes alloc         allocs
---------                             ----      ---------   -----------         ------
BenchmarkBuildBidderNameHashSet-18   50244    22.66 μs/op    21333 B/op   12 allocs/op
ok      github.com/prebid/prebid-server/v2/openrtb_ext  1.415s
```

After:
```
BenchmarkBuildBidderNameHashSet
PASS
benchmark                              iter       time/iter   bytes alloc        allocs
---------                              ----       ---------   -----------        ------
BenchmarkBuildBidderNameHashSet-18   152774   7813.00 ns/op    10312 B/op   3 allocs/op
ok      github.com/prebid/prebid-server/v2/openrtb_ext  1.309s
```