### PR TITLE
OpenX: Determine bid type from bid.mtype

### DIFF
--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -236,7 +236,7 @@ func (a *OpenxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRe
 		for i := range sb.Bid {
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
 				Bid:      &sb.Bid[i],
-				BidType:  getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp),
+				BidType:  getBidType(sb.Bid[i].MType, sb.Bid[i].ImpID, internalRequest.Imp),
 				BidVideo: getBidVideo(&sb.Bid[i]),
 			})
 		}
@@ -252,6 +252,19 @@ func getBidVideo(bid *openrtb2.Bid) *openrtb_ext.ExtBidPrebidVideo {
 	return &openrtb_ext.ExtBidPrebidVideo{
 		PrimaryCategory: primaryCategory,
 		Duration:        int(bid.Dur),
+	}
+}
+
+func getBidType(mtype openrtb2.MarkupType, impId string, imps []openrtb2.Imp) openrtb_ext.BidType {
+	switch mtype {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo
+	case openrtb2.MarkupNative:
+		return openrtb_ext.BidTypeNative
+	default:
+		return getMediaTypeForImp(impId, imps)
 	}
 }
 

--- a/adapters/openx/openxtest/exemplary/fledge.json
+++ b/adapters/openx/openxtest/exemplary/fledge.json
@@ -57,7 +57,8 @@
                 "adm": "some-test-ad",
                 "crid": "crid_10",
                 "h": 90,
-                "w": 728
+                "w": 728,
+                "mtype": 1
               }]
             }
           ],
@@ -91,7 +92,8 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 728,
-            "h": 90
+            "h": 90,
+            "mtype": 1
           },
           "type": "banner"
         }

--- a/adapters/openx/openxtest/exemplary/simple-banner.json
+++ b/adapters/openx/openxtest/exemplary/simple-banner.json
@@ -53,7 +53,8 @@
                 "adm": "{\"ver\": \"1.2\", \"assets\": [{\"id\": 1, \"required\": 1,\"title\": {\"text\": \"OpenX (Title)\"}}], \"link\": {\"url\": \"https://www.openx.com/\"}, \"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
                 "crid": "crid_10",
                 "h": 90,
-                "w": 728
+                "w": 728,
+                "mtype": 1
               }]
             }
           ],
@@ -75,7 +76,8 @@
             "adm": "{\"ver\": \"1.2\", \"assets\": [{\"id\": 1, \"required\": 1,\"title\": {\"text\": \"OpenX (Title)\"}}], \"link\": {\"url\": \"https://www.openx.com/\"}, \"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
             "crid": "crid_10",
             "w": 728,
-            "h": 90
+            "h": 90,
+            "mtype": 1
           },
           "type": "banner"
         }

--- a/adapters/openx/openxtest/exemplary/simple-native.json
+++ b/adapters/openx/openxtest/exemplary/simple-native.json
@@ -56,7 +56,8 @@
                 "adm": "{\"ver\": \"1.2\", \"assets\": [{\"id\": 1, \"required\": 1,\"title\": {\"text\": \"OpenX (Title)\"}}], \"link\": {\"url\": \"https://www.openx.com/\"}, \"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
                 "crid": "crid_10",
                 "w": 300,
-                "h": 200
+                "h": 200,
+                "mtype": 4
               }]
             }
           ]
@@ -77,7 +78,8 @@
             "adm": "{\"ver\": \"1.2\", \"assets\": [{\"id\": 1, \"required\": 1,\"title\": {\"text\": \"OpenX (Title)\"}}], \"link\": {\"url\": \"https://www.openx.com/\"}, \"eventtrackers\":[{\"event\":1,\"method\":1,\"url\":\"http://example.com/impression\"}]}",
             "crid": "crid_10",
             "w": 300,
-            "h": 200
+            "h": 200,
+            "mtype": 4
           },
           "type": "native"
         }

--- a/adapters/openx/openxtest/exemplary/simple-video.json
+++ b/adapters/openx/openxtest/exemplary/simple-video.json
@@ -63,7 +63,8 @@
                 "h": 576,
                 "cattax": 1,
                 "cat": ["IAB20"],
-                "dur": 30
+                "dur": 30,
+                "mtype": 2
               }]
             }
           ]
@@ -88,7 +89,8 @@
             "h": 576,
             "cattax": 1,
             "cat": ["IAB20"],
-            "dur": 30
+            "dur": 30,
+            "mtype": 2
           },
           "video": {
             "duration": 30,

--- a/adapters/openx/openxtest/exemplary/video-rewarded.json
+++ b/adapters/openx/openxtest/exemplary/video-rewarded.json
@@ -70,7 +70,8 @@
                 "adm": "some-test-ad",
                 "crid": "crid_10",
                 "w": 1024,
-                "h": 576
+                "h": 576,
+                "mtype": 2
               }]
             }
           ]
@@ -92,7 +93,8 @@
             "adm": "some-test-ad",
             "crid": "crid_10",
             "w": 1024,
-            "h": 576
+            "h": 576,
+            "mtype": 2
           },
           "type": "video"
         }

--- a/adapters/openx/openxtest/supplemental/missing-mtype.json
+++ b/adapters/openx/openxtest/supplemental/missing-mtype.json
@@ -36,26 +36,6 @@
         }
       },
       {
-        "id": "banner-imp-2",
-        "banner": {},
-        "ext": {
-          "bidder": {
-            "unit": "222",
-            "delDomain": "se-demo-d.openx.net"
-          }
-        }
-      },
-      {
-        "id": "video-imp-2",
-        "video": {"mimes": ["video/mp4"]},
-        "ext": {
-          "bidder": {
-            "unit": "444",
-            "delDomain": "se-demo-d.openx.net"
-          }
-        }
-      },
-      {
         "id": "banner-native-imp-1",
         "banner": {},
         "native": {
@@ -122,11 +102,6 @@
               "tagid": "666"
             },
             {
-              "id": "banner-imp-2",
-              "banner": {},
-              "tagid": "222"
-            },
-            {
               "id": "banner-native-imp-1",
               "banner": {},
               "native": {
@@ -151,7 +126,7 @@
             "delDomain": "se-demo-d.openx.net"
           }
         },
-        "impIDs":["banner-imp-1","native-imp-1","banner-imp-2","banner-native-imp-1","multi-type-imp"]
+        "impIDs":["banner-imp-1","native-imp-1","banner-native-imp-1","multi-type-imp"]
       },
       "mockResponse": {
         "status": 200,
@@ -164,32 +139,22 @@
                 {
                   "id": "banner-bid-1",
                   "impid": "banner-imp-1",
-                  "price": 0.1,
-                  "mtype": 1
+                  "price": 0.1
                 },
                 {
                   "id": "native-bid-1",
                   "impid": "native-imp-1",
-                  "price": 0.1,
-                  "mtype": 4
-                },
-                {
-                  "id": "banner-bid-2",
-                  "impid": "banner-imp-2",
-                  "price": 0.2,
-                  "mtype": 1
+                  "price": 0.1
                 },
                 {
                   "id": "banner-native-bid-1",
                   "impid": "banner-native-imp-1",
-                  "price": 0,
-                  "mtype": 4
+                  "price": 0
                 },
                 {
                   "id": "multi-type-bid",
                   "impid": "multi-type-imp",
-                  "price": 0,
-                  "mtype": 2
+                  "price": 0
                 }
               ]
             }
@@ -227,53 +192,7 @@
                 {
                   "id": "video-bid-1",
                   "impid": "video-imp-1",
-                  "price": 0.1,
-                  "mtype": 2
-                }
-              ]
-            }
-          ]
-        }
-      }
-    },
-    {
-      "expectedRequest": {
-        "uri": "http://rtb.openx.net/prebid",
-        "body": {
-          "id": "test-request-id",
-          "imp": [
-            {
-              "id": "video-imp-2",
-              "video": {
-                "mimes": [
-                  "video/mp4"
-                ]
-              },
-              "tagid": "444"
-            }
-          ],
-          "ext": {
-            "bc": "hb_pbs_1.0.0",
-            "delDomain": "se-demo-d.openx.net"
-          }
-        },
-        "impIDs": [
-          "video-imp-2"
-        ]
-      },
-      "mockResponse": {
-        "status": 200,
-        "body": {
-          "id": "test-request-id",
-          "seatbid": [
-            {
-              "seat": "openx",
-              "bid": [
-                {
-                  "id": "video-bid-2",
-                  "impid": "video-imp-2",
-                  "price": 0.2,
-                  "mtype": 2
+                  "price": 0.1
                 }
               ]
             }
@@ -315,8 +234,7 @@
                 {
                   "id": "video-native-bid-1",
                   "impid": "video-native-imp-1",
-                  "price": 0.0,
-                  "mtype": 4
+                  "price": 0.0
                 }
               ]
             }
@@ -334,8 +252,7 @@
           "bid": {
             "id": "banner-bid-1",
             "impid": "banner-imp-1",
-            "price": 0.1,
-            "mtype": 1
+            "price": 0.1
           },
           "type": "banner"
         },
@@ -343,37 +260,25 @@
           "bid": {
             "id": "native-bid-1",
             "impid": "native-imp-1",
-            "price": 0.1,
-            "mtype": 4
+            "price": 0.1
           },
           "type": "native"
-        },
-        {
-          "bid": {
-            "id": "banner-bid-2",
-            "impid": "banner-imp-2",
-            "price": 0.2,
-            "mtype": 1
-          },
-          "type": "banner"
         },
         {
           "bid": {
             "id": "banner-native-bid-1",
             "impid": "banner-native-imp-1",
-            "price": 0,
-            "mtype": 4
+            "price": 0
           },
-          "type": "native"
+          "type": "banner"
         },
         {
           "bid": {
             "id": "multi-type-bid",
             "impid": "multi-type-imp",
-            "price": 0,
-            "mtype": 2
+            "price": 0
           },
-          "type": "video"
+          "type": "banner"
         }
       ]
     },
@@ -384,22 +289,7 @@
           "bid": {
             "id": "video-bid-1",
             "impid": "video-imp-1",
-            "price": 0.1,
-            "mtype": 2
-          },
-          "type": "video"
-        }
-      ]
-    },
-    {
-      "currency": "USD",
-      "bids": [
-        {
-          "bid": {
-            "id": "video-bid-2",
-            "impid": "video-imp-2",
-            "price": 0.2,
-            "mtype": 2
+            "price": 0.1
           },
           "type": "video"
         }
@@ -412,10 +302,9 @@
           "bid": {
             "id": "video-native-bid-1",
             "impid": "video-native-imp-1",
-            "price": 0.0,
-            "mtype": 4
+            "price": 0.0
           },
-          "type": "native"
+          "type": "video"
         }
       ]
     }


### PR DESCRIPTION
OpenX started to return mtype field for bids in bid response, so now bid type can be determined based on this property in OpenX bidder adapter.
We want to determine bid type based on bid mtype from bid response, to be able to process multi-format requests.