### PR TITLE
Fix: Rubicon segtax test

### DIFF
--- a/adapters/rubicon/rubicontest/exemplary/segtax-attributes.json
+++ b/adapters/rubicon/rubicontest/exemplary/segtax-attributes.json
@@ -408,11 +408,7 @@
                     "pbadslot": "pbadslot",
                     "pbs_login": "xuser",
                     "pbs_url": "http://hosturl.com",
-                    "pbs_version": "",
-                    "pagecat": [
-                      "val1",
-                      "val2"
-                    ]
+                    "pbs_version": ""
                   },
                   "track": {
                     "mint": "",


### PR DESCRIPTION
#3919 was merged a few weeks ago which removed logic that copies `pagecat` to `imp[].ext.rp.target`. Then #3915 was merged which added a new test that expected `imp[].ext.rp.target.pagecat` to exist. This PR rectifies this by removing the new test expectation.