### PR TITLE
Modularity: Add hook code to module invocation context

### DIFF
--- a/hooks/hookexecution/execution.go
+++ b/hooks/hookexecution/execution.go
@@ -71,6 +71,7 @@ func executeGroup[H any, P any](
 
 	for _, hook := range group.Hooks {
 		mCtx := executionCtx.getModuleContext(hook.Module)
+		mCtx.HookImplCode = hook.Code
 		newPayload := handleModuleActivities(hook.Code, executionCtx.activityControl, payload, executionCtx.account)
 		wg.Add(1)
 		go func(hw hooks.HookWrapper[H], moduleCtx hookstage.ModuleInvocationContext) {

--- a/hooks/hookstage/invocation.go
+++ b/hooks/hookstage/invocation.go
@@ -27,6 +27,8 @@ type ModuleInvocationContext struct {
 	Endpoint string
 	// ModuleContext holds values that the module passes to itself from the previous stages.
 	ModuleContext ModuleContext
+	// HookImplCode is the hook_impl_code for a module instance to differentiate between multiple hooks
+	HookImplCode string
 }
 
 // ModuleContext holds arbitrary data passed between module hooks at different stages.


### PR DESCRIPTION
[Fixes #4035] Add the hook.Code to the ModuleInvocationContext.