### PR TITLE
Include EIDs from user.ext.eids in 2.6 upgrade function

### DIFF
--- a/openrtb_ext/convert_up.go
+++ b/openrtb_ext/convert_up.go
@@ -193,7 +193,6 @@ func moveEIDFrom25To26(r *RequestWrapper) {
 	r.User.EIDs = existingEIDs
 }
 
-
 // moveRewardedFromPrebidExtTo26 modifies the impression to move the Prebid specific
 // rewarded video signal (imp[].ext.prebid.is_rewarded_inventory) to the OpenRTB 2.6
 // location (imp[].rwdd). If the OpenRTB 2.6 location is already present the Prebid

--- a/openrtb_ext/convert_up.go
+++ b/openrtb_ext/convert_up.go
@@ -168,30 +168,31 @@ func moveEIDFrom25To26(r *RequestWrapper) {
 		return
 	}
 
-	// If 2.6 location is present, append only new eids based on 'source'
+	// If 2.6 location is present, append only new eids based on 'source'.
 	existingEIDs := r.User.EIDs
 	for _, eid25 := range *eids25 {
-		// We only compare if both 'source' fields are non-nil.
-		// Adjust this if you need special handling for nil sources.
-		if eid25.Source == nil {
-			// Example: always append if source is nil:
+		// If source is empty, decide what to do. Example: always append if empty
+		if eid25.Source == "" {
 			existingEIDs = append(existingEIDs, eid25)
 			continue
 		}
 
 		found := false
 		for _, eid26 := range existingEIDs {
-			if eid26.Source != nil && *eid25.Source == *eid26.Source {
+			// Compare strings directly
+			if eid25.Source == eid26.Source {
 				found = true
 				break
 			}
 		}
+
 		if !found {
 			existingEIDs = append(existingEIDs, eid25)
 		}
 	}
 	r.User.EIDs = existingEIDs
 }
+
 
 // moveRewardedFromPrebidExtTo26 modifies the impression to move the Prebid specific
 // rewarded video signal (imp[].ext.prebid.is_rewarded_inventory) to the OpenRTB 2.6

--- a/openrtb_ext/convert_up.go
+++ b/openrtb_ext/convert_up.go
@@ -147,51 +147,50 @@ func moveUSPrivacyFrom25To26(r *RequestWrapper) {
 
 // moveEIDFrom25To26 modifies the request to move the OpenRTB 2.5 external identifiers
 // (req.user.ext.eids) to the OpenRTB 2.6 location (req.user.eids). If the OpenRTB 2.6
-// location is already present the OpenRTB 2.5 external identifiers are appended for 
+// location is already present the OpenRTB 2.5 external identifiers are appended for
 // sources not already in the eids array
 func moveEIDFrom25To26(r *RequestWrapper) {
-    // Read 2.5 location
-    userExt, _ := r.GetUserExt()
-    eids25 := userExt.GetEid()
+	// Read 2.5 location
+	userExt, _ := r.GetUserExt()
+	eids25 := userExt.GetEid()
 
-    // Clear 2.5 location
-    userExt.SetEid(nil)
+	// Clear 2.5 location
+	userExt.SetEid(nil)
 
-    // If there's no eids25, there's nothing to move or merge
-    if eids25 == nil || len(*eids25) == 0 {
-        return
-    }
+	// If there's no eids25, there's nothing to move or merge
+	if eids25 == nil || len(*eids25) == 0 {
+		return
+	}
 
-    // If there's no 2.6 location, simply set eids
-    if r.User.EIDs == nil {
-        r.User.EIDs = *eids25
-        return
-    }
+	// If there's no 2.6 location, simply set eids
+	if r.User.EIDs == nil {
+		r.User.EIDs = *eids25
+		return
+	}
 
-    // If 2.6 location is present, append only new eids based on 'source'
-    existingEIDs := r.User.EIDs
-    for _, eid25 := range *eids25 {
-        // We only compare if both 'source' fields are non-nil.
-        // Adjust logic if you need to handle nil sources differently.
-        if eid25.Source == nil {
-            // If your spec allows a nil source and you want to handle it,
-            // you may choose to always append or skip. Example: always append:
-            existingEIDs = append(existingEIDs, eid25)
-            continue
-        }
+	// If 2.6 location is present, append only new eids based on 'source'
+	existingEIDs := r.User.EIDs
+	for _, eid25 := range *eids25 {
+		// We only compare if both 'source' fields are non-nil.
+		// Adjust this if you need special handling for nil sources.
+		if eid25.Source == nil {
+			// Example: always append if source is nil:
+			existingEIDs = append(existingEIDs, eid25)
+			continue
+		}
 
-        found := false
-        for _, eid26 := range existingEIDs {
-            if eid26.Source != nil && *eid25.Source == *eid26.Source {
-                found = true
-                break
-            }
-        }
-        if !found {
-            existingEIDs = append(existingEIDs, eid25)
-        }
-    }
-    r.User.EIDs = existingEIDs
+		found := false
+		for _, eid26 := range existingEIDs {
+			if eid26.Source != nil && *eid25.Source == *eid26.Source {
+				found = true
+				break
+			}
+		}
+		if !found {
+			existingEIDs = append(existingEIDs, eid25)
+		}
+	}
+	r.User.EIDs = existingEIDs
 }
 
 // moveRewardedFromPrebidExtTo26 modifies the impression to move the Prebid specific

--- a/openrtb_ext/convert_up.go
+++ b/openrtb_ext/convert_up.go
@@ -194,7 +194,6 @@ func moveEIDFrom25To26(r *RequestWrapper) {
     r.User.EIDs = existingEIDs
 }
 
-
 // moveRewardedFromPrebidExtTo26 modifies the impression to move the Prebid specific
 // rewarded video signal (imp[].ext.prebid.is_rewarded_inventory) to the OpenRTB 2.6
 // location (imp[].rwdd). If the OpenRTB 2.6 location is already present the Prebid

--- a/openrtb_ext/convert_up.go
+++ b/openrtb_ext/convert_up.go
@@ -171,7 +171,7 @@ func moveEIDFrom25To26(r *RequestWrapper) {
 	// If 2.6 location is present, append only new eids based on 'source'.
 	existingEIDs := r.User.EIDs
 	for _, eid25 := range *eids25 {
-		// If source is empty, decide what to do. Example: always append if empty
+		// If source is empty, append
 		if eid25.Source == "" {
 			existingEIDs = append(existingEIDs, eid25)
 			continue

--- a/openrtb_ext/convert_up_test.go
+++ b/openrtb_ext/convert_up_test.go
@@ -375,33 +375,31 @@ func TestMoveEIDFrom25To26(t *testing.T) {
 		},
 		{
 			description: "2.5 Appended Because Different Source from all 2.6 eids",
-  			givenRequest: openrtb2.BidRequest{
-    				User: &openrtb2.User{
-      					EIDs: []openrtb2.EID{{Source: "1"}},
-      					Ext:  json.RawMessage(`{"eids":[{"source":"2"}]}`),
-    				},
-  			},
-  			expectedRequest: openrtb2.BidRequest{
-    				User: &openrtb2.User{
-      					// We now expect both EIDs to be present
-      					EIDs: []openrtb2.EID{{Source: "1"}, {Source: "2"}},
-    				},
-  			},
+			givenRequest: openrtb2.BidRequest{
+				User: &openrtb2.User{
+					EIDs: []openrtb2.EID{{Source: "1"}},
+					Ext:  json.RawMessage(`{"eids":[{"source":"2"}]}`),
+				},
+			},
+			expectedRequest: openrtb2.BidRequest{
+				User: &openrtb2.User{
+					EIDs: []openrtb2.EID{{Source: "1"}, {Source: "2"}},
+				},
+			},
 		},
 		{
 			description: "2.5 Not Appended Because Same Source exists IN 2.6",
-  			givenRequest: openrtb2.BidRequest{
-    				User: &openrtb2.User{
-      					EIDs: []openrtb2.EID{{Source: "1"}},              
-     					Ext:  json.RawMessage(`{"eids":[{"source":"1"}]}`),
-    				},
-  			},
-  			expectedRequest: openrtb2.BidRequest{
-    				User: &openrtb2.User{
-      					// We do NOT expect a duplicate {Source:"1"} to be appended
-      					EIDs: []openrtb2.EID{{Source: "1"}},
-    				},
-  			},
+			givenRequest: openrtb2.BidRequest{
+				User: &openrtb2.User{
+					EIDs: []openrtb2.EID{{Source: "1"}},
+					Ext:  json.RawMessage(`{"eids":[{"source":"1"}]}`),
+				},
+			},
+			expectedRequest: openrtb2.BidRequest{
+				User: &openrtb2.User{
+					EIDs: []openrtb2.EID{{Source: "1"}},
+				},
+			},
 		},
 		{
 			description:     "2.6 Left Alone",

--- a/openrtb_ext/convert_up_test.go
+++ b/openrtb_ext/convert_up_test.go
@@ -378,7 +378,7 @@ func TestMoveEIDFrom25To26(t *testing.T) {
 			givenRequest: openrtb2.BidRequest{
 				User: &openrtb2.User{
 					EIDs: []openrtb2.EID{{Source: "1"}},
-					Ext:  json.RawMessage(`{"eids":[{"source":"2"}]}`),
+					Ext:  eid2Json,
 				},
 			},
 			expectedRequest: openrtb2.BidRequest{
@@ -392,7 +392,7 @@ func TestMoveEIDFrom25To26(t *testing.T) {
 			givenRequest: openrtb2.BidRequest{
 				User: &openrtb2.User{
 					EIDs: []openrtb2.EID{{Source: "1"}},
-					Ext:  json.RawMessage(`{"eids":[{"source":"1"}]}`),
+					Ext:  eid1Json,
 				},
 			},
 			expectedRequest: openrtb2.BidRequest{

--- a/openrtb_ext/convert_up_test.go
+++ b/openrtb_ext/convert_up_test.go
@@ -374,9 +374,34 @@ func TestMoveEIDFrom25To26(t *testing.T) {
 			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1}},
 		},
 		{
-			description:     "2.5 Dropped",
-			givenRequest:    openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1, Ext: eid2Json}},
-			expectedRequest: openrtb2.BidRequest{User: &openrtb2.User{EIDs: eid1}},
+			description: "2.5 Appended Because Different Source from all 2.6 eids",
+  			givenRequest: openrtb2.BidRequest{
+    				User: &openrtb2.User{
+      					EIDs: []openrtb2.EID{{Source: "1"}},
+      					Ext:  json.RawMessage(`{"eids":[{"source":"2"}]}`),
+    				},
+  			},
+  			expectedRequest: openrtb2.BidRequest{
+    				User: &openrtb2.User{
+      					// We now expect both EIDs to be present
+      					EIDs: []openrtb2.EID{{Source: "1"}, {Source: "2"}},
+    				},
+  			},
+		},
+		{
+			description: "2.5 Not Appended Because Same Source exists IN 2.6",
+  			givenRequest: openrtb2.BidRequest{
+    				User: &openrtb2.User{
+      					EIDs: []openrtb2.EID{{Source: "1"}},              
+     					Ext:  json.RawMessage(`{"eids":[{"source":"1"}]}`),
+    				},
+  			},
+  			expectedRequest: openrtb2.BidRequest{
+    				User: &openrtb2.User{
+      					// We do NOT expect a duplicate {Source:"1"} to be appended
+      					EIDs: []openrtb2.EID{{Source: "1"}},
+    				},
+  			},
 		},
 		{
 			description:     "2.6 Left Alone",


### PR DESCRIPTION
PR to propose we keep all the eids on 2.6 upgrade from both the 2.5 location and the 2.6 location if both exist. This may frequently happen if PBS js adapter is setting the 2.6 location and the publisher is manually writing to the 2.5 location.