### PR TITLE
Adagio: Add site bidder param and web inventory tests

### DIFF
--- a/adapters/adagio/adagiotest/exemplary/banner-web.json
+++ b/adapters/adagio/adagiotest/exemplary/banner-web.json
@@ -1,0 +1,157 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "banner": {
+          "w": 320,
+          "h": 50
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "banner": {
+                "w": 320,
+                "h": 50
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ],
+              "type": "banner",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "crid": "20",
+            "adomain": [
+              "awesome.com"
+            ],
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "seat": "adagio",
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/adagiotest/exemplary/multi-formats-app.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-formats-app.json
@@ -53,7 +53,7 @@
           },
           "ext": {
             "bidder": {
-              "organizationId": "1002",
+              "organizationId": "1000",
               "placement": "some-placement",
               "pagetype": "some-pagetype",
               "category": "some-category"
@@ -135,7 +135,7 @@
                 },
                 "ext": {
                   "bidder": {
-                    "organizationId": "1002",
+                    "organizationId": "1000",
                     "placement": "some-placement",
                     "pagetype": "some-pagetype",
                     "category": "some-category"

--- a/adapters/adagio/adagiotest/exemplary/multi-formats-web.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-formats-web.json
@@ -1,0 +1,183 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "banner": {
+          "w": 320,
+          "h": 50
+        },
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480,
+          "minduration": 120,
+          "maxduration": 150
+        },
+        "native": {
+          "ver": "1.1",
+          "request": "{\"adunit\":2,\"assets\":[{\"id\":3,\"img\":{\"h\":120,\"hmin\":0,\"type\":3,\"w\":180,\"wmin\":0},\"required\":1},{\"id\":0,\"required\":1,\"title\":{\"len\":25}},{\"data\":{\"len\":25,\"type\":1},\"id\":4,\"required\":1},{\"data\":{\"len\":140,\"type\":2},\"id\":6,\"required\":1}],\"context\":1,\"layout\":1,\"contextsubtype\":11,\"plcmtcnt\":1,\"plcmttype\":2,\"ver\":\"1.1\",\"ext\":{\"banner\":{\"w\":320,\"h\":50}}}"
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "banner": {
+                "w": 320,
+                "h": 50
+              },
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480,
+                "minduration": 120,
+                "maxduration": 150
+              },
+              "native": {
+                "ver": "1.1",
+                "request": "{\"adunit\":2,\"assets\":[{\"id\":3,\"img\":{\"h\":120,\"hmin\":0,\"type\":3,\"w\":180,\"wmin\":0},\"required\":1},{\"id\":0,\"required\":1,\"title\":{\"len\":25}},{\"data\":{\"len\":25,\"type\":1},\"id\":4,\"required\":1},{\"data\":{\"len\":140,\"type\":2},\"id\":6,\"required\":1}],\"context\":1,\"layout\":1,\"contextsubtype\":11,\"plcmtcnt\":1,\"plcmttype\":2,\"ver\":\"1.1\",\"ext\":{\"banner\":{\"w\":320,\"h\":50}}}"
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "some-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ],
+              "type": "banner",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "some-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "seat": "adagio",
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/adagiotest/exemplary/multi-imps-app.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-imps-app.json
@@ -40,7 +40,7 @@
           },
           "ext": {
             "bidder": {
-              "organizationId": "1002",
+              "organizationId": "1000",
               "placement": "some-placement",
               "pagetype": "some-pagetype",
               "category": "some-category"
@@ -55,7 +55,7 @@
             },
             "ext": {
               "bidder": {
-                "organizationId": "1002",
+                "organizationId": "1000",
                 "placement": "some-placement2",
                 "pagetype": "some-pagetype",
                 "category": "some-category"
@@ -124,7 +124,7 @@
                 },
                 "ext": {
                   "bidder": {
-                    "organizationId": "1002",
+                    "organizationId": "1000",
                     "placement": "some-placement",
                     "pagetype": "some-pagetype",
                     "category": "some-category"
@@ -139,7 +139,7 @@
                 },
                 "ext": {
                   "bidder": {
-                    "organizationId": "1002",
+                    "organizationId": "1000",
                     "placement": "some-placement2",
                     "pagetype": "some-pagetype",
                     "category": "some-category"

--- a/adapters/adagio/adagiotest/exemplary/multi-imps-web.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-imps-web.json
@@ -1,0 +1,220 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "banner": {
+          "w": 320,
+          "h": 50
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      },
+      {
+        "id": "some-impression-id2",
+        "banner": {
+          "w": 640,
+          "h": 100
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement2",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "banner": {
+                "w": 320,
+                "h": 50
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            },
+            {
+              "id": "some-impression-id2",
+              "banner": {
+                "w": 640,
+                "h": 100
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement2",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id",
+          "some-impression-id2"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "some-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                },
+                {
+                  "id": "b3ae1b4e2fc24a4fb45540082e98e162",
+                  "impid": "some-impression-id2",
+                  "price": 3.0,
+                  "adm": "some-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 640,
+                  "h": 100,
+                  "mtype": 1
+                }
+              ],
+              "type": "banner",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "some-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "seat": "adagio",
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "id": "b3ae1b4e2fc24a4fb45540082e98e162",
+            "impid": "some-impression-id2",
+            "price": 3.0,
+            "adm": "some-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 640,
+            "h": 100,
+            "mtype": 1
+          },
+          "seat": "adagio",
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/adagiotest/exemplary/native-web.json
+++ b/adapters/adagio/adagiotest/exemplary/native-web.json
@@ -1,0 +1,157 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "native": {
+          "ver": "1.1",
+          "request": "{\"adunit\":2,\"assets\":[{\"id\":3,\"img\":{\"h\":120,\"hmin\":0,\"type\":3,\"w\":180,\"wmin\":0},\"required\":1},{\"id\":0,\"required\":1,\"title\":{\"len\":25}},{\"data\":{\"len\":25,\"type\":1},\"id\":4,\"required\":1},{\"data\":{\"len\":140,\"type\":2},\"id\":6,\"required\":1}],\"context\":1,\"layout\":1,\"contextsubtype\":11,\"plcmtcnt\":1,\"plcmttype\":2,\"ver\":\"1.1\",\"ext\":{\"banner\":{\"w\":320,\"h\":50}}}"
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "native": {
+                "ver": "1.1",
+                "request": "{\"adunit\":2,\"assets\":[{\"id\":3,\"img\":{\"h\":120,\"hmin\":0,\"type\":3,\"w\":180,\"wmin\":0},\"required\":1},{\"id\":0,\"required\":1,\"title\":{\"len\":25}},{\"data\":{\"len\":25,\"type\":1},\"id\":4,\"required\":1},{\"data\":{\"len\":140,\"type\":2},\"id\":6,\"required\":1}],\"context\":1,\"layout\":1,\"contextsubtype\":11,\"plcmtcnt\":1,\"plcmttype\":2,\"ver\":\"1.1\",\"ext\":{\"banner\":{\"w\":320,\"h\":50}}}"
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 4
+                }
+              ],
+              "type": "native",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "crid": "20",
+            "adomain": [
+              "awesome.com"
+            ],
+            "w": 320,
+            "h": 50,
+            "mtype": 4
+          },
+          "seat": "adagio",
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/adagiotest/exemplary/request-with-rtd-module.json
+++ b/adapters/adagio/adagiotest/exemplary/request-with-rtd-module.json
@@ -1,0 +1,235 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "domain": "test.com",
+      "page": "test.com/some-page.html",
+      "publisher": {
+        "id": "123456789",
+        "domain": "test.com"
+      },
+      "ext": {
+        "data": {
+          "pagetype": "my-pagetype-from-ortb2-site-ext-data",
+          "category": "my-category-from-ortb2-site-ext-data",
+          "adg_rtd": {
+            "uid": "some-uid",
+            "pageviewId": "some-pageviewId",
+            "features": {
+              "page_dimensions": "1512x371",
+              "viewport_dimensions": "1512x371",
+              "user_timestamp": "1742463886",
+              "dom_loading": "23"
+            },
+            "session": {
+              "rnd": 0.9089453747025482,
+              "pages": 4,
+              "new": false,
+              "vwSmplg": 0.1,
+              "vwSmplgNxt": 0.1,
+              "expiry": 1742462010772,
+              "lastActivityTime": 1742460286113,
+              "id": "some-id",
+              "testName": "some-name",
+              "testVersion": "some-version"
+            }
+          }
+        }
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "banner": {
+          "w": 320,
+          "h": 50
+        },
+        "secure": 1,
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          },
+          "data": {
+            "divId": "divId-from-ortb2Imp-ext-data",
+            "placement": "my-placement-from-ortb2Imp-ext-data",
+            "adg_rtd": {
+              "adunit_position": "8x138"
+            }
+          },
+          "gpid": "gpid#123"
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "domain": "test.com",
+            "page": "test.com/some-page.html",
+            "publisher": {
+              "id": "123456789",
+              "domain": "test.com"
+            },
+            "ext": {
+              "data": {
+                "pagetype": "my-pagetype-from-ortb2-site-ext-data",
+                "category": "my-category-from-ortb2-site-ext-data",
+                "adg_rtd": {
+                  "uid": "some-uid",
+                  "pageviewId": "some-pageviewId",
+                  "features": {
+                    "page_dimensions": "1512x371",
+                    "viewport_dimensions": "1512x371",
+                    "user_timestamp": "1742463886",
+                    "dom_loading": "23"
+                  },
+                  "session": {
+                    "rnd": 0.9089453747025482,
+                    "pages": 4,
+                    "new": false,
+                    "vwSmplg": 0.1,
+                    "vwSmplgNxt": 0.1,
+                    "expiry": 1742462010772,
+                    "lastActivityTime": 1742460286113,
+                    "id": "some-id",
+                    "testName": "some-name",
+                    "testVersion": "some-version"
+                  }
+                }
+              }
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "banner": {
+                "w": 320,
+                "h": 50
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                },
+                "data": {
+                  "divId": "divId-from-ortb2Imp-ext-data",
+                  "placement": "my-placement-from-ortb2Imp-ext-data",
+                  "adg_rtd": {
+                    "adunit_position": "8x138"
+                  }
+                },
+                "gpid": "gpid#123"
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ],
+              "type": "banner",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "crid": "20",
+            "adomain": [
+              "awesome.com"
+            ],
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "seat": "adagio",
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/adagiotest/exemplary/video-web.json
+++ b/adapters/adagio/adagiotest/exemplary/video-web.json
@@ -1,0 +1,167 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "source": {
+      "tid": "some-tid"
+    },
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480,
+          "minduration": 120,
+          "maxduration": 150
+        },
+        "ext": {
+          "bidder": {
+            "organizationId": "1000",
+            "placement": "some-placement",
+            "site": "test-com",
+            "pagetype": "some-pagetype",
+            "category": "some-category"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://mp-ams.4dex.io/pbserver",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "tmax": 1000,
+          "user": {
+            "buyeruid": "awesome-user"
+          },
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "source": {
+            "tid": "some-tid"
+          },
+          "imp": [
+            {
+              "id": "some-impression-id",
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480,
+                "minduration": 120,
+                "maxduration": 150
+              },
+              "ext": {
+                "bidder": {
+                  "organizationId": "1000",
+                  "placement": "some-placement",
+                  "site": "test-com",
+                  "pagetype": "some-pagetype",
+                  "category": "some-category"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": [
+          "some-impression-id"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 2
+                }
+              ],
+              "type": "video",
+              "seat": "adagio"
+            }
+          ],
+          "cur": "USD",
+          "ext": {
+            "responsetimemillis": {
+              "adagio": 154
+            },
+            "tmaxrequest": 1000
+          }
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "crid": "20",
+            "adomain": [
+              "awesome.com"
+            ],
+            "w": 320,
+            "h": 50,
+            "mtype": 2
+          },
+          "seat": "adagio",
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adagio/params_test.go
+++ b/adapters/adagio/params_test.go
@@ -35,9 +35,13 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"organizationId":"1000","placement":"some-placement"}`,
+	`{"organizationId":"1000","placement":"some-placement","site":"mywebsite-com"}`,
 	`{"organizationId":"1000","placement":"some-placement","pagetype":"some-pagetype"}`,
 	`{"organizationId":"1000","placement":"some-placement","category":"some-category"}`,
+	`{"organizationId":"1000","placement":"some-placement","pagetype":"some-pagetype","site":"mywebsite-com"}`,
+	`{"organizationId":"1000","placement":"some-placement","category":"some-category","site":"mywebsite-com"}`,
 	`{"organizationId":"1000","placement":"some-placement","pagetype":"some-pagetype","category":"some-category"}`,
+	`{"organizationId":"1000","placement":"some-placement","pagetype":"some-pagetype","category":"some-category","site":"mywebsite-com"}`,
 }
 
 var invalidParams = []string{
@@ -52,6 +56,7 @@ var invalidParams = []string{
 	`{"placement":"some-placement"}`,
 	`{"category":"some-category"}`,
 	`{"pagetype":"some-pagetype"}`,
+	`{"site":"mywebsite-com"}`,
 	`{"organizationId":1000}`,
 	`{"organizationId":1000,"placement":"some-placement"}`,
 	`{"organizationId":"1000","placement":"this-is-a-very-very-long-placement"}`,
@@ -60,4 +65,6 @@ var invalidParams = []string{
 	`{"organizationId":"1000","placement":"some-placement","pagetype":"this-is-a-very-very-long-pagetype"}`,
 	`{"organizationId":"1000","placement":"some-placement","category":123456}`,
 	`{"organizationId":"1000","placement":"some-placement","category":"this-is-a-very-very-long-category"}`,
+	`{"organizationId":"1000","placement":"some-placement","site":123456}`,
+	`{"organizationId":"1000","placement":"some-placement","site":"this-is-a-very-very-very-very-very-very-long-site-name"}`,
 }

--- a/openrtb_ext/imp_adagio.go
+++ b/openrtb_ext/imp_adagio.go
@@ -3,6 +3,7 @@ package openrtb_ext
 type ExtImpAdagio struct {
 	OrganizationID string `json:"organizationId"`
 	Placement      string `json:"placement"`
+	Site           string `json:"site,omitempty"`
 	Pagetype       string `json:"pagetype,omitempty"`
 	Category       string `json:"category,omitempty"`
 }

--- a/static/bidder-info/adagio.yaml
+++ b/static/bidder-info/adagio.yaml
@@ -1,10 +1,14 @@
 # Please deploy this config in each of your datacenters with the appropriate regional subdomain.
 # Replace the `REGION` by one of the value below:
-# - For AMER: las => (https://mp-las.4dex.io/pbserver)
-# - For EMEA: ams => (https://mp-ams.4dex.io/pbserver)
-# - For APAC: tyo => (https://mp-tyo.4dex.io/pbserver)
+# - For AMER: las => (https://mp-las.4dex.io/pbserver and https://u-las.4dex.io/pbserver/usync.html)
+# - For EMEA: ams => (https://mp-ams.4dex.io/pbserver and https://u-amx.4dex.io/pbserver/usync.html)
+# - For APAC: tyo => (https://mp-tyo.4dex.io/pbserver and https://u-tyo.4dex.io/pbserver/usync.html)
 # And set disabled to `false`.
 endpoint: "https://mp-REGION.4dex.io/pbserver"
+userSync:
+  iframe:
+    url: "https://u-REGION.4dex.io/pbserver/usync.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
+    userMacro: "{UID}"
 disabled: true
 
 endpointCompression: gzip

--- a/static/bidder-params/adagio.json
+++ b/static/bidder-params/adagio.json
@@ -13,6 +13,11 @@
       "description": "Refers to the placement of an adunit in a page. Must not contain any information about the type of device.",
       "maxLength": 30
     },
+    "site": {
+      "type": "string",
+      "description": "Name of the site. Handed out by Adagio.",
+      "maxLength": 50
+    },
     "pagetype": {
       "type": "string",
       "description": "Describes what kind of content will be present in the page.",


### PR DESCRIPTION
# Type of change
[x] Updated bidder adapter

# Description of change

This PR introduces the core logic required for handling web inventory in our Prebid Server adapter. Although the functionality is in place, web inventory is **disabled by default** (this is intentional). We’ll assist our alpha partners in configuring their `adagio.yaml` files to enable it.