### PR TITLE
PubMatic: Remove req.ext.prebid from bid requests

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -65,7 +65,6 @@ type extRequestAdServer struct {
 	Wrapper     *pubmaticWrapperExt `json:"wrapper,omitempty"`
 	Acat        []string            `json:"acat,omitempty"`
 	Marketplace *marketplaceReqExt  `json:"marketplace,omitempty"`
-	openrtb_ext.ExtRequest
 }
 
 type respExt struct {
@@ -351,7 +350,6 @@ func extractPubmaticExtFromRequest(request *openrtb2.BidRequest) (extRequestAdSe
 	if err != nil {
 		return pmReqExt, fmt.Errorf("error decoding Request.ext : %s", err.Error())
 	}
-	pmReqExt.ExtRequest = *reqExt
 
 	reqExtBidderParams := make(map[string]json.RawMessage)
 	if reqExt.Prebid.BidderParams != nil {

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -197,14 +197,8 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 					Ext: json.RawMessage(`{"prebid":{"bidderparams":{}}}`),
 				},
 			},
-			expectedReqExt: extRequestAdServer{
-				ExtRequest: openrtb_ext.ExtRequest{
-					Prebid: openrtb_ext.ExtRequestPrebid{
-						BidderParams: json.RawMessage("{}"),
-					},
-				},
-			},
-			wantErr: false,
+			expectedReqExt: extRequestAdServer{},
+			wantErr:        false,
 		},
 		{
 			name: "Only Pubmatic wrapper ext present",
@@ -215,11 +209,6 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			},
 			expectedReqExt: extRequestAdServer{
 				Wrapper: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
-				ExtRequest: openrtb_ext.ExtRequest{
-					Prebid: openrtb_ext.ExtRequestPrebid{
-						BidderParams: json.RawMessage(`{"wrapper":{"profile":123,"version":456}}`),
-					},
-				},
 			},
 			wantErr: false,
 		},
@@ -242,11 +231,6 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			expectedReqExt: extRequestAdServer{
 				Wrapper: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
 				Acat:    []string{"drg", "dlu", "ssr"},
-				ExtRequest: openrtb_ext.ExtRequest{
-					Prebid: openrtb_ext.ExtRequestPrebid{
-						BidderParams: json.RawMessage(`{"acat":[" drg \t","dlu","ssr"],"wrapper":{"profile":123,"version":456}}`),
-					},
-				},
 			},
 			wantErr: false,
 		},
@@ -259,11 +243,6 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			},
 			expectedReqExt: extRequestAdServer{
 				Wrapper: &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
-				ExtRequest: openrtb_ext.ExtRequest{
-					Prebid: openrtb_ext.ExtRequestPrebid{
-						BidderParams: json.RawMessage(`{"acat":[1,3,4],"wrapper":{"profile":123,"version":456}}`),
-					},
-				},
 			},
 			wantErr: true,
 		},
@@ -277,12 +256,6 @@ func TestExtractPubmaticExtFromRequest(t *testing.T) {
 			expectedReqExt: extRequestAdServer{
 				Marketplace: &marketplaceReqExt{AllowedBidders: []string{"pubmatic", "groupm"}},
 				Wrapper:     &pubmaticWrapperExt{ProfileID: 123, VersionID: 456},
-				ExtRequest: openrtb_ext.ExtRequest{
-					Prebid: openrtb_ext.ExtRequestPrebid{
-						BidderParams:         json.RawMessage(`{"wrapper":{"profile":123,"version":456}}`),
-						AlternateBidderCodes: &openrtb_ext.ExtAlternateBidderCodes{Enabled: true, Bidders: map[string]openrtb_ext.ExtAdapterAlternateBidderCodes{"pubmatic": {Enabled: true, AllowedBidderCodes: []string{"groupm"}}}},
-					},
-				},
 			},
 			wantErr: false,
 		},

--- a/adapters/pubmatic/pubmatictest/exemplary/banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/banner.json
@@ -46,8 +46,7 @@
 			        	"id": "1234"
 		      	}
 		      }
-     },
-  
+     }, 
     "httpCalls": [
       {
         "expectedRequest": {
@@ -89,12 +88,7 @@
                     "profile": 5123,
                     "version":1
                 },
-                "acat": ["drg","dlu","ssr"],
-                "prebid": {
-                  "bidderparams": {
-                    "acat": ["drg","dlu","ssr"]
-                  }
-                }
+                "acat": ["drg","dlu","ssr"]
             }
           },
           "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/exemplary/fledge.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/fledge.json
@@ -47,7 +47,7 @@
               }
             }
           ],
-          "ext": {"prebid":{}}
+          "ext": {}
         },
         "impIDs":["test-imp-id"]
       },

--- a/adapters/pubmatic/pubmatictest/exemplary/native.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/native.json
@@ -56,8 +56,7 @@
                       "wrapper": {
                           "profile": 5123,
                           "version": 1
-                      },
-                      "prebid": {}
+                      }
                   }
               },
               "impIDs":["test-native-imp"]

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -53,7 +53,6 @@
         }
       }
     },
-  
     "httpCalls": [
       {
         "expectedRequest": {
@@ -100,12 +99,7 @@
                     "profile": 5123,
                     "version":1
                 },
-                "acat": ["drg","dlu","ssr"],
-                "prebid": {
-                  "bidderparams": {
-                    "acat": ["drg","dlu","ssr"]
-                  }
-                }
+                "acat": ["drg","dlu","ssr"]
             }
           },
           "impIDs":["test-video-imp"]

--- a/adapters/pubmatic/pubmatictest/supplemental/app.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/app.json
@@ -40,7 +40,6 @@
 		    	}
 		    }
     },
-  
     "httpCalls": [
       {
         "expectedRequest": {
@@ -81,8 +80,7 @@
                 "wrapper": {
                     "profile": 5123,
                     "version":1
-                },
-                "prebid": {}
+                }
             }
           },
           "impIDs":["app-imp"]

--- a/adapters/pubmatic/pubmatictest/supplemental/dctrAndPmZoneID.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/dctrAndPmZoneID.json
@@ -92,8 +92,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
@@ -58,7 +58,6 @@
             }
           }
      },
-
      "httpCalls": [
       {
         "expectedRequest": {
@@ -103,22 +102,6 @@
                 "acat": ["drg","dlu","ssr"],
                 "marketplace": {
                   "allowedbidders": ["pubmatic", "groupm"]
-                },
-                "prebid": {
-                  "bidderparams": {
-                    "acat": ["drg","dlu","ssr"]
-                  },
-                  "alternatebiddercodes": {
-                    "enabled": true,
-                    "bidders": {
-                      "pubmatic": {
-                        "enabled": true,
-                        "allowedbiddercodes": [
-                          "groupm"
-                        ]
-                      }
-                    }
-                  }
                 }
             }
           },

--- a/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExt.json
@@ -97,8 +97,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExtPbAdslot.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExtPbAdslot.json
@@ -93,8 +93,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/impExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/impExt.json
@@ -84,7 +84,6 @@
                         }
                     },
                     "ext": {
-                        "prebid": {},
                         "wrapper": {
                             "profile": 5123,
                             "version": 1

--- a/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/invalidparam.json
@@ -94,7 +94,6 @@
 			}
 		}
     },
-  
     "expectedMakeRequestsErrors": [
         {
             "value": "Invalid adSlot AdTag_Div1@",

--- a/adapters/pubmatic/pubmatictest/supplemental/multiplemedia.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/multiplemedia.json
@@ -25,7 +25,6 @@
         "id": "siteID"
         }
     },
-  
     "httpCalls": [
         {
           "expectedRequest": {
@@ -54,9 +53,7 @@
                       "id": "999"
                   }
               },
-              "ext" : {
-                "prebid": {}
-              }
+              "ext" : {}
             },
             "impIDs":["multiple-media-imp"]
           },

--- a/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
@@ -53,7 +53,6 @@
                       }
                   },
                   "ext": {
-                      "prebid": {},
                       "wrapper": {
                           "profile": 5123,
                           "version": 1

--- a/adapters/pubmatic/pubmatictest/supplemental/nilReqExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/nilReqExt.json
@@ -90,8 +90,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/noAdSlot.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/noAdSlot.json
@@ -38,7 +38,6 @@
             }
         }
     },
-
     "httpCalls": [{
         "expectedRequest": {
             "uri": "https://hbopenbid.pubmatic.com/translator?source=prebid-server",
@@ -72,8 +71,7 @@
                     "wrapper": {
                         "profile": 5123,
                         "version": 1
-                    },
-                    "prebid": {}
+                    }
                 }
             },
             "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/pmZoneIDInKeywords.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/pmZoneIDInKeywords.json
@@ -91,8 +91,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]

--- a/adapters/pubmatic/pubmatictest/supplemental/reqBidderParams.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/reqBidderParams.json
@@ -99,14 +99,6 @@
             "wrapper": {
               "profile": 1234,
               "version": 2
-            },
-            "prebid": {
-              "bidderparams": {
-                "wrapper": {
-                  "profile": 1234,
-                  "version": 2
-                }
-              }
             }
           }
         },

--- a/adapters/pubmatic/pubmatictest/supplemental/trimPublisherID.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/trimPublisherID.json
@@ -89,8 +89,7 @@
             "wrapper": {
               "profile": 5123,
               "version": 1
-            },
-            "prebid": {}
+            }
           }
         },
         "impIDs":["test-imp-id"]


### PR DESCRIPTION
Hi Team,

The PubMatic Adapter is currently not utilizing the `req.ext.prebid` object from the backend. As this parameter is not being used, we can safely skip passing it in the PubMatic Adapter requests.

To address this, I am raising a PR to remove the `req.ext.prebid` parameter from PubMatic requests.

Let me know if you have any concerns or require further input.
