### PR TITLE
VIS.X: relay bid currency from bid response

### DIFF
--- a/adapters/visx/visx.go
+++ b/adapters/visx/visx.go
@@ -49,6 +49,7 @@ type visxSeatBid struct {
 
 type visxResponse struct {
 	SeatBid []visxSeatBid `json:"seatbid,omitempty"`
+	Cur     string        `json:"cur,omitempty"`
 }
 
 // MakeRequests makes the HTTP requests which should be made to fetch bids.
@@ -139,6 +140,11 @@ func (a *VisxAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalReq
 			})
 		}
 	}
+
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
+
 	return bidResponse, nil
 
 }

--- a/adapters/visx/visxtest/exemplary/headers_ipv4.json
+++ b/adapters/visx/visxtest/exemplary/headers_ipv4.json
@@ -131,7 +131,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/headers_ipv6.json
+++ b/adapters/visx/visxtest/exemplary/headers_ipv6.json
@@ -131,7 +131,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/multitype-banner-response.json
+++ b/adapters/visx/visxtest/exemplary/multitype-banner-response.json
@@ -139,7 +139,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/multitype-video-response.json
+++ b/adapters/visx/visxtest/exemplary/multitype-video-response.json
@@ -139,7 +139,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/simple-banner.json
+++ b/adapters/visx/visxtest/exemplary/simple-banner.json
@@ -127,7 +127,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/simple-video.json
+++ b/adapters/visx/visxtest/exemplary/simple-video.json
@@ -127,7 +127,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["USD"],
+                "cur": "USD",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/exemplary/with_currency.json
+++ b/adapters/visx/visxtest/exemplary/with_currency.json
@@ -50,7 +50,7 @@
         "mockResponse": {
             "status": 200,
             "body": {
-                "cur": ["EUR"],
+                "cur": "EUR",
                 "seatbid": [
                     {
                         "bid": [

--- a/adapters/visx/visxtest/supplemental/wrong_imp_type.json
+++ b/adapters/visx/visxtest/supplemental/wrong_imp_type.json
@@ -44,7 +44,7 @@
 	  "mockResponse": {
 		  "status": 200,
 		  "body": {
-              "cur": ["USD"],
+              "cur": "USD",
 			  "seatbid": [{
 				  "seat": "51",
 				  "bid": [{

--- a/adapters/visx/visxtest/supplemental/wrong_impid.json
+++ b/adapters/visx/visxtest/supplemental/wrong_impid.json
@@ -52,7 +52,7 @@
 	  "mockResponse": {
 		  "status": 200,
 		  "body": {
-              "cur": ["USD"],
+              "cur": "USD",
 			  "seatbid": [{
 				  "seat": "51",
 				  "bid": [{

--- a/static/bidder-info/visx.yaml
+++ b/static/bidder-info/visx.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://t.visx.net/s2s_bid?wrapperType=s2s_prebid_standard:0.1.1"
+endpoint: "https://t.visx.net/s2s_bid?wrapperType=s2s_prebid_standard:0.1.2"
 maintainer:
   email: "supply.partners@yoc.com"
 gvlVendorID: 154


### PR DESCRIPTION
This PR resolves an issue occured when the  bid currency from the VIS.X S2S bid response is not passed to the internal bid response in Prebid Server's Go version, causing the currency to default to USD in all cases. The bid currency will now be dynamically set based on the response from the VIS.X S2S bid response, ensuring proper handling of different currencies in the bidding process.