### PR TITLE
create intenze.yaml and add alias

### DIFF
--- a/static/bidder-info/intenze.yaml
+++ b/static/bidder-info/intenze.yaml
@@ -1,0 +1,4 @@
+aliasOf: "gothamads"
+endpoint: "http://lb-east.intenze.co/?pass={{.AccountID}}"
+maintainer:
+  email: "connect@intenze.co"


### PR DESCRIPTION
Hi, Gothamads is changing its name to Intenze.
But I have my doubts about this. First of all, I saw that Pbs has a [guidelines](https://docs.prebid.org/faq/prebid-server-faq.html#how-can-we-rename-our-bid-adapter) so there is two ways 
1. Create a new yaml file with alias
2. Or rename the entire adapter. 
For us, it would be preferable the second choice to do it all at once. We have asked some of our partners to stop using the gothamads adapter, so no one is using it now. And then switch to intenze