### PR TITLE
PubMatic: Remove empty prebid object from failing tests

### DIFF
--- a/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExt.json
@@ -102,8 +102,7 @@
                         "wrapper": {
                             "profile": 5123,
                             "version": 1
-                        },
-                        "prebid": {}
+                        }
                     }
                 },
                 "impIDs": [

--- a/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExtPrebid.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExtPrebid.json
@@ -110,8 +110,7 @@
                         "wrapper": {
                             "profile": 5123,
                             "version": 1
-                        },
-                        "prebid": {}
+                        }
                     }
                 },
                 "impIDs": [


### PR DESCRIPTION
Fixes tests introduced in #4000 that were not updated in accordance with #4092.