### PR TITLE
Smartadserver: Add second endpoint for programmatic guaranteed

### DIFF
--- a/adapters/smartadserver/smartadserver.go
+++ b/adapters/smartadserver/smartadserver.go
@@ -17,14 +17,16 @@ import (
 )
 
 type SmartAdserverAdapter struct {
-	host   string
-	Server config.Server
+	defaultHost   string
+	secondaryHost string
+	Server        config.Server
 }
 
 // Builder builds a new instance of the SmartAdserver adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
 	bidder := &SmartAdserverAdapter{
-		host: config.Endpoint,
+		defaultHost:   config.Endpoint,
+		secondaryHost: "https://prebid-global.smartadserver.com",
 	}
 	return bidder, nil
 }
@@ -60,6 +62,9 @@ func (a *SmartAdserverAdapter) MakeRequests(request *openrtb2.BidRequest, reqInf
 	}
 
 	var imps []openrtb2.Imp
+	var impSmartadserverExts []openrtb_ext.ExtImpSmartadserverOut
+	isProgrammaticGuaranteed := false
+	impExtKey := "bidder"
 
 	// Filter out impressions that do not have the proper bidder extensions
 	for _, imp := range request.Imp {
@@ -71,18 +76,49 @@ func (a *SmartAdserverAdapter) MakeRequests(request *openrtb2.BidRequest, reqInf
 			continue
 		}
 
-		var smartadserverExt openrtb_ext.ExtImpSmartadserver
-		if err := jsonutil.Unmarshal(bidderExt.Bidder, &smartadserverExt); err != nil {
+		var smartadserverExtIn openrtb_ext.ExtImpSmartadserverIn
+		if err := jsonutil.Unmarshal(bidderExt.Bidder, &smartadserverExtIn); err != nil {
 			errs = append(errs, &errortypes.BadInput{
 				Message: "Error parsing smartadserverExt parameters",
 			})
 			continue
 		}
 
-		imps = append(imps, imp)
+		if !isProgrammaticGuaranteed && smartadserverExtIn.ProgrammaticGuaranteed {
+			isProgrammaticGuaranteed = true
+			impExtKey = "smartadserver"
+		}
 
-		// Adding publisher id.
-		smartRequest.Site.Publisher.ID = strconv.Itoa(smartadserverExt.NetworkID)
+		imps = append(imps, imp)
+		impSmartadserverExts = append(impSmartadserverExts, openrtb_ext.ExtImpSmartadserverOut(smartadserverExtIn))
+
+		// Properly set publisher id from extentions for coming request
+		smartRequest.Site.Publisher.ID = strconv.Itoa(smartadserverExtIn.NetworkID)
+	}
+
+	// Loop again to serialize extension properly
+	for index, imp := range imps {
+		var completeExt map[string]any
+		if err := json.Unmarshal(imp.Ext, &completeExt); err != nil {
+			errs = append(errs, &errortypes.BadInput{
+				Message: "Error parsing imp.Ext object",
+			})
+			continue
+		}
+
+		// Delete `bidder`extensions, then write it again with either `bidder` or `smartadserver` key, without unwanted elements.
+		delete(completeExt, "bidder")
+		completeExt[impExtKey] = impSmartadserverExts[index]
+
+		var errMarshal error
+		if imp.Ext, errMarshal = json.Marshal(completeExt); errMarshal != nil {
+			errs = append(errs, &errortypes.BadInput{
+				Message: errMarshal.Error(),
+			})
+			continue
+		}
+
+		imps[index] = imp
 	}
 
 	// Only create the request if it has at least one correctly formatted impression
@@ -97,7 +133,7 @@ func (a *SmartAdserverAdapter) MakeRequests(request *openrtb2.BidRequest, reqInf
 			return nil, errs
 		}
 
-		url, err := a.BuildEndpointURL()
+		url, err := a.BuildEndpointURL(isProgrammaticGuaranteed)
 		if url == "" {
 			errs = append(errs, err)
 			return nil, errs
@@ -158,16 +194,26 @@ func (a *SmartAdserverAdapter) MakeBids(internalRequest *openrtb2.BidRequest, ex
 }
 
 // BuildEndpointURL : Builds endpoint url
-func (a *SmartAdserverAdapter) BuildEndpointURL() (string, error) {
-	uri, err := url.Parse(a.host)
+func (a *SmartAdserverAdapter) BuildEndpointURL(isProgrammaticGuaranteed bool) (string, error) {
+	host := a.defaultHost
+
+	if isProgrammaticGuaranteed {
+		host = a.secondaryHost
+	}
+
+	uri, err := url.Parse(host)
 	if err != nil || uri.Scheme == "" || uri.Host == "" {
 		return "", &errortypes.BadInput{
-			Message: "Malformed URL: " + a.host + ".",
+			Message: "Malformed URL: " + host + ".",
 		}
 	}
 
-	uri.Path = path.Join(uri.Path, "api/bid")
-	uri.RawQuery = "callerId=5"
+	if isProgrammaticGuaranteed {
+		uri.Path = path.Join(uri.Path, "ortb")
+	} else {
+		uri.Path = path.Join(uri.Path, "api/bid")
+		uri.RawQuery = "callerId=5"
+	}
 
 	return uri.String(), nil
 }

--- a/adapters/smartadserver/smartadservertest/exemplary/multi-banner-programmatic-guaranteed.json
+++ b/adapters/smartadserver/smartadservertest/exemplary/multi-banner-programmatic-guaranteed.json
@@ -27,7 +27,8 @@
             "siteId": 1,
             "pageId": 2,
             "formatId": 4,
-            "networkId": 73
+            "networkId": 73,
+            "programmaticGuaranteed": true
           }
         }
       }
@@ -37,7 +38,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://prebid-global.smartadserver.com/ortb",
         "body": {
           "id": "test-request-multi-id",
           "imp": [
@@ -47,7 +48,7 @@
                 "format": [{"w": 728, "h": 90}]
               },
               "ext": {
-                "bidder": {
+                "smartadserver": {
                   "siteId": 1,
                   "pageId": 2,
                   "formatId": 3,
@@ -61,7 +62,7 @@
                 "format": [{"w": 300, "h": 150}]
               },
               "ext": {
-                "bidder": {
+                "smartadserver": {
                   "siteId": 1,
                   "pageId": 2,
                   "formatId": 4,

--- a/adapters/smartadserver/smartadservertest/exemplary/simple-banner-programmatic-guaranteed.json
+++ b/adapters/smartadserver/smartadservertest/exemplary/simple-banner-programmatic-guaranteed.json
@@ -1,0 +1,98 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [{"w": 728, "h": 90}]
+        },
+        "ext": {
+          "bidder": {
+            "siteId": 1,
+            "pageId": 2,
+            "formatId": 3,
+            "networkId": 73,
+            "programmaticGuaranteed": true
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://prebid-global.smartadserver.com/ortb",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [{"w": 728, "h": 90}]
+              },
+              "ext": {
+                "smartadserver": {
+                  "siteId": 1,
+                  "pageId": 2,
+                  "formatId": 3,
+                  "networkId": 73
+                }
+              }
+            }
+          ],
+          "site": {
+            "publisher": {
+              "id": "73"
+            }
+          }
+        },
+        "impIDs":["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "smartadserver",
+              "bid": [{
+                "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                "impid": "test-imp-id",
+                "price": 0.500000,
+                "adm": "some-test-ad",
+                "crid": "crid_10",
+                "h": 90,
+                "w": 728,
+                "mtype": 1
+              }]
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+            "impid": "test-imp-id",
+            "price": 0.5,
+            "adm": "some-test-ad",
+            "crid": "crid_10",
+            "w": 728,
+            "h": 90,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/openrtb_ext/imp_smartadserver.go
+++ b/openrtb_ext/imp_smartadserver.go
@@ -1,9 +1,18 @@
 package openrtb_ext
 
 // ExtImpSmartadserver defines the contract for bidrequest.imp[i].ext.prebid.bidder.smartadserver
-type ExtImpSmartadserver struct {
-	SiteID    int `json:"siteId"`
-	PageID    int `json:"pageId"`
-	FormatID  int `json:"formatId"`
-	NetworkID int `json:"networkId"`
+type ExtImpSmartadserverIn struct {
+	SiteID                 int  `json:"siteId"`
+	PageID                 int  `json:"pageId"`
+	FormatID               int  `json:"formatId"`
+	NetworkID              int  `json:"networkId"`
+	ProgrammaticGuaranteed bool `json:"programmaticGuaranteed"`
+}
+
+type ExtImpSmartadserverOut struct {
+	SiteID                 int  `json:"siteId"`
+	PageID                 int  `json:"pageId"`
+	FormatID               int  `json:"formatId"`
+	NetworkID              int  `json:"networkId"`
+	ProgrammaticGuaranteed bool `json:"-"`
 }


### PR DESCRIPTION
## Summary

This PR updates the behavior of the SmartAdServer adapter.

The adapter now is able to send bidrequest to 2 different endpoints depending on the presence and value of `programmaticGuaranteed` key in the extension.

There is only 2 different endpoints, no more. We based our implementation on [this issue](https://github.com/prebid/prebid-server/issues/3538) to comply with your expectations.