### PR TITLE
Prebid cache: a non-200 status code in the response is recorded as a successful label in the metric

### DIFF
--- a/prebid_cache_client/client.go
+++ b/prebid_cache_client/client.go
@@ -116,13 +116,14 @@ func (c *clientImpl) PutJson(ctx context.Context, values []Cacheable) (uuids []s
 		return uuidsToReturn, errs
 	}
 	defer anResp.Body.Close()
-	c.metrics.RecordPrebidCacheRequestTime(true, elapsedTime)
 
 	responseBody, err := io.ReadAll(anResp.Body)
-	if anResp.StatusCode != 200 {
+	if anResp.StatusCode != 200 || err != nil {
+		c.metrics.RecordPrebidCacheRequestTime(false, elapsedTime)
 		logError(&errs, "Prebid Cache call to %s returned %d: %s", c.putUrl, anResp.StatusCode, responseBody)
 		return uuidsToReturn, errs
 	}
+	c.metrics.RecordPrebidCacheRequestTime(true, elapsedTime)
 
 	currentIndex := 0
 	processResponse := func(uuidObj []byte, _ jsonparser.ValueType, _ int, err error) {

--- a/prebid_cache_client/client_test.go
+++ b/prebid_cache_client/client_test.go
@@ -49,7 +49,7 @@ func TestBadResponse(t *testing.T) {
 	defer server.Close()
 
 	metricsMock := &metrics.MetricsEngineMock{}
-	metricsMock.On("RecordPrebidCacheRequestTime", true, mock.Anything).Once()
+	metricsMock.On("RecordPrebidCacheRequestTime", false, mock.Anything).Once()
 
 	client := &clientImpl{
 		httpClient: server.Client(),


### PR DESCRIPTION
I got a 400 error from Prebid Cache due to the exceeding of request size limit, but it was recorded as successful in Prometheus.