### PR TITLE
fix endpoint of Ogury adapter

### DIFF
--- a/static/bidder-info/ogury.yaml
+++ b/static/bidder-info/ogury.yaml
@@ -1,4 +1,4 @@
-endpoint: "http://prebids2s.presage.io/api/header-bidding-request"
+endpoint: "https://prebids2s.presage.io/api/header-bidding-request"
 endpointCompression: gzip
 geoscope:
   - global


### PR DESCRIPTION
This should be `https`.
The `http` endpoint just does a redirect to `https`. 