### PR TITLE
Smilewanted: change endpoint to HTTPS

### DIFF
--- a/static/bidder-info/smilewanted.yaml
+++ b/static/bidder-info/smilewanted.yaml
@@ -1,4 +1,4 @@
-endpoint: "http://prebid-server.smilewanted.com"
+endpoint: "https://prebid-server.smilewanted.com"
 maintainer:
   email: "tech@smilewanted.com"
 gvlVendorID: 639


### PR DESCRIPTION
In order to improve the security and compliance of our communications, we request that Prebid Server be updated to use HTTPS by default.