### PR TITLE
Consumable Adaptor:  Endpoint Update

### DIFF
--- a/static/bidder-info/consumable.yaml
+++ b/static/bidder-info/consumable.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://e.serverbid.com/api/v2"
+endpoint: "https://e.serverbid.com"
 maintainer:
   email: "prebid@consumable.com"
 gvlVendorID: 591


### PR DESCRIPTION
Updating the endpoint to a new version that removed the /api/v2 at the end.