### PR TITLE
PubMatic: Fix missing bid type in bid response

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -470,6 +470,7 @@ func (a *PubmaticAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 			typedBid := &adapters.TypedBid{
 				Bid:      &bid,
 				BidVideo: &openrtb_ext.ExtBidPrebidVideo{},
+				BidType:  mType,
 			}
 
 			var bidExt *pubmaticBidExt

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -437,6 +437,7 @@ func TestPubmaticAdapter_MakeBids(t *testing.T) {
 							Ext:     json.RawMessage(`{"dspid": 6, "deal_channel": 1, "prebiddealpriority": 1}`),
 						},
 						DealPriority: 1,
+						BidType:      openrtb_ext.BidTypeBanner,
 						BidVideo:     &openrtb_ext.ExtBidPrebidVideo{},
 						BidMeta: &openrtb_ext.ExtBidPrebidMeta{
 							MediaType: "banner",
@@ -472,6 +473,7 @@ func TestPubmaticAdapter_MakeBids(t *testing.T) {
 							MType:   1,
 							Ext:     json.RawMessage(`{"dspid": 6, "deal_channel": 1, "prebiddealpriority": -1}`),
 						},
+						BidType:  openrtb_ext.BidTypeBanner,
 						BidVideo: &openrtb_ext.ExtBidPrebidVideo{},
 						BidMeta: &openrtb_ext.ExtBidPrebidMeta{
 							MediaType: "banner",
@@ -507,6 +509,7 @@ func TestPubmaticAdapter_MakeBids(t *testing.T) {
 							MType:   1,
 							Ext:     json.RawMessage(`{"dspid": 6, "deal_channel": 1, "prebiddealpriority": -1, "ibv": true}`),
 						},
+						BidType:  openrtb_ext.BidTypeBanner,
 						BidVideo: &openrtb_ext.ExtBidPrebidVideo{},
 						BidMeta: &openrtb_ext.ExtBidPrebidMeta{
 							MediaType: "video",

--- a/adapters/pubmatic/pubmatictest/exemplary/banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/banner.json
@@ -149,7 +149,8 @@
                 "deal_channel": 1,
                 "prebiddealpriority": 1
               }
-            }
+            },
+             "type": "banner"
           }
         ]
       }

--- a/adapters/pubmatic/pubmatictest/exemplary/fledge.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/fledge.json
@@ -126,7 +126,8 @@
             "h": 90,
             "mtype": 1,
             "ext": {}
-          }
+          },
+           "type": "banner"
         }
       ],
       "fledgeauctionconfigs": [

--- a/adapters/pubmatic/pubmatictest/exemplary/native.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/native.json
@@ -108,7 +108,8 @@
                           "deal_channel": 1,
                           "bidtype": 2
                       }
-                  }
+                  },
+                   "type": "native"
               }
           ]
       }

--- a/adapters/pubmatic/pubmatictest/exemplary/video.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/video.json
@@ -171,6 +171,7 @@
                 }
               }
             },
+            "type": "video",
             "video" :{
               "duration" : 5,
               "primary_category": ""

--- a/adapters/pubmatic/pubmatictest/supplemental/app.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/app.json
@@ -133,7 +133,8 @@
               "h": 250,
               "mtype": 1,
               "dealid":"test deal"
-            }
+            },
+             "type": "banner"
           }
         ]
       }

--- a/adapters/pubmatic/pubmatictest/supplemental/bid_ext_ibv_true.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/bid_ext_ibv_true.json
@@ -189,6 +189,7 @@
                 }
               }
             },
+            "type": "banner",
             "video" :{
               "duration" : 5,
               "primary_category": ""

--- a/adapters/pubmatic/pubmatictest/supplemental/dctrAndPmZoneID.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/dctrAndPmZoneID.json
@@ -156,7 +156,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+          "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExt.json
@@ -168,7 +168,8 @@
                             "dspid": 6,
                             "deal_channel": 1
                         }
-                    }
+                    },
+                    "type": "banner"
                 }
             ]
         }

--- a/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExtPrebid.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/displayManagerInAppExtPrebid.json
@@ -176,7 +176,8 @@
                             "dspid": 6,
                             "deal_channel": 1
                         }
-                    }
+                    },
+                    "type": "banner"
                 }
             ]
         }

--- a/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/extra-bid.json
@@ -182,7 +182,8 @@
                 "dspid": 6,
                 "deal_channel": 1
               }
-            }
+            },
+            "type": "banner"
           },
           {
             "bid": {
@@ -203,6 +204,7 @@
                 "marketplace": "groupm"
               }
             },
+            "type": "banner",
             "seat": "groupm"
           }
         ]

--- a/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExt.json
@@ -161,7 +161,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+          "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExtPbAdslot.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/gptSlotNameInImpExtPbAdslot.json
@@ -157,7 +157,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+          "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/impExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/impExt.json
@@ -151,7 +151,8 @@
                             "dspid": 6,
                             "deal_channel": 1
                         }
-                    }
+                    },
+                    "type": "banner"
                 }
             ]
         }

--- a/adapters/pubmatic/pubmatictest/supplemental/multiplemedia.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/multiplemedia.json
@@ -111,7 +111,8 @@
                   "dspid": 6,
                   "deal_channel": 1
                 }
-              }
+              },
+              "type": "banner"
             }
           ]
         }

--- a/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/native_invalid_adm.json
@@ -108,7 +108,8 @@
                         "deal_channel": 1,
                         "bidtype": 2
                     }
-                }
+                },
+                "type": "native"
               }
           ]
       }

--- a/adapters/pubmatic/pubmatictest/supplemental/nilReqExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/nilReqExt.json
@@ -154,7 +154,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+           "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/noAdSlot.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/noAdSlot.json
@@ -124,7 +124,8 @@
                     "dspid": 6,
                     "deal_channel": 1
                 }
-            }
+            },
+             "type": "banner"
         }]
     }]
 }

--- a/adapters/pubmatic/pubmatictest/supplemental/pmZoneIDInKeywords.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/pmZoneIDInKeywords.json
@@ -155,7 +155,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+           "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/reqBidderParams.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/reqBidderParams.json
@@ -163,7 +163,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+           "type": "banner"
         }
       ]
     }

--- a/adapters/pubmatic/pubmatictest/supplemental/trimPublisherID.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/trimPublisherID.json
@@ -153,7 +153,8 @@
               "dspid": 6,
               "deal_channel": 1
             }
-          }
+          },
+           "type": "banner"
         }
       ]
     }


### PR DESCRIPTION
This PR restores the `bid.ext.prebid.type` field in the PubMatic response, which was unintentionally removed in the previous [PR](https://github.com/prebid/prebid-server/pull/4189).