### PR TITLE
Fix cache init and update timeouts in stored requests

### DIFF
--- a/stored_requests/events/database/database.go
+++ b/stored_requests/events/database/database.go
@@ -78,7 +78,7 @@ func (e *DatabaseEventProducer) Invalidations() <-chan events.Invalidation {
 }
 
 func (e *DatabaseEventProducer) fetchAll() (fetchErr error) {
-	timeout := e.cfg.CacheInitTimeout * time.Millisecond
+	timeout := e.cfg.CacheInitTimeout
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -115,7 +115,7 @@ func (e *DatabaseEventProducer) fetchAll() (fetchErr error) {
 }
 
 func (e *DatabaseEventProducer) fetchDelta() (fetchErr error) {
-	timeout := e.cfg.CacheUpdateTimeout * time.Millisecond
+	timeout := e.cfg.CacheUpdateTimeout
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
There are redundant conversions to interval in milliseconds which duplicates the same in initialization of the config.
https://github.com/prebid/prebid-server/blob/df58baff01da6946cd7f075a10790cd1c52ea1f0/stored_requests/config/config.go#L208

https://github.com/prebid/prebid-server/blob/df58baff01da6946cd7f075a10790cd1c52ea1f0/stored_requests/config/config.go#L210