### PR TITLE
Bidder throttling code to increase network stability.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -124,10 +124,13 @@ type PriceFloorFetcher struct {
 const MIN_COOKIE_SIZE_BYTES = 500
 
 type HTTPClient struct {
-	MaxConnsPerHost     int `mapstructure:"max_connections_per_host"`
-	MaxIdleConns        int `mapstructure:"max_idle_connections"`
-	MaxIdleConnsPerHost int `mapstructure:"max_idle_connections_per_host"`
-	IdleConnTimeout     int `mapstructure:"idle_connection_timeout_seconds"`
+	MaxConnsPerHost           int  `mapstructure:"max_connections_per_host"`
+	MaxIdleConns              int  `mapstructure:"max_idle_connections"`
+	MaxIdleConnsPerHost       int  `mapstructure:"max_idle_connections_per_host"`
+	IdleConnTimeout           int  `mapstructure:"idle_connection_timeout_seconds"`
+	EnableThrottling          bool `mapstructure:"enable_throttling"`
+	LongQueueWaitThresholdMS  int  `mapstructure:"long_queue_wait_threshold_ms"`
+	ShortQueueWaitThresholdMS int  `mapstructure:"short_queue_wait_threshold_ms"`
 }
 
 func (cfg *Configuration) validate(v *viper.Viper) []error {

--- a/config/config.go
+++ b/config/config.go
@@ -124,13 +124,24 @@ type PriceFloorFetcher struct {
 const MIN_COOKIE_SIZE_BYTES = 500
 
 type HTTPClient struct {
-	MaxConnsPerHost           int  `mapstructure:"max_connections_per_host"`
-	MaxIdleConns              int  `mapstructure:"max_idle_connections"`
-	MaxIdleConnsPerHost       int  `mapstructure:"max_idle_connections_per_host"`
-	IdleConnTimeout           int  `mapstructure:"idle_connection_timeout_seconds"`
-	EnableThrottling          bool `mapstructure:"enable_throttling"`
-	LongQueueWaitThresholdMS  int  `mapstructure:"long_queue_wait_threshold_ms"`
-	ShortQueueWaitThresholdMS int  `mapstructure:"short_queue_wait_threshold_ms"`
+	MaxConnsPerHost     int          `mapstructure:"max_connections_per_host"`
+	MaxIdleConns        int          `mapstructure:"max_idle_connections"`
+	MaxIdleConnsPerHost int          `mapstructure:"max_idle_connections_per_host"`
+	IdleConnTimeout     int          `mapstructure:"idle_connection_timeout_seconds"`
+	Throttle            HTTPThrottle `mapstructure:"throttle"`
+}
+
+type HTTPThrottle struct {
+	// Enables bidder throttling
+	EnableThrottling bool `mapstructure:"enable_throttling"`
+	// If enabled, we will only log that the bidder was to be throttled, but not actually throttle it.
+	SimulateThrottlingOnly bool `mapstructure:"simulate_throttling_only"`
+	// Queue wait time that is considered unhealthy
+	LongQueueWaitThresholdMS int `mapstructure:"long_queue_wait_threshold_ms"`
+	// Queue wait time that is short enough to be considered a healthy signal
+	ShortQueueWaitThresholdMS int `mapstructure:"short_queue_wait_threshold_ms"`
+	// ThrottleWindow controls the speed that the throttling logic will react to changes in the health of the bidder.
+	ThrottleWindow int `mapstructure:"throttle_window"`
 }
 
 func (cfg *Configuration) validate(v *viper.Viper) []error {

--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -18,6 +18,7 @@ const (
 	FailedToMarshalErrorCode
 	FailedToUnmarshalErrorCode
 	InvalidImpFirstPartyDataErrorCode
+	BidderTemporarilyTrottledErrorCode
 )
 
 // Defines numeric codes for well-known warnings.

--- a/errortypes/code.go
+++ b/errortypes/code.go
@@ -18,7 +18,7 @@ const (
 	FailedToMarshalErrorCode
 	FailedToUnmarshalErrorCode
 	InvalidImpFirstPartyDataErrorCode
-	BidderTemporarilyTrottledErrorCode
+	BidderTemporarilyThrottledErrorCode
 )
 
 // Defines numeric codes for well-known warnings.

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -178,6 +178,25 @@ func (err *BidderTemporarilyDisabled) Severity() Severity {
 	return SeverityWarning
 }
 
+// BidderThrottled is used when a bidder is temporarily disabled due to throttling.
+// This is a per request throttling, so subsequent requests may be allowed.
+// The initial usecase is to flag bidders that are temporarily disabled due to high error rates or other issues.
+type BidderThrottled struct {
+	Message string
+}
+
+func (err *BidderThrottled) Error() string {
+	return err.Message
+}
+
+func (err *BidderThrottled) Code() int {
+	return BidderTemporarilyTrottledErrorCode
+}
+
+func (err *BidderThrottled) Severity() Severity {
+	return SeverityWarning
+}
+
 // MalformedAcct should be used when the retrieved account config cannot be unmarshaled
 // These errors will be written to http.ResponseWriter before canceling execution
 type MalformedAcct struct {

--- a/errortypes/errortypes.go
+++ b/errortypes/errortypes.go
@@ -190,7 +190,7 @@ func (err *BidderThrottled) Error() string {
 }
 
 func (err *BidderThrottled) Code() int {
-	return BidderTemporarilyTrottledErrorCode
+	return BidderTemporarilyThrottledErrorCode
 }
 
 func (err *BidderThrottled) Severity() Severity {

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -125,7 +125,7 @@ func AdaptBidder(bidder adapters.Bidder, client *http.Client, cfg *config.Config
 		},
 	}
 	if ba.config.ThrottleConfig.throttleWindow <= 0 {
-		ba.config.ThrottleConfig.throttleWindow = 100
+		ba.config.ThrottleConfig.throttleWindow = 1000
 	}
 	// Precalculate bulk and delta values for health updates.
 	ba.config.ThrottleConfig.deltaValue = 1.0 / float64(ba.config.ThrottleConfig.throttleWindow)
@@ -861,6 +861,7 @@ func (bidder *BidderAdapter) getHealth() float64 {
 // logHealthCheck registers a health check for the bidder. True for a healthy result, false for an unhealthy result.
 func (bidder *BidderAdapter) logHealthCheck(success bool) {
 	if !bidder.config.ThrottleConfig.enabled {
+		// Don't update health if throttling is not enabled
 		return
 	}
 	for {

--- a/exchange/bidder_health_test.go
+++ b/exchange/bidder_health_test.go
@@ -1,0 +1,288 @@
+package exchange
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prebid/prebid-server/v3/metrics"
+	"github.com/prebid/prebid-server/v3/metrics/config"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+var testAdapter = BidderAdapter{
+	me: &config.NilMetricsEngine{},
+	config: bidderAdapterConfig{
+		ThrottleConfig: bidderAdapterThrottleConfig{
+			enabled:        true,
+			throttleWindow: 100,
+			bulkValue:      0.99,
+			deltaValue:     0.01,
+		},
+	},
+}
+
+func TestBidderAdapter_LogHealthCheck(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialHealth float64
+		success       bool
+		expectedRange struct {
+			min float64
+			max float64
+		}
+	}{
+		{
+			name:          "success with zero initial health",
+			initialHealth: 0.0,
+			success:       true,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: -0.001, // Allow for small floating point errors
+				max: 0.001,
+			},
+		},
+		{
+			name:          "failure with zero initial health",
+			initialHealth: 0.0,
+			success:       false,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: 0.009, // 0.99*0 + 0.01 = 0.01
+				max: 0.011, // Allow for small floating point errors
+			},
+		},
+		{
+			name:          "success with 0.5 initial health",
+			initialHealth: 0.5,
+			success:       true,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: 0.485, // 0.99*0.5 = 0.495
+				max: 0.505, // Allow for small floating point errors
+			},
+		},
+		{
+			name:          "failure with 0.5 initial health",
+			initialHealth: 0.5,
+			success:       false,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: 0.495, // 0.99*0.5 + 0.01 = 0.505
+				max: 0.515, // Allow for small floating point errors
+			},
+		},
+		{
+			name:          "success with 1.0 initial health",
+			initialHealth: 1.0,
+			success:       true,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: 0.98, // 0.99*1.0 = 0.99
+				max: 1.0,  // Allow for small floating point errors
+			},
+		},
+		{
+			name:          "failure with 1.0 initial health",
+			initialHealth: 1.0,
+			success:       false,
+			expectedRange: struct {
+				min float64
+				max float64
+			}{
+				min: 0.99,  // 0.99*1.0 + 0.01 = 1.0
+				max: 1.001, // Allow for small floating point errors
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new BidderAdapter with the initial health value
+			bidder := &BidderAdapter{}
+			*bidder = testAdapter
+			bidder.healthBits = math.Float64bits(tc.initialHealth)
+
+			// Call the logHealthCheck method
+			bidder.logHealthCheck(tc.success)
+
+			// Check the result is within expected range
+			actual := bidder.getHealth()
+			assert.True(t, actual >= tc.expectedRange.min && actual <= tc.expectedRange.max,
+				"Health value %f should be between %f and %f", actual, tc.expectedRange.min, tc.expectedRange.max)
+		})
+	}
+}
+
+func TestBidderAdapter_LogHealthCheck_ConcurrentAccess(t *testing.T) {
+	bidder := &BidderAdapter{}
+	*bidder = testAdapter
+	bidder.healthBits = math.Float64bits(0.5) // Start at 0.5
+
+	const numGoroutines = 100
+	const updatesPerGoroutine = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Launch multiple goroutines to update health concurrently
+	for i := 0; i < numGoroutines; i++ {
+		go func(routineNum int) {
+			defer wg.Done()
+			// Alternate between success and failure
+			success := routineNum%2 == 0
+			for j := 0; j < updatesPerGoroutine; j++ {
+				bidder.logHealthCheck(success)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Check that the final health value is valid
+	health := bidder.getHealth()
+	assert.False(t, math.IsNaN(health), "Health should not be NaN")
+	assert.False(t, math.IsInf(health, 0), "Health should not be infinite")
+	assert.True(t, health >= 0, "Health should not be negative")
+}
+
+func TestBidderAdapter_ShouldRequest(t *testing.T) {
+	testCases := []struct {
+		name           string
+		healthValue    float64
+		expectedAlways bool
+		description    string
+	}{
+		{
+			name:           "health below threshold",
+			healthValue:    0.1,
+			expectedAlways: true,
+			description:    "When health < 0.2, shouldRequest should always return true",
+		},
+		{
+			name:           "health at threshold",
+			healthValue:    0.21,
+			expectedAlways: false,
+			description:    "When health = 0.2, shouldRequest should be probabilistic",
+		},
+		{
+			name:           "health above threshold",
+			healthValue:    0.6,
+			expectedAlways: false,
+			description:    "When health > 0.2, shouldRequest should be probabilistic",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new BidderAdapter with the given health value
+			meMock := metrics.MetricsEngineMock{}
+			var biddername openrtb_ext.BidderName
+			meMock.On("RecordAdapterThrottled", biddername).Return()
+			bidder := &BidderAdapter{}
+			*bidder = testAdapter
+			bidder.me = &meMock
+			atomic.StoreUint64(&bidder.healthBits, math.Float64bits(tc.healthValue))
+
+			if tc.expectedAlways {
+				// Test multiple times to ensure it's consistently returning true
+				for i := 0; i < 100; i++ {
+					result := bidder.shouldRequest()
+					assert.True(t, result, tc.description)
+				}
+			} else {
+				// For probabilistic cases, we'll test that it sometimes returns false by running many iterations
+				const numTests = 1000
+				throttledCount := 0
+				passedCount := 0
+
+				for i := 0; i < numTests; i++ {
+					if bidder.shouldRequest() {
+						passedCount++
+						// t.Log("Health check returned true on iteration", i, "for health value", tc.healthValue)
+					} else {
+						throttledCount++
+						// t.Log("Health check returned false on iteration", i, "for health value", tc.healthValue)
+					}
+				}
+
+				// We should see at least some false responses if the health is above 0.2
+				if tc.healthValue > 0.2 {
+					assert.True(t, throttledCount > 0, "Expected at least some false responses for health %f", tc.healthValue)
+					meMock.AssertNumberOfCalls(t, "RecordAdapterThrottled", throttledCount)
+				}
+			}
+		})
+	}
+}
+
+func TestBidderAdapter_HealthIntegration(t *testing.T) {
+	// Test integration between logHealthCheck and shouldRequest
+	bidder := &BidderAdapter{}
+	*bidder = testAdapter
+
+	// Start with zero health - should always request
+	bidder.healthBits = math.Float64bits(0.0)
+
+	// Check initial state
+	assert.Equal(t, float64(0.0), bidder.getHealth())
+	assert.True(t, bidder.shouldRequest(), "Should initially always request with zero health")
+
+	// Log many failures to increase health
+	for i := 0; i < 100; i++ {
+		bidder.logHealthCheck(false)
+	}
+
+	// Now health should be higher, near 1.0
+	health := bidder.getHealth()
+	assert.True(t, health > 0.5, "Health should increase with failures (current: %f)", health)
+
+	// With higher health, some requests should be throttled
+	// Since shouldRequest has randomness, we need to run it many times
+	const numTests = 1000
+	throttledCount := 0
+	for i := 0; i < numTests; i++ {
+		rand.Seed(int64(i)) // For deterministic testing
+		if !bidder.shouldRequest() {
+			throttledCount++
+		}
+	}
+
+	// We should see some throttled requests now
+	assert.True(t, throttledCount > 0, "Expected some requests to be throttled with high health")
+	t.Logf("Health: %f, Throttled: %d/%d", health, throttledCount, numTests)
+
+	// Now log many successes to decrease health
+	for i := 0; i < 100; i++ {
+		bidder.logHealthCheck(true)
+	}
+
+	// Health should decrease
+	newHealth := bidder.getHealth()
+	assert.True(t, newHealth < health, "Health should decrease with successes (before: %f, after: %f)", health, newHealth)
+}
+
+func TestBidderAdapter_GetHealth(t *testing.T) {
+	testValues := []float64{0.0, 0.1, 0.5, 0.99, 1.0}
+
+	for _, val := range testValues {
+		bidder := &BidderAdapter{}
+		*bidder = testAdapter
+		bidder.healthBits = math.Float64bits(val)
+
+		actual := bidder.getHealth()
+		assert.InDelta(t, val, actual, 0.000001, "getHealth() should return the stored health value")
+	}
+}

--- a/exchange/bidder_validate_bids.go
+++ b/exchange/bidder_validate_bids.go
@@ -41,6 +41,14 @@ func (v *validatedBidder) requestBid(ctx context.Context, bidderRequest BidderRe
 	return seatBids, extraBidderRespInfo, errs
 }
 
+func (v *validatedBidder) logHealthCheck(success bool) {
+	v.bidder.logHealthCheck(success)
+}
+
+func (v *validatedBidder) shouldRequest() bool {
+	return v.bidder.shouldRequest()
+}
+
 // validateBids will run some validation checks on the returned bids and excise any invalid bids
 func removeInvalidBids(request *openrtb2.BidRequest, seatBid *entities.PbsOrtbSeatBid, debug bool) []error {
 	// Exit early if there is nothing to do.

--- a/exchange/bidder_validate_bids_test.go
+++ b/exchange/bidder_validate_bids_test.go
@@ -363,3 +363,12 @@ type mockAdaptedBidder struct {
 func (b *mockAdaptedBidder) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) ([]*entities.PbsOrtbSeatBid, extraBidderRespInfo, []error) {
 	return b.bidResponse, b.extraRespInfo, b.errorResponse
 }
+
+func (b *mockAdaptedBidder) logHealthCheck(success bool) {
+	// No-op
+}
+
+func (b *mockAdaptedBidder) shouldRequest() bool {
+	// Always return the healthy response.
+	return true
+}

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -5660,6 +5660,14 @@ func (b *validatingBidder) requestBid(ctx context.Context, bidderRequest BidderR
 	return
 }
 
+func (b *validatingBidder) logHealthCheck(success bool) {
+	// This is a no-op.
+}
+
+func (b *validatingBidder) shouldRequest() bool {
+	return true
+}
+
 type capturingRequestBidder struct {
 	req *openrtb2.BidRequest
 }
@@ -5773,6 +5781,13 @@ type panicingAdapter struct{}
 
 func (panicingAdapter) requestBid(ctx context.Context, bidderRequest BidderRequest, conversions currency.Conversions, reqInfo *adapters.ExtraRequestInfo, adsCertSigner adscert.Signer, bidRequestMetadata bidRequestOptions, alternateBidderCodes openrtb_ext.ExtAlternateBidderCodes, executor hookexecution.StageExecutor, ruleToAdjustments openrtb_ext.AdjustmentsByDealID) (posb []*entities.PbsOrtbSeatBid, extraInfo extraBidderRespInfo, errs []error) {
 	panic("Panic! Panic! The world is ending!")
+}
+
+func (panicingAdapter) logHealthCheck(success bool) {
+	// This is a no-op, but it is required to implement the Adapter interface.
+}
+func (panicingAdapter) shouldRequest() bool {
+	return true
 }
 
 func blankAdapterConfig(bidderList []openrtb_ext.BidderName) map[string]config.Adapter {

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -371,6 +371,13 @@ func (me *MultiMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 	}
 }
 
+// RecordAdapterThrottled across all engines
+func (me *MultiMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
+	for _, thisME := range *me {
+		thisME.RecordAdapterThrottled(adapter)
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -545,4 +552,8 @@ func (me *NilMetricsEngine) RecordModuleExecutionError(labels metrics.ModuleLabe
 }
 
 func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
+}
+
+// RecordAdapterThrottled as a noop
+func (me *NilMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -472,4 +472,5 @@ type MetricsEngine interface {
 	RecordModuleSuccessRejected(labels ModuleLabels)
 	RecordModuleExecutionError(labels ModuleLabels)
 	RecordModuleTimeout(labels ModuleLabels)
+	RecordAdapterThrottled(adapterName openrtb_ext.BidderName)
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -226,3 +226,7 @@ func (me *MetricsEngineMock) RecordModuleExecutionError(labels ModuleLabels) {
 func (me *MetricsEngineMock) RecordModuleTimeout(labels ModuleLabels) {
 	me.Called(labels)
 }
+
+func (me *MetricsEngineMock) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
+	me.Called(adapterName)
+}


### PR DESCRIPTION
This code will throttle requests to bidders that are experiencing issues to improve general prebid performance and give the bidder some breathing room to recover. If a bidder's health is poor, we will reject some fraction of requests to a bidder to preserve resources on both the PBS side and the bidder side. We always allow at least 10% of requests through, so we can quickly see signs of recovery.

Health is measured in two ways. Successfully returning a request (no network errors or timeouts, we are not considering HTTP status codes beyond explicit server error (<200 or 500+) in judging a successful request) are a sign of good health, errors are a sign of bad health. On top of this, spending a long time in the queue waiting for an HTTP connect to use is a sign of bad health. Waiting a short period of time is a sign of good health. A moderate wait time does not move the needle.
