### PR TITLE
New Adapter: ttd - TheTradeDesk alias

### DIFF
--- a/static/bidder-info/ttd.yaml
+++ b/static/bidder-info/ttd.yaml
@@ -1,0 +1,1 @@
+aliasOf: thetradedesk


### PR DESCRIPTION
Prebid.js has uses `ttd` as bidder code. Adding a alias to allow this seamless lookup.