### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go
-			"VARIANT": "1.23",
+			"VARIANT": "1.24",
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"

--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.4
+          go-version: 1.24.0
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.4
+        go-version: 1.24.0
 
     - name: Checkout Merged Branch
       uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y wget
 WORKDIR /tmp
-RUN wget https://dl.google.com/go/go1.23.4.linux-amd64.tar.gz && \
-    tar -xf go1.23.4.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz && \
+    tar -xf go1.24.0.linux-amd64.tar.gz && \
     mv go /usr/local
 RUN mkdir -p /app/prebid-server/
 WORKDIR /app/prebid-server/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that you deploy the `/static` directory, as Prebid Server requires those 
 
 ## Developing
 
-Prebid Server requires [Go](https://go.dev) version 1.22 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
+Prebid Server requires [Go](https://go.dev) version 1.23 or newer. You can develop on any operating system that Go supports; however, please note that our helper scripts are written in bash.
 
 1. Clone The Repository
 ``` bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prebid/prebid-server/v3
 
-go 1.22
+go 1.23
 
 retract v3.0.0 // Forgot to update major version in import path and module name
 


### PR DESCRIPTION
Updates the main build from 1.23 to 1.24. Upgrades the minimum feature set from 1.22 to 1.23.