### PR TITLE
CWire: Add domainId param and app capability

### DIFF
--- a/adapters/cwire/cwiretest/exemplary/app-imp-ext.json
+++ b/adapters/cwire/cwiretest/exemplary/app-imp-ext.json
@@ -1,0 +1,160 @@
+{
+  "mockBidRequest": {
+    "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+    "cur": [
+      "CHF"
+    ],
+    "imp": [
+      {
+        "id": "102",
+        "banner": {
+          "h": 250,
+          "w": 300,
+          "pos": 0
+        },
+        "ext": {
+          "bidder": {
+            "cwcreative": "9999",
+            "placementId": 15,
+            "domainId": 42
+          }
+        }
+      }
+    ],
+    "app": {
+      "publisher": {
+        "id": "123456789"
+      },
+      "cat": [
+        "IAB22-1"
+      ],
+      "bundle": "com.app.awesome",
+      "name": "Awesome App",
+      "domain": "awesomeapp.com",
+      "id": "123456789"
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:108.0) Gecko/20100101 Firefox/108.0"
+    },
+    "user": {
+      "id": "55816b39711f9b5acf3b90e313ed29e51665623f",
+      "geo": {
+        "country": "ch",
+        "region": "basel-stadt",
+        "city": "basel"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://cwi.re/prebid/adapter-endpoint",
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "body": {
+          "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+          "cur": [
+            "CHF"
+          ],
+          "imp": [
+            {
+              "id": "102",
+              "banner": {
+                "h": 250,
+                "w": 300,
+                "pos": 0
+              },
+              "ext": {
+                "bidder": {
+                  "cwcreative": "9999",
+                  "placementId": 15,
+                  "domainId": 42
+                }
+              }
+            }
+          ],
+          "app": {
+            "publisher": {
+              "id": "123456789"
+            },
+            "cat": [
+              "IAB22-1"
+            ],
+            "bundle": "com.app.awesome",
+            "name": "Awesome App",
+            "domain": "awesomeapp.com",
+            "id": "123456789"
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:108.0) Gecko/20100101 Firefox/108.0"
+          },
+          "user": {
+            "id": "55816b39711f9b5acf3b90e313ed29e51665623f",
+            "geo": {
+              "country": "ch",
+              "region": "basel-stadt",
+              "city": "basel"
+            }
+          }
+        },
+        "impIDs": [
+          "102"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "headers": {},
+        "body": {
+          "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+          "cur": "CHF",
+          "seatbid": [
+            {
+              "seat": "cwire",
+              "group": 0,
+              "bid": [
+                {
+                  "id": "333",
+                  "impid": "102",
+                  "price": 8.00,
+                  "crid": "9999",
+                  "adm": "<h3>Example Ad</h3>",
+                  "w": 1,
+                  "h": 1,
+                  "nurl": "https://embed.cwi.re/delivery/prebid-server/win/333",
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "CHF",
+      "bids": [
+        {
+          "bid": {
+            "id": "333",
+            "impid": "102",
+            "price": 8.00,
+            "crid": "9999",
+            "adm": "<h3>Example Ad</h3>",
+            "w": 1,
+            "h": 1,
+            "nurl": "https://embed.cwi.re/delivery/prebid-server/win/333",
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/cwire/cwiretest/exemplary/app.json
+++ b/adapters/cwire/cwiretest/exemplary/app.json
@@ -1,0 +1,146 @@
+{
+  "mockBidRequest": {
+    "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+    "cur": [
+      "CHF"
+    ],
+    "imp": [
+      {
+        "id": "102",
+        "banner": {
+          "h": 250,
+          "w": 300,
+          "pos": 0
+        }
+      }
+    ],
+    "app": {
+      "publisher": {
+        "id": "123456789"
+      },
+      "cat": [
+        "IAB22-1"
+      ],
+      "bundle": "com.app.awesome",
+      "name": "Awesome App",
+      "domain": "awesomeapp.com",
+      "id": "123456789"
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:108.0) Gecko/20100101 Firefox/108.0"
+    },
+    "user": {
+      "id": "55816b39711f9b5acf3b90e313ed29e51665623f",
+      "geo": {
+        "country": "ch",
+        "region": "basel-stadt",
+        "city": "basel"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://cwi.re/prebid/adapter-endpoint",
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "body": {
+          "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+          "cur": [
+            "CHF"
+          ],
+          "imp": [
+            {
+              "id": "102",
+              "banner": {
+                "h": 250,
+                "w": 300,
+                "pos": 0
+              }
+            }
+          ],
+          "app": {
+            "publisher": {
+              "id": "123456789"
+            },
+            "cat": [
+              "IAB22-1"
+            ],
+            "bundle": "com.app.awesome",
+            "name": "Awesome App",
+            "domain": "awesomeapp.com",
+            "id": "123456789"
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:108.0) Gecko/20100101 Firefox/108.0"
+          },
+          "user": {
+            "id": "55816b39711f9b5acf3b90e313ed29e51665623f",
+            "geo": {
+              "country": "ch",
+              "region": "basel-stadt",
+              "city": "basel"
+            }
+          }
+        },
+        "impIDs": [
+          "102"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "headers": {},
+        "body": {
+          "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+          "cur": "CHF",
+          "seatbid": [
+            {
+              "seat": "cwire",
+              "group": 0,
+              "bid": [
+                {
+                  "id": "333",
+                  "impid": "102",
+                  "price": 8.00,
+                  "crid": "4321",
+                  "adm": "<h3>Example Ad</h3>",
+                  "w": 1,
+                  "h": 1,
+                  "nurl": "https://embed.cwi.re/delivery/prebid-server/win/333",
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "CHF",
+      "bids": [
+        {
+          "bid": {
+            "id": "333",
+            "impid": "102",
+            "price": 8.00,
+            "crid": "4321",
+            "adm": "<h3>Example Ad</h3>",
+            "w": 1,
+            "h": 1,
+            "nurl": "https://embed.cwi.re/delivery/prebid-server/win/333",
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/cwire/params_test.go
+++ b/adapters/cwire/params_test.go
@@ -55,6 +55,9 @@ var validParams = []string{
 	`{"placementId":123,"pageId":321,"cwcreative":"3746"}`,
 	`{"placementId":123,"pageId":321}`,
 	`{"placementId":123}`,
+	`{"placementId":123,"domainId":333,"pageId":321,"cwcreative":"3746"}`,
+	`{"placementId":123,"domainId":333,"pageId":321}`,
+	`{"placementId":123},"domainId":333}`,
 	`{}`,
 }
 

--- a/openrtb_ext/imp_cwire.go
+++ b/openrtb_ext/imp_cwire.go
@@ -2,6 +2,7 @@ package openrtb_ext
 
 // ImpExtCwire defines the contract for MakeRequests `request.imp[i].ext.bidder`
 type ImpExtCWire struct {
+	DomainID    int      `json:"domainId,omitempty"`
 	PlacementID int      `json:"placementId,omitempty"`
 	PageID      int      `json:"pageId,omitempty"`
 	CwCreative  string   `json:"cwcreative,omitempty"`

--- a/static/bidder-info/cwire.yaml
+++ b/static/bidder-info/cwire.yaml
@@ -5,6 +5,9 @@ endpointCompression: gzip
 gvlVendorID: 1081
 modifyingVastXmlAllowed: false
 capabilities:
+  app:
+    mediaTypes:
+      - banner
   site:
     mediaTypes:
       - banner

--- a/static/bidder-params/cwire.json
+++ b/static/bidder-params/cwire.json
@@ -8,9 +8,13 @@
       "type": "integer",
       "description": "An ID which identifies this placement of the impression"
     },
-    "pageId": {
+    "domainId": {
       "type": "integer",
       "description": "An ID which identifies the site selling the impression"
+    },
+    "pageId": {
+      "type": "integer",
+      "description": "An ID which identifies the site selling the impression (deprecated)"
     },
     "cwcreative": {
       "type": "string",


### PR DESCRIPTION
This updates the CWire adapter:

1. adds 'domainId'
2. adds the 'app' capability.

The docs are already updated since we did the analogous change for Prebid.js.
