### PR TITLE
Sharethrough: Add geoscope to config

### DIFF
--- a/static/bidder-info/sharethrough.yaml
+++ b/static/bidder-info/sharethrough.yaml
@@ -4,6 +4,8 @@ maintainer:
 gvlVendorID: 80
 openrtb:
   version: 2.6
+geoscope:
+  - global
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Adding a `geoscope` entry to the Sharethrough PBS adapter's YAML file.