### PR TITLE
Fix: Delete user.ext.prebid.buyeruids after extraction

### DIFF
--- a/endpoints/openrtb2/sample-requests/valid-whole/exemplary/user-ext-prebid-buyeruids.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/exemplary/user-ext-prebid-buyeruids.json
@@ -1,0 +1,170 @@
+{
+  "description": "Bid request with user.ext.prebid.buyeruids object",
+  "config": {
+    "mockBidders": [
+      {
+        "bidderName": "appnexus",
+        "currency": "USD",
+        "price": 1.00
+      },
+      {
+        "bidderName": "pubmatic",
+        "currency": "USD",
+        "price": 2.00
+      }
+    ],
+    "bidderInfoOverrides": {
+      "appnexus": {
+        "openrtb": {
+          "version": "2.5"
+        }
+      },
+      "pubmatic": {
+        "openrtb": {
+          "version": "2.6"
+        }
+      }
+    }
+  },
+  "mockBidRequest": {
+    "id": "request-id",
+    "site": {
+      "page": "prebid.org"
+    },
+    "imp": [
+      {
+        "id": "imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "appnexus": {
+            "placementId": 12883451
+          },
+          "pubmatic": {
+            "publisherId": "123"
+          }
+        }
+      }
+    ],
+    "user": {
+      "consent": "some-consent-string",
+      "ext": {
+        "prebid": {
+          "buyeruids": {
+            "appnexus": "appnexus-buyeruid",
+            "pubmatic": "pubmatic-buyeruid" 
+          }
+        }
+      }
+    }
+  },
+  "expectedMockBidderRequests": {
+    "appnexus": {
+      "id": "request-id",
+      "site": {
+        "page": "prebid.org",
+        "ext": {
+          "amp": 0
+        }
+      },
+      "at": 1,
+      "device": {
+        "ip": "192.0.2.1"
+      },
+      "imp": [
+      {
+        "id": "imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 12883451
+          }
+        },
+        "secure": 1
+      }],
+      "user": {
+        "buyeruid": "appnexus-buyeruid",
+        "ext": {
+          "consent": "some-consent-string"
+        }
+      }
+    },
+    "pubmatic": {
+      "id": "request-id",
+      "site": {
+        "page": "prebid.org",
+        "ext": {
+          "amp": 0
+        }
+      },
+      "at": 1,
+      "device": {
+        "ip": "192.0.2.1"
+      },
+      "imp": [
+      {
+        "id": "imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "123"
+          }
+        },
+        "secure": 1
+      }],
+      "user": {
+        "buyeruid": "pubmatic-buyeruid",
+        "consent": "some-consent-string"
+      }
+    }
+  },
+  "expectedBidResponse": {
+    "id": "request-id",
+    "seatbid": [
+      {
+        "bid": [
+          {
+            "id": "appnexus-bid",
+            "impid": "imp-id",
+            "price": 1.0
+          }
+        ],
+        "seat": "appnexus"
+      },
+      {
+        "bid": [
+          {
+            "id": "pubmatic-bid",
+            "impid": "imp-id",
+            "price": 2.0
+          }
+        ],
+        "seat": "pubmatic"
+      }
+    ],
+    "bidid": "test bid id",
+    "cur": "USD",
+    "nbr": 0
+  },
+  "expectedReturnCode": 200
+}

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -612,11 +612,15 @@ func extractBuyerUIDs(req *openrtb_ext.RequestWrapper) (map[string]string, error
 	if prebid == nil {
 		return nil, nil
 	}
-	userExt.SetPrebid(nil)
+
+	buyerUIDs := prebid.BuyerUIDs
+
+	prebid.BuyerUIDs = nil
+	userExt.SetPrebid(prebid)
 
 	// The API guarantees that user.ext.prebid.buyeruids exists and has at least one ID defined,
 	// as long as user.ext.prebid exists.
-	return prebid.BuyerUIDs, nil
+	return buyerUIDs, nil
 }
 
 // splitImps takes a list of Imps and returns a map of imps which have been sanitized for each bidder.

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -82,11 +82,12 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		return
 	}
 
-	explicitBuyerUIDs, err := extractBuyerUIDs(req)
+	explicitBuyerUIDs, err := extractAndCleanBuyerUIDs(req)
 	if err != nil {
 		errs = []error{err}
 		return
 	}
+
 	lowerCaseExplicitBuyerUIDs := make(map[string]string)
 	for bidder, uid := range explicitBuyerUIDs {
 		lowerKey := strings.ToLower(bidder)
@@ -598,16 +599,18 @@ func isBidderInExtAlternateBidderCodes(adapter, currentMultiBidBidder string, ad
 	return false
 }
 
-// extractBuyerUIDs parses the values from user.ext.prebid.buyeruids, and then deletes those values from the ext.
+// extractAndCleanBuyerUIDs parses the values from user.ext.prebid.buyeruids, and then deletes those values from the ext.
 // This prevents a Bidder from using these values to figure out who else is involved in the Auction.
-func extractBuyerUIDs(req *openrtb_ext.RequestWrapper) (map[string]string, error) {
+func extractAndCleanBuyerUIDs(req *openrtb_ext.RequestWrapper) (map[string]string, error) {
 	if req.User == nil {
 		return nil, nil
 	}
+
 	userExt, err := req.GetUserExt()
 	if err != nil {
 		return nil, err
 	}
+
 	prebid := userExt.GetPrebid()
 	if prebid == nil {
 		return nil, nil

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -3557,7 +3557,18 @@ func TestCleanOpenRTBRequestsBuyerUID(t *testing.T) {
 				me:                &metrics.MetricsEngineMock{},
 				gdprPermsBuilder:  gdprPermissionsBuilder,
 				hostSChainNode:    nil,
-				bidderInfo:        config.BidderInfos{},
+				bidderInfo:        config.BidderInfos{
+					"appnexus": config.BidderInfo{
+						OpenRTB: &config.OpenRTBInfo{
+							Version: "2.5",
+						},
+					},
+					"pubmatic": config.BidderInfo{
+						OpenRTB: &config.OpenRTBInfo{
+							Version: "2.5",
+						},
+					},
+				},
 			}
 
 			results, _, errs := reqSplitter.cleanOpenRTBRequests(context.Background(), auctionReq, nil, gdpr.SignalNo, false, nil)

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -5595,7 +5595,7 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 	}
 }
 
-func TestExtractBuyerUIDs(t *testing.T) {
+func TestExtractAndCleanBuyerUIDs(t *testing.T) {
 	tests := []struct {
 		name              string
 		user              *openrtb2.User
@@ -5666,7 +5666,7 @@ func TestExtractBuyerUIDs(t *testing.T) {
 				},
 			}
 
-			result, err := extractBuyerUIDs(&req)
+			result, err := extractAndCleanBuyerUIDs(&req)
 			if test.expectError {
 				assert.NotNil(t, err)
 			} else {

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -3423,6 +3423,152 @@ func TestCleanOpenRTBRequestsBidAdjustment(t *testing.T) {
 	}
 }
 
+func TestCleanOpenRTBRequestsBuyerUID(t *testing.T) {
+	tcf2Consent := "COzTVhaOzTVhaGvAAAENAiCIAP_AAH_AAAAAAEEUACCKAAA"
+
+	buyerUIDAppnexus := `{"appnexus": "a123"}`
+	buyerUIDAppnexusMixedCase := `{"aPpNeXuS": "a123"}`
+	buyerUIDBoth := `{"appnexus": "a123", "pubmatic": "p456"}`
+
+	bidderParamsAppnexus := `{"appnexus": {"placementId": 1}}`
+	bidderParamsBoth := `{"appnexus": {"placementId": 1}, "pubmatic": {"publisherId": "abc"}}`
+
+	tests := []struct {
+		name          string
+		bidderParams  string
+		user          openrtb2.User
+		expectedUsers map[string]openrtb2.User
+	}{
+		{
+			name:         "one-bidder-with-prebid-buyeruid",
+			bidderParams: bidderParamsAppnexus,
+			user: openrtb2.User{
+				ID:      "some-id",
+				Ext:     json.RawMessage(`{"data": 1, "test": 2, "prebid": {"buyeruids": ` + buyerUIDAppnexus + `}}`),
+				Consent: tcf2Consent,
+			},
+			expectedUsers: map[string]openrtb2.User{
+				"appnexus": {
+					ID:       "some-id",
+					BuyerUID: "a123",
+					Ext:      json.RawMessage(`{"consent":"` + tcf2Consent + `","data":1,"test":2}`),
+				},
+			},
+		},
+		{
+			name:         "one-bidder-with-prebid-buyeruid-mixed-case",
+			bidderParams: bidderParamsAppnexus,
+			user: openrtb2.User{
+				ID:      "some-id",
+				Ext:     json.RawMessage(`{"data": 1, "test": 2, "prebid": {"buyeruids": ` + buyerUIDAppnexusMixedCase + `}}`),
+				Consent: tcf2Consent,
+			},
+			expectedUsers: map[string]openrtb2.User{
+				"appnexus": {
+					ID:       "some-id",
+					BuyerUID: "a123",
+					Ext:      json.RawMessage(`{"consent":"` + tcf2Consent + `","data":1,"test":2}`),
+				},
+			},
+		},
+		{
+			name:         "one-bidder-with-buyeruid-already-set",
+			bidderParams: bidderParamsAppnexus,
+			user: openrtb2.User{
+				ID:       "some-id",
+				BuyerUID: "already-set-buyeruid",
+				Ext:      json.RawMessage(`{"data": 1, "test": 2, "prebid": {"buyeruids": ` + buyerUIDAppnexus + `}}`),
+				Consent:  tcf2Consent,
+			},
+			expectedUsers: map[string]openrtb2.User{
+				"appnexus": {
+					ID:       "some-id",
+					BuyerUID: "already-set-buyeruid",
+					Ext:      json.RawMessage(`{"consent":"` + tcf2Consent + `","data":1,"test":2}`),
+				},
+			},
+		},
+		{
+			name:         "two-bidder-with-prebid-buyeruids",
+			bidderParams: bidderParamsBoth,
+			user: openrtb2.User{
+				ID:      "some-id",
+				Ext:     json.RawMessage(`{"data": 1, "test": 2, "prebid": {"buyeruids": ` + buyerUIDBoth + `}}`),
+				Consent: tcf2Consent,
+			},
+			expectedUsers: map[string]openrtb2.User{
+				"appnexus": {
+					ID:       "some-id",
+					BuyerUID: "a123",
+					Ext:      json.RawMessage(`{"consent":"` + tcf2Consent + `","data":1,"test":2}`),
+				},
+				"pubmatic": {
+					ID:       "some-id",
+					BuyerUID: "p456",
+					Ext:      json.RawMessage(`{"consent":"` + tcf2Consent + `","data":1,"test":2}`),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			req := &openrtb2.BidRequest{
+				Site: &openrtb2.Site{
+					Publisher: &openrtb2.Publisher{
+						ID: "some-publisher-id",
+					},
+				},
+				Imp: []openrtb2.Imp{{
+					ID: "some-imp-id",
+					Banner: &openrtb2.Banner{
+						Format: []openrtb2.Format{{
+							W: 300,
+							H: 250,
+						}},
+					},
+					Ext: json.RawMessage(`{"prebid":{"tid":"123", "bidder":` + string(test.bidderParams) + `}}`),
+				}},
+				User: &test.user,
+			}
+
+			auctionReq := AuctionRequest{
+				BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: req},
+				UserSyncs:         &emptyUsersync{},
+				Account: config.Account{
+					GDPR: config.AccountGDPR{
+						Enabled: ptrutil.ToPtr(false),
+					},
+				},
+				TCF2Config: gdpr.NewTCF2Config(config.TCF2{}, config.AccountGDPR{}),
+			}
+			gdprPermissionsBuilder := fakePermissionsBuilder{
+				permissions: &permissionsMock{
+					allowAllBidders: true,
+					passGeo:         false,
+					passID:          false,
+					activitiesError: nil,
+				},
+			}.Builder
+
+			reqSplitter := &requestSplitter{
+				bidderToSyncerKey: map[string]string{},
+				me:                &metrics.MetricsEngineMock{},
+				gdprPermsBuilder:  gdprPermissionsBuilder,
+				hostSChainNode:    nil,
+				bidderInfo:        config.BidderInfos{},
+			}
+
+			results, _, errs := reqSplitter.cleanOpenRTBRequests(context.Background(), auctionReq, nil, gdpr.SignalNo, false, nil)
+			for _, v := range results {
+				assert.Empty(t, errs)
+				assert.Equal(t, test.expectedUsers[string(v.BidderName)], *v.BidRequest.User)
+			}
+		})
+	}
+}
+
 func TestApplyFPD(t *testing.T) {
 	testCases := []struct {
 		description               string
@@ -5435,5 +5581,91 @@ func TestRemoveImpsWithStoredResponses(t *testing.T) {
 		removeImpsWithStoredResponses(request, testCase.storedBidResponses)
 		assert.NoError(t, request.RebuildRequest())
 		assert.Equal(t, testCase.expectedImps, request.Imp, "incorrect Impressions for testCase %s", testCase.description)
+	}
+}
+
+func TestExtractBuyerUIDs(t *testing.T) {
+	tests := []struct {
+		name              string
+		user              *openrtb2.User
+		expectedBuyerUIDs map[string]string
+		expectError       bool
+	}{
+		{
+			name:              "user_is_nil",
+			user:              nil,
+			expectedBuyerUIDs: nil,
+			expectError:       false,
+		},
+		{
+			name: "user.ext_is_nil",
+			user: &openrtb2.User{
+				Ext: nil,
+			},
+			expectedBuyerUIDs: nil,
+			expectError:       false,
+		},
+		{
+			name: "user.ext_malformed",
+			user: &openrtb2.User{
+				Ext: json.RawMessage(`{"prebid":}`),
+			},
+			expectedBuyerUIDs: nil,
+			expectError:       true,
+		},
+		{
+			name: "user.ext.prebid_is_nil",
+			user: &openrtb2.User{
+				Ext: json.RawMessage(`{"prebid":null}`),
+			},
+			expectedBuyerUIDs: nil,
+			expectError:       false,
+		},
+		{
+			name: "user.ext.prebid.buyeruids_is_nil",
+			user: &openrtb2.User{
+				Ext: json.RawMessage(`{"prebid":{"buyeruids": null}}`),
+			},
+			expectedBuyerUIDs: nil,
+			expectError:       false,
+		},
+		{
+			name: "user.ext.prebid.buyeruids_is_empty",
+			user: &openrtb2.User{
+				Ext: json.RawMessage(`{"prebid":{"buyeruids": {}}}`),
+			},
+			expectedBuyerUIDs: nil,
+			expectError:       false,
+		},
+		{
+			name: "user.ext.prebid.buyeruids_is_populated",
+			user: &openrtb2.User{
+				Ext: json.RawMessage(`{"prebid":{"buyeruids": {"appnexus":"a123", "pubmatic":"p456"}}}`),
+			},
+			expectedBuyerUIDs: map[string]string{"appnexus": "a123", "pubmatic": "p456"},
+			expectError:       false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := openrtb_ext.RequestWrapper{
+				BidRequest: &openrtb2.BidRequest{
+					User: test.user,
+				},
+			}
+
+			result, err := extractBuyerUIDs(&req)
+			if test.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Len(t, result, len(test.expectedBuyerUIDs))
+			for bidder, buyerUID := range result {
+				assert.Equal(t, test.expectedBuyerUIDs[bidder], buyerUID)
+			}
+		})
 	}
 }

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -3575,9 +3575,9 @@ func TestCleanOpenRTBRequestsBuyerUID(t *testing.T) {
 
 			assert.Empty(t, errs)
 			for _, v := range results {
-				assert.Equal(t, test.expectedUsers[string(v.BidderName)], *v.BidRequest.User)
 				require.NotNil(t, v.BidRequest, "bidrequest")
 				require.NotNil(t, v.BidRequest.User, "bidrequest.user")
+				assert.Equal(t, test.expectedUsers[string(v.BidderName)], *v.BidRequest.User)
 			}
 		})
 	}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -3557,7 +3557,7 @@ func TestCleanOpenRTBRequestsBuyerUID(t *testing.T) {
 				me:                &metrics.MetricsEngineMock{},
 				gdprPermsBuilder:  gdprPermissionsBuilder,
 				hostSChainNode:    nil,
-				bidderInfo:        config.BidderInfos{
+				bidderInfo: config.BidderInfos{
 					"appnexus": config.BidderInfo{
 						OpenRTB: &config.OpenRTBInfo{
 							Version: "2.5",


### PR DESCRIPTION
A problem was introduced in v3.0.0 where `user.ext.prebid.buyeruids` are not being scrubbed for bidder requests containing at least one `user` field that needs to be converted down to its 2.5 location. For example, if the incoming request contains either `user.consent` or `user.ext.consent` and some bidder only supports ORTB 2.5 (no explicit 2.6 support declaration in their YAML), the buyeruids are not scrubbed.