### PR TITLE
Dianomi: Update user syncs to send gdpr_consent

### DIFF
--- a/static/bidder-info/dianomi.yaml
+++ b/static/bidder-info/dianomi.yaml
@@ -16,8 +16,8 @@ capabilities:
       - video
 userSync:
   iframe:
-    url: 'https://www-prebid.dianomi.com/prebid/usersync/index.html?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}'
+    url: 'https://www-prebid.dianomi.com/prebid/usersync/index.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}'
     userMacro: '$UID'
   redirect:
-    url: 'https://data.dianomi.com/frontend/usync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}'
+    url: 'https://data.dianomi.com/frontend/usync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}'
     userMacro: '$UID'


### PR DESCRIPTION
Hi,

We spotted an error in our prebid adapter default config, we really expect gdpr_consent as standard rather than consent.