### PR TITLE
Revert "Fix: Rubicon segtax test (#4143)"

### DIFF
--- a/adapters/rubicon/rubicontest/exemplary/segtax-attributes.json
+++ b/adapters/rubicon/rubicontest/exemplary/segtax-attributes.json
@@ -408,7 +408,11 @@
                     "pbadslot": "pbadslot",
                     "pbs_login": "xuser",
                     "pbs_url": "http://hosturl.com",
-                    "pbs_version": ""
+                    "pbs_version": "",
+                    "pagecat": [
+                      "val1",
+                      "val2"
+                    ]
                   },
                   "track": {
                     "mint": "",


### PR DESCRIPTION
This reverts commit 02048f2062c539a94b7123c470ea917d33ec4147.

This is the first of two Rubicon segtax related reverts.

The segtax behavior is unpredictable and is suspected to be attributed to the use of an unmaintained library that was introduced as part of this effort.