### PR TITLE
CI: sequence actions/checkout before actions/setup-go

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -12,17 +12,17 @@ jobs:
   run-coverage:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.0
-
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
 
       - name: Discover Adapter Directories
         id: get_directories

--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Checkout Merged Branch
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: 1.24.0
-
-    - name: Checkout Merged Branch
-      uses: actions/checkout@v4
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
         # Resolves to empty string for push events and falls back to HEAD.
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
 
     - name: Validate
       run: |


### PR DESCRIPTION
# Changes

Reorders GitHub workflows using actions/checkout and actions/setup-go: run actions/checkout before actions/setup-go.

Running actions/checkout first checks out the go.sum file so the cache can hit. This matches the step-order demonstrated in the setup-go README:[^setup-go]

```
steps:
  - uses: actions/checkout@v4
  - uses: actions/setup-go@v5
```

[^setup-go]: https://github.com/actions/setup-go?tab=readme-ov-file#basic

# Motivation

The actions/setup-go build cache always misses because go.sum isn't present when the step runs. Here's the warning message and some timing notes [^example]

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/prebid-server/prebid-server. Supported file pattern: go.sum

[^example]: https://github.com/prebid/prebid-server/actions/runs/16729524538/job/47353933940#step:2:16

| Timestamp | Log | Note |
|:-- |:--------- |:----- |
| 17:08:45 | Run ./validate.sh --nofmt --cov --race 10 | Validate step starts. | 
| 17:08:50 | go: downloading google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 | Last dependency starts downloading. |
| 17:12:56 | ok  	github.com/prebid/prebid-server/v3	0.009s	coverage: 3.1% of statements | First test log — four minutes later! |

# Validation

The first time this updated workflow runs (against this PR!) the setup-go step will _still_ cache-miss, but it shouldn't emit the "Dependencies file is not found" log — the cache is just empty!

Subsequent runs should realize the speedup.