### PR TITLE
Update code-path-changes workflow

### DIFF
--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -1,7 +1,7 @@
 name: Notify Code Path Changes
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths:
       - '**'


### PR DESCRIPTION
turns out that github won't send environmental secrets for the 'pull_request' action, but it will on 'pull_request_target'.

Sorry, didn't know this for the first round. 

Tested in the sourcecred repo.