### PR TITLE
Rules Engine Module: Select model group based on weights

### DIFF
--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -50,3 +50,6 @@ type FakeRandomNumberGenerator struct {
 func (f FakeRandomNumberGenerator) GenerateInt63() int64 {
 	return f.Number
 }
+func (f FakeRandomNumberGenerator) Intn(n int) int {
+	return int(f.Number)
+}

--- a/modules/prebid/rulesengine/cache_entry.go
+++ b/modules/prebid/rulesengine/cache_entry.go
@@ -15,6 +15,7 @@ import (
 type hash = string
 
 type cacheEntry struct {
+	enabled                                 bool
 	timestamp                               time.Time
 	hashedConfig                            hash
 	ruleSetsForProcessedAuctionRequestStage []cacheRuleSet[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]

--- a/modules/prebid/rulesengine/hook_processed_auction.go
+++ b/modules/prebid/rulesengine/hook_processed_auction.go
@@ -2,10 +2,10 @@ package rulesengine
 
 import (
 	"fmt"
-	"math/rand"
 
 	hs "github.com/prebid/prebid-server/v3/hooks/hookstage"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/prebid/prebid-server/v3/util/randomutil"
 )
 
 type RequestWrapper = openrtb_ext.RequestWrapper
@@ -21,7 +21,7 @@ func handleProcessedAuctionHook(
 	}
 
 	for _, ruleSet := range ruleSets {
-		selectedGroup, err := selectModelGroup(ruleSet.modelGroups)
+		selectedGroup, err := selectModelGroup(ruleSet.modelGroups, randomutil.RandomNumberGenerator{})
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("failed to select model group: %s", err))
 			continue
@@ -36,36 +36,36 @@ func handleProcessedAuctionHook(
 	return result, nil
 }
 
-func selectModelGroup(modelGroups []ModelGroup) (ModelGroup, error) {
-    if len(modelGroups) == 0 {
-        return ModelGroup{}, fmt.Errorf("no model groups available")
-    }
+func selectModelGroup(modelGroups []ModelGroup, rg randomutil.RandomGenerator) (ModelGroup, error) {
+	if len(modelGroups) == 0 {
+		return ModelGroup{}, fmt.Errorf("no model groups available")
+	}
 
-    if len(modelGroups) == 1 {
-        return modelGroups[0], nil
-    }
+	if len(modelGroups) == 1 {
+		return modelGroups[0], nil
+	}
 
-    // Create cumulative weight distribution
-    totalWeight := 0
-    cumulativeWeights := make([]int, len(modelGroups))
+	// Create cumulative weight distribution
+	totalWeight := 0
+	cumulativeWeights := make([]int, len(modelGroups))
 
-    for i, group := range modelGroups {
-        weight := 100
-        if group.weight > 0 {
-            weight = group.weight
-        }
-        totalWeight += weight
-        cumulativeWeights[i] = totalWeight
-    }
+	for i, group := range modelGroups {
+		weight := 100
+		if group.weight > 0 {
+			weight = group.weight
+		}
+		totalWeight += weight
+		cumulativeWeights[i] = totalWeight
+	}
 
-    randomValue := rand.Intn(totalWeight) + 1
+	randomValue := rg.Intn(totalWeight) + 1
 
-    // Find the model group corresponding to the random value
-    for i, threshold := range cumulativeWeights {
-        if randomValue <= threshold {
-            return modelGroups[i], nil
-        }
-    }
+	// Find the model group corresponding to the random value
+	for i, threshold := range cumulativeWeights {
+		if randomValue <= threshold {
+			return modelGroups[i], nil
+		}
+	}
 
-    return modelGroups[0], nil
+	return modelGroups[0], nil
 }

--- a/modules/prebid/rulesengine/hook_processed_auction.go
+++ b/modules/prebid/rulesengine/hook_processed_auction.go
@@ -1,9 +1,16 @@
 package rulesengine
 
 import (
+	"fmt"
+	"math/rand"
+
 	hs "github.com/prebid/prebid-server/v3/hooks/hookstage"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 )
+
+type RequestWrapper = openrtb_ext.RequestWrapper
+type ProcessedAuctionChangeSet = hs.ChangeSet[hs.ProcessedAuctionRequestPayload]
+type ModelGroup = cacheModelGroup[RequestWrapper, ProcessedAuctionChangeSet]
 
 func handleProcessedAuctionHook(
 	ruleSets []cacheRuleSet[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]],
@@ -14,14 +21,51 @@ func handleProcessedAuctionHook(
 	}
 
 	for _, ruleSet := range ruleSets {
-		for _, modelGroup := range ruleSet.modelGroups {
-			err := modelGroup.tree.Run(payload.Request, &result.ChangeSet)
-			if err != nil {
-				//TODO: classify errors as warnings or errors
-				result.Errors = append(result.Errors, err.Error())
-			}
+		selectedGroup, err := selectModelGroup(ruleSet.modelGroups)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("failed to select model group: %s", err))
+			continue
+		}
+
+		if err := selectedGroup.tree.Run(payload.Request, &result.ChangeSet); err != nil {
+			//TODO: classify errors as warnings or errors
+			result.Errors = append(result.Errors, err.Error())
 		}
 	}
 
 	return result, nil
+}
+
+func selectModelGroup(modelGroups []ModelGroup) (ModelGroup, error) {
+    if len(modelGroups) == 0 {
+        return ModelGroup{}, fmt.Errorf("no model groups available")
+    }
+
+    if len(modelGroups) == 1 {
+        return modelGroups[0], nil
+    }
+
+    // Create cumulative weight distribution
+    totalWeight := 0
+    cumulativeWeights := make([]int, len(modelGroups))
+
+    for i, group := range modelGroups {
+        weight := 100
+        if group.weight > 0 {
+            weight = group.weight
+        }
+        totalWeight += weight
+        cumulativeWeights[i] = totalWeight
+    }
+
+    randomValue := rand.Intn(totalWeight) + 1
+
+    // Find the model group corresponding to the random value
+    for i, threshold := range cumulativeWeights {
+        if randomValue <= threshold {
+            return modelGroups[i], nil
+        }
+    }
+
+    return modelGroups[0], nil
 }

--- a/modules/prebid/rulesengine/hook_processed_auction_test.go
+++ b/modules/prebid/rulesengine/hook_processed_auction_test.go
@@ -1,0 +1,136 @@
+package rulesengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectModelGroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelGroups   []ModelGroup
+		mockRandValue int
+		expectedIndex int
+		expectedError error
+	}{
+		{
+			name:          "empty-model-groups",
+			modelGroups:   []ModelGroup{},
+			expectedError: fmt.Errorf("no model groups available"),
+		},
+		{
+			name: "single-model-group",
+			modelGroups: []ModelGroup{
+				{weight: 100, analyticsKey: "group1"},
+			},
+			expectedIndex: 0,
+			expectedError: nil,
+		},
+		{
+			name: "equal-weights-first-selected",
+			modelGroups: []ModelGroup{
+				{weight: 50, analyticsKey: "group1"},
+				{weight: 50, analyticsKey: "group2"},
+			},
+			mockRandValue: 25,
+			expectedIndex: 0,
+			expectedError: nil,
+		},
+		{
+			name: "equal-weights-second-selected",
+			modelGroups: []ModelGroup{
+				{weight: 50, analyticsKey: "group1"},
+				{weight: 50, analyticsKey: "group2"},
+			},
+			mockRandValue: 75,
+			expectedIndex: 1,
+			expectedError: nil,
+		},
+		{
+			name: "uneven-weights-first-selected",
+			modelGroups: []ModelGroup{
+				{weight: 70, analyticsKey: "group1"},
+				{weight: 30, analyticsKey: "group2"},
+			},
+			mockRandValue: 65,
+			expectedIndex: 0,
+			expectedError: nil,
+		},
+		{
+			name: "uneven-weights-second-selected",
+			modelGroups: []ModelGroup{
+				{weight: 70, analyticsKey: "group1"},
+				{weight: 30, analyticsKey: "group2"},
+			},
+			mockRandValue: 75,
+			expectedIndex: 1,
+			expectedError: nil,
+		},
+		{
+			name: "three-groups-with-middle-selected",
+			modelGroups: []ModelGroup{
+				{weight: 20, analyticsKey: "group1"},
+				{weight: 30, analyticsKey: "group2"},
+				{weight: 50, analyticsKey: "group3"},
+			},
+			mockRandValue: 35,
+			expectedIndex: 1,
+			expectedError: nil,
+		},
+		{
+			name: "zero-weight-defaults-to-100-first-selected",
+			modelGroups: []ModelGroup{
+				{weight: 0, analyticsKey: "group1"},
+				{weight: 50, analyticsKey: "group2"},
+			},
+			mockRandValue: 80, // Will select second group (101-150)
+			expectedIndex: 0,
+			expectedError: nil,
+		},
+		{
+			name: "zero-weight-defaults-to-100-second-selected",
+			modelGroups: []ModelGroup{
+				{weight: 0, analyticsKey: "group1"},
+				{weight: 50, analyticsKey: "group2"},
+			},
+			mockRandValue: 120,
+			expectedIndex: 1,
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRandom := &mockRandomGenerator{returnValue: tt.mockRandValue}
+
+			result, err := selectModelGroup(tt.modelGroups, mockRandom)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.modelGroups[tt.expectedIndex].analyticsKey, result.analyticsKey)
+			}
+		})
+	}
+}
+
+// mockRandomGenerator implements randomutil.RandomGenerator for testing
+type mockRandomGenerator struct {
+	returnValue int
+}
+
+func (g *mockRandomGenerator) Intn(n int) int {
+	// Ensure return value is within the range [0,n)
+	if g.returnValue >= n {
+		return g.returnValue % n
+	}
+	return g.returnValue
+}
+
+func (g *mockRandomGenerator) GenerateInt63() int64 {
+	return int64(g.returnValue)
+}

--- a/modules/prebid/rulesengine/module.go
+++ b/modules/prebid/rulesengine/module.go
@@ -81,6 +81,10 @@ func (m Module) HandleProcessedAuctionHook(
 		m.TreeManager.requests <- bi
 	}
 
+	if !co.enabled {
+		return hs.HookResult[hs.ProcessedAuctionRequestPayload]{}, nil
+	}
+
 	ruleSets := co.ruleSetsForProcessedAuctionRequestStage
 
 	return handleProcessedAuctionHook(ruleSets, payload)

--- a/modules/prebid/rulesengine/tree_manager.go
+++ b/modules/prebid/rulesengine/tree_manager.go
@@ -41,6 +41,11 @@ func (tb *treeManager) Run(c cacher) error {
 				break
 			}
 
+			if !parsedCfg.Enabled {
+				// TODO: log metric
+				break
+			}
+
 			newCacheObj, err := NewCacheEntry(parsedCfg, req.config)
 			if err != nil {
 				// TODO: log error / metric

--- a/modules/prebid/rulesengine/tree_manager.go
+++ b/modules/prebid/rulesengine/tree_manager.go
@@ -42,6 +42,7 @@ func (tb *treeManager) Run(c cacher) error {
 			}
 
 			if !parsedCfg.Enabled {
+				c.Delete(req.accountID)
 				// TODO: log metric
 				break
 			}

--- a/modules/prebid/rulesengine/tree_test.go
+++ b/modules/prebid/rulesengine/tree_test.go
@@ -33,10 +33,10 @@ func BuildTestRules() rules.Tree[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.Pro
 		Root: &rules.Node[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{
 			SchemaFunction: devCountryFunc,
 			Children: map[string]*rules.Node[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{
-				"true": &rules.Node[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{
+				"true": {
 					ResultFunctions: []rules.ResultFunction[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{resFuncTrue},
 				},
-				"false": &rules.Node[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{
+				"false": {
 					ResultFunctions: []rules.ResultFunction[openrtb_ext.RequestWrapper, hs.ChangeSet[hs.ProcessedAuctionRequestPayload]]{resFuncFalse},
 				},
 			},

--- a/util/randomutil/randomutil.go
+++ b/util/randomutil/randomutil.go
@@ -6,10 +6,15 @@ import (
 
 type RandomGenerator interface {
 	GenerateInt63() int64
+	Intn(n int) int
 }
 
 type RandomNumberGenerator struct{}
 
 func (RandomNumberGenerator) GenerateInt63() int64 {
 	return rand.Int63()
+}
+
+func (r RandomNumberGenerator) Intn(n int) int {
+	return rand.Intn(n)
 }


### PR DESCRIPTION
- Select model group based on weights
- Adds enabled flag to cache entry, and if false, rule sets are not processed 
- Delete cache entry if account has disabled the module