### PR TITLE
e-planning: Add support for adomain

### DIFF
--- a/adapters/eplanning/eplanning.go
+++ b/adapters/eplanning/eplanning.go
@@ -66,6 +66,7 @@ type hbResponseAd struct {
 	Price        string `json:"pr"`
 	AdM          string `json:"adm"`
 	CrID         string `json:"crid"`
+	Adomain      string `json:"adom,omitempty"`
 	Width        uint64 `json:"w,omitempty"`
 	Height       uint64 `json:"h,omitempty"`
 }
@@ -506,6 +507,10 @@ func (adapter *EPlanningAdapter) MakeBids(internalRequest *openrtb2.BidRequest, 
 					CrID:  ad.CrID,
 					W:     int64(ad.Width),
 					H:     int64(ad.Height),
+				}
+
+				if ad.Adomain != "" {
+					bid.ADomain = []string{ad.Adomain}
 				}
 
 				bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{

--- a/adapters/eplanning/eplanning_test.go
+++ b/adapters/eplanning/eplanning_test.go
@@ -1,11 +1,12 @@
 package eplanning
 
 import (
+	"testing"
+
 	"github.com/prebid/prebid-server/v3/adapters"
 	"github.com/prebid/prebid-server/v3/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v3/config"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
-	"testing"
 )
 
 func TestJsonSamples(t *testing.T) {

--- a/adapters/eplanning/eplanningtest/exemplary/simple-banner-2.json
+++ b/adapters/eplanning/eplanningtest/exemplary/simple-banner-2.json
@@ -43,6 +43,7 @@
               "a": [{
                 "i": "123456789abcdef",
                 "pr": "0.5",
+                "adom":"test.com",
                 "adm": "<div>test</div>",
                 "crid": "abcdef123456789",
                 "id": "adid12345",
@@ -65,6 +66,7 @@
             "id": "123456789abcdef",
             "impid": "test-imp-id",
             "price": 0.5,
+            "adomain":["test.com"],
             "adm": "<div>test</div>",
             "adid": "adid12345",
             "crid": "abcdef123456789",


### PR DESCRIPTION
Adding a new, optional, response field adom/adomain to the e-planning adapter to comply with Microsoft Monetize requirements