### PR TITLE
IX: Pass ext.ixdiag fields through

### DIFF
--- a/adapters/ix/ix_test.go
+++ b/adapters/ix/ix_test.go
@@ -195,7 +195,7 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbsv":"1.880","pbjsv":"7.20"}}`),
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbjsv":"7.20","pbsp":"go","pbsv":"1.880"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "1.880-abcdef",
@@ -208,7 +208,7 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":{"server":{"externalurl":"http://localhost:8000","gvlid":0,"datacenter":""}},"ixdiag":{"pbsv":"1.880"}}`),
+				Ext: json.RawMessage(`{"prebid":{"server":{"externalurl":"http://localhost:8000","gvlid":0,"datacenter":""}},"ixdiag":{"pbsp":"go","pbsv":"1.880"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "1.880-abcdef",
@@ -220,7 +220,7 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":null,"ixdiag":{"pbsv":"1.880"}}`),
+				Ext: json.RawMessage(`{"ixdiag":{"pbsp":"go","pbsv":"1.880"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "1.880-abcdef",
@@ -232,7 +232,7 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":null,"ixdiag":{"pbsv":"0.23.1"}}`),
+				Ext: json.RawMessage(`{"ixdiag":{"pbsp":"go","pbsv":"0.23.1"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "0.23.1-3-g4ee257d8",
@@ -245,7 +245,7 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbsv":"1.880","pbjsv":"7.20"}}`),
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbjsv":"7.20","pbsp":"go","pbsv":"1.880"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "1.880",
@@ -258,7 +258,20 @@ func TestBuildIxDiag(t *testing.T) {
 			},
 			expectedRequest: &openrtb2.BidRequest{
 				ID:  "1",
-				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbjsv":"7.20"}}`),
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"pbjsv":"7.20","pbsp":"go","pbsv":"unknown"}}`),
+			},
+			expectError: false,
+			pbsVersion:  "",
+		},
+		{
+			description: "request ixdiag contain other fields that should pass-through along with additional version fields",
+			request: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"msd":2,"msi":1,"nvin":"123"}}`),
+			},
+			expectedRequest: &openrtb2.BidRequest{
+				ID:  "1",
+				Ext: json.RawMessage(`{"prebid":{"channel":{"name":"web","version":"7.20"}},"ixdiag":{"msd":2,"msi":1,"nvin":"123","pbjsv":"7.20","pbsp":"go","pbsv":"unknown"}}`),
 			},
 			expectError: false,
 			pbsVersion:  "",
@@ -280,8 +293,8 @@ func TestBuildIxDiag(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			ixDiag := &IxDiag{}
-			err := setIxDiagIntoExtRequest(test.request, ixDiag, test.pbsVersion)
+			ixDiagFields := make(map[string]interface{})
+			err := setIxDiagIntoExtRequest(test.request, ixDiagFields, test.pbsVersion)
 			if test.expectError {
 				assert.NotNil(t, err)
 			} else {

--- a/adapters/ix/ixtest/exemplary/additional-consent.json
+++ b/adapters/ix/ixtest/exemplary/additional-consent.json
@@ -57,6 +57,12 @@
                                 "consented_providers": [1]
                             }
                         }
+                    },
+                    "ext": {
+                         "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                         }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/exemplary/app-site-id.json
+++ b/adapters/ix/ixtest/exemplary/app-site-id.json
@@ -65,7 +65,9 @@
                     },
                     "ext": {
                         "ixdiag": {
-                          "pbjsv": "7.0.0"
+                            "pbjsv": "7.0.0",
+                            "pbsp": "go",
+                            "pbsv": "unknown"
                         },
                         "prebid": {
                           "channel": {

--- a/adapters/ix/ixtest/exemplary/banner-no-format.json
+++ b/adapters/ix/ixtest/exemplary/banner-no-format.json
@@ -41,7 +41,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/fledge.json
+++ b/adapters/ix/ixtest/exemplary/fledge.json
@@ -70,6 +70,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/exemplary/ixdiag.json
+++ b/adapters/ix/ixtest/exemplary/ixdiag.json
@@ -4,25 +4,13 @@
         "imp": [
             {
                 "id": "test-imp-id-1",
-                "video": {
-                    "mimes": [
-                        "video/mp4"
-                    ],
-                    "minduration": 15,
-                    "maxduration": 30,
-                    "protocols": [
-                        2,
-                        3,
-                        5,
-                        6,
-                        7,
-                        8
-                    ],
-                    "w": 940,
-                    "h": 560,
-                    "podid": "1",
-                    "slotinpod": 1,
-                    "podseq": 1
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
                 },
                 "ext": {
                     "bidder": {
@@ -47,47 +35,68 @@
                         8
                     ],
                     "w": 940,
-                    "h": 560,
-                    "podid": "1",
-                    "slotinpod": -1,
-                    "podseq": 1
+                    "h": 560
                 },
                 "ext": {
                     "bidder": {
-                        "siteId": "569749"
+                        "siteId": "569750"
+                    }
+                }
+            },
+            {
+                "id": "test-imp-id-3",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 600
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "siteId": "569751"
                     }
                 }
             }
-        ]
+        ],
+        "site": {
+            "page": "https://www.example.com/"
+        },
+        "ext": {
+            "prebid": {
+                "channel": {
+                    "name": "web",
+                    "version": "7.0.0"
+                }
+            },
+            "ixdiag": {
+                "msd": 2,
+                "msi": 2,
+                "mfu": 0,
+                "ren": false,
+                "version": "6.29.1"
+            }
+        }
     },
     "httpCalls": [
         {
             "expectedRequest": {
                 "uri": "http://host/endpoint",
                 "body": {
-                  "id": "test-request-id",
+                    "id": "test-request-id",
                     "imp": [
                         {
                             "id": "test-imp-id-1",
-                            "video": {
-                                "mimes": [
-                                    "video/mp4"
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
                                 ],
-                                "minduration": 15,
-                                "maxduration": 30,
-                                "protocols": [
-                                    2,
-                                    3,
-                                    5,
-                                    6,
-                                    7,
-                                    8
-                                ],
-                                "w": 940,
-                                "h": 560,
-                                "podid": "1",
-                                "slotinpod": 1,
-                                "podseq": 1
+                                "w": 300,
+                                "h": 250
                             },
                             "ext": {
                                 "bidder": {
@@ -112,26 +121,59 @@
                                     8
                                 ],
                                 "w": 940,
-                                "h": 560,
-                                "podid": "1",
-                                "slotinpod": -1,
-                                "podseq": 1
+                                "h": 560
                             },
                             "ext": {
                                 "bidder": {
-                                    "siteId": "569749"
+                                    "siteId": "569750"
                                 }
                             }
+                        },
+                        {
+                            "banner": {
+                              "format": [
+                                {
+                                  "h": 600,
+                                  "w": 300
+                                }
+                              ],
+                              "h": 600,
+                              "w": 300
+                            },
+                            "ext": {
+                              "bidder": {
+                                "siteId": "569751"
+                              }
+                            },
+                            "id": "test-imp-id-3"
                         }
                     ],
+                    "site": {
+                        "page": "https://www.example.com/",
+                        "publisher": {
+                        }
+                    },
                     "ext": {
                         "ixdiag": {
+                            "mfu": 0,
+                            "msd": 2,
+                            "msi": 2,
+                            "multipleSiteIds": "569749, 569750, 569751",
+                            "pbjsv": "7.0.0",
                             "pbsp": "go",
-                            "pbsv": "unknown"
+                            "pbsv": "unknown",
+                            "ren": false,
+                            "version": "6.29.1"
+                        },
+                        "prebid": {
+                          "channel": {
+                            "name": "web",
+                            "version": "7.0.0"
+                          }
                         }
                     }
                 },
-                "impIDs":["test-imp-id-1","test-imp-id-2"]
+                "impIDs":["test-imp-id-1","test-imp-id-2","test-imp-id-3"]
             },
             "mockResponse": {
                 "status": 200,
@@ -152,32 +194,8 @@
                                     ],
                                     "cid": "958",
                                     "crid": "29681110",
-                                    "h": 560,
-                                    "w": 940,
-                                    "dur": 30,
-                                    "ext": {
-                                        "ix": {}
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "seat": "958",
-                            "bid": [
-                                {
-                                    "id": "7706636740145184841",
-                                    "impid": "test-imp-id-2",
-                                    "price": 0.75,
-                                    "adid": "29681110",
-                                    "adm": "some-test-ad",
-                                    "adomain": [
-                                        "https://advertiser.example.com"
-                                    ],
-                                    "cid": "958",
-                                    "crid": "29681110",
-                                    "h": 560,
-                                    "w": 940,
-                                    "dur": 30,
+                                    "h": 250,
+                                    "w": 300,
                                     "ext": {
                                         "ix": {}
                                     }
@@ -207,37 +225,15 @@
                         ],
                         "cid": "958",
                         "crid": "29681110",
-                        "h": 560,
-                        "w": 940,
-                        "dur": 30,
-                    "ext": {
-                        "ix": {}
-                    }
-                },
-                "type": "video"
-            },
-            {
-                "bid": {
-                    "id": "7706636740145184841",
-                    "impid": "test-imp-id-2",
-                    "price": 0.75,
-                    "adm": "some-test-ad",
-                    "adid": "29681110",
-                    "adomain": [
-                        "https://advertiser.example.com"
-                    ],
-                    "cid": "958",
-                    "crid": "29681110",
-                    "h": 560,
-                    "w": 940,
-                    "dur": 30,
-                "ext": {
-                    "ix": {}
+                        "w": 300,
+                        "h": 250,
+                        "ext": {
+                            "ix": {}
+                        }
+                    },
+                    "type": "banner"
                 }
-            },
-                "type": "video"
-            }
-        ]
-    }
+            ]
+        }
     ]
 }

--- a/adapters/ix/ixtest/exemplary/multi-format-with-ext-prebid-type.json
+++ b/adapters/ix/ixtest/exemplary/multi-format-with-ext-prebid-type.json
@@ -75,7 +75,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["multi-format-test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/multi-format-with-mtype.json
+++ b/adapters/ix/ixtest/exemplary/multi-format-with-mtype.json
@@ -75,7 +75,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["multi-format-test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/multi-imp-multi-size-requests.json
+++ b/adapters/ix/ixtest/exemplary/multi-imp-multi-size-requests.json
@@ -144,6 +144,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id-1","test-imp-id-2","test-imp-id-3"]

--- a/adapters/ix/ixtest/exemplary/multi-imp-requests.json
+++ b/adapters/ix/ixtest/exemplary/multi-imp-requests.json
@@ -197,7 +197,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id-1","test-imp-id-2","test-imp-id-3","test-imp-id-4","test-imp-id-5"]
             },

--- a/adapters/ix/ixtest/exemplary/multibid.json
+++ b/adapters/ix/ixtest/exemplary/multibid.json
@@ -41,7 +41,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/multiple-siteIds.json
+++ b/adapters/ix/ixtest/exemplary/multiple-siteIds.json
@@ -148,8 +148,10 @@
                     },
                     "ext": {
                         "ixdiag": {
-                          "multipleSiteIds": "569749, 569750, 569751",
-                          "pbjsv": "7.0.0"
+                            "multipleSiteIds": "569749, 569750, 569751",
+                            "pbjsv": "7.0.0",
+                            "pbsp": "go",
+                            "pbsv": "unknown"
                         },
                         "prebid": {
                           "channel": {

--- a/adapters/ix/ixtest/exemplary/native-eventtrackers-compat-12.json
+++ b/adapters/ix/ixtest/exemplary/native-eventtrackers-compat-12.json
@@ -35,7 +35,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/no-pub-id.json
+++ b/adapters/ix/ixtest/exemplary/no-pub-id.json
@@ -54,6 +54,12 @@
                             "id": "569749",
                             "name": "publisher-name"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/exemplary/no-pub.json
+++ b/adapters/ix/ixtest/exemplary/no-pub.json
@@ -50,6 +50,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/exemplary/simple-audio.json
+++ b/adapters/ix/ixtest/exemplary/simple-audio.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/simple-banner-multi-size.json
+++ b/adapters/ix/ixtest/exemplary/simple-banner-multi-size.json
@@ -68,6 +68,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/exemplary/simple-native.json
+++ b/adapters/ix/ixtest/exemplary/simple-native.json
@@ -35,7 +35,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/exemplary/simple-video.json
+++ b/adapters/ix/ixtest/exemplary/simple-video.json
@@ -61,7 +61,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/app-site-id-publisher.json
+++ b/adapters/ix/ixtest/supplemental/app-site-id-publisher.json
@@ -69,7 +69,9 @@
                     },
                     "ext": {
                         "ixdiag": {
-                          "pbjsv": "7.0.0"
+                            "pbjsv": "7.0.0",
+                            "pbsp": "go",
+                            "pbsv": "unknown"
                         },
                         "prebid": {
                           "channel": {

--- a/adapters/ix/ixtest/supplemental/bad-fledge.json
+++ b/adapters/ix/ixtest/supplemental/bad-fledge.json
@@ -70,6 +70,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/supplemental/bad-imp-id.json
+++ b/adapters/ix/ixtest/supplemental/bad-imp-id.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/bad-request.json
+++ b/adapters/ix/ixtest/supplemental/bad-request.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/bad-response-body.json
+++ b/adapters/ix/ixtest/supplemental/bad-response-body.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/dsa-request.json
+++ b/adapters/ix/ixtest/supplemental/dsa-request.json
@@ -102,6 +102,12 @@
                   ]
                 }
               }
+            },
+            "ext": {
+              "ixdiag": {
+                "pbsp": "go",
+                "pbsv": "unknown"
+              }
             }
           },
           "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/supplemental/fledge-no-bid.json
+++ b/adapters/ix/ixtest/supplemental/fledge-no-bid.json
@@ -70,6 +70,12 @@
                         "publisher": {
                             "id": "569749"
                         }
+                    },
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
                     }
                 },
                 "impIDs":["test-imp-id"]

--- a/adapters/ix/ixtest/supplemental/multi-imp-requests-error.json
+++ b/adapters/ix/ixtest/supplemental/multi-imp-requests-error.json
@@ -116,7 +116,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id-2","test-imp-id-3"]
             },

--- a/adapters/ix/ixtest/supplemental/native-eventtrackers-empty.json
+++ b/adapters/ix/ixtest/supplemental/native-eventtrackers-empty.json
@@ -35,7 +35,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/native-eventtrackers-missing.json
+++ b/adapters/ix/ixtest/supplemental/native-eventtrackers-missing.json
@@ -35,7 +35,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/native-missing.json
+++ b/adapters/ix/ixtest/supplemental/native-missing.json
@@ -35,7 +35,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/no-content.json
+++ b/adapters/ix/ixtest/supplemental/no-content.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/not-found.json
+++ b/adapters/ix/ixtest/supplemental/not-found.json
@@ -45,7 +45,13 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "ext": {
+                        "ixdiag": {
+                            "pbsp": "go",
+                            "pbsv": "unknown"
+                        }
+                    }
                 },
                 "impIDs":["test-imp-id"]
             },

--- a/adapters/ix/ixtest/supplemental/sid.json
+++ b/adapters/ix/ixtest/supplemental/sid.json
@@ -63,9 +63,10 @@
         "body": {
           "ext": {
             "ixdiag": {
-              "multipleSiteIds": "569749, 569750"
-            },
-            "prebid": null
+              "multipleSiteIds": "569749, 569750",
+              "pbsp": "go",
+              "pbsv": "unknown"
+            }
           },
           "id": "test-request-id",
           "imp": [


### PR DESCRIPTION
This PR implements the pass-through of the ext.ixdiag field from the incoming bid request to the exchange. The existing IX adapter code already sets a few fields in ixdiag and sends them to the exchange, but it does not account for ext.ixdiag from the incoming request. This implementation combines the existing ixdiag fields set by PBS with the ext.ixdiag fields from the incoming request.