### PR TITLE
Adnuntius: Use format=prebidServer on adserver requests

### DIFF
--- a/adapters/adnuntius/adnuntius.go
+++ b/adapters/adnuntius/adnuntius.go
@@ -169,7 +169,7 @@ func makeEndpointUrl(ortbRequest openrtb2.BidRequest, a *adapter, noCookies bool
 	}
 
 	q.Set("tzo", fmt.Sprint(tzo))
-	q.Set("format", "prebid")
+	q.Set("format", "prebidServer")
 
 	url := endpointUrl + "?" + q.Encode()
 	return url, nil

--- a/adapters/adnuntius/adnuntiustest/exemplary/simple-banner.json
+++ b/adapters/adnuntius/adnuntiustest/exemplary/simple-banner.json
@@ -31,7 +31,7 @@
     "httpCalls": [
         {
             "expectedRequest": {
-                "uri": "http://whatever.url?format=prebid&tzo=0",
+                "uri": "http://whatever.url?format=prebidServer&tzo=0",
                 "body": {
                     "adUnits": [
                         {

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-dealId.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-dealId.json
@@ -31,7 +31,7 @@
   "httpCalls": [
       {
           "expectedRequest": {
-              "uri": "http://whatever.url?format=prebid&tzo=0",
+              "uri": "http://whatever.url?format=prebidServer&tzo=0",
               "body": {
                   "adUnits": [
                       {

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-legalName-omitted.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-legalName-omitted.json
@@ -45,7 +45,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-legalName.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-legalName.json
@@ -45,7 +45,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-omitted.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-dsa-advertiser-omitted.json
@@ -45,7 +45,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-gdpr.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-gdpr.json
@@ -38,7 +38,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://gdpr.url?consentString=CONSENT_STRING&format=prebid&gdpr=1&tzo=0",
+				"uri": "http://gdpr.url?consentString=CONSENT_STRING&format=prebidServer&gdpr=1&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-gross-bids.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-gross-bids.json
@@ -31,7 +31,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-net-bids.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-net-bids.json
@@ -31,7 +31,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-noCookies-parameter.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-noCookies-parameter.json
@@ -31,7 +31,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&noCookies=true&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&noCookies=true&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-noCookies.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-noCookies.json
@@ -35,7 +35,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&noCookies=true&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&noCookies=true&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-order-multi-imp.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-order-multi-imp.json
@@ -51,7 +51,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/check-userId.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/check-userId.json
@@ -30,7 +30,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/empty-regs-ext.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/empty-regs-ext.json
@@ -33,7 +33,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/empty-regs.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/empty-regs.json
@@ -32,7 +32,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/height-error.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/height-error.json
@@ -30,7 +30,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/max-deals-test.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/max-deals-test.json
@@ -32,7 +32,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/send-header-information.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/send-header-information.json
@@ -50,7 +50,7 @@
 						"Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Mobile Safari/537.36"
 					]
 				},
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/site-ext.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/site-ext.json
@@ -37,7 +37,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/size-check.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/size-check.json
@@ -28,7 +28,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&noCookies=true&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&noCookies=true&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/status-400.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/status-400.json
@@ -27,7 +27,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/test-networks.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/test-networks.json
@@ -32,7 +32,7 @@
 	"httpCalls": [
 			{
 					"expectedRequest": {
-							"uri": "http://whatever.url?format=prebid&tzo=0",
+							"uri": "http://whatever.url?format=prebidServer&tzo=0",
 							"body": {
 									"adUnits": [
 											{

--- a/adapters/adnuntius/adnuntiustest/supplemental/user-ext.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/user-ext.json
@@ -39,7 +39,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{

--- a/adapters/adnuntius/adnuntiustest/supplemental/width-error.json
+++ b/adapters/adnuntius/adnuntiustest/supplemental/width-error.json
@@ -30,7 +30,7 @@
 	"httpCalls": [
 		{
 			"expectedRequest": {
-				"uri": "http://whatever.url?format=prebid&tzo=0",
+				"uri": "http://whatever.url?format=prebidServer&tzo=0",
 				"body": {
 					"adUnits": [
 						{


### PR DESCRIPTION
Instead of `format=json`, use `format=prebidServer` in adserver requests.