### PR TITLE
Rules Engine Module: log validation errors, graceful tree mgr shutdown

### DIFF
--- a/modules/modules.go
+++ b/modules/modules.go
@@ -25,7 +25,7 @@ type Builder interface {
 	// It returns hook repository created based on the implemented hook interfaces by modules
 	// and a map of modules to a list of stage names for which module provides hooks
 	// or an error encountered during module initialization.
-	Build(cfg config.Modules, client moduledeps.ModuleDeps) (hooks.HookRepository, map[string][]string, error)
+	Build(cfg config.Modules, client moduledeps.ModuleDeps) (hooks.HookRepository, map[string][]string, *ShutdownModules, error)
 }
 
 type (
@@ -49,7 +49,7 @@ type builder struct {
 func (m *builder) Build(
 	cfg config.Modules,
 	deps moduledeps.ModuleDeps,
-) (hooks.HookRepository, map[string][]string, error) {
+) (hooks.HookRepository, map[string][]string, *ShutdownModules, error) {
 	modules := make(map[string]interface{})
 	for vendor, moduleBuilders := range m.builders {
 		for moduleName, builder := range moduleBuilders {
@@ -60,7 +60,7 @@ func (m *builder) Build(
 			id := fmt.Sprintf("%s.%s", vendor, moduleName)
 			if data, ok := cfg[vendor][moduleName]; ok {
 				if conf, err = jsonutil.Marshal(data); err != nil {
-					return nil, nil, fmt.Errorf(`failed to marshal "%s" module config: %s`, id, err)
+					return nil, nil, nil, fmt.Errorf(`failed to marshal "%s" module config: %s`, id, err)
 				}
 
 				if values, ok := data.(map[string]interface{}); ok {
@@ -77,7 +77,7 @@ func (m *builder) Build(
 
 			module, err := builder(conf, deps)
 			if err != nil {
-				return nil, nil, fmt.Errorf(`failed to init "%s" module: %s`, id, err)
+				return nil, nil, nil, fmt.Errorf(`failed to init "%s" module: %s`, id, err)
 			}
 
 			modules[id] = module
@@ -86,10 +86,12 @@ func (m *builder) Build(
 
 	collection, err := createModuleStageNamesCollection(modules)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	repo, err := hooks.NewHookRepository(modules)
 
-	return repo, collection, err
+	sdm := NewShutdownModules(modules)
+
+	return repo, collection, sdm, err
 }

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -30,62 +30,70 @@ func TestModuleBuilderBuild(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		givenModule           interface{}
-		givenConfig           config.Modules
-		givenHookBuilderErr   error
-		expectedHookRepo      hooks.HookRepository
-		expectedModulesStages map[string][]string
-		expectedErr           error
+		givenModule             interface{}
+		givenConfig             config.Modules
+		givenHookBuilderErr     error
+		expectedHookRepo        hooks.HookRepository
+		expectedModulesStages   map[string][]string
+		expectedShutdownModules *ShutdownModules
+		expectedErr             error
 	}{
 		"Can build module with config": {
-			givenModule:           module{},
-			givenConfig:           defaultModulesConfig,
-			expectedModulesStages: map[string][]string{vendor + "_" + moduleName: {hooks.StageEntrypoint.String(), hooks.StageAuctionResponse.String()}},
-			expectedHookRepo:      defaultHookRepository,
-			expectedErr:           nil,
+			givenModule:             module{},
+			givenConfig:             defaultModulesConfig,
+			expectedModulesStages:   map[string][]string{vendor + "_" + moduleName: {hooks.StageEntrypoint.String(), hooks.StageAuctionResponse.String()}},
+			expectedHookRepo:        defaultHookRepository,
+			expectedShutdownModules: &ShutdownModules{modules: []Shutdowner{module{}}},
+			expectedErr:             nil,
 		},
 		"Module is not added to hook repository if it's disabled": {
-			givenModule:           module{},
-			givenConfig:           map[string]map[string]interface{}{vendor: {moduleName: map[string]interface{}{"enabled": false, "attr": "val"}}},
-			expectedModulesStages: map[string][]string{},
-			expectedHookRepo:      emptyHookRepository,
-			expectedErr:           nil,
+			givenModule:             module{},
+			givenConfig:             map[string]map[string]interface{}{vendor: {moduleName: map[string]interface{}{"enabled": false, "attr": "val"}}},
+			expectedModulesStages:   map[string][]string{},
+			expectedHookRepo:        emptyHookRepository,
+			expectedShutdownModules: &ShutdownModules{modules: []Shutdowner{}},
+			expectedErr:             nil,
 		},
 		"Module considered disabled if status property not defined in module config": {
-			givenModule:           module{},
-			givenConfig:           map[string]map[string]interface{}{vendor: {moduleName: map[string]interface{}{"foo": "bar"}}},
-			expectedHookRepo:      emptyHookRepository,
-			expectedModulesStages: map[string][]string{},
-			expectedErr:           nil,
+			givenModule:             module{},
+			givenConfig:             map[string]map[string]interface{}{vendor: {moduleName: map[string]interface{}{"foo": "bar"}}},
+			expectedHookRepo:        emptyHookRepository,
+			expectedModulesStages:   map[string][]string{},
+			expectedShutdownModules: &ShutdownModules{modules: []Shutdowner{}},
+			expectedErr:             nil,
 		},
 		"Module considered disabled if its config not provided and as a result skipped from execution": {
-			givenModule:           module{},
-			givenConfig:           nil,
-			expectedHookRepo:      emptyHookRepository,
-			expectedModulesStages: map[string][]string{},
-			expectedErr:           nil,
+			givenModule:             module{},
+			givenConfig:             nil,
+			expectedHookRepo:        emptyHookRepository,
+			expectedModulesStages:   map[string][]string{},
+			expectedShutdownModules: &ShutdownModules{modules: []Shutdowner{}},
+			expectedErr:             nil,
 		},
 		"Fails if module does not implement any hook interface": {
-			givenModule:           struct{}{},
-			givenConfig:           defaultModulesConfig,
-			expectedHookRepo:      nil,
-			expectedModulesStages: nil,
-			expectedErr:           fmt.Errorf(`hook "%s.%s" does not implement any supported hook interface`, vendor, moduleName),
+			givenModule:             struct{}{},
+			givenConfig:             defaultModulesConfig,
+			expectedHookRepo:        nil,
+			expectedModulesStages:   nil,
+			expectedShutdownModules: nil,
+			expectedErr:             fmt.Errorf(`hook "%s.%s" does not implement any supported hook interface`, vendor, moduleName),
 		},
 		"Fails if module builder function returns error": {
-			givenModule:           module{},
-			givenConfig:           defaultModulesConfig,
-			givenHookBuilderErr:   errors.New("failed to build module"),
-			expectedHookRepo:      nil,
-			expectedModulesStages: nil,
-			expectedErr:           fmt.Errorf(`failed to init "%s.%s" module: %s`, vendor, moduleName, "failed to build module"),
+			givenModule:             module{},
+			givenConfig:             defaultModulesConfig,
+			givenHookBuilderErr:     errors.New("failed to build module"),
+			expectedHookRepo:        nil,
+			expectedModulesStages:   nil,
+			expectedShutdownModules: nil,
+			expectedErr:             fmt.Errorf(`failed to init "%s.%s" module: %s`, vendor, moduleName, "failed to build module"),
 		},
 		"Fails if config marshaling returns error": {
-			givenModule:           module{},
-			givenConfig:           map[string]map[string]interface{}{vendor: {moduleName: math.Inf(1)}},
-			expectedHookRepo:      nil,
-			expectedModulesStages: nil,
-			expectedErr:           fmt.Errorf(`failed to marshal "%s.%s" module config: unsupported value: +Inf`, vendor, moduleName),
+			givenModule:             module{},
+			givenConfig:             map[string]map[string]interface{}{vendor: {moduleName: math.Inf(1)}},
+			expectedHookRepo:        nil,
+			expectedModulesStages:   nil,
+			expectedShutdownModules: nil,
+			expectedErr:             fmt.Errorf(`failed to marshal "%s.%s" module config: unsupported value: +Inf`, vendor, moduleName),
 		},
 	}
 
@@ -101,9 +109,10 @@ func TestModuleBuilderBuild(t *testing.T) {
 				},
 			}
 
-			repo, modulesStages, err := builder.Build(test.givenConfig, moduledeps.ModuleDeps{HTTPClient: http.DefaultClient})
+			repo, modulesStages, shutdownModules, err := builder.Build(test.givenConfig, moduledeps.ModuleDeps{HTTPClient: http.DefaultClient})
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedModulesStages, modulesStages)
+			assert.Equal(t, test.expectedShutdownModules, shutdownModules)
 			assert.Equal(t, test.expectedHookRepo, repo)
 		})
 	}
@@ -117,4 +126,8 @@ func (h module) HandleEntrypointHook(_ context.Context, _ hookstage.ModuleInvoca
 
 func (h module) HandleAuctionResponseHook(_ context.Context, _ hookstage.ModuleInvocationContext, _ hookstage.AuctionResponsePayload) (hookstage.HookResult[hookstage.AuctionResponsePayload], error) {
 	return hookstage.HookResult[hookstage.AuctionResponsePayload]{}, nil
+}
+
+func (h module) Shutdown() error {
+	return nil
 }

--- a/modules/prebid/rulesengine/module.go
+++ b/modules/prebid/rulesengine/module.go
@@ -25,6 +25,7 @@ func Builder(_ json.RawMessage, _ moduledeps.ModuleDeps) (interface{}, error) {
 	}
 
 	tm := treeManager{
+		done:            make(chan struct{}),
 		requests:        make(chan buildInstruction),
 		schemaValidator: schemaValidator,
 	}
@@ -92,6 +93,13 @@ func (m Module) HandleProcessedAuctionHook(
 	ruleSets := co.ruleSetsForProcessedAuctionRequestStage
 
 	return handleProcessedAuctionHook(ruleSets, payload)
+}
+
+// Shutdown signals the module to stop processing and waits for the tree manager to finish
+// processing any remaining build instructions in the channel.
+func (m Module) Shutdown() {
+	m.TreeManager.Shutdown()
+	<-m.TreeManager.done
 }
 
 // rebuildTrees returns true if the trees for this account need to be rebuilt; false otherwise

--- a/modules/prebid/rulesengine/tree_builder_test.go
+++ b/modules/prebid/rulesengine/tree_builder_test.go
@@ -68,11 +68,15 @@ func GetConf() json.RawMessage {
      "schema": [
      {
        "function": "deviceCountryIn",
-       "args": [["USA", "UKR"]]
+       "args": {
+         "countries": ["USA", "UKR"]
+       }     
      },
      {
        "function": "dataCenterIn",
-       "args": [["us-east", "us-west"]]
+       "args": {
+         "datacenters": ["us-east", "us-west"]
+       } 
      },
      {
        "function": "channel"

--- a/modules/prebid/rulesengine/tree_manager.go
+++ b/modules/prebid/rulesengine/tree_manager.go
@@ -36,7 +36,7 @@ func (tm *treeManager) Run(c cacher) error {
 				break
 			}
 
-			parsedCfg, err := config.NewConfig(*req.config, tb.schemaValidator)
+			parsedCfg, err := config.NewConfig(*req.config, tm.schemaValidator)
 			if err != nil {
 				// TODO: log metric
 				glog.Errorf("Rules engine error parsing config for account %s: %v", req.accountID, err)

--- a/modules/prebid/rulesengine/tree_test.go
+++ b/modules/prebid/rulesengine/tree_test.go
@@ -25,9 +25,9 @@ func TestExecuteRulesFullConfig(t *testing.T) {
 }
 
 func BuildTestRules() rules.Tree[openrtb_ext.RequestWrapper, hs.HookResult[hs.ProcessedAuctionRequestPayload]] {
-	devCountryFunc, _ := rules.NewDeviceCountryIn(json.RawMessage(`[["USA"]]`))          // handle err
-	resFuncTrue, _ := NewIncludeBidders(json.RawMessage(`[{ "bidders": ["bidderA"]}]`))  //handle err
-	resFuncFalse, _ := NewExcludeBidders(json.RawMessage(`[{ "bidders": ["bidderB"]}]`)) //handle err
+	devCountryFunc, _ := rules.NewDeviceCountryIn(json.RawMessage(`{"countries": ["USA"]}`)) // handle err
+	resFuncTrue, _ := NewIncludeBidders(json.RawMessage(`[{ "bidders": ["bidderA"]}]`))      //handle err
+	resFuncFalse, _ := NewExcludeBidders(json.RawMessage(`[{ "bidders": ["bidderB"]}]`))     //handle err
 
 	rules := rules.Tree[openrtb_ext.RequestWrapper, hs.HookResult[hs.ProcessedAuctionRequestPayload]]{
 		Root: &rules.Node[openrtb_ext.RequestWrapper, hs.HookResult[hs.ProcessedAuctionRequestPayload]]{

--- a/modules/shutdown.go
+++ b/modules/shutdown.go
@@ -1,0 +1,40 @@
+package modules
+
+import (
+	"github.com/golang/glog"
+)
+
+// Shutdowner is an interface that defines a method for shutting down modules.
+type Shutdowner interface {
+	Shutdown() error
+}
+
+// ShutdownModules is a struct that holds a slice of Shutdowner modules.
+type ShutdownModules struct {
+	modules []Shutdowner
+}
+
+// NewShutdownModules creates a new ShutdownModules instance from a map of modules.
+// It filters the modules to include only those that implement the Shutdowner interface.
+func NewShutdownModules(modules map[string]interface{}) *ShutdownModules {
+	sm := ShutdownModules{
+		modules: make([]Shutdowner, 0),
+	}
+
+	for _, module := range modules {
+		if v, ok := module.(Shutdowner); ok {
+			sm.modules = append(sm.modules, v)
+		}
+	}
+	return &sm
+}
+
+// Shutdown iterates over all modules and calls their Shutdown method.
+func (s *ShutdownModules) Shutdown() {
+	for _, module := range s.modules {
+		if err := module.Shutdown(); err != nil {
+			glog.Errorf("Error shutting down module: %v", err)
+		}
+	}
+	return
+}

--- a/modules/shutdown_test.go
+++ b/modules/shutdown_test.go
@@ -1,153 +1,153 @@
 package modules
 
 import (
-    "errors"
-    "testing"
+	"errors"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // mockShutdownModule is a test implementation of the ShutdownModule interface
 type mockShutdownModule struct {
-    name          string
-    shutdownCalls int
-    shouldError   bool
+	name          string
+	shutdownCalls int
+	shouldError   bool
 }
 
 func (m *mockShutdownModule) Shutdown() error {
-    m.shutdownCalls++
-    if m.shouldError {
-        return errors.New("mock shutdown error")
-    }
-    return nil
+	m.shutdownCalls++
+	if m.shouldError {
+		return errors.New("mock shutdown error")
+	}
+	return nil
 }
 
 // nonShutdownModule doesn't implement the ShutdownModule interface
 type nonShutdownModule struct {
-    name string
+	name string
 }
 
 func TestNewShutdownModules(t *testing.T) {
-    tests := []struct {
-        name              string
-        modules           map[string]interface{}
+	tests := []struct {
+		name              string
+		modules           map[string]interface{}
 		expectModuleNames []string
-    }{
-        {
-            name:      "nil-modules",
-            modules:   nil,
-            expectModuleNames: []string{},
-        },
-        {
-            name:      "empty-modules",
-            modules:   map[string]interface{}{},
-            expectModuleNames: []string{},
-        },
-        {
-            name: "single-module",
-            modules: map[string]interface{}{
-                "module1": &mockShutdownModule{name: "module1"},
-            },
+	}{
+		{
+			name:              "nil-modules",
+			modules:           nil,
+			expectModuleNames: []string{},
+		},
+		{
+			name:              "empty-modules",
+			modules:           map[string]interface{}{},
+			expectModuleNames: []string{},
+		},
+		{
+			name: "single-module",
+			modules: map[string]interface{}{
+				"module1": &mockShutdownModule{name: "module1"},
+			},
 			expectModuleNames: []string{"module1"},
-        },
-        {
-            name: "multiple-modules",
-            modules: map[string]interface{}{
-                "module1": &mockShutdownModule{name: "module1"},
-                "module2": &mockShutdownModule{name: "module2"},
-                "module3": &mockShutdownModule{name: "module3"},
-            },
+		},
+		{
+			name: "multiple-modules",
+			modules: map[string]interface{}{
+				"module1": &mockShutdownModule{name: "module1"},
+				"module2": &mockShutdownModule{name: "module2"},
+				"module3": &mockShutdownModule{name: "module3"},
+			},
 			expectModuleNames: []string{"module1", "module2", "module3"},
-        },
-        {
-            name: "non-shutdown-module",
-            modules: map[string]interface{}{
-                "module1": &mockShutdownModule{name: "module1"},
-                "module2": &nonShutdownModule{name: "non-shutdown-module"},
-                "module3": &mockShutdownModule{name: "module3"},
-            },
+		},
+		{
+			name: "non-shutdown-module",
+			modules: map[string]interface{}{
+				"module1": &mockShutdownModule{name: "module1"},
+				"module2": &nonShutdownModule{name: "non-shutdown-module"},
+				"module3": &mockShutdownModule{name: "module3"},
+			},
 			expectModuleNames: []string{"module1", "module3"},
-        },
-    }
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
 			result := NewShutdownModules(tt.modules)
-			
+
 			assert.NotNil(t, result)
 
-            resultModuleNames := make([]string, len(result.modules))
-            for i, module := range result.modules {
-                resultModuleNames[i] = module.(*mockShutdownModule).name
-            }
+			resultModuleNames := make([]string, len(result.modules))
+			for i, module := range result.modules {
+				resultModuleNames[i] = module.(*mockShutdownModule).name
+			}
 
-            assert.ElementsMatch(t, tt.expectModuleNames, resultModuleNames)
-        })
-    }
+			assert.ElementsMatch(t, tt.expectModuleNames, resultModuleNames)
+		})
+	}
 }
 
 func TestShutdownModules_Shutdown(t *testing.T) {
-    tests := []struct {
-        name          string
-        modules       []Shutdowner
-    }{
-        {
-            name:        "empty-modules-succeeds",
-            modules:     []Shutdowner{},
-        },
-        {
-            name: "single-module-success",
-            modules: []Shutdowner{
-                &mockShutdownModule{name: "module1", shouldError: false},
-            },
-        },
-        {
-            name: "multiple-modules-success",
-            modules: []Shutdowner{
-                &mockShutdownModule{name: "module1", shouldError: false},
-                &mockShutdownModule{name: "module2", shouldError: false},
-                &mockShutdownModule{name: "module3", shouldError: false},
-            },
-        },
-        {
-            name: "first-module-error-returns-error",
-            modules: []Shutdowner{
-                &mockShutdownModule{name: "module1", shouldError: true},
-                &mockShutdownModule{name: "module2", shouldError: false},
-            },
-        },
-        {
-            name: "middle-module-error-returns-error",
-            modules: []Shutdowner{
-                &mockShutdownModule{name: "module1", shouldError: false},
-                &mockShutdownModule{name: "module2", shouldError: true},
-                &mockShutdownModule{name: "module3", shouldError: false},
-            },
-        },
-        {
-            name: "all-modules-called-despite-errors",
-            modules: []Shutdowner{
-                &mockShutdownModule{name: "module1", shouldError: true},
-                &mockShutdownModule{name: "module2", shouldError: true},
-                &mockShutdownModule{name: "module3", shouldError: false},
-            },
-        },
-    }
+	tests := []struct {
+		name    string
+		modules []Shutdowner
+	}{
+		{
+			name:    "empty-modules-succeeds",
+			modules: []Shutdowner{},
+		},
+		{
+			name: "single-module-success",
+			modules: []Shutdowner{
+				&mockShutdownModule{name: "module1", shouldError: false},
+			},
+		},
+		{
+			name: "multiple-modules-success",
+			modules: []Shutdowner{
+				&mockShutdownModule{name: "module1", shouldError: false},
+				&mockShutdownModule{name: "module2", shouldError: false},
+				&mockShutdownModule{name: "module3", shouldError: false},
+			},
+		},
+		{
+			name: "first-module-error-returns-error",
+			modules: []Shutdowner{
+				&mockShutdownModule{name: "module1", shouldError: true},
+				&mockShutdownModule{name: "module2", shouldError: false},
+			},
+		},
+		{
+			name: "middle-module-error-returns-error",
+			modules: []Shutdowner{
+				&mockShutdownModule{name: "module1", shouldError: false},
+				&mockShutdownModule{name: "module2", shouldError: true},
+				&mockShutdownModule{name: "module3", shouldError: false},
+			},
+		},
+		{
+			name: "all-modules-called-despite-errors",
+			modules: []Shutdowner{
+				&mockShutdownModule{name: "module1", shouldError: true},
+				&mockShutdownModule{name: "module2", shouldError: true},
+				&mockShutdownModule{name: "module3", shouldError: false},
+			},
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-            sm := &ShutdownModules{
-                modules: tt.modules,
-            }            
-            sm.Shutdown()
-            
-            for _, module := range tt.modules {
-                mockModule, ok := module.(*mockShutdownModule)
-                assert.True(t, ok)
-                assert.Equal(t, 1, mockModule.shutdownCalls)
-            }
-        })
-    }
+			sm := &ShutdownModules{
+				modules: tt.modules,
+			}
+			sm.Shutdown()
+
+			for _, module := range tt.modules {
+				mockModule, ok := module.(*mockShutdownModule)
+				assert.True(t, ok)
+				assert.Equal(t, 1, mockModule.shutdownCalls)
+			}
+		})
+	}
 }

--- a/modules/shutdown_test.go
+++ b/modules/shutdown_test.go
@@ -1,0 +1,153 @@
+package modules
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+// mockShutdownModule is a test implementation of the ShutdownModule interface
+type mockShutdownModule struct {
+    name          string
+    shutdownCalls int
+    shouldError   bool
+}
+
+func (m *mockShutdownModule) Shutdown() error {
+    m.shutdownCalls++
+    if m.shouldError {
+        return errors.New("mock shutdown error")
+    }
+    return nil
+}
+
+// nonShutdownModule doesn't implement the ShutdownModule interface
+type nonShutdownModule struct {
+    name string
+}
+
+func TestNewShutdownModules(t *testing.T) {
+    tests := []struct {
+        name              string
+        modules           map[string]interface{}
+		expectModuleNames []string
+    }{
+        {
+            name:      "nil-modules",
+            modules:   nil,
+            expectModuleNames: []string{},
+        },
+        {
+            name:      "empty-modules",
+            modules:   map[string]interface{}{},
+            expectModuleNames: []string{},
+        },
+        {
+            name: "single-module",
+            modules: map[string]interface{}{
+                "module1": &mockShutdownModule{name: "module1"},
+            },
+			expectModuleNames: []string{"module1"},
+        },
+        {
+            name: "multiple-modules",
+            modules: map[string]interface{}{
+                "module1": &mockShutdownModule{name: "module1"},
+                "module2": &mockShutdownModule{name: "module2"},
+                "module3": &mockShutdownModule{name: "module3"},
+            },
+			expectModuleNames: []string{"module1", "module2", "module3"},
+        },
+        {
+            name: "non-shutdown-module",
+            modules: map[string]interface{}{
+                "module1": &mockShutdownModule{name: "module1"},
+                "module2": &nonShutdownModule{name: "non-shutdown-module"},
+                "module3": &mockShutdownModule{name: "module3"},
+            },
+			expectModuleNames: []string{"module1", "module3"},
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+
+			result := NewShutdownModules(tt.modules)
+			
+			assert.NotNil(t, result)
+
+            resultModuleNames := make([]string, len(result.modules))
+            for i, module := range result.modules {
+                resultModuleNames[i] = module.(*mockShutdownModule).name
+            }
+
+            assert.ElementsMatch(t, tt.expectModuleNames, resultModuleNames)
+        })
+    }
+}
+
+func TestShutdownModules_Shutdown(t *testing.T) {
+    tests := []struct {
+        name          string
+        modules       []Shutdowner
+    }{
+        {
+            name:        "empty-modules-succeeds",
+            modules:     []Shutdowner{},
+        },
+        {
+            name: "single-module-success",
+            modules: []Shutdowner{
+                &mockShutdownModule{name: "module1", shouldError: false},
+            },
+        },
+        {
+            name: "multiple-modules-success",
+            modules: []Shutdowner{
+                &mockShutdownModule{name: "module1", shouldError: false},
+                &mockShutdownModule{name: "module2", shouldError: false},
+                &mockShutdownModule{name: "module3", shouldError: false},
+            },
+        },
+        {
+            name: "first-module-error-returns-error",
+            modules: []Shutdowner{
+                &mockShutdownModule{name: "module1", shouldError: true},
+                &mockShutdownModule{name: "module2", shouldError: false},
+            },
+        },
+        {
+            name: "middle-module-error-returns-error",
+            modules: []Shutdowner{
+                &mockShutdownModule{name: "module1", shouldError: false},
+                &mockShutdownModule{name: "module2", shouldError: true},
+                &mockShutdownModule{name: "module3", shouldError: false},
+            },
+        },
+        {
+            name: "all-modules-called-despite-errors",
+            modules: []Shutdowner{
+                &mockShutdownModule{name: "module1", shouldError: true},
+                &mockShutdownModule{name: "module2", shouldError: true},
+                &mockShutdownModule{name: "module3", shouldError: false},
+            },
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+
+            sm := &ShutdownModules{
+                modules: tt.modules,
+            }            
+            sm.Shutdown()
+            
+            for _, module := range tt.modules {
+                mockModule, ok := module.(*mockShutdownModule)
+                assert.True(t, ok)
+                assert.Equal(t, 1, mockModule.shutdownCalls)
+            }
+        })
+    }
+}

--- a/router/router.go
+++ b/router/router.go
@@ -186,7 +186,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 	}
 
 	moduleDeps := moduledeps.ModuleDeps{HTTPClient: generalHttpClient, RateConvertor: rateConvertor}
-	repo, moduleStageNames, err := modules.NewBuilder().Build(cfg.Hooks.Modules, moduleDeps)
+	repo, moduleStageNames, shutdownModules, err := modules.NewBuilder().Build(cfg.Hooks.Modules, moduleDeps)
 	if err != nil {
 		glog.Fatalf("Failed to init hook modules: %v", err)
 	}
@@ -198,7 +198,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 	analyticsRunner := analyticsBuild.New(&cfg.Analytics)
 
 	// register the analytics runner for shutdown
-	r.shutdowns = append(r.shutdowns, shutdown, analyticsRunner.Shutdown)
+	r.shutdowns = append(r.shutdowns, shutdown, analyticsRunner.Shutdown, shutdownModules.Shutdown)
 
 	paramsValidator, err := openrtb_ext.NewBidderParamsValidator(schemaDirectory)
 	if err != nil {

--- a/rules/schema_functions_test.go
+++ b/rules/schema_functions_test.go
@@ -1636,7 +1636,7 @@ func TestNewDataCenterIn(t *testing.T) {
 			expectedDataCenterIn: &dataCenterIn{
 				DataCenters: []string{"dc1"},
 				DataCenterDir: map[string]struct{}{
-					"dc1": struct{}{},
+					"dc1": {},
 				},
 			},
 			expectedError: nil,
@@ -1677,7 +1677,7 @@ func TestNewEidIn(t *testing.T) {
 			expectedDataCenterIn: &eidIn{
 				EidSources: []string{"pubcid.org"},
 				Eids: map[string]struct{}{
-					"pubcid.org": struct{}{},
+					"pubcid.org": {},
 				},
 			},
 			expectedError: nil,
@@ -1724,8 +1724,8 @@ func TestNewGppSidIn(t *testing.T) {
 			expectedGppSidIn: &gppSidIn{
 				SidList: []int8{1, 5},
 				GppSids: map[int8]struct{}{
-					1: struct{}{},
-					5: struct{}{},
+					1: {},
+					5: {},
 				},
 			},
 			expectedError: nil,
@@ -1976,7 +1976,7 @@ func TestNewRequestSchemaFunction(t *testing.T) {
 			expectedSchemaFunc: &dataCenterIn{
 				DataCenters: []string{"dc1"},
 				DataCenterDir: map[string]struct{}{
-					"dc1": struct{}{},
+					"dc1": {},
 				},
 			},
 		},
@@ -1991,7 +1991,7 @@ func TestNewRequestSchemaFunction(t *testing.T) {
 			expectedSchemaFunc: &deviceCountryIn{
 				Countries: []string{"JPN"},
 				CountryDirectory: map[string]struct{}{
-					"JPN": struct{}{},
+					"JPN": {},
 				},
 			},
 		},
@@ -2006,7 +2006,7 @@ func TestNewRequestSchemaFunction(t *testing.T) {
 			expectedSchemaFunc: &eidIn{
 				EidSources: []string{"pubcid.org"},
 				Eids: map[string]struct{}{
-					"pubcid.org": struct{}{},
+					"pubcid.org": {},
 				},
 			},
 		},
@@ -2026,8 +2026,8 @@ func TestNewRequestSchemaFunction(t *testing.T) {
 			expectedSchemaFunc: &gppSidIn{
 				SidList: []int8{1, 5},
 				GppSids: map[int8]struct{}{
-					1: struct{}{},
-					5: struct{}{},
+					1: {},
+					5: {},
 				},
 			},
 		},


### PR DESCRIPTION
- Use glog directly in tree manager to log validation errors. The tree manager runs outside of the request flow via a go routine spawned at startup during the module build process. In the future we will pass a global logger object that implements the logger interface as a module dependency at startup instead. All logging via hooks takes place by adding warnings, errors and debug messages to the hook result which is then sent to the logger by the modularity infrastructure. This option is not available because there are no hook results outside of the request flow.
- Updated the modularity infrastructure so modules that need to shutdown go routines they spawn may be able to do so. This was accomplished by adding a `Shutdowner` interface to the modularity infrastructure with a single function `Shutdown` that may be implemented by modules.
- Add graceful shutdown logic to the module tree manager by adding a done signaling channel and a Shutdown tree manager receiver function.
- Fixed a few typos in the tree manager
- Fixed a few tests that broke when we moved from schema function `"args"` as an array to `"args"` as an object.

Note no tests have been added for the shutdown logic yet. I will do that on another PR. I have tested this behavior though manually.