### PR TITLE
Sharethrough: Declare support for OpenRTB 2.6

### DIFF
--- a/static/bidder-info/sharethrough.yaml
+++ b/static/bidder-info/sharethrough.yaml
@@ -2,6 +2,8 @@ endpoint: "https://btlr.sharethrough.com/universal/v1?supply_id=FGMrCMMc"
 maintainer:
   email: pubgrowth.engineering@sharethrough.com
 gvlVendorID: 80
+openrtb:
+  version: 2.6
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
## Overview / Summary
This work just involves updating our config file (`sharethrough.yaml`) to indicate that our exchange has support for oRTB 2.6-compliant bid requests.