### PR TITLE
Fix: Avoid account config JSON marshal when preparing module context

### DIFF
--- a/config/account.go
+++ b/config/account.go
@@ -320,7 +320,7 @@ type AccountHooks struct {
 
 // AccountModules mapping provides account-level module configuration
 // format: map[vendor_name]map[module_name]json.RawMessage
-type AccountModules map[string]map[string]interface{}
+type AccountModules map[string]map[string]json.RawMessage
 
 // ModuleConfig returns the account-level module config.
 // The id argument must be passed in the form "vendor.module_name",
@@ -333,18 +333,7 @@ func (m AccountModules) ModuleConfig(id string) (json.RawMessage, error) {
 
 	vendor := ns[0]
 	module := ns[1]
-
-	data, found := m[vendor][module]
-	if !found {
-		return nil, nil
-	}
-
-	bytes, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal module config for %s: %w", id, err)
-	}
-
-	return json.RawMessage(bytes), nil
+	return m[vendor][module], nil
 }
 
 type AccountPrivacy struct {


### PR DESCRIPTION
This fix addresses an issue introduced in #4407. Prior to #4407, when a module context was prepared, the account config for a given module was already in raw JSON format and was subsequently simply attached to the module context passed to the module.
When we introduced the rules engine module, our use case required a default account rules engine module config so to work around a viper library limitation, we changed the format from `map[string]map[string]json.RawMessage` to `map[string]map[string]interface{}` and took the recommended workaround approach of adding in a `json.Marshal` step to convert the account config to the required `json.RawMessage` format. We missed the fact that this has a significant penalty and applies to every request.
This PR rolls back this logic and then works around the viper limitation by allowing viper to marshal the host defined account defaults module configs to `map[string]map[string]interface{}` at startup which we then immediately convert to `map[string]map[string]json.RawMessage` so that it can be used throughout the request flow without performance penalty.

Rather than create the `HostAccount` object with a copy of each field in `Account`, we could embed an object in each of these called `BaseAccount` but this would require changes throughout the code base wherever we construct an account object. We can do this but I would like buy-in on this approach before proceeding.