### PR TITLE
Tighten security on code-path-changes workflow

### DIFF
--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -14,6 +14,9 @@ env:
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The PBS-Java team did some research and found that there are some potential vulnerabilities with pull_request_trigger workflows that allow GITHUB_TOKEN writes. This update limits this action to read activities.