### PR TITLE
Seedtag: Fix required content-type header on http calls

### DIFF
--- a/adapters/seedtag/seedtag.go
+++ b/adapters/seedtag/seedtag.go
@@ -57,11 +57,16 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 		return nil, []error{err}
 	}
 
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+
 	requestData := &adapters.RequestData{
-		Method: http.MethodPost,
-		Uri:    a.endpoint,
-		Body:   requestJSON,
-		ImpIDs: openrtb_ext.GetImpIDs(requestCopy.Imp),
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    requestJSON,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(requestCopy.Imp),
 	}
 
 	return []*adapters.RequestData{requestData}, errors

--- a/adapters/seedtag/seedtagtest/exemplary/banner.json
+++ b/adapters/seedtag/seedtagtest/exemplary/banner.json
@@ -34,6 +34,10 @@
         {
             "expectedRequest": {
                 "uri": "http://url.seedtag.com",
+                "headers": {
+                    "Content-Type": ["application/json;charset=utf-8"],
+                    "Accept": ["application/json"]
+                },
                 "body": {
                     "id": "test-request-id",
                     "imp": [

--- a/adapters/seedtag/seedtagtest/exemplary/bidfloor_converted.json
+++ b/adapters/seedtag/seedtagtest/exemplary/bidfloor_converted.json
@@ -48,6 +48,10 @@
         {
             "expectedRequest": {
                 "uri": "http://url.seedtag.com",
+                "headers": {
+                    "Content-Type": ["application/json;charset=utf-8"],
+                    "Accept": ["application/json"]
+                },
                 "body": {
                     "id": "test-request-id",
                     "imp": [

--- a/adapters/seedtag/seedtagtest/exemplary/video.json
+++ b/adapters/seedtag/seedtagtest/exemplary/video.json
@@ -36,6 +36,10 @@
         {
             "expectedRequest": {
                 "uri": "http://url.seedtag.com",
+                "headers": {
+                    "Content-Type": ["application/json;charset=utf-8"],
+                    "Accept": ["application/json"]
+                },
                 "body": {
                     "id": "test-request-id",
                     "imp": [


### PR DESCRIPTION
We were missing to add the required content-type headers to request Seedtag server-to-server endpoint. This situation lead to unparsed body payloads for the first integrations.