### PR TITLE
Request: Add hb_env=amp targeting to AMP responses

### DIFF
--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/addtl-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/addtl-consent-through-query.json
@@ -120,6 +120,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
@@ -112,6 +112,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
@@ -115,6 +115,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
@@ -117,6 +117,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
@@ -115,6 +115,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliased-buyeruids-case-insensitive.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliased-buyeruids-case-insensitive.json
@@ -64,6 +64,8 @@
       "hb_cache_id_Appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_Appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_Appnexus": "amp",
       "hb_pb": "2.00",
       "hb_pb_Appnexus": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliased-buyeruids.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliased-buyeruids.json
@@ -64,6 +64,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "2.00",
       "hb_pb_appnexus": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliases.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/aliases.json
@@ -55,6 +55,8 @@
       "hb_cache_id_unknown": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_unknow": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_unknown": "amp",
       "hb_pb": "2.00",
       "hb_pb_unknown": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/buyeruids-camel-case.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/buyeruids-camel-case.json
@@ -57,6 +57,8 @@
       "hb_cache_id_YahooAds": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_YahooA": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_YahooAds": "amp",
       "hb_pb": "2.00",
       "hb_pb_YahooAds": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/buyeruids-case-insensitive.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/buyeruids-case-insensitive.json
@@ -57,6 +57,8 @@
       "hb_cache_id_Appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_Appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_Appnexus": "amp",
       "hb_pb": "2.00",
       "hb_pb_Appnexus": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/gdpr-no-consentstring.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/gdpr-no-consentstring.json
@@ -53,6 +53,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "3.00",
       "hb_pb_appnexus": "3.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/gdpr.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/gdpr.json
@@ -58,6 +58,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/imp-with-stored-resp.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/imp-with-stored-resp.json
@@ -45,6 +45,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "5.00",
       "hb_pb_appnexus": "5.00"
     },

--- a/endpoints/openrtb2/sample-requests/amp/valid-supplementary/ortb-2.5-to-2.6-upconvert.json
+++ b/endpoints/openrtb2/sample-requests/amp/valid-supplementary/ortb-2.5-to-2.6-upconvert.json
@@ -285,6 +285,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "15.00",
       "hb_pb_appnexus": "15.00"
     },

--- a/endpoints/openrtb2/sample-requests/hooks/amp.json
+++ b/endpoints/openrtb2/sample-requests/hooks/amp.json
@@ -52,6 +52,8 @@
       "hb_cache_id_appnexus": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_appnex": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_appnexus": "amp",
       "hb_pb": "2.00",
       "hb_pb_appnexus": "2.00"
     },

--- a/endpoints/openrtb2/sample-requests/hooks/amp_bidder_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/amp_bidder_reject.json
@@ -57,6 +57,8 @@
       "hb_cache_id_rubicon": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_rubico": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_rubicon": "amp",
       "hb_pb": "1.00",
       "hb_pb_rubicon": "1.00"
     },

--- a/endpoints/openrtb2/sample-requests/hooks/amp_bidder_response_reject.json
+++ b/endpoints/openrtb2/sample-requests/hooks/amp_bidder_response_reject.json
@@ -57,6 +57,8 @@
       "hb_cache_id_rubicon": "0",
       "hb_cache_path": "/pbcache/endpoint",
       "hb_cache_path_rubico": "/pbcache/endpoint",
+      "hb_env": "amp",
+      "hb_env_rubicon": "amp",
       "hb_pb": "1.00",
       "hb_pb_rubicon": "1.00"
     },

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -501,7 +501,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 			if len(cacheErrs) > 0 {
 				errs = append(errs, cacheErrs...)
 			}
-			
+
 			env := ""
 			if r.BidRequestWrapper.BidRequest.App != nil {
 				env = openrtb_ext.HbEnvKeyApp

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -501,9 +501,17 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 			if len(cacheErrs) > 0 {
 				errs = append(errs, cacheErrs...)
 			}
+			
+			env := ""
+			if r.BidRequestWrapper.BidRequest.App != nil {
+				env = openrtb_ext.HbEnvKeyApp
+			}
+			if r.RequestType == "amp" {
+				env = openrtb_ext.HbEnvKeyAmp
+			}
 
 			if targData.includeWinners || targData.includeBidderKeys || targData.includeFormat {
-				targData.setTargeting(auc, r.BidRequestWrapper.BidRequest.App != nil, bidCategory, r.Account.TruncateTargetAttribute, multiBidMap)
+				targData.setTargeting(auc, env, bidCategory, r.Account.TruncateTargetAttribute, multiBidMap)
 			}
 		}
 		bidResponseExt = e.makeExtBidResponse(adapterBids, adapterExtra, *r, responseDebugAllow, requestExtPrebid.Passthrough, fledge, errs)

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -504,10 +504,10 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 
 			env := ""
 			if r.BidRequestWrapper.BidRequest.App != nil {
-				env = openrtb_ext.HbEnvKeyApp
+				env = openrtb_ext.EnvAppValue
 			}
 			if r.RequestType == "amp" {
-				env = openrtb_ext.HbEnvKeyAmp
+				env = openrtb_ext.EnvAmpValue
 			}
 
 			if targData.includeWinners || targData.includeBidderKeys || targData.includeFormat {

--- a/exchange/targeting.go
+++ b/exchange/targeting.go
@@ -41,7 +41,7 @@ type targetData struct {
 // The one exception is the `hb_cache_id` key. Since our APIs explicitly document cache keys to be on a "best effort" basis,
 // it's ok if those stay in the auction. For now, this method implements a very naive cache strategy.
 // In the future, we should implement a more clever retry & backoff strategy to balance the success rate & performance.
-func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMapping map[string]string, truncateTargetAttr *int, multiBidMap map[string]openrtb_ext.ExtMultiBid) {
+func (targData *targetData) setTargeting(auc *auction, env string, categoryMapping map[string]string, truncateTargetAttr *int, multiBidMap map[string]openrtb_ext.ExtMultiBid) {
 	for impId, topBidsPerImp := range auc.allBidsByBidder {
 		overallWinner := auc.winningBids[impId]
 		for originalBidderName, topBidsPerBidder := range topBidsPerImp {
@@ -96,8 +96,8 @@ func (targData *targetData) setTargeting(auc *auction, isApp bool, categoryMappi
 					targData.addKeys(targets, openrtb_ext.DealKey, topBid.Bid.DealID, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 
-				if isApp {
-					targData.addKeys(targets, openrtb_ext.EnvKey, openrtb_ext.EnvAppValue, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
+				if env != "" {
+					targData.addKeys(targets, openrtb_ext.EnvKey, env, targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)
 				}
 				if len(categoryMapping) > 0 {
 					targData.addKeys(targets, openrtb_ext.CategoryDurationKey, categoryMapping[topBid.Bid.ID], targetingBidderCode, isOverallWinner, truncateTargetAttr, bidHasDeal)

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -1083,6 +1083,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		AppEnv: "",
 		Auction: auction{
@@ -1114,8 +1115,9 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
-		AppEnv: openrtb_ext.HbEnvKeyAmp,
+		AppEnv: openrtb_ext.EnvAmpValue,
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
@@ -1146,8 +1148,9 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
-		AppEnv: openrtb_ext.HbEnvKeyApp,
+		AppEnv: openrtb_ext.EnvAppValue,
 		Auction: auction{
 			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
 				"ImpId-1": {
@@ -1178,6 +1181,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
+			prefix:           DefaultKeyPrefix,
 		},
 		AppEnv: "custom-targeting",
 		Auction: auction{

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -313,7 +313,7 @@ type TargetingTestData struct {
 	Description        string
 	TargetData         targetData
 	Auction            auction
-	IsApp              bool
+	AppEnv             string
 	CategoryMapping    map[string]string
 	ExpectedPbsBids    map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid
 	TruncateTargetAttr *int
@@ -1078,6 +1078,133 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			},
 		},
 	},
+		{
+		Description: "Empty targeting environment test",
+		TargetData: targetData{
+			priceGranularity: lookupPriceGranularity("med"),
+			includeWinners:   true,
+		},
+		AppEnv: "",
+		Auction: auction{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder": "appnexus",
+							"hb_pb":     "1.20",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
+	{
+		Description: "Amp targeting environment test",
+		TargetData: targetData{
+			priceGranularity: lookupPriceGranularity("med"),
+			includeWinners:   true,
+		},
+		AppEnv: openrtb_ext.HbEnvKeyAmp,
+		Auction: auction{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder": "appnexus",
+							"hb_pb":     "1.20",
+							"hb_env":    "amp",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
+	{
+		Description: "App targeting environment test",
+		TargetData: targetData{
+			priceGranularity: lookupPriceGranularity("med"),
+			includeWinners:   true,
+		},
+		AppEnv: openrtb_ext.HbEnvKeyApp,
+		Auction: auction{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder": "appnexus",
+							"hb_pb":     "1.20",
+							"hb_env":    "mobile-app",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
+	{
+		Description: "Custom targeting environment test",
+		TargetData: targetData{
+			priceGranularity: lookupPriceGranularity("med"),
+			includeWinners:   true,
+		},
+		AppEnv: "custom-targeting",
+		Auction: auction{
+			allBidsByBidder: map[string]map[openrtb_ext.BidderName][]*entities.PbsOrtbBid{
+				"ImpId-1": {
+					openrtb_ext.BidderAppnexus: {{
+						Bid:     bid123,
+						BidType: openrtb_ext.BidTypeBanner,
+					}},
+				},
+			},
+		},
+		ExpectedPbsBids: map[string]map[openrtb_ext.BidderName][]ExpectedPbsBid{
+			"ImpId-1": {
+				openrtb_ext.BidderAppnexus: []ExpectedPbsBid{
+					{
+						BidTargets: map[string]string{
+							"hb_bidder": "appnexus",
+							"hb_pb":     "1.20",
+							"hb_env":    "custom-targeting",
+						},
+					},
+				},
+			},
+		},
+		TruncateTargetAttr: nil,
+	},
 }
 
 func TestSetTargeting(t *testing.T) {
@@ -1102,7 +1229,7 @@ func TestSetTargeting(t *testing.T) {
 		}
 		auc.winningBids = winningBids
 		targData := test.TargetData
-		targData.setTargeting(auc, test.IsApp, test.CategoryMapping, test.TruncateTargetAttr, test.MultiBidMap)
+		targData.setTargeting(auc, test.AppEnv, test.CategoryMapping, test.TruncateTargetAttr, test.MultiBidMap)
 		for imp, targetsByBidder := range test.ExpectedPbsBids {
 			for bidder, expectedTargets := range targetsByBidder {
 				for i, expected := range expectedTargets {

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -1078,7 +1078,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 			},
 		},
 	},
-		{
+	{
 		Description: "Empty targeting environment test",
 		TargetData: targetData{
 			priceGranularity: lookupPriceGranularity("med"),

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -168,7 +168,7 @@ const (
 
 	// EnvAppValue used as a value for EnvKey
 	EnvAppValue string = "mobile-app"
-	HbEnvKeyAmp string = "amp"
+	EnvAmpValue string = "amp"
 
 	CategoryDurationKey TargetingKey = "_pb_cat_dur"
 )

--- a/openrtb_ext/bid.go
+++ b/openrtb_ext/bid.go
@@ -141,7 +141,8 @@ type TargetingKey string
 const (
 	PbKey TargetingKey = "_pb"
 
-	// EnvKey exists to support the Prebid Universal Creative. If it exists, the only legal value is mobile-app.
+	// EnvKey exists to support the Prebid Universal Creative.
+	// If it exists, the only legal values are "mobile-app" and "amp".
 	// It will exist only if the incoming bidRequest defined request.app instead of request.site.
 	EnvKey TargetingKey = "_env"
 
@@ -167,6 +168,7 @@ const (
 
 	// EnvAppValue used as a value for EnvKey
 	EnvAppValue string = "mobile-app"
+	HbEnvKeyAmp string = "amp"
 
 	CategoryDurationKey TargetingKey = "_pb_cat_dur"
 )


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] technical debt (test coverage, refactoring, etc.)

### ✨ What's the context?
https://github.com/prebid/prebid-server/issues/3812
https://github.com/prebid/prebid-server/issues/3095

### 🧠 Rationale behind the change
As per requirements stated in the above-mentioned issues, `hb_env` targeting attribute should be equal to `amp` in the targeting for AMP responses similar to what's done now setting `hb_env=mobile-app` for PBSDK requests.

### 🧪 Test plan
New functionality is covered by `TestSetTargeting` unit test in `exchange/targeting_test.go`.