### PR TITLE
Rules Engine Module: Fix validateRuleSet bug

### DIFF
--- a/modules/prebid/rulesengine/config/config.go
+++ b/modules/prebid/rulesengine/config/config.go
@@ -94,6 +94,14 @@ func validateRuleSet(r *RuleSet) error {
 			r.ModelGroups[i].Weight = 100
 		}
 
+		if len(r.ModelGroups[i].Schema) > 0 && len(r.ModelGroups[i].Rules) == 0 {
+			return fmt.Errorf("ModelGroup %d has schema functions but no rules", i)
+		}
+
+		if len(r.ModelGroups[i].Schema) == 0 && len(r.ModelGroups[i].Rules) > 0 {
+			return fmt.Errorf("ModelGroup %d has no schema functions to test its rules against", i)
+		}
+
 		for j := 0; j < len(r.ModelGroups[i].Rules); j++ {
 			if len(r.ModelGroups[i].Schema) != len(r.ModelGroups[i].Rules[j].Conditions) {
 				return fmt.Errorf("ModelGroup %d number of schema functions differ from number of conditions of rule %d", i, j)

--- a/modules/prebid/rulesengine/config/config_test.go
+++ b/modules/prebid/rulesengine/config/config_test.go
@@ -372,7 +372,19 @@ func TestValidateRuleSet(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc: "Schema functions but no rules",
+			desc: "Success.-zero-schema-functions,-zero-rules",
+			ruleSet: &RuleSet{
+				ModelGroups: []ModelGroup{
+					{
+						Schema: []Schema{},
+						Rules:  []Rule{},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Schema-functions-but-no-rules",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -384,19 +396,31 @@ func TestValidateRuleSet(t *testing.T) {
 			expectedErr: errors.New("ModelGroup 0 has schema functions but no rules"),
 		},
 		{
+			desc: "Schema-functions-but-no-rule-conditions",
+			ruleSet: &RuleSet{
+				ModelGroups: []ModelGroup{
+					{
+						Schema: []Schema{{Func: "channel"}},
+						Rules:  []Rule{{Conditions: []string{}}},
+					},
+				},
+			},
+			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
+		},
+		{
 			desc: "No schema functions, at least one rule",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
 						Schema: []Schema{},
-						Rules:  []Rule{{Conditions: []string{"web"}}},
+						Rules:  []Rule{{Conditions: []string{}}},
 					},
 				},
 			},
 			expectedErr: errors.New("ModelGroup 0 has no schema functions to test its rules against"),
 		},
 		{
-			desc: "More rules than schema functions",
+			desc: "More-rule-conditions-than-schema-functions",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -408,7 +432,7 @@ func TestValidateRuleSet(t *testing.T) {
 			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
 		},
 		{
-			desc: "More schema functions than rule conditions",
+			desc: "More-schema-functions-than-rule-conditions",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -423,7 +447,7 @@ func TestValidateRuleSet(t *testing.T) {
 			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
 		},
 		{
-			desc: "Success. Equal number of schema functions and result functions",
+			desc: "Success.-Equal-number-of-schema-functions-and-result-functions",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -433,36 +457,6 @@ func TestValidateRuleSet(t *testing.T) {
 						},
 						Rules: []Rule{{Conditions: []string{"true", "web"}}},
 					},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			desc: "Success. Weights add up to 100",
-			ruleSet: &RuleSet{
-				ModelGroups: []ModelGroup{
-					{Weight: 98},
-					{Weight: 2},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			desc: "Success. Weights don't add to 100",
-			ruleSet: &RuleSet{
-				ModelGroups: []ModelGroup{
-					{Weight: 50},
-					{},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			desc: "Success. All weights are 0",
-			ruleSet: &RuleSet{
-				ModelGroups: []ModelGroup{
-					{Weight: 0},
-					{Weight: 0},
 				},
 			},
 			expectedErr: nil,

--- a/modules/prebid/rulesengine/config/config_test.go
+++ b/modules/prebid/rulesengine/config/config_test.go
@@ -372,12 +372,51 @@ func TestValidateRuleSet(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc: "Error is expected. Unequal number of schema and result functions",
+			desc: "Schema functions but no rules",
+			ruleSet: &RuleSet{
+				ModelGroups: []ModelGroup{
+					{
+						Schema: []Schema{{Func: "channel"}},
+						Rules:  []Rule{},
+					},
+				},
+			},
+			expectedErr: errors.New("ModelGroup 0 has schema functions but no rules"),
+		},
+		{
+			desc: "No schema functions, at least one rule",
+			ruleSet: &RuleSet{
+				ModelGroups: []ModelGroup{
+					{
+						Schema: []Schema{},
+						Rules:  []Rule{{Conditions: []string{"web"}}},
+					},
+				},
+			},
+			expectedErr: errors.New("ModelGroup 0 has no schema functions to test its rules against"),
+		},
+		{
+			desc: "More rules than schema functions",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
 						Schema: []Schema{{Func: "channel"}},
 						Rules:  []Rule{{Conditions: []string{"amp", "web"}}},
+					},
+				},
+			},
+			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
+		},
+		{
+			desc: "More schema functions than rule conditions",
+			ruleSet: &RuleSet{
+				ModelGroups: []ModelGroup{
+					{
+						Schema: []Schema{
+							{Func: "channel"},
+							{Func: "deviceCountry"},
+						},
+						Rules: []Rule{{Conditions: []string{"web"}}},
 					},
 				},
 			},

--- a/modules/prebid/rulesengine/config/config_test.go
+++ b/modules/prebid/rulesengine/config/config_test.go
@@ -372,7 +372,7 @@ func TestValidateRuleSet(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc: "Success.-zero-schema-functions,-zero-rules",
+			desc: "no-schema-functions-and-no-rules",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -408,7 +408,7 @@ func TestValidateRuleSet(t *testing.T) {
 			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
 		},
 		{
-			desc: "No schema functions, at least one rule",
+			desc: "no-schema-functions-and-at-least-one-rule",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{
@@ -447,7 +447,7 @@ func TestValidateRuleSet(t *testing.T) {
 			expectedErr: errors.New("ModelGroup 0 number of schema functions differ from number of conditions of rule 0"),
 		},
 		{
-			desc: "Success.-Equal-number-of-schema-functions-and-result-functions",
+			desc: "equal-number-of-schema-functions-and-result-functions",
 			ruleSet: &RuleSet{
 				ModelGroups: []ModelGroup{
 					{


### PR DESCRIPTION
We can accept empty `modelgroups[i].schema`, `modelgroups[i].rules`, and `modelgroups[i].rules[j].conditions`, but a valid tree must get built with an equal number of `modelgroups[i].schemas` and `modelgroups[i].rules[j].conditions`, which implies that, if there are any `modelgroups[i].schemas`, we must have at least one `modelgroups[i].rules` entry to consider an input to be valid.  This pull request closes a loophole in `validateRuleSet(r *RuleSet)` that was allowing us to pass as valid a `modelgroup` with `modelgroups[i].schemas` but zero entries in `modelgroups[i].rules` and viceversa.
