### PR TITLE
Targeting: Add configurable targeting prefix

### DIFF
--- a/adservertargeting/respdataprocessor.go
+++ b/adservertargeting/respdataprocessor.go
@@ -103,16 +103,13 @@ func resolveKey(respTargetingData ResponseTargetingData, bidderName string) stri
 
 func truncateTargetingKeys(targetingData map[string]string, truncateTargetAttribute *int) map[string]string {
 	maxLength := MaxKeyLength
-	if truncateTargetAttribute != nil {
+	if truncateTargetAttribute != nil && *truncateTargetAttribute > 0 {
 		maxLength = *truncateTargetAttribute
-		if maxLength <= 0 {
-			maxLength = MaxKeyLength
-		}
 	}
 
 	targetingDataTruncated := make(map[string]string)
 	for key, value := range targetingData {
-		newKey := openrtb_ext.TargetingKey(key).TruncateKey(maxLength)
+		newKey := openrtb_ext.TargetingKey(key).TruncateKey("", maxLength)
 		targetingDataTruncated[newKey] = value
 	}
 	return targetingDataTruncated

--- a/config/account.go
+++ b/config/account.go
@@ -43,6 +43,7 @@ type Account struct {
 	BidAdjustments          *openrtb_ext.ExtRequestPrebidBidAdjustments `mapstructure:"bidadjustments" json:"bidadjustments"`
 	Privacy                 AccountPrivacy                              `mapstructure:"privacy" json:"privacy"`
 	PreferredMediaType      openrtb_ext.PreferredMediaType              `mapstructure:"preferredmediatype" json:"preferredmediatype"`
+	TargetingPrefix         string                                      `mapstructure:"targeting_prefix" json:"targeting_prefix"`
 }
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -549,7 +549,7 @@ func buildVideoResponse(bidresponse *openrtb2.BidResponse, podErrors []PodError)
 			if err := jsonutil.UnmarshalValid(bid.Ext, &tempRespBidExt); err != nil {
 				return nil, err
 			}
-			if tempRespBidExt.Prebid.Targeting[formatTargetingKey(openrtb_ext.HbVastCacheKey, seatBid.Seat)] == "" {
+			if findTargetingByKey(tempRespBidExt.Prebid.Targeting, formatTargetingKey(openrtb_ext.VastCacheKey, seatBid.Seat)) == "" {
 				continue
 			}
 
@@ -558,10 +558,10 @@ func buildVideoResponse(bidresponse *openrtb2.BidResponse, podErrors []PodError)
 			podId, _ := strconv.ParseInt(podNum, 0, 64)
 
 			videoTargeting := openrtb_ext.VideoTargeting{
-				HbPb:       tempRespBidExt.Prebid.Targeting[formatTargetingKey(openrtb_ext.HbpbConstantKey, seatBid.Seat)],
-				HbPbCatDur: tempRespBidExt.Prebid.Targeting[formatTargetingKey(openrtb_ext.HbCategoryDurationKey, seatBid.Seat)],
-				HbCacheID:  tempRespBidExt.Prebid.Targeting[formatTargetingKey(openrtb_ext.HbVastCacheKey, seatBid.Seat)],
-				HbDeal:     tempRespBidExt.Prebid.Targeting[formatTargetingKey(openrtb_ext.HbDealIDConstantKey, seatBid.Seat)],
+				HbPb:       findTargetingByKey(tempRespBidExt.Prebid.Targeting, formatTargetingKey(openrtb_ext.PbKey, seatBid.Seat)),
+				HbPbCatDur: findTargetingByKey(tempRespBidExt.Prebid.Targeting, formatTargetingKey(openrtb_ext.CategoryDurationKey, seatBid.Seat)),
+				HbCacheID:  findTargetingByKey(tempRespBidExt.Prebid.Targeting, formatTargetingKey(openrtb_ext.VastCacheKey, seatBid.Seat)),
+				HbDeal:     findTargetingByKey(tempRespBidExt.Prebid.Targeting, formatTargetingKey(openrtb_ext.DealKey, seatBid.Seat)),
 			}
 
 			adPod := findAdPod(podId, adPods)
@@ -605,6 +605,17 @@ func formatTargetingKey(key openrtb_ext.TargetingKey, bidderName string) string 
 		return string(fullKey[0:exchange.MaxKeyLength])
 	}
 	return fullKey
+}
+
+func findTargetingByKey(targetingMap map[string]string, keyWithoutPrefix string) string {
+	for k, v := range targetingMap {
+		prefixIndex := strings.Index(k, "_")
+		// find potentially truncated key in original key name without prefixes
+		if prefixIndex > 0 && strings.HasPrefix(keyWithoutPrefix, k[prefixIndex:]) {
+			return v
+		}
+	}
+	return ""
 }
 
 func findAdPod(podInd int64, pods []*openrtb_ext.AdPod) *openrtb_ext.AdPod {

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -1147,13 +1147,48 @@ func TestVideoEndpointAppendBidderNames(t *testing.T) {
 }
 
 func TestFormatTargetingKey(t *testing.T) {
-	res := formatTargetingKey(openrtb_ext.HbCategoryDurationKey, "appnexus")
-	assert.Equal(t, "hb_pb_cat_dur_appnex", res, "Tergeting key constructed incorrectly")
+	res := formatTargetingKey(openrtb_ext.CategoryDurationKey, "appnexus")
+	assert.Equal(t, "_pb_cat_dur_appnexus", res, "Tergeting key constructed incorrectly")
 }
 
 func TestFormatTargetingKeyLongKey(t *testing.T) {
-	res := formatTargetingKey(openrtb_ext.HbpbConstantKey, "20.00")
-	assert.Equal(t, "hb_pb_20.00", res, "Tergeting key constructed incorrectly")
+	res := formatTargetingKey(openrtb_ext.PbKey, "20.00")
+	assert.Equal(t, "_pb_20.00", res, "Tergeting key constructed incorrectly")
+}
+
+func TestFindTargetingByKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		targetingMap     map[string]string
+		keyWithoutPrefix string
+		expectedResult   string
+	}{
+		{
+			name: "Correct match",
+			targetingMap: map[string]string{
+				"hb_key": "hb_key12345454",
+			},
+			keyWithoutPrefix: "_key12345454",
+			expectedResult:   "hb_key12345454",
+		},
+		{
+			name: "Dismatching",
+			targetingMap: map[string]string{
+				"hb_key": "hb_key12345454",
+			},
+			keyWithoutPrefix: "12345454",
+			expectedResult:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findTargetingByKey(tt.targetingMap, tt.keyWithoutPrefix)
+			if result != tt.expectedResult {
+				t.Errorf("expected %v, got %v", tt.expectedResult, result)
+			}
+		})
+	}
 }
 
 func TestVideoAuctionResponseHeaders(t *testing.T) {

--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -37,6 +37,8 @@ const (
 	SecBrowsingTopicsWarningCode
 	InvalidUserEIDsWarningCode
 	InvalidUserUIDsWarningCode
+	TooLongTargetingPrefixWarningCode
+	TooShortTargetingPrefixWarningCode
 )
 
 // Coder provides an error or warning code with severity.

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -14,9 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prebid/prebid-server/v3/ortb"
-	"github.com/prebid/prebid-server/v3/privacy"
-
 	"github.com/prebid/prebid-server/v3/adapters"
 	"github.com/prebid/prebid-server/v3/adservertargeting"
 	"github.com/prebid/prebid-server/v3/bidadjustment"
@@ -33,7 +30,9 @@ import (
 	"github.com/prebid/prebid-server/v3/macros"
 	"github.com/prebid/prebid-server/v3/metrics"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/prebid/prebid-server/v3/ortb"
 	"github.com/prebid/prebid-server/v3/prebid_cache_client"
+	"github.com/prebid/prebid-server/v3/privacy"
 	"github.com/prebid/prebid-server/v3/stored_requests"
 	"github.com/prebid/prebid-server/v3/stored_responses"
 	"github.com/prebid/prebid-server/v3/usersync"
@@ -269,9 +268,13 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 
 	cacheInstructions := getExtCacheInstructions(requestExtPrebid)
 
-	targData := getExtTargetData(requestExtPrebid, cacheInstructions)
+	targData, warning := getExtTargetData(requestExtPrebid, cacheInstructions, r.Account)
 	if targData != nil {
 		_, targData.cacheHost, targData.cachePath = e.cache.GetExtCacheData()
+	}
+
+	for _, w := range warning {
+		r.Warnings = append(r.Warnings, w)
 	}
 
 	// Get currency rates conversions for the auction

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -9,6 +9,8 @@ import (
 )
 
 const MaxKeyLength = 20
+const MinKeyLength = 12 // longest attribute length without prefix
+const DefaultKeyPrefix = "hb"
 
 // targetData tracks information about the winning Bid in each Imp.
 //
@@ -30,6 +32,7 @@ type targetData struct {
 	// cacheHost and cachePath exist to supply cache host and path as targeting parameters
 	cacheHost string
 	cachePath string
+	prefix    string
 }
 
 // setTargeting writes all the targeting params into the bids.
@@ -66,38 +69,38 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 
 				targets := make(map[string]string, 10)
 				if cpm, ok := auc.roundedPrices[topBid]; ok {
-					targData.addKeys(targets, openrtb_ext.HbpbConstantKey, cpm, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.PbKey, cpm, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
-				targData.addKeys(targets, openrtb_ext.HbBidderConstantKey, string(targetingBidderCode), targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+				targData.addKeys(targets, openrtb_ext.BidderKey, string(targetingBidderCode), targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				if hbSize := makeHbSize(topBid.Bid); hbSize != "" {
-					targData.addKeys(targets, openrtb_ext.HbSizeConstantKey, hbSize, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.SizeKey, hbSize, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if cacheID, ok := auc.cacheIds[topBid.Bid]; ok {
-					targData.addKeys(targets, openrtb_ext.HbCacheKey, cacheID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.CacheKey, cacheID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if vastID, ok := auc.vastCacheIds[topBid.Bid]; ok {
-					targData.addKeys(targets, openrtb_ext.HbVastCacheKey, vastID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.VastCacheKey, vastID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if targData.includeFormat {
-					targData.addKeys(targets, openrtb_ext.HbFormatKey, string(topBid.BidType), targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.FormatKey, string(topBid.BidType), targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 
 				if targData.cacheHost != "" {
-					targData.addKeys(targets, openrtb_ext.HbConstantCacheHostKey, targData.cacheHost, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.CacheHostKey, targData.cacheHost, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if targData.cachePath != "" {
-					targData.addKeys(targets, openrtb_ext.HbConstantCachePathKey, targData.cachePath, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.CachePathKey, targData.cachePath, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 
 				if bidHasDeal {
-					targData.addKeys(targets, openrtb_ext.HbDealIDConstantKey, topBid.Bid.DealID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.DealKey, topBid.Bid.DealID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 
 				if isApp {
-					targData.addKeys(targets, openrtb_ext.HbEnvKey, openrtb_ext.HbEnvKeyApp, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.EnvKey, openrtb_ext.EnvAppValue, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if len(categoryMapping) > 0 {
-					targData.addKeys(targets, openrtb_ext.HbCategoryDurationKey, categoryMapping[topBid.Bid.ID], targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+					targData.addKeys(targets, openrtb_ext.CategoryDurationKey, categoryMapping[topBid.Bid.ID], targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				topBid.BidTargets = targets
 			}
@@ -106,20 +109,15 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 }
 
 func (targData *targetData) addKeys(keys map[string]string, key openrtb_ext.TargetingKey, value string, bidderName openrtb_ext.BidderName, overallWinner bool, truncateTargetAttr *int, bidHasDeal bool) {
-	var maxLength int
-	if truncateTargetAttr != nil {
+	maxLength := MaxKeyLength
+	if truncateTargetAttr != nil && *truncateTargetAttr > 0 {
 		maxLength = *truncateTargetAttr
-		if maxLength < 0 {
-			maxLength = MaxKeyLength
-		}
-	} else {
-		maxLength = MaxKeyLength
 	}
 	if targData.includeBidderKeys || (targData.alwaysIncludeDeals && bidHasDeal) {
-		keys[key.BidderKey(bidderName, maxLength)] = value
+		keys[key.BidderKey(targData.prefix, bidderName, maxLength)] = value
 	}
 	if targData.includeWinners && overallWinner {
-		keys[key.TruncateKey(maxLength)] = value
+		keys[key.TruncateKey(targData.prefix, maxLength)] = value
 	}
 }
 

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -46,26 +46,71 @@ var mockBids = map[openrtb_ext.BidderName][]*openrtb2.Bid{
 
 // Prevents #378. This is not a JSON test because the cache ID values aren't reproducible, which makes them a pain to test in that format.
 func TestTargetingCache(t *testing.T) {
-	bids := runTargetingAuction(t, mockBids, true, true, true, false)
+	bids := runTargetingAuction(t, mockBids, true, true, true, false, "", "")
 
 	// Make sure that the cache keys exist on the bids where they're expected to
-	assertKeyExists(t, bids["winning-bid"], string(openrtb_ext.HbCacheKey), true)
-	assertKeyExists(t, bids["winning-bid"], openrtb_ext.HbCacheKey.BidderKey(openrtb_ext.BidderAppnexus, MaxKeyLength), true)
+	assertKeyExists(t, bids["winning-bid"], DefaultKeyPrefix+string(openrtb_ext.CacheKey), true)
+	assertKeyExists(t, bids["winning-bid"], openrtb_ext.CacheKey.BidderKey(DefaultKeyPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), true)
 
-	assertKeyExists(t, bids["contending-bid"], string(openrtb_ext.HbCacheKey), false)
-	assertKeyExists(t, bids["contending-bid"], openrtb_ext.HbCacheKey.BidderKey(openrtb_ext.BidderRubicon, MaxKeyLength), true)
+	assertKeyExists(t, bids["contending-bid"], DefaultKeyPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["contending-bid"], openrtb_ext.CacheKey.BidderKey(DefaultKeyPrefix, openrtb_ext.BidderRubicon, MaxKeyLength), true)
 
-	assertKeyExists(t, bids["losing-bid"], string(openrtb_ext.HbCacheKey), false)
-	assertKeyExists(t, bids["losing-bid"], openrtb_ext.HbCacheKey.BidderKey(openrtb_ext.BidderAppnexus, MaxKeyLength), false)
+	assertKeyExists(t, bids["losing-bid"], DefaultKeyPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["losing-bid"], openrtb_ext.CacheKey.BidderKey(DefaultKeyPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), false)
 
 	//assert hb_cache_host was included
-	assert.Contains(t, string(bids["winning-bid"].Ext), string(openrtb_ext.HbConstantCacheHostKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), DefaultKeyPrefix+string(openrtb_ext.CacheHostKey))
 	assert.Contains(t, string(bids["winning-bid"].Ext), "www.pbcserver.com")
 
 	//assert hb_cache_path was included
-	assert.Contains(t, string(bids["winning-bid"].Ext), string(openrtb_ext.HbConstantCachePathKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), DefaultKeyPrefix+string(openrtb_ext.CachePathKey))
 	assert.Contains(t, string(bids["winning-bid"].Ext), "/pbcache/endpoint")
+}
 
+func TestTargetingCacheRequestPrefix(t *testing.T) {
+	reqPrefix := "req"
+	bids := runTargetingAuction(t, mockBids, true, true, true, false, reqPrefix, "acc")
+
+	// Make sure that the cache keys exist on the bids where they're expected to
+	assertKeyExists(t, bids["winning-bid"], reqPrefix+string(openrtb_ext.CacheKey), true)
+	assertKeyExists(t, bids["winning-bid"], openrtb_ext.CacheKey.BidderKey(reqPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), true)
+
+	assertKeyExists(t, bids["contending-bid"], reqPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["contending-bid"], openrtb_ext.CacheKey.BidderKey(reqPrefix, openrtb_ext.BidderRubicon, MaxKeyLength), true)
+
+	assertKeyExists(t, bids["losing-bid"], reqPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["losing-bid"], openrtb_ext.CacheKey.BidderKey(reqPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), false)
+
+	//assert hb_cache_host was included
+	assert.Contains(t, string(bids["winning-bid"].Ext), reqPrefix+string(openrtb_ext.CacheHostKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), "www.pbcserver.com")
+
+	//assert hb_cache_path was included
+	assert.Contains(t, string(bids["winning-bid"].Ext), reqPrefix+string(openrtb_ext.CachePathKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), "/pbcache/endpoint")
+}
+
+func TestTargetingCacheAccountPrefix(t *testing.T) {
+	accPrefix := "acc"
+	bids := runTargetingAuction(t, mockBids, true, true, true, false, "", accPrefix)
+
+	// Make sure that the cache keys exist on the bids where they're expected to
+	assertKeyExists(t, bids["winning-bid"], accPrefix+string(openrtb_ext.CacheKey), true)
+	assertKeyExists(t, bids["winning-bid"], openrtb_ext.CacheKey.BidderKey(accPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), true)
+
+	assertKeyExists(t, bids["contending-bid"], accPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["contending-bid"], openrtb_ext.CacheKey.BidderKey(accPrefix, openrtb_ext.BidderRubicon, MaxKeyLength), true)
+
+	assertKeyExists(t, bids["losing-bid"], accPrefix+string(openrtb_ext.CacheKey), false)
+	assertKeyExists(t, bids["losing-bid"], openrtb_ext.CacheKey.BidderKey(accPrefix, openrtb_ext.BidderAppnexus, MaxKeyLength), false)
+
+	//assert hb_cache_host was included
+	assert.Contains(t, string(bids["winning-bid"].Ext), accPrefix+string(openrtb_ext.CacheHostKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), "www.pbcserver.com")
+
+	//assert hb_cache_path was included
+	assert.Contains(t, string(bids["winning-bid"].Ext), accPrefix+string(openrtb_ext.CachePathKey))
+	assert.Contains(t, string(bids["winning-bid"].Ext), "/pbcache/endpoint")
 }
 
 func assertKeyExists(t *testing.T, bid *openrtb2.Bid, key string, expected bool) {
@@ -78,7 +123,7 @@ func assertKeyExists(t *testing.T, bid *openrtb2.Bid, key string, expected bool)
 
 // runAuction takes a bunch of mock bids by Bidder and runs an auction. It returns a map of Bids indexed by their ImpID.
 // If includeCache is true, the auction will be run with cacheing as well, so the cache targeting keys should exist.
-func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*openrtb2.Bid, includeCache bool, includeWinners bool, includeBidderKeys bool, isApp bool) map[string]*openrtb2.Bid {
+func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*openrtb2.Bid, includeCache bool, includeWinners bool, includeBidderKeys bool, isApp bool, requestPrefix string, accountPrefix string) map[string]*openrtb2.Bid {
 	server := httptest.NewServer(http.HandlerFunc(mockServer))
 	defer server.Close()
 
@@ -113,7 +158,7 @@ func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*op
 
 	req := &openrtb2.BidRequest{
 		Imp: imps,
-		Ext: buildTargetingExt(includeCache, includeWinners, includeBidderKeys),
+		Ext: buildTargetingExt(includeCache, includeWinners, includeBidderKeys, requestPrefix),
 	}
 	if isApp {
 		req.App = &openrtb2.App{}
@@ -123,10 +168,12 @@ func runTargetingAuction(t *testing.T, mockBids map[openrtb_ext.BidderName][]*op
 
 	auctionRequest := &AuctionRequest{
 		BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: req},
-		Account:           config.Account{},
-		UserSyncs:         &emptyUsersync{},
-		HookExecutor:      &hookexecution.EmptyHookExecutor{},
-		TCF2Config:        gdpr.NewTCF2Config(config.TCF2{}, config.AccountGDPR{}),
+		Account: config.Account{
+			TargetingPrefix: accountPrefix,
+		},
+		UserSyncs:    &emptyUsersync{},
+		HookExecutor: &hookexecution.EmptyHookExecutor{},
+		TCF2Config:   gdpr.NewTCF2Config(config.TCF2{}, config.AccountGDPR{}),
 	}
 
 	debugLog := DebugLog{}
@@ -153,16 +200,16 @@ func buildAdapterMap(bids map[openrtb_ext.BidderName][]*openrtb2.Bid, mockServer
 	return adapterMap
 }
 
-func buildTargetingExt(includeCache bool, includeWinners bool, includeBidderKeys bool) json.RawMessage {
+func buildTargetingExt(includeCache bool, includeWinners bool, includeBidderKeys bool, prefix string) json.RawMessage {
 	var targeting string
 	if includeWinners && includeBidderKeys {
-		targeting = `{"pricegranularity":{"precision":2,"ranges": [{"min": 0,"max": 20,"increment": 0.1}]},"includewinners": true, "includebidderkeys": true}`
+		targeting = `{"prefix":"` + prefix + `","pricegranularity":{"precision":2,"ranges": [{"min": 0,"max": 20,"increment": 0.1}]},"includewinners": true, "includebidderkeys": true}`
 	} else if !includeWinners && includeBidderKeys {
-		targeting = `{"precision":2,"includewinners": false}`
+		targeting = `{"prefix":"` + prefix + `","precision":2,"includewinners": false}`
 	} else if includeWinners && !includeBidderKeys {
-		targeting = `{"precision":2,"includebidderkeys": false}`
+		targeting = `{"prefix":"` + prefix + `","precision":2,"includebidderkeys": false}`
 	} else {
-		targeting = `{"precision":2,"includewinners": false, "includebidderkeys": false}`
+		targeting = `{"prefix":"` + prefix + `","precision":2,"includewinners": false, "includebidderkeys": false}`
 	}
 
 	if includeCache {
@@ -342,6 +389,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -377,6 +425,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -419,6 +468,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity:   lookupPriceGranularity("med"),
 			alwaysIncludeDeals: true,
+			prefix:             DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -469,6 +519,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:    true,
 			includeBidderKeys: true,
 			includeFormat:     true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -518,6 +569,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeBidderKeys: true,
 			cacheHost:         "cache.prebid.com",
 			cachePath:         "cache",
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -567,10 +619,67 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TruncateTargetAttr: nil,
 	},
 	{
+		Description: "Cache and deal targeting test custom prefix",
+		TargetData: targetData{
+			priceGranularity:  lookupPriceGranularity("med"),
+			includeBidderKeys: true,
+			cacheHost:         "cache.prebid.com",
+			cachePath:         "cache",
+			prefix:            "blah",
+		},
+		Auction: auction{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+					openrtb_ext.BidderRubicon: {{
+						Bid:     bid111,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+			cacheIds: map[*openrtb2.Bid]string{
+				bid123: "55555",
+				bid111: "cacheme",
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"blah_bidder_appnexus": "appnexus",
+							"blah_pb_appnexus":     "1.20",
+							"blah_cache_id_appnex": "55555",
+							"blah_cache_host_appn": "cache.prebid.com",
+							"blah_cache_path_appn": "cache",
+						},
+					},
+				},
+				openrtb_ext.BidderRubicon: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"blah_bidder_rubicon":  "rubicon",
+							"blah_pb_rubicon":      "1.10",
+							"blah_cache_id_rubico": "cacheme",
+							"blah_deal_rubicon":    "mydeal",
+							"blah_cache_host_rubi": "cache.prebid.com",
+							"blah_cache_path_rubi": "cache",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
+	{
 		Description: "bidder with no dealID should not have deal targeting",
 		TargetData: targetData{
 			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -601,6 +710,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -643,6 +753,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -685,6 +796,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -727,6 +839,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -762,6 +875,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -797,6 +911,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
@@ -834,6 +949,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			includeWinners:    true,
 			includeBidderKeys: true,
 			includeFormat:     true,
+			prefix:            DefaultKeyPrefix,
 		},
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -925,8 +925,9 @@ func getExtCacheInstructions(requestExtPrebid *openrtb_ext.ExtRequestPrebid) ext
 	return cacheInstructions
 }
 
-func getExtTargetData(requestExtPrebid *openrtb_ext.ExtRequestPrebid, cacheInstructions extCacheInstructions) *targetData {
+func getExtTargetData(requestExtPrebid *openrtb_ext.ExtRequestPrebid, cacheInstructions extCacheInstructions, account config.Account) (*targetData, []*errortypes.Warning) {
 	if requestExtPrebid != nil && requestExtPrebid.Targeting != nil {
+		prefix, warning := getTargetDataPrefix(requestExtPrebid.Targeting.Prefix, account)
 		return &targetData{
 			alwaysIncludeDeals:        requestExtPrebid.Targeting.AlwaysIncludeDeals,
 			includeBidderKeys:         ptrutil.ValueOrDefault(requestExtPrebid.Targeting.IncludeBidderKeys),
@@ -937,10 +938,49 @@ func getExtTargetData(requestExtPrebid *openrtb_ext.ExtRequestPrebid, cacheInstr
 			mediaTypePriceGranularity: ptrutil.ValueOrDefault(requestExtPrebid.Targeting.MediaTypePriceGranularity),
 			preferDeals:               requestExtPrebid.Targeting.PreferDeals,
 			priceGranularity:          ptrutil.ValueOrDefault(requestExtPrebid.Targeting.PriceGranularity),
+			prefix:                    prefix,
+		}, warning
+	}
+
+	return nil, nil
+}
+
+func getTargetDataPrefix(requestPrefix string, account config.Account) (string, []*errortypes.Warning) {
+	var warnings []*errortypes.Warning
+
+	maxLength := MaxKeyLength
+	if account.TruncateTargetAttribute != nil {
+		if *account.TruncateTargetAttribute > MinKeyLength {
+			maxLength = *account.TruncateTargetAttribute
+		}
+
+		if *account.TruncateTargetAttribute < MinKeyLength {
+			warnings = append(warnings, &errortypes.Warning{
+				WarningCode: errortypes.TooShortTargetingPrefixWarningCode,
+				Message:     "targeting prefix is shorter than 'MinKeyLength' value: increase prefix length",
+			})
+			return DefaultKeyPrefix, warnings
 		}
 	}
 
-	return nil
+	maxLength -= MinKeyLength
+	result := DefaultKeyPrefix
+
+	if requestPrefix != "" {
+		result = requestPrefix
+	} else if account.TargetingPrefix != "" {
+		result = account.TargetingPrefix
+	}
+
+	if len(result) > maxLength {
+		warnings = append(warnings, &errortypes.Warning{
+			WarningCode: errortypes.TooLongTargetingPrefixWarningCode,
+			Message:     "targeting prefix combined with key attribute is longer than 'settings.targeting.truncate-attr-chars' value: decrease prefix length or increase truncate-attr-chars",
+		})
+		return DefaultKeyPrefix, warnings
+	}
+
+	return result, warnings
 }
 
 // getDebugInfo returns the boolean flags that allow for debug information in bidResponse.Ext, the SeatBid.httpcalls slice, and

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -138,40 +138,40 @@ func ParseBidType(bidType string) (BidType, error) {
 type TargetingKey string
 
 const (
-	HbpbConstantKey TargetingKey = "hb_pb"
+	PbKey TargetingKey = "_pb"
 
-	// HbEnvKey exists to support the Prebid Universal Creative. If it exists, the only legal value is mobile-app.
+	// EnvKey exists to support the Prebid Universal Creative. If it exists, the only legal value is mobile-app.
 	// It will exist only if the incoming bidRequest defined request.app instead of request.site.
-	HbEnvKey TargetingKey = "hb_env"
+	EnvKey TargetingKey = "_env"
 
-	// HbCacheHost and HbCachePath exist to supply cache host and path as targeting parameters
-	HbConstantCacheHostKey TargetingKey = "hb_cache_host"
-	HbConstantCachePathKey TargetingKey = "hb_cache_path"
+	// CacheHostKey and CachePathKey exist to supply cache host and path as targeting parameters
+	CacheHostKey TargetingKey = "_cache_host"
+	CachePathKey TargetingKey = "_cache_path"
 
-	// HbBidderConstantKey is the name of the Bidder. For example, "appnexus" or "rubicon".
-	HbBidderConstantKey TargetingKey = "hb_bidder"
-	HbSizeConstantKey   TargetingKey = "hb_size"
-	HbDealIDConstantKey TargetingKey = "hb_deal"
+	// BidderKey is the name of the Bidder. For example, "appnexus" or "rubicon".
+	BidderKey TargetingKey = "_bidder"
+	SizeKey   TargetingKey = "_size"
+	DealKey   TargetingKey = "_deal"
 
-	// HbFormatKey is the format of the bid. For example, "video", "banner"
-	HbFormatKey TargetingKey = "hb_format"
+	// FormatKey is the format of the bid. For example, "video", "banner"
+	FormatKey TargetingKey = "_format"
 
-	// HbCacheKey and HbVastCacheKey store UUIDs which can be used to fetch things from prebid cache.
+	// CacheKey and VastCacheKey store UUIDs which can be used to fetch things from prebid cache.
 	// Callers should *never* assume that either of these exist, since the call to the cache may always fail.
 	//
-	// HbVastCacheKey's UUID will fetch the entire bid JSON, while HbVastCacheKey will fetch just the VAST XML.
-	// HbVastCacheKey will only ever exist for Video bids.
-	HbCacheKey     TargetingKey = "hb_cache_id"
-	HbVastCacheKey TargetingKey = "hb_uuid"
+	// VastCacheKey's UUID will fetch the entire bid JSON, while VastCacheKey will fetch just the VAST XML.
+	// VastCacheKey will only ever exist for Video bids.
+	CacheKey     TargetingKey = "_cache_id"
+	VastCacheKey TargetingKey = "_uuid"
 
-	// This is not a key, but values used by the HbEnvKey
-	HbEnvKeyApp string = "mobile-app"
+	// EnvAppValue used as a value for EnvKey
+	EnvAppValue string = "mobile-app"
 
-	HbCategoryDurationKey TargetingKey = "hb_pb_cat_dur"
+	CategoryDurationKey TargetingKey = "_pb_cat_dur"
 )
 
-func (key TargetingKey) BidderKey(bidder BidderName, maxLength int) string {
-	s := string(key) + "_" + string(bidder)
+func (key TargetingKey) BidderKey(prefix string, bidder BidderName, maxLength int) string {
+	s := prefix + string(key) + "_" + string(bidder)
 	if maxLength != 0 {
 		return s[:min(len(s), maxLength)]
 	}
@@ -185,11 +185,12 @@ func min(x, y int) int {
 	return y
 }
 
-func (key TargetingKey) TruncateKey(maxLength int) string {
+func (key TargetingKey) TruncateKey(prefix string, maxLength int) string {
+	result := prefix + string(key)
 	if maxLength > 0 {
-		return string(key)[:min(len(string(key)), maxLength)]
+		return result[:min(len(result), maxLength)]
 	}
-	return string(key)
+	return result
 }
 
 const (

--- a/openrtb_ext/bid_test.go
+++ b/openrtb_ext/bid_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestBidderKey(t *testing.T) {
-	apnKey := HbpbConstantKey.BidderKey(BidderAppnexus, 50)
+	apnKey := PbKey.BidderKey("hb", BidderAppnexus, 50)
 	if apnKey != "hb_pb_appnexus" {
 		t.Errorf("Bad resolved targeting key. Expected hb_pb_appnexus, got %s", apnKey)
 	}
 }
 
 func TestTruncatedKey(t *testing.T) {
-	apnKey := HbpbConstantKey.BidderKey(BidderAppnexus, 8)
+	apnKey := PbKey.BidderKey("hb", BidderAppnexus, 8)
 	if apnKey != "hb_pb_ap" {
 		t.Errorf("Bad truncated targeting key. Expected hb_pb_ap, got %s", apnKey)
 	}
@@ -30,25 +30,25 @@ func TestTruncateKey(t *testing.T) {
 		{
 			description:          "Targeting key is smaller than max length, expect targeting key to stay the same",
 			givenMaxLength:       15,
-			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			givenTargetingKey:    TargetingKey("_bidder_key"),
 			expectedTargetingKey: "hb_bidder_key",
 		},
 		{
 			description:          "Targeting key is larger than max length, expect targeting key to be truncated",
 			givenMaxLength:       9,
-			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			givenTargetingKey:    TargetingKey("_bidder_key"),
 			expectedTargetingKey: "hb_bidder",
 		},
 		{
 			description:          "Max length isn't greater than zero, expect targeting key to not be truncated",
 			givenMaxLength:       0,
-			givenTargetingKey:    TargetingKey("hb_bidder_key"),
+			givenTargetingKey:    TargetingKey("_bidder_key"),
 			expectedTargetingKey: "hb_bidder_key",
 		},
 	}
 
 	for _, test := range testCases {
-		truncatedKey := test.givenTargetingKey.TruncateKey(test.givenMaxLength)
+		truncatedKey := test.givenTargetingKey.TruncateKey("hb", test.givenMaxLength)
 		assert.Equalf(t, test.expectedTargetingKey, truncatedKey, "The Targeting Key is incorrect: %s\n", test.description)
 	}
 }

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -203,6 +203,7 @@ type ExtRequestTargeting struct {
 	PreferDeals               bool                       `json:"preferdeals,omitempty"`
 	AppendBidderNames         bool                       `json:"appendbiddernames,omitempty"`
 	AlwaysIncludeDeals        bool                       `json:"alwaysincludedeals,omitempty"`
+	Prefix                    string                     `json:"prefix,omitempty"`
 }
 
 type ExtIncludeBrandCategory struct {
@@ -492,6 +493,7 @@ func (erp *ExtRequestPrebid) Clone() *ExtRequestPrebid {
 			DurationRangeSec:  slices.Clone(erp.Targeting.DurationRangeSec),
 			PreferDeals:       erp.Targeting.PreferDeals,
 			AppendBidderNames: erp.Targeting.AppendBidderNames,
+			Prefix:            erp.Targeting.Prefix,
 		}
 		if erp.Targeting.PriceGranularity != nil {
 			newPriceGranularity := &PriceGranularity{


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [x] configuration
- [ ] technical debt (test coverage, refactoring, etc.)

### ✨ What's the context?
https://github.com/prebid/prebid-server/issues/3094

### 🧠 Rationale behind the change
According to ticket [3094](https://github.com/prebid/prebid-server/issues/3094) some publishers want a different set of ad targeting prefixes than hb_. In the current change was added a possibility to configure prefix in:
-  request with ext.prebid.targeting.prefix
-  account-level configuration: account.targeting_prefix
If both ext.prebid.targeting.prefix and account.targeting_prefix config are present, prefer the request value.
The length of prefix is controlled by settings.targeting.truncate-attr-chars.

### 🧪 Test plan
New functionality is covered by `TestFindTargetingByKey`, `TestGetTargetDataPrefix` and `TestTargetingCacheRequestPrefix`