### PR TITLE
TheTradeDesk: Throw error for malformed endpoint url

### DIFF
--- a/adapters/thetradedesk/thetradedesk.go
+++ b/adapters/thetradedesk/thetradedesk.go
@@ -17,8 +17,6 @@ import (
 	"github.com/prebid/openrtb/v20/openrtb2"
 )
 
-//const PREBID_INTEGRATION_TYPE = "1"
-
 type adapter struct {
 	bidderEndpointTemplate string
 	defaultEndpoint        string
@@ -87,13 +85,12 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 	bidderEndpoint, err := a.buildEndpointURL(supplySourceId)
 	if err != nil {
-		return nil, []error{errors.New("Failed to build endpoint URL")}
+		return nil, []error{err}
 	}
 
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
-	//headers.Add("x-integration-type", PREBID_INTEGRATION_TYPE) this will be parsed and added conditionally later
 	return []*adapters.RequestData{{
 		Method:  "POST",
 		Uri:     bidderEndpoint,
@@ -105,6 +102,9 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 func (a *adapter) buildEndpointURL(supplySourceId string) (string, error) {
 	if supplySourceId == "" {
+		if a.defaultEndpoint == "" {
+			return "", errors.New("Either supplySourceId or a default endpoint must be provided")
+		}
 		return a.defaultEndpoint, nil
 	}
 

--- a/adapters/thetradedesk/thetradedesk_test.go
+++ b/adapters/thetradedesk/thetradedesk_test.go
@@ -2,6 +2,7 @@ package thetradedesk
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/prebid/prebid-server/v3/adapters/adapterstest"
 	"net/http"
 	"testing"
@@ -425,7 +426,7 @@ func TestTheTradeDeskAdapter_BuildEndpoint(t *testing.T) {
 			supplySourceId:   "",
 			defaultEndpoint:  "",
 			expectedEndpoint: "",
-			wantErr:          nil,
+			wantErr:          []error{errors.New("Either supplySourceId or a default endpoint must be provided")},
 		},
 	}
 
@@ -442,6 +443,9 @@ func TestTheTradeDeskAdapter_BuildEndpoint(t *testing.T) {
 			finalEndpoint, err := a.buildEndpointURL(tt.supplySourceId)
 			if tt.wantErr != nil {
 				assert.NotNil(t, err)
+				assert.Equal(t, tt.wantErr[0].Error(), err.Error())
+			} else {
+				assert.Nil(t, err)
 			}
 			assert.Equal(t, tt.expectedEndpoint, finalEndpoint)
 		})


### PR DESCRIPTION
The publisher of intermediary mush inform either `supplySourceId` or a default in the `thetradedesk.yaml` file to be used.
If none is specified a malformed will be formed and send request to TheTradeDesk servers that cannot be resolved.