### PR TITLE
TMax: Add default host config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	StatusResponse    string          `mapstructure:"status_response"`
 	AuctionTimeouts   AuctionTimeouts `mapstructure:"auction_timeouts_ms"`
 	TmaxAdjustments   TmaxAdjustments `mapstructure:"tmax_adjustments"`
+	TmaxDefault       int             `mapstructure:"tmax_default"`
 	CacheURL          Cache           `mapstructure:"cache"`
 	ExtCacheURL       ExternalCache   `mapstructure:"external_cache"`
 	RecaptchaSecret   string          `mapstructure:"recaptcha_secret"`
@@ -1209,6 +1210,8 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("tmax_adjustments.bidder_response_duration_min_ms", 0)
 	v.SetDefault("tmax_adjustments.bidder_network_latency_buffer_ms", 0)
 	v.SetDefault("tmax_adjustments.pbs_response_preparation_duration_ms", 0)
+
+	v.SetDefault("tmax_default", 500)
 
 	/* IPv4
 	/*  Site Local: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16

--- a/config/config.go
+++ b/config/config.go
@@ -1211,7 +1211,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("tmax_adjustments.bidder_network_latency_buffer_ms", 0)
 	v.SetDefault("tmax_adjustments.pbs_response_preparation_duration_ms", 0)
 
-	v.SetDefault("tmax_default", 500)
+	v.SetDefault("tmax_default", 0)
 
 	/* IPv4
 	/*  Site Local: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,6 +227,8 @@ func TestDefaults(t *testing.T) {
 	cmpUnsignedInts(t, "tmax_adjustments.bidder_network_latency_buffer_ms", 0, cfg.TmaxAdjustments.BidderNetworkLatencyBuffer)
 	cmpUnsignedInts(t, "tmax_adjustments.pbs_response_preparation_duration_ms", 0, cfg.TmaxAdjustments.PBSResponsePreparationDuration)
 
+	cmpInts(t, "tmax_default", 500, cfg.TmaxDefault)
+
 	cmpInts(t, "account_defaults.privacy.ipv6.anon_keep_bits", 56, cfg.AccountDefaults.Privacy.IPv6Config.AnonKeepBits)
 	cmpInts(t, "account_defaults.privacy.ipv4.anon_keep_bits", 24, cfg.AccountDefaults.Privacy.IPv4Config.AnonKeepBits)
 
@@ -549,6 +551,7 @@ tmax_adjustments:
   bidder_response_duration_min_ms: 700
   bidder_network_latency_buffer_ms: 100
   pbs_response_preparation_duration_ms: 100
+tmax_default: 600
 analytics:
   agma:
     enabled: true
@@ -650,6 +653,7 @@ func TestFullConfig(t *testing.T) {
 	cmpUnsignedInts(t, "tmax_adjustments.bidder_response_duration_min_ms", 700, cfg.TmaxAdjustments.BidderResponseDurationMin)
 	cmpUnsignedInts(t, "tmax_adjustments.bidder_network_latency_buffer_ms", 100, cfg.TmaxAdjustments.BidderNetworkLatencyBuffer)
 	cmpUnsignedInts(t, "tmax_adjustments.pbs_response_preparation_duration_ms", 100, cfg.TmaxAdjustments.PBSResponsePreparationDuration)
+	cmpInts(t, "tmax_default", 600, cfg.TmaxDefault)
 
 	//Assert the price floor values
 	cmpBools(t, "price_floors.enabled", true, cfg.PriceFloors.Enabled)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,7 +227,7 @@ func TestDefaults(t *testing.T) {
 	cmpUnsignedInts(t, "tmax_adjustments.bidder_network_latency_buffer_ms", 0, cfg.TmaxAdjustments.BidderNetworkLatencyBuffer)
 	cmpUnsignedInts(t, "tmax_adjustments.pbs_response_preparation_duration_ms", 0, cfg.TmaxAdjustments.PBSResponsePreparationDuration)
 
-	cmpInts(t, "tmax_default", 500, cfg.TmaxDefault)
+	cmpInts(t, "tmax_default", 0, cfg.TmaxDefault)
 
 	cmpInts(t, "account_defaults.privacy.ipv6.anon_keep_bits", 56, cfg.AccountDefaults.Privacy.IPv6Config.AnonKeepBits)
 	cmpInts(t, "account_defaults.privacy.ipv4.anon_keep_bits", 24, cfg.AccountDefaults.Privacy.IPv4Config.AnonKeepBits)

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -524,7 +524,7 @@ func (deps *endpointDeps) parseAmpRequest(httpRequest *http.Request) (req *openr
 		return
 	}
 
-	if err := ortb.SetDefaults(req); err != nil {
+	if err := ortb.SetDefaults(req, deps.cfg.TmaxDefault); err != nil {
 		errs = append(errs, err)
 		return
 	}

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -550,7 +550,7 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request, labels *metric
 		errs = append(errs, errsL...)
 	}
 
-	if err := ortb.SetDefaults(req); err != nil {
+	if err := ortb.SetDefaults(req, deps.cfg.TmaxDefault); err != nil {
 		errs = []error{err}
 		return
 	}

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -265,7 +265,7 @@ func (deps *endpointDeps) VideoAuctionEndpoint(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := ortb.SetDefaults(bidReqWrapper); err != nil {
+	if err := ortb.SetDefaults(bidReqWrapper, deps.cfg.TmaxDefault); err != nil {
 		handleError(&labels, w, errL, &vo, &debugLog)
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/copystructure v1.2.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/prebid/go-gdpr v1.12.0
 	github.com/prebid/go-gpp v0.2.0
@@ -57,7 +58,6 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/ortb/default.go
+++ b/ortb/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultSecure                     = int8(1)
 )
 
-func SetDefaults(r *openrtb_ext.RequestWrapper) error {
+func SetDefaults(r *openrtb_ext.RequestWrapper, defaultTmax int) error {
 	requestExt, err := r.GetRequestExt()
 	if err != nil {
 		return err
@@ -34,6 +34,10 @@ func SetDefaults(r *openrtb_ext.RequestWrapper) error {
 		if modified {
 			r.SetImp(imps)
 		}
+	}
+
+	if r.TMax == 0 {
+		r.TMax = int64(defaultTmax)
 	}
 
 	return nil

--- a/ortb/default_test.go
+++ b/ortb/default_test.go
@@ -22,6 +22,7 @@ func TestSetDefaults(t *testing.T) {
 		name            string
 		givenRequest    openrtb2.BidRequest
 		expectedRequest openrtb2.BidRequest
+		tMax            int
 		expectedErr     string
 	}{
 		{
@@ -45,6 +46,18 @@ func TestSetDefaults(t *testing.T) {
 			givenRequest:    openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}, {Secure: nil}}},
 			expectedRequest: openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}, {Secure: &secure1}}},
 		},
+		{
+			name:            "tmax_not_set_should_be_set_to_default", // tests integration with setDefaultsImp
+			givenRequest:    openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}}, TMax: 0},
+			expectedRequest: openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}}, TMax: 100},
+			tMax:            100,
+		},
+		{
+			name:            "tmax_set_should_remain_the_same", // tests integration with setDefaultsImp
+			givenRequest:    openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}}, TMax: 200},
+			expectedRequest: openrtb2.BidRequest{Imp: []openrtb2.Imp{{Secure: &secure0}}, TMax: 200},
+			tMax:            100,
+		},
 	}
 
 	for _, test := range testCases {
@@ -52,7 +65,7 @@ func TestSetDefaults(t *testing.T) {
 			wrapper := &openrtb_ext.RequestWrapper{BidRequest: &test.givenRequest}
 
 			// run
-			err := SetDefaults(wrapper)
+			err := SetDefaults(wrapper, test.tMax)
 
 			// assert error
 			if len(test.expectedErr) > 0 {


### PR DESCRIPTION
TMax default is currently set via the default stored request. This PR provides the option to set the default on the host config. This can be beneficial to host companies that do not use the default stored request for other purposes but still want to set a default tmax since there is a performance hit associated with using the default stored request.