### PR TITLE
Currency: Common currency reference conversion

### DIFF
--- a/currency/aggregate_conversions_test.go
+++ b/currency/aggregate_conversions_test.go
@@ -64,9 +64,16 @@ func TestGroupedGetRate(t *testing.T) {
 			},
 		},
 		{
-			expectedError: ConversionNotFoundError{FromCur: "GBP", ToCur: "EUR"},
+			expectedError: ConversionNotFoundError{FromCur: "RON", ToCur: "EUR"},
 			testCases: []aTest{
-				{"Valid three-digit currency codes, but conversion rate not found", "GBP", "EUR", 0},
+				{"Valid three-digit currency codes, but conversion from-currency rate not found", "RON", "EUR", 0},
+				{"Valid three-digit currency codes, but conversion to-currency rate not found", "EUR", "RON", 0},
+			},
+		},
+		{
+			expectedError: nil,
+			testCases: []aTest{
+				{"Valid three-digit currency codes, intermediate conversion rate has been used", "GBP", "EUR", 2 / 3.0},
 			},
 		},
 	}

--- a/currency/rates.go
+++ b/currency/rates.go
@@ -46,6 +46,19 @@ func (r *Rates) GetRate(from, to string) (float64, error) {
 			// In case we have an entry TO -> FROM
 			return 1 / conversion, nil
 		}
+
+		// Try to find currency rates via intermediate currency
+		for _, units := range r.Conversions {
+			toConversion, toPresent := units[toUnit.String()]
+			if !toPresent {
+				continue
+			}
+			fromConversion, fromPresent := units[fromUnit.String()]
+			if fromPresent {
+				return toConversion / fromConversion, nil
+			}
+		}
+
 		return 0, ConversionNotFoundError{FromCur: fromUnit.String(), ToCur: toUnit.String()}
 	}
 	return 0, errors.New("rates are nil")

--- a/currency/rates.go
+++ b/currency/rates.go
@@ -20,10 +20,10 @@ func NewRates(conversions map[string]map[string]float64) *Rates {
 	}
 }
 
-// FindConversionRate returns the conversion rate between two currencies
+// FindIntermediateConversionRate returns the conversion rate between two currencies
 // if a valid conversion exists in the provided rates container.
 // Otherwise, it returns a ConversionNotFoundError.
-func FindConversionRate(r *Rates, from, to currency.Unit) (float64, error) {
+func FindIntermediateConversionRate(r *Rates, from, to currency.Unit) (float64, error) {
 	for _, conversions := range r.Conversions {
 		toRate, hasToRate := conversions[to.String()]
 		fromRate, hasFromRate := conversions[from.String()]
@@ -64,7 +64,7 @@ func (r *Rates) GetRate(from, to string) (float64, error) {
 		}
 
 		// Try to find currency rates via intermediate currency
-		return FindConversionRate(r, fromUnit, toUnit)
+		return FindIntermediateConversionRate(r, fromUnit, toUnit)
 	}
 	return 0, errors.New("rates are nil")
 }

--- a/currency/rates_test.go
+++ b/currency/rates_test.go
@@ -186,6 +186,79 @@ func TestGetRate_ReverseConversion(t *testing.T) {
 	}
 }
 
+func TestGetRate_IntermediateConversion(t *testing.T) {
+
+	// Setup:
+	rates := NewRates(map[string]map[string]float64{
+		"USD": {
+			"SEK": 10.23842,
+			"NOK": 10.47089,
+		},
+		"EUR": {
+			"THB": 35.23842,
+			"ZAR": 18.47089,
+		},
+	})
+
+	testCases := []struct {
+		from         string
+		to           string
+		expectedRate float64
+		description  string
+		hasError     bool
+	}{
+		{
+			from:         "NOK",
+			to:           "SEK",
+			expectedRate: 0.9777984488424574,
+			hasError:     false,
+			description:  "case 1 - Both rates are present in intermediate USD currency",
+		},
+		{
+			from:         "SEK",
+			to:           "NOK",
+			expectedRate: 1 / 0.9777984488424574,
+			hasError:     false,
+			description:  "case 2 - Both rates are present in intermediate USD currency inverse",
+		},
+		{
+			from:         "THB",
+			to:           "ZAR",
+			expectedRate: 0.5241690745498806,
+			hasError:     false,
+			description:  "case 3 - Both rates are present in intermediate EUR currency",
+		},
+		{
+			from:         "ZAR",
+			to:           "THB",
+			expectedRate: 1 / 0.5241690745498806,
+			hasError:     false,
+			description:  "case 4 - Both rates are present in intermediate EUR currency inverse",
+		},
+		{
+			from:         "NOK",
+			to:           "ZAR",
+			expectedRate: 0,
+			hasError:     true,
+			description:  "case 5 - Rates are present in different intermediate currencies, unable to convert error should be returned",
+		},
+	}
+
+	for _, tc := range testCases {
+		// Execute:
+		rate, err := rates.GetRate(tc.from, tc.to)
+
+		// Verify:
+		if tc.hasError {
+			assert.NotNil(t, err, "err shouldn't be nil")
+			assert.Equal(t, float64(0), rate, "rate should be 0")
+		} else {
+			assert.Nil(t, err, "err should be nil: "+tc.description)
+			assert.Equal(t, tc.expectedRate, rate, "rate doesn't match the expected one: "+tc.description)
+		}
+	}
+}
+
 func TestGetRate_EmptyRates(t *testing.T) {
 
 	// Setup:

--- a/currency/rates_test.go
+++ b/currency/rates_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/prebid/prebid-server/v3/util/jsonutil"
+	"golang.org/x/text/currency"
 )
 
 func TestUnMarshallRates(t *testing.T) {
@@ -186,8 +187,7 @@ func TestGetRate_ReverseConversion(t *testing.T) {
 	}
 }
 
-func TestGetRate_IntermediateConversion(t *testing.T) {
-
+func TestGetRate_FindConversionRate(t *testing.T) {
 	// Setup:
 	rates := NewRates(map[string]map[string]float64{
 		"USD": {
@@ -246,7 +246,16 @@ func TestGetRate_IntermediateConversion(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Execute:
-		rate, err := rates.GetRate(tc.from, tc.to)
+		fromUnit, err := currency.ParseISO(tc.from)
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
+		toUnit, err := currency.ParseISO(tc.to)
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
+
+		rate, err := FindConversionRate(rates, fromUnit, toUnit)
 
 		// Verify:
 		if tc.hasError {


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] technical debt (test coverage, refactoring, etc.)

### ✨ What's the context?
https://github.com/prebid/prebid-server/issues/3566

### 🧠 Rationale behind the change
The Prebid.js currency module is able to cross convert currencies using USD (or GBP) as a common currency reference. This feature is not currently implemented in PBS Go, so the following error exists:
`Unable to convert from currency NOK to desired ad server currency SEK`.

In this PR we implement the common currency reference conversion logic (`FindIntermediateConversionRate` method) in the `currency` package.

[Related change in PBS Java](https://github.com/prebid/prebid-server-java/pull/3084)

### 🧪 Test plan
New functionality is covered by `TestGetRate_FindIntermediateConversionRate` unit test in `currency/rates_test.go`.