### PR TITLE
Reserve IGS name

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -277,6 +277,7 @@ const (
 	BidderReservedSKAdN   BidderName = "skadn"   // Reserved for Apple's SKAdNetwork OpenRTB extension.
 	BidderReservedTID     BidderName = "tid"     // Reserved for Per-Impression Transactions IDs for Multi-Impression Bid Requests.
 	BidderReservedAE      BidderName = "ae"      // Reserved for FLEDGE Auction Environment
+	BidderReservedIGS     BidderName = "igs"      // Reserved for FLEDGE Auction Environment
 )
 
 // IsBidderNameReserved returns true if the specified name is a case insensitive match for a reserved bidder name.
@@ -314,6 +315,10 @@ func IsBidderNameReserved(name string) bool {
 	}
 
 	if strings.EqualFold(name, string(BidderReservedAE)) {
+		return true
+	}
+
+	if strings.EqualFold(name, string(BidderReservedIGS)) {
 		return true
 	}
 


### PR DESCRIPTION
Reserves IGS as not a bidder. 

It seems like this function is gone? https://github.com/prebid/prebid-server/commit/6aab539f321ca50ffccf1d84f4399ec4567919ba#diff-785f5ab5ebde657757f3b3c34bf30a939782678d61bf1ea43f844c4f22a012d9R1450