### PR TITLE
Remove deprecated github.com/pkg/errors

### DIFF
--- a/adservertargeting/requestlookup.go
+++ b/adservertargeting/requestlookup.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/pkg/errors"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 )
 
@@ -93,7 +92,7 @@ func getValueFromQueryParam(path string, queryParams url.Values) (json.RawMessag
 		if val != "" {
 			return json.RawMessage(val), nil
 		} else {
-			return nil, errors.Errorf("value not found for path: %s", path)
+			return nil, fmt.Errorf("value not found for path: %s", path)
 		}
 	}
 	return nil, nil

--- a/adservertargeting/respdataprocessor.go
+++ b/adservertargeting/respdataprocessor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 	"github.com/prebid/prebid-server/v3/util/jsonutil"
@@ -170,7 +169,7 @@ func getRespData(bidderResp *openrtb2.BidResponse, field string) (string, error)
 		return fmt.Sprint(bidderResp.NBR.Val()), nil
 
 	default:
-		return "", errors.Errorf("key not found for field in bid response: %s", field)
+		return "", fmt.Errorf("key not found for field in bid response: %s", field)
 	}
 
 }

--- a/adservertargeting/utils.go
+++ b/adservertargeting/utils.go
@@ -1,10 +1,10 @@
 package adservertargeting
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/pkg/errors"
 	"github.com/prebid/prebid-server/v3/errortypes"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 )
@@ -40,12 +40,12 @@ func typedLookup(data []byte, path string, keys ...string) ([]byte, error) {
 	if err != nil && err != jsonparser.KeyPathNotFoundError {
 		return nil, err
 	} else if err != nil && err == jsonparser.KeyPathNotFoundError {
-		return nil, errors.Errorf("value not found for path: %s", path)
+		return nil, fmt.Errorf("value not found for path: %s", path)
 	}
 	if verifyType(dataType) {
 		return value, nil
 	}
-	return nil, errors.Errorf("incorrect value type for path: %s, value can only be string or number", path)
+	return nil, fmt.Errorf("incorrect value type for path: %s, value can only be string or number", path)
 }
 
 func verifyType(dataType jsonparser.ValueType) bool {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/modern-go/reflect2 v1.0.2
-	github.com/pkg/errors v0.9.1
 	github.com/prebid/go-gdpr v1.12.0
 	github.com/prebid/go-gpp v0.2.0
 	github.com/prebid/openrtb/v20 v20.3.0
@@ -63,6 +62,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/modules/fiftyonedegrees/devicedetection/config.go
+++ b/modules/fiftyonedegrees/devicedetection/config.go
@@ -2,11 +2,10 @@ package devicedetection
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
-	"github.com/pkg/errors"
-
 	"github.com/prebid/prebid-server/v3/util/jsonutil"
 )
 
@@ -65,7 +64,7 @@ func (c *config) getPerformanceProfile() dd.PerformanceProfile {
 func parseConfig(data json.RawMessage) (config, error) {
 	var cfg config
 	if err := jsonutil.UnmarshalValid(data, &cfg); err != nil {
-		return cfg, errors.Wrap(err, "failed to parse config")
+		return cfg, fmt.Errorf("failed to parse config: %w", err)
 	}
 	return cfg, nil
 }
@@ -73,7 +72,7 @@ func parseConfig(data json.RawMessage) (config, error) {
 func validateConfig(cfg config) error {
 	_, err := os.Stat(cfg.DataFile.Path)
 	if err != nil {
-		return errors.Wrap(err, "error opening hash file path")
+		return fmt.Errorf("error opening hash file path: %w", err)
 	}
 
 	return nil

--- a/modules/fiftyonedegrees/devicedetection/device_detector.go
+++ b/modules/fiftyonedegrees/devicedetection/device_detector.go
@@ -1,9 +1,10 @@
 package devicedetection
 
 import (
+	"fmt"
+
 	"github.com/51Degrees/device-detection-go/v4/dd"
 	"github.com/51Degrees/device-detection-go/v4/onpremise"
-	"github.com/pkg/errors"
 )
 
 type engine interface {
@@ -28,7 +29,7 @@ func newDeviceDetector(cfg *dd.ConfigHash, moduleConfig *config) (*defaultDevice
 		engineOptions...,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create onpremise engine.")
+		return nil, fmt.Errorf("failed to create onpremise engine: %w", err)
 	}
 
 	deviceDetector := &defaultDeviceDetector{
@@ -147,7 +148,7 @@ func (x defaultDeviceDetector) getSupportedHeaders() []dd.EvidenceKey {
 func (x defaultDeviceDetector) getDeviceInfo(evidence []onpremise.Evidence, ua string) (*deviceInfo, error) {
 	results, err := x.engine.Process(evidence)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to process evidence")
+		return nil, fmt.Errorf("failed to process evidence: %w", err)
 	}
 	defer results.Free()
 

--- a/modules/fiftyonedegrees/devicedetection/device_info_extractor.go
+++ b/modules/fiftyonedegrees/devicedetection/device_info_extractor.go
@@ -1,10 +1,10 @@
 package devicedetection
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // deviceInfoExtractor is a struct that contains the methods to extract device information
@@ -61,7 +61,7 @@ func (x deviceInfoExtractor) extract(results Results, ua string) (*deviceInfo, e
 	geoLocation, _ := strconv.ParseBool(x.getValue(results, deviceInfoGeoLocation))
 	deviceId, err := results.DeviceId()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get device id.")
+		return nil, fmt.Errorf("failed to get device id: %w", err)
 	}
 	hardwareModel := x.getValue(results, deviceInfoHardwareModel)
 	hardwareFamily := x.getValue(results, deviceInfoHardwareFamily)

--- a/modules/fiftyonedegrees/devicedetection/evidence_extractor.go
+++ b/modules/fiftyonedegrees/devicedetection/evidence_extractor.go
@@ -1,12 +1,12 @@
 package devicedetection
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
-	"github.com/51Degrees/device-detection-go/v4/onpremise"
-	"github.com/pkg/errors"
-
 	"github.com/51Degrees/device-detection-go/v4/dd"
+	"github.com/51Degrees/device-detection-go/v4/onpremise"
 	"github.com/prebid/prebid-server/v3/hooks/hookstage"
 )
 
@@ -62,11 +62,11 @@ func (x *defaultEvidenceExtractor) extract(ctx hookstage.ModuleContext) ([]onpre
 
 	suaStrings, err := x.getEvidenceStrings(ctx[evidenceFromSuaCtxKey])
 	if err != nil {
-		return nil, "", errors.Wrap(err, "error extracting sua evidence")
+		return nil, "", fmt.Errorf("error extracting sua evidence: %w", err)
 	}
 	headerString, err := x.getEvidenceStrings(ctx[evidenceFromHeadersCtxKey])
 	if err != nil {
-		return nil, "", errors.Wrap(err, "error extracting header evidence")
+		return nil, "", fmt.Errorf("error extracting header evidence: %w", err)
 	}
 
 	// Merge evidence from headers and SUA, sua has higher priority

--- a/modules/fiftyonedegrees/devicedetection/module.go
+++ b/modules/fiftyonedegrees/devicedetection/module.go
@@ -3,11 +3,11 @@ package devicedetection
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 	"github.com/51Degrees/device-detection-go/v4/onpremise"
-	"github.com/pkg/errors"
 	"github.com/prebid/prebid-server/v3/hooks/hookstage"
 	"github.com/prebid/prebid-server/v3/modules/moduledeps"
 )
@@ -35,12 +35,12 @@ func configHashFromConfig(cfg *config) *dd.ConfigHash {
 func Builder(rawConfig json.RawMessage, _ moduledeps.ModuleDeps) (interface{}, error) {
 	cfg, err := parseConfig(rawConfig)
 	if err != nil {
-		return Module{}, errors.Wrap(err, "failed to parse config")
+		return Module{}, fmt.Errorf("failed to parse config: %w", err)
 	}
 
 	err = validateConfig(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid config")
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	configHash := configHashFromConfig(&cfg)
@@ -50,7 +50,7 @@ func Builder(rawConfig json.RawMessage, _ moduledeps.ModuleDeps) (interface{}, e
 		&cfg,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create device detector")
+		return nil, fmt.Errorf("failed to create device detector: %w", err)
 	}
 
 	return Module{


### PR DESCRIPTION
github.com/pkg/errors is obsolete. https://pkg.go.dev/fmt#Errorf supports `%w` for wrapped errors