### PR TITLE
Issue #3681 - Enhance module framework to support A/B testing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1210,16 +1210,16 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("tmax_adjustments.pbs_response_preparation_duration_ms", 0)
 
 	/* IPv4
-	/*  Site Local: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-	/*  Link Local: 169.254.0.0/16
-	/*  Loopback:   127.0.0.0/8
-	/*
-	/* IPv6
-	/*  Loopback:      ::1/128
-	/*  Documentation: 2001:db8::/32
-	/*  Unique Local:  fc00::/7
-	/*  Link Local:    fe80::/10
-	/*  Multicast:     ff00::/8
+	   /*  Site Local: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+	   /*  Link Local: 169.254.0.0/16
+	   /*  Loopback:   127.0.0.0/8
+	   /*
+	   /* IPv6
+	   /*  Loopback:      ::1/128
+	   /*  Documentation: 2001:db8::/32
+	   /*  Unique Local:  fc00::/7
+	   /*  Link Local:    fe80::/10
+	   /*  Multicast:     ff00::/8
 	*/
 	v.SetDefault("request_validation.ipv4_private_networks", []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "127.0.0.0/8"})
 	v.SetDefault("request_validation.ipv6_private_networks", []string{"::1/128", "fc00::/7", "fe80::/10", "ff00::/8", "2001:db8::/32"})
@@ -1273,6 +1273,9 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("experiment.adscert.remote.signing_timeout_ms", 5)
 
 	v.SetDefault("hooks.enabled", false)
+	v.SetDefault("hooks.host_execution_plan.abtests.enabled", false)
+	v.SetDefault("hooks.host_execution_plan.abtests.percent_active", 100)
+	v.SetDefault("hooks.host_execution_plan.abtests.log_analytics_tag", true)
 
 	for bidderName := range bidderInfos {
 		setBidderDefaults(v, strings.ToLower(bidderName))

--- a/config/hooks.go
+++ b/config/hooks.go
@@ -14,6 +14,7 @@ type Hooks struct {
 type Modules map[string]map[string]interface{}
 
 type HookExecutionPlan struct {
+	ABTests   []ABTest `mapstructure:"abtests" json:"abtests"`
 	Endpoints map[string]struct {
 		Stages map[string]struct {
 			Groups []HookExecutionGroup `mapstructure:"groups" json:"groups"`
@@ -31,4 +32,19 @@ type HookExecutionGroup struct {
 		// HookImplCode is an arbitrary value, used to identify hook when sending metrics, debug information, etc.
 		HookImplCode string `mapstructure:"hook_impl_code" json:"hook_impl_code"`
 	} `mapstructure:"hook_sequence" json:"hook_sequence"`
+}
+
+type ABTest struct {
+	// ModuleCode is a composite value in the format: {vendor_name}.{module_name}
+	ModuleCode string `mapstructure:"module_code" json:"module_code"`
+	Enabled    *bool  `mapstructure:"enabled" json:"enabled"`
+	// Accounts is a slice of accounts that will trigger module execution
+	// An empty slice will trigger module execution for all accounts
+	Accounts []interface{} `mapstructure:"accounts" json:"accounts"`
+	// PercentActive enables specifying the percentage of requests that will trigger module execution
+	// The default value (nil) will trigger module execution on every request, the same as if the value "100" is set
+	PercentActive *uint16 `mapstructure:"percent_active" json:"percent_active"`
+	// LogAnalyticsTag specifies whether module execution result will get noted in the analytics log
+	// The default value (nil) will enable writing results to the analytics log, the same as if the value "true" is set
+	LogAnalyticsTag *bool `mapstructure:"log_analytics_tag" json:"log_analytics_tag"`
 }

--- a/endpoints/openrtb2/test_utils.go
+++ b/endpoints/openrtb2/test_utils.go
@@ -1559,6 +1559,10 @@ func (m mockPlanBuilder) PlanForAuctionResponseStage(_ string, _ *config.Account
 	return m.auctionResponsePlan
 }
 
+func (m mockPlanBuilder) ABTestMap() map[string]hooks.ABTest {
+	return make(map[string]hooks.ABTest)
+}
+
 func makePlan[H any](hook H) hooks.Plan[H] {
 	return hooks.Plan[H]{
 		{

--- a/hooks/empty_plan.go
+++ b/hooks/empty_plan.go
@@ -36,3 +36,7 @@ func (e EmptyPlanBuilder) PlanForAllProcessedBidResponsesStage(endpoint string, 
 func (e EmptyPlanBuilder) PlanForAuctionResponseStage(endpoint string, account *config.Account) Plan[hookstage.AuctionResponse] {
 	return nil
 }
+
+func (e EmptyPlanBuilder) ABTestMap() map[string]ABTest {
+	return make(map[string]ABTest)
+}

--- a/hooks/hookanalytics/analytics.go
+++ b/hooks/hookanalytics/analytics.go
@@ -42,4 +42,6 @@ const (
 	ResultStatusBlock  ResultStatus = "success-block"
 	ResultStatusModify ResultStatus = "success-modify"
 	ResultStatusError  ResultStatus = "error"
+	ResultStatusRun    ResultStatus = "run"
+	ResultStatusSkip   ResultStatus = "skip"
 )

--- a/hooks/hookexecution/executor_test.go
+++ b/hooks/hookexecution/executor_test.go
@@ -57,7 +57,7 @@ func TestEmptyHookExecutor(t *testing.T) {
 }
 
 func TestExecuteEntrypointStage(t *testing.T) {
-	const body string = `{"name": "John", "last_name": "Doe"}`
+	const body string = `{"name": "John", "last_name": "Doe", "site": {"publisher": {"id": "account-id"}}}`
 	const urlString string = "https://prebid.com/openrtb2/auction"
 
 	foobarModuleCtx := &moduleContexts{ctxs: map[string]hookstage.ModuleContext{"foobar": nil}}
@@ -349,6 +349,204 @@ func TestExecuteEntrypointStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "ABTests are applied with percentages",
+			givenBody:        body,
+			givenUrl:         urlString,
+			givenPlanBuilder: TestWithModuleABPlanBuilder{},
+			expectedBody:     body,
+			expectedHeader:   http.Header{},
+			expectedQuery:    url.Values{},
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityHttpRequest,
+					Stage:  hooks.StageEntrypoint.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "ABTests are applied with user-id",
+			givenBody:        body,
+			givenUrl:         urlString,
+			givenPlanBuilder: TestWithModuleABPlanAccountBuilder{},
+			expectedBody:     body,
+			expectedHeader:   http.Header{},
+			expectedQuery:    url.Values{},
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityHttpRequest,
+					Stage:  hooks.StageEntrypoint.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -413,7 +611,7 @@ func TestMetricsAreGatheredDuringHookExecution(t *testing.T) {
 }
 
 func TestExecuteRawAuctionStage(t *testing.T) {
-	const body string = `{"name": "John", "last_name": "Doe"}`
+	const body string = `{"name": "John", "last_name": "Doe", "site": {"publisher": {"id": "account-id"}}}`
 	const bodyUpdated string = `{"last_name": "Doe", "foo": "bar"}`
 	const urlString string = "https://prebid.com/openrtb2/auction"
 
@@ -663,6 +861,200 @@ func TestExecuteRawAuctionStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "ABTests are applied with percentages",
+			givenBody:        body,
+			givenUrl:         urlString,
+			givenPlanBuilder: TestWithModuleABPlanBuilder{},
+			expectedBody:     body,
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionRequest,
+					Stage:  hooks.StageRawAuctionRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "ABTests are applied with user-id",
+			givenBody:        body,
+			givenUrl:         urlString,
+			givenPlanBuilder: TestWithModuleABPlanAccountBuilder{},
+			expectedBody:     body,
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionRequest,
+					Stage:  hooks.StageRawAuctionRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -881,6 +1273,198 @@ func TestExecuteProcessedAuctionStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "ABTests are applied with percentages",
+			givenPlanBuilder: TestWithModuleABPlanBuilder{},
+			givenRequest:     openrtb_ext.RequestWrapper{BidRequest: &req},
+			expectedRequest:  req,
+			expectedErr:      nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionRequest,
+					Stage:  hooks.StageProcessedAuctionRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "ABTests are applied with user-id",
+			givenPlanBuilder: TestWithModuleABPlanAccountBuilder{},
+			givenRequest:     openrtb_ext.RequestWrapper{BidRequest: &req},
+			expectedRequest:  req,
+			expectedErr:      nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionRequest,
+					Stage:  hooks.StageProcessedAuctionRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -890,6 +1474,7 @@ func TestExecuteProcessedAuctionStage(t *testing.T) {
 			privacyConfig := getModuleActivities("foo", false, false)
 			ac := privacy.NewActivityControl(privacyConfig)
 			exec.SetActivityControl(ac)
+			exec.accountID = "account-id"
 
 			err := exec.ExecuteProcessedAuctionStage(&test.givenRequest)
 
@@ -1151,6 +1736,198 @@ func TestExecuteBidderRequestStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:           "ABTests are applied with percentages",
+			givenBidderRequest:    &openrtb2.BidRequest{ID: "some-id", User: &openrtb2.User{ID: "user-id"}},
+			givenPlanBuilder:      TestWithModuleABPlanBuilder{},
+			expectedBidderRequest: expectedBidderRequest,
+			expectedReject:        nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entity(bidderName),
+					Stage:  hooks.StageBidderRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:           "ABTests are applied with user-id",
+			givenBidderRequest:    &openrtb2.BidRequest{ID: "some-id", User: &openrtb2.User{ID: "user-id"}},
+			givenPlanBuilder:      TestWithModuleABPlanAccountBuilder{},
+			expectedBidderRequest: expectedBidderRequest,
+			expectedReject:        nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entity(bidderName),
+					Stage:  hooks.StageBidderRequest.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1159,6 +1936,7 @@ func TestExecuteBidderRequestStage(t *testing.T) {
 			privacyConfig := getModuleActivities("foo", false, false)
 			ac := privacy.NewActivityControl(privacyConfig)
 			exec.SetActivityControl(ac)
+			exec.accountID = "account-id"
 
 			reject := exec.ExecuteBidderRequestStage(&openrtb_ext.RequestWrapper{BidRequest: test.givenBidderRequest}, bidderName)
 
@@ -1407,6 +2185,198 @@ func TestExecuteRawBidderResponseStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:            "ABTests are applied with percentages",
+			givenPlanBuilder:       TestWithModuleABPlanBuilder{},
+			givenBidderResponse:    resp,
+			expectedBidderResponse: expResp,
+			expectedReject:         nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: vEntity,
+					Stage:  hooks.StageRawBidderResponse.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:            "ABTests are applied with user-id",
+			givenPlanBuilder:       TestWithModuleABPlanAccountBuilder{},
+			givenBidderResponse:    resp,
+			expectedBidderResponse: expResp,
+			expectedReject:         nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: vEntity,
+					Stage:  hooks.StageRawBidderResponse.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1416,6 +2386,7 @@ func TestExecuteRawBidderResponseStage(t *testing.T) {
 			privacyConfig := getModuleActivities("foo", false, false)
 			ac := privacy.NewActivityControl(privacyConfig)
 			exec.SetActivityControl(ac)
+			exec.accountID = "account-id"
 
 			reject := exec.ExecuteRawBidderResponseStage(&test.givenBidderResponse, "the-bidder")
 
@@ -1682,6 +2653,202 @@ func TestExecuteAllProcessedBidResponsesStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "ABTests are applied with percentages",
+			givenBiddersResponse: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+				"some-bidder": {Bids: []*entities.PbsOrtbBid{{DealPriority: 1}}},
+			},
+			givenPlanBuilder:        TestWithModuleABPlanBuilder{},
+			expectedBiddersResponse: expectedAllProcBidResponses,
+			expectedReject:          nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAllProcessedBidResponses,
+					Stage:  hooks.StageAllProcessedBidResponses.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "ABTests are applied with user-id",
+			givenBiddersResponse: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+				"some-bidder": {Bids: []*entities.PbsOrtbBid{{DealPriority: 1}}},
+			},
+			givenPlanBuilder:        TestWithModuleABPlanAccountBuilder{},
+			expectedBiddersResponse: expectedAllProcBidResponses,
+			expectedReject:          nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAllProcessedBidResponses,
+					Stage:  hooks.StageAllProcessedBidResponses.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1691,6 +2858,7 @@ func TestExecuteAllProcessedBidResponsesStage(t *testing.T) {
 			privacyConfig := getModuleActivities("foo", false, false)
 			ac := privacy.NewActivityControl(privacyConfig)
 			exec.SetActivityControl(ac)
+			exec.accountID = "account-id"
 
 			exec.ExecuteAllProcessedBidResponsesStage(test.givenBiddersResponse)
 
@@ -1927,6 +3095,198 @@ func TestExecuteAuctionResponseStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "ABTests are applied with percentages",
+			givenPlanBuilder: TestWithModuleABPlanBuilder{},
+			givenResponse:    resp,
+			expectedResponse: resp,
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionResponse,
+					Stage:  hooks.StageAuctionResponse.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "ABTests are applied with user-id",
+			givenPlanBuilder: TestWithModuleABPlanAccountBuilder{},
+			givenResponse:    resp,
+			expectedResponse: resp,
+			expectedReject:   nil,
+			expectedModuleContexts: &moduleContexts{ctxs: map[string]hookstage.ModuleContext{
+				"module-1": hookstage.ModuleContext(nil),
+			}},
+			expectedStageOutcomes: []StageOutcome{
+				{
+					Entity: entityAuctionResponse,
+					Stage:  hooks.StageAuctionResponse.String(),
+					Groups: []GroupOutcome{
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusRun,
+														Values: map[string]interface{}{
+															"module": "module-1",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-1",
+										HookImplCode: "foo",
+									},
+									Status:        StatusSuccess,
+									Action:        ActionNone,
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+						{
+							InvocationResults: []HookOutcome{
+								{
+									AnalyticsTags: hookanalytics.Analytics{
+										Activities: []hookanalytics.Activity{
+											{
+												Name:   "core-module-abtests",
+												Status: "success",
+												Results: []hookanalytics.Result{
+													{
+														Status: hookanalytics.ResultStatusSkip,
+														Values: map[string]interface{}{
+															"module": "module-2",
+														},
+														AppliedTo: hookanalytics.AppliedTo{
+															Bidder:   "",
+															BidIds:   []string(nil),
+															ImpIds:   []string(nil),
+															Request:  false,
+															Response: false,
+														},
+													},
+												},
+											},
+										},
+									},
+									HookID: HookID{
+										ModuleCode:   "module-2",
+										HookImplCode: "",
+									},
+									Status:        StatusSuccess,
+									Action:        "",
+									Message:       "",
+									DebugMessages: nil,
+									Errors:        nil,
+									Warnings:      nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1936,6 +3296,7 @@ func TestExecuteAuctionResponseStage(t *testing.T) {
 			privacyConfig := getModuleActivities("foo", false, false)
 			ac := privacy.NewActivityControl(privacyConfig)
 			exec.SetActivityControl(ac)
+			exec.accountID = "account-id"
 
 			exec.ExecuteAuctionResponseStage(test.givenResponse)
 
@@ -2610,5 +3971,265 @@ func (e TestAllHookResultsBuilder) PlanForEntrypointStage(_ string) hooks.Plan[h
 				{Module: "module.x-1", Code: "code-2", Hook: mockRejectHook{}},
 			},
 		},
+	}
+}
+
+type TestWithModuleABPlanBuilder struct {
+	hooks.EmptyPlanBuilder
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForEntrypointStage(_ string) hooks.Plan[hookstage.Entrypoint] {
+	return hooks.Plan[hookstage.Entrypoint]{
+		hooks.Group[hookstage.Entrypoint]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.Entrypoint]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.Entrypoint]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.Entrypoint]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForRawAuctionStage(_ string, _ *config.Account) hooks.Plan[hookstage.RawAuctionRequest] {
+	return hooks.Plan[hookstage.RawAuctionRequest]{
+		hooks.Group[hookstage.RawAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawAuctionRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.RawAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawAuctionRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForProcessedAuctionStage(_ string, _ *config.Account) hooks.Plan[hookstage.ProcessedAuctionRequest] {
+	return hooks.Plan[hookstage.ProcessedAuctionRequest]{
+		hooks.Group[hookstage.ProcessedAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.ProcessedAuctionRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.ProcessedAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.ProcessedAuctionRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForBidderRequestStage(_ string, _ *config.Account) hooks.Plan[hookstage.BidderRequest] {
+	return hooks.Plan[hookstage.BidderRequest]{
+		hooks.Group[hookstage.BidderRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.BidderRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.BidderRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.BidderRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForRawBidderResponseStage(_ string, _ *config.Account) hooks.Plan[hookstage.RawBidderResponse] {
+	return hooks.Plan[hookstage.RawBidderResponse]{
+		hooks.Group[hookstage.RawBidderResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawBidderResponse]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.RawBidderResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawBidderResponse]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForAllProcessedBidResponsesStage(_ string, _ *config.Account) hooks.Plan[hookstage.AllProcessedBidResponses] {
+	return hooks.Plan[hookstage.AllProcessedBidResponses]{
+		hooks.Group[hookstage.AllProcessedBidResponses]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AllProcessedBidResponses]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.AllProcessedBidResponses]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AllProcessedBidResponses]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) PlanForAuctionResponseStage(_ string, _ *config.Account) hooks.Plan[hookstage.AuctionResponse] {
+	return hooks.Plan[hookstage.AuctionResponse]{
+		hooks.Group[hookstage.AuctionResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AuctionResponse]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.AuctionResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AuctionResponse]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanBuilder) ABTestMap() map[string]hooks.ABTest {
+	return map[string]hooks.ABTest{
+		"module-1": {PercentActive: 100, LogAnalyticsTag: true},
+		"module-2": {PercentActive: 0, LogAnalyticsTag: true},
+	}
+}
+
+type TestWithModuleABPlanAccountBuilder struct {
+	hooks.EmptyPlanBuilder
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForEntrypointStage(_ string) hooks.Plan[hookstage.Entrypoint] {
+	return hooks.Plan[hookstage.Entrypoint]{
+		hooks.Group[hookstage.Entrypoint]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.Entrypoint]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.Entrypoint]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.Entrypoint]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForRawAuctionStage(_ string, _ *config.Account) hooks.Plan[hookstage.RawAuctionRequest] {
+	return hooks.Plan[hookstage.RawAuctionRequest]{
+		hooks.Group[hookstage.RawAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawAuctionRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.RawAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawAuctionRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForProcessedAuctionStage(_ string, _ *config.Account) hooks.Plan[hookstage.ProcessedAuctionRequest] {
+	return hooks.Plan[hookstage.ProcessedAuctionRequest]{
+		hooks.Group[hookstage.ProcessedAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.ProcessedAuctionRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.ProcessedAuctionRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.ProcessedAuctionRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForBidderRequestStage(_ string, _ *config.Account) hooks.Plan[hookstage.BidderRequest] {
+	return hooks.Plan[hookstage.BidderRequest]{
+		hooks.Group[hookstage.BidderRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.BidderRequest]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.BidderRequest]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.BidderRequest]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForRawBidderResponseStage(_ string, _ *config.Account) hooks.Plan[hookstage.RawBidderResponse] {
+	return hooks.Plan[hookstage.RawBidderResponse]{
+		hooks.Group[hookstage.RawBidderResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawBidderResponse]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.RawBidderResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.RawBidderResponse]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForAllProcessedBidResponsesStage(_ string, _ *config.Account) hooks.Plan[hookstage.AllProcessedBidResponses] {
+	return hooks.Plan[hookstage.AllProcessedBidResponses]{
+		hooks.Group[hookstage.AllProcessedBidResponses]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AllProcessedBidResponses]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.AllProcessedBidResponses]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AllProcessedBidResponses]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) PlanForAuctionResponseStage(_ string, _ *config.Account) hooks.Plan[hookstage.AuctionResponse] {
+	return hooks.Plan[hookstage.AuctionResponse]{
+		hooks.Group[hookstage.AuctionResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AuctionResponse]{
+				{Module: "module-1", Code: "foo", Hook: mockModuleABHook{}},
+			},
+		},
+		hooks.Group[hookstage.AuctionResponse]{
+			Timeout: 10 * time.Millisecond,
+			Hooks: []hooks.HookWrapper[hookstage.AuctionResponse]{
+				{Module: "module-2", Code: "bar", Hook: mockModuleABHook{}},
+			},
+		},
+	}
+}
+
+func (e TestWithModuleABPlanAccountBuilder) ABTestMap() map[string]hooks.ABTest {
+	return map[string]hooks.ABTest{
+		"module-1": {Accounts: []string{"account-id"}, PercentActive: 100, LogAnalyticsTag: true},
+		"module-2": {Accounts: []string{"not-account-id"}, PercentActive: 100, LogAnalyticsTag: true},
 	}
 }

--- a/hooks/hookexecution/mocks_test.go
+++ b/hooks/hookexecution/mocks_test.go
@@ -219,6 +219,36 @@ func (e mockModuleContextHook) HandleAuctionResponseHook(_ context.Context, miCt
 	return hookstage.HookResult[hookstage.AuctionResponsePayload]{ModuleContext: miCtx.ModuleContext}, nil
 }
 
+type mockModuleABHook struct{}
+
+func (e mockModuleABHook) HandleEntrypointHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.EntrypointPayload) (hookstage.HookResult[hookstage.EntrypointPayload], error) {
+	return hookstage.HookResult[hookstage.EntrypointPayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleRawAuctionHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.RawAuctionRequestPayload) (hookstage.HookResult[hookstage.RawAuctionRequestPayload], error) {
+	return hookstage.HookResult[hookstage.RawAuctionRequestPayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleProcessedAuctionHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.ProcessedAuctionRequestPayload) (hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload], error) {
+	return hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleBidderRequestHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.BidderRequestPayload) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+	return hookstage.HookResult[hookstage.BidderRequestPayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleRawBidderResponseHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.RawBidderResponsePayload) (hookstage.HookResult[hookstage.RawBidderResponsePayload], error) {
+	return hookstage.HookResult[hookstage.RawBidderResponsePayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleAllProcessedBidResponsesHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.AllProcessedBidResponsesPayload) (hookstage.HookResult[hookstage.AllProcessedBidResponsesPayload], error) {
+	return hookstage.HookResult[hookstage.AllProcessedBidResponsesPayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
+func (e mockModuleABHook) HandleAuctionResponseHook(_ context.Context, miCtx hookstage.ModuleInvocationContext, _ hookstage.AuctionResponsePayload) (hookstage.HookResult[hookstage.AuctionResponsePayload], error) {
+	return hookstage.HookResult[hookstage.AuctionResponsePayload]{ModuleContext: miCtx.ModuleContext}, nil
+}
+
 type mockFailureHook struct{}
 
 func (h mockFailureHook) HandleEntrypointHook(_ context.Context, _ hookstage.ModuleInvocationContext, _ hookstage.EntrypointPayload) (hookstage.HookResult[hookstage.EntrypointPayload], error) {


### PR DESCRIPTION
## Introduction
Closes original server [Issue #3681](https://github.com/prebid/prebid-server/issues/3681) as specified.

## Configuration
```yaml
hooks:
  host_execution_plan:
    abtests:
      - module_code: postindustria.ab_testing
        enabled: true
        accounts: [ 123, 456, 789, "p-bid-account-y9eg0fEH" ]
        percent_active: 50
        log_analytics_tag: true
```
