### PR TITLE
Fix graceful shutdown if admin server is not enabled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	stopAdmin := make(chan os.Signal)
 	stopMain := make(chan os.Signal)
 	stopPrometheus := make(chan os.Signal)
+	var stopChannels = []chan<- os.Signal{stopMain}
 	done := make(chan struct{})
 
 	if cfg.UnixSocketEnable && len(cfg.UnixSocketName) > 0 { // start the unix_socket server if config enable-it.
@@ -54,6 +55,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 	}
 
 	if cfg.Admin.Enabled {
+		stopChannels = append(stopChannels, stopAdmin)
 		adminServer := newAdminServer(cfg, adminHandler)
 		go shutdownAfterSignals(adminServer, stopAdmin, done)
 
@@ -70,6 +72,7 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 			prometheusListener net.Listener
 			prometheusServer   = newPrometheusServer(cfg, metrics)
 		)
+		stopChannels = append(stopChannels, stopPrometheus)
 		go shutdownAfterSignals(prometheusServer, stopPrometheus, done)
 		if prometheusListener, err = newTCPListener(prometheusServer.Addr, nil); err != nil {
 			glog.Errorf("Error listening for TCP connections on %s: %v for prometheus server", prometheusServer.Addr, err)
@@ -77,10 +80,9 @@ func Listen(cfg *config.Configuration, handler http.Handler, adminHandler http.H
 		}
 
 		go runServer(prometheusServer, "Prometheus", prometheusListener)
-		wait(stopSignals, done, stopMain, stopAdmin, stopPrometheus)
-	} else {
-		wait(stopSignals, done, stopMain, stopAdmin)
 	}
+
+	wait(stopSignals, done, stopChannels...)
 
 	return
 }


### PR DESCRIPTION
If admin server is not enabled https://github.com/prebid/prebid-server/blob/243c0f06f0f9ea2cb6cf0994dc7791ae63e957ed/server/server.go#L56-L58
PBS cannot stop gracefully as it awaits on `stopAdmin` channel which is never triggered https://github.com/prebid/prebid-server/blob/243c0f06f0f9ea2cb6cf0994dc7791ae63e957ed/server/server.go#L80
