### PR TITLE
Docker example updates

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -8,7 +8,12 @@ In the Sample, we use `docker` and `docker-compose` to instantiate examples; wit
 The docker image used in `docker-compose.yml` is the `Dockerfile` residing in the root level of the repository. 
 
 > [!NOTE] 
-> Depending on what version of Docker is installed on your system, `docker-compose` might be considered deprecated.  If you receive an error when trying to run `docker-compose`, use `docker compose` (without the dash) instead.
+> Depending on what version of Docker is installed on your system, `docker-compose` might be considered deprecated.
+>
+> - Run `docker-compose` for docker compose version 1.X.
+> - Run `docker compose` (without the dash) for docker compose versions 2.X and 3.X. 
+>
+> For more details please refer to the [History and development of Docker compose](https://docs.docker.com/compose/intro/history/). 
 
 ## Option 1 - Standard Docker Engine
 Install `docker` and `docker-compose` via the [official docker page](https://docs.docker.com/compose/install/#scenario-one-install-docker-desktop). If you cannot use the official docker engine due to restrictions of its license, see the option below about using Podman instead of Docker. 

--- a/sample/README.md
+++ b/sample/README.md
@@ -7,6 +7,11 @@ The Sample describes several demos of quickly spinning up different Prebid Serve
 In the Sample, we use `docker` and `docker-compose` to instantiate examples; with docker providing a unified setup and interface,  you can spin up a demo server instance locally with only one command without knowing all the complexities.
 The docker image used in `docker-compose.yml` is the `Dockerfile` residing in the root level of the repository. 
 
+
+> [!NOTE] 
+> Depending on what version of Docker is installed on your system, `docker-compose` might be considered deprecated.  If you receive an error when trying to run `docker-compose`, use `docker compose` (without the dash) instead.
+
+
 ## Option 1 - Standard Docker Engine
 Install `docker` and `docker-compose` via the [official docker page](https://docs.docker.com/compose/install/#scenario-one-install-docker-desktop). If you cannot use the official docker engine due to restrictions of its license, see the option below about using Podman instead of Docker. 
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -7,10 +7,8 @@ The Sample describes several demos of quickly spinning up different Prebid Serve
 In the Sample, we use `docker` and `docker-compose` to instantiate examples; with docker providing a unified setup and interface,  you can spin up a demo server instance locally with only one command without knowing all the complexities.
 The docker image used in `docker-compose.yml` is the `Dockerfile` residing in the root level of the repository. 
 
-
 > [!NOTE] 
 > Depending on what version of Docker is installed on your system, `docker-compose` might be considered deprecated.  If you receive an error when trying to run `docker-compose`, use `docker compose` (without the dash) instead.
-
 
 ## Option 1 - Standard Docker Engine
 Install `docker` and `docker-compose` via the [official docker page](https://docs.docker.com/compose/install/#scenario-one-install-docker-desktop). If you cannot use the official docker engine due to restrictions of its license, see the option below about using Podman instead of Docker. 


### PR DESCRIPTION
## Overview

### Docker Invocation
Adding a note to the README file for the "sample" directory to alert readers that it might, depending upon their system setup, be necessary to invoke `docker compose` rather than `docker-compose` when running the examples.