### PR TITLE
Medianet: Update codepath-notification email

### DIFF
--- a/.github/workflows/scripts/codepath-notification
+++ b/.github/workflows/scripts/codepath-notification
@@ -16,4 +16,4 @@ rubicon: header-bidding@magnite.com
 pubmatic: header-bidding@pubmatic.com
 openx: prebid@openx.com
 adapters/ix|imp_ix|ix.json|ix.yaml: pdu-supply-prebid@indexexchange.com
-medianet: prebid-support@media.net
+medianet: prebid@media.net


### PR DESCRIPTION
Changed the email in codepath-notification from prebid-support@media.net to prebid@media.net