### PR TITLE
Adding stale PR workflow

### DIFF
--- a/.github/workflows/slack-stale-pr.yml
+++ b/.github/workflows/slack-stale-pr.yml
@@ -1,4 +1,4 @@
-name: Find stale PRs
+name: Post Stale PRs To Slack
 
 on:
   # run Monday 9am and on-demand

--- a/.github/workflows/slack_stale_pr.yml
+++ b/.github/workflows/slack_stale_pr.yml
@@ -1,0 +1,27 @@
+name: Find stale PRs
+
+on:
+  # run Monday 9am and on-demand
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 9 * * 1'
+
+jobs:
+  fetch-PRs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch pull requests
+        id: local
+        uses: paritytech/stale-pr-finder@v0.3.0
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          days-stale: 14
+          ignoredLabels: "blocked"
+      - name: Post to a Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "${{ steps.local.outputs.message }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This has been tested over in the sourcecred repo.

The goal is to slack a summary of stale PRs to the #prebid-server-dev channel once/week.