### PR TITLE
Metrics: Record GVL fetch count

### DIFF
--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -35,11 +35,11 @@ type RequestInfo struct {
 }
 
 // NewPermissionsBuilder takes host config data used to configure the builder function it returns
-func NewPermissionsBuilder(cfg config.GDPR, gvlVendorIDs map[openrtb_ext.BidderName]uint16, vendorListFetcher VendorListFetcher, metricsEngine metrics.MetricsEngine) PermissionsBuilder {
+func NewPermissionsBuilder(cfg config.GDPR, gvlVendorIDs map[openrtb_ext.BidderName]uint16, vendorListFetcher VendorListFetcher, me metrics.MetricsEngine) PermissionsBuilder {
 	return func(tcf2Cfg TCF2ConfigReader, requestInfo RequestInfo) Permissions {
 		purposeEnforcerBuilder := NewPurposeEnforcerBuilder(tcf2Cfg)
 
-		return NewPermissions(cfg, tcf2Cfg, gvlVendorIDs, vendorListFetcher, purposeEnforcerBuilder, requestInfo, metricsEngine)
+		return NewPermissions(cfg, tcf2Cfg, gvlVendorIDs, vendorListFetcher, purposeEnforcerBuilder, requestInfo, me)
 	}
 }
 

--- a/gdpr/gdpr.go
+++ b/gdpr/gdpr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/metrics"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 )
 
@@ -34,16 +35,16 @@ type RequestInfo struct {
 }
 
 // NewPermissionsBuilder takes host config data used to configure the builder function it returns
-func NewPermissionsBuilder(cfg config.GDPR, gvlVendorIDs map[openrtb_ext.BidderName]uint16, vendorListFetcher VendorListFetcher) PermissionsBuilder {
+func NewPermissionsBuilder(cfg config.GDPR, gvlVendorIDs map[openrtb_ext.BidderName]uint16, vendorListFetcher VendorListFetcher, metricsEngine metrics.MetricsEngine) PermissionsBuilder {
 	return func(tcf2Cfg TCF2ConfigReader, requestInfo RequestInfo) Permissions {
 		purposeEnforcerBuilder := NewPurposeEnforcerBuilder(tcf2Cfg)
 
-		return NewPermissions(cfg, tcf2Cfg, gvlVendorIDs, vendorListFetcher, purposeEnforcerBuilder, requestInfo)
+		return NewPermissions(cfg, tcf2Cfg, gvlVendorIDs, vendorListFetcher, purposeEnforcerBuilder, requestInfo, metricsEngine)
 	}
 }
 
 // NewPermissions gets a per-request Permissions object that can then be used to check GDPR permissions for a given bidder.
-func NewPermissions(cfg config.GDPR, tcf2Config TCF2ConfigReader, vendorIDs map[openrtb_ext.BidderName]uint16, fetcher VendorListFetcher, purposeEnforcerBuilder PurposeEnforcerBuilder, requestInfo RequestInfo) Permissions {
+func NewPermissions(cfg config.GDPR, tcf2Config TCF2ConfigReader, vendorIDs map[openrtb_ext.BidderName]uint16, fetcher VendorListFetcher, purposeEnforcerBuilder PurposeEnforcerBuilder, requestInfo RequestInfo, metricsEngine metrics.MetricsEngine) Permissions {
 	if !cfg.Enabled {
 		return &AlwaysAllow{}
 	}
@@ -60,6 +61,7 @@ func NewPermissions(cfg config.GDPR, tcf2Config TCF2ConfigReader, vendorIDs map[
 		consent:                requestInfo.Consent,
 		aliasGVLIDs:            requestInfo.AliasGVLIDs,
 		purposeEnforcerBuilder: purposeEnforcerBuilder,
+		metrics:                metricsEngine,
 	}
 
 	if cfg.HostVendorID == 0 {

--- a/gdpr/gdpr_test.go
+++ b/gdpr/gdpr_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prebid/go-gdpr/consentconstants"
 	"github.com/prebid/go-gdpr/vendorlist"
 	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/metrics"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 
 	"github.com/stretchr/testify/assert"
@@ -43,14 +44,14 @@ func TestNewPermissions(t *testing.T) {
 			HostVendorID: tt.hostVendorID,
 		}
 		vendorIDs := map[openrtb_ext.BidderName]uint16{}
-		vendorListFetcher := func(ctx context.Context, specVersion, listVersion uint16) (vendorlist.VendorList, error) {
+		vendorListFetcher := func(ctx context.Context, specVersion, listVersion uint16, metricsEngine metrics.MetricsEngine) (vendorlist.VendorList, error) {
 			return nil, nil
 		}
 
 		fakePurposeEnforcerBuilder := fakePurposeEnforcerBuilder{
 			purposeEnforcer: nil,
 		}.Builder
-		perms := NewPermissions(config, &tcf2Config{}, vendorIDs, vendorListFetcher, fakePurposeEnforcerBuilder, RequestInfo{})
+		perms := NewPermissions(config, &tcf2Config{}, vendorIDs, vendorListFetcher, fakePurposeEnforcerBuilder, RequestInfo{}, &metrics.MetricsEngineMock{})
 
 		assert.IsType(t, tt.wantType, perms, tt.description)
 	}

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -20,6 +20,7 @@ type permissionsImpl struct {
 	fetchVendorList        VendorListFetcher
 	gdprDefaultValue       string
 	hostVendorID           int
+	metrics                metrics.MetricsEngine
 	nonStandardPublishers  map[string]struct{}
 	purposeEnforcerBuilder PurposeEnforcerBuilder
 	vendorIDs              map[openrtb_ext.BidderName]uint16
@@ -29,8 +30,6 @@ type permissionsImpl struct {
 	consent     string
 	gdprSignal  Signal
 	publisherID string
-
-	metrics metrics.MetricsEngine
 }
 
 // HostCookiesAllowed determines whether the host is allowed to set cookies on the user's device

--- a/gdpr/impl.go
+++ b/gdpr/impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
 	tcf2 "github.com/prebid/go-gdpr/vendorconsent/tcf2"
+	"github.com/prebid/prebid-server/v3/metrics"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 )
 
@@ -28,6 +29,8 @@ type permissionsImpl struct {
 	consent     string
 	gdprSignal  Signal
 	publisherID string
+
+	metrics metrics.MetricsEngine
 }
 
 // HostCookiesAllowed determines whether the host is allowed to set cookies on the user's device
@@ -199,7 +202,7 @@ func (p *permissionsImpl) allowID(bidder openrtb_ext.BidderName, consentMeta tcf
 
 // getVendor retrieves the GVL vendor information for a particular bidder
 func (p *permissionsImpl) getVendor(ctx context.Context, vendorID uint16, pc parsedConsent) (api.Vendor, error) {
-	vendorList, err := p.fetchVendorList(ctx, pc.specVersion, pc.listVersion)
+	vendorList, err := p.fetchVendorList(ctx, pc.specVersion, pc.listVersion, p.metrics)
 	if err != nil {
 		return nil, err
 	}

--- a/gdpr/impl_test.go
+++ b/gdpr/impl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prebid/go-gdpr/vendorlist"
 	"github.com/prebid/go-gdpr/vendorlist2"
 	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/metrics"
 	"github.com/prebid/prebid-server/v3/openrtb_ext"
 
 	"github.com/stretchr/testify/assert"
@@ -883,8 +884,8 @@ func parseVendorListDataV2(t *testing.T, data string) vendorlist.VendorList {
 	return parsed
 }
 
-func listFetcher(specVersionLists map[uint16]map[uint16]vendorlist.VendorList) func(context.Context, uint16, uint16) (vendorlist.VendorList, error) {
-	return func(ctx context.Context, specVersion, listVersion uint16) (vendorlist.VendorList, error) {
+func listFetcher(specVersionLists map[uint16]map[uint16]vendorlist.VendorList) func(context.Context, uint16, uint16, metrics.MetricsEngine) (vendorlist.VendorList, error) {
+	return func(ctx context.Context, specVersion, listVersion uint16, metricsEngine metrics.MetricsEngine) (vendorlist.VendorList, error) {
 		if lists, ok := specVersionLists[specVersion]; ok {
 			if data, ok := lists[listVersion]; ok {
 				return data, nil
@@ -894,7 +895,7 @@ func listFetcher(specVersionLists map[uint16]map[uint16]vendorlist.VendorList) f
 	}
 }
 
-func failedListFetcher(ctx context.Context, specVersion, listVersion uint16) (vendorlist.VendorList, error) {
+func failedListFetcher(ctx context.Context, specVersion, listVersion uint16, metricsEngine metrics.MetricsEngine) (vendorlist.VendorList, error) {
 	return nil, errors.New("vendor list can't be fetched")
 }
 

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -116,7 +116,7 @@ func newOccasionalSaver(timeout time.Duration) func(ctx context.Context, client 
 	}
 }
 
-func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors, metricsEngine metrics.MetricsEngine) uint16 {
+func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors, me metrics.MetricsEngine) uint16 {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		glog.Errorf("Failed to build GET %s request. Cookie syncs may be affected: %v", url, err)
@@ -137,11 +137,10 @@ func saveOne(ctx context.Context, client *http.Client, url string, saver saveVen
 	}
 	if resp.StatusCode != http.StatusOK {
 		glog.Errorf("GET %s returned %d. Cookie syncs may be affected.", url, resp.StatusCode)
-		//metricsEngine.RecordVendorListFetch(fail)
+		me.RecordGvlListRequest()
 		return 0
 	}
-	// log GVL fetch metric here
-	//metricsEngine.RecordVendorListFetch(success)
+	me.RecordGvlListRequest()
 
 	var newList api.VendorList
 	newList, err = vendorlist2.ParseEagerly(respBody)

--- a/gdpr/vendorlist-fetching.go
+++ b/gdpr/vendorlist-fetching.go
@@ -15,11 +15,12 @@ import (
 	"github.com/prebid/go-gdpr/vendorlist"
 	"github.com/prebid/go-gdpr/vendorlist2"
 	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/metrics"
 	"golang.org/x/net/context/ctxhttp"
 )
 
 type saveVendors func(uint16, uint16, api.VendorList)
-type VendorListFetcher func(ctx context.Context, specVersion uint16, listVersion uint16) (vendorlist.VendorList, error)
+type VendorListFetcher func(ctx context.Context, specVersion uint16, listVersion uint16, metricsEngine metrics.MetricsEngine) (vendorlist.VendorList, error)
 
 // This file provides the vendorlist-fetching function for Prebid Server.
 //
@@ -27,15 +28,15 @@ type VendorListFetcher func(ctx context.Context, specVersion uint16, listVersion
 //
 // Nothing in this file is exported. Public APIs can be found in gdpr.go
 
-func NewVendorListFetcher(initCtx context.Context, cfg config.GDPR, client *http.Client, urlMaker func(uint16, uint16) string) VendorListFetcher {
+func NewVendorListFetcher(initCtx context.Context, cfg config.GDPR, client *http.Client, metricsEngine metrics.MetricsEngine, urlMaker func(uint16, uint16) string) VendorListFetcher {
 	cacheSave, cacheLoad := newVendorListCache()
 
 	preloadContext, cancel := context.WithTimeout(initCtx, cfg.Timeouts.InitTimeout())
 	defer cancel()
-	preloadCache(preloadContext, client, urlMaker, cacheSave)
+	preloadCache(preloadContext, client, urlMaker, cacheSave, metricsEngine)
 
 	saveOneRateLimited := newOccasionalSaver(cfg.Timeouts.ActiveTimeout())
-	return func(ctx context.Context, specVersion, listVersion uint16) (vendorlist.VendorList, error) {
+	return func(ctx context.Context, specVersion, listVersion uint16, metricsEngine metrics.MetricsEngine) (vendorlist.VendorList, error) {
 		// Attempt To Load From Cache
 		if list := cacheLoad(specVersion, listVersion); list != nil {
 			return list, nil
@@ -43,7 +44,7 @@ func NewVendorListFetcher(initCtx context.Context, cfg config.GDPR, client *http
 
 		// Attempt To Download
 		// - May not add to cache immediately.
-		saveOneRateLimited(ctx, client, urlMaker(specVersion, listVersion), cacheSave)
+		saveOneRateLimited(ctx, client, urlMaker(specVersion, listVersion), cacheSave, metricsEngine)
 
 		// Attempt To Load From Cache Again
 		// - May have been added by the call to saveOneRateLimited.
@@ -61,7 +62,7 @@ func makeVendorListNotFoundError(specVersion, listVersion uint16) error {
 }
 
 // preloadCache saves all the known versions of the vendor list for future use.
-func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16, uint16) string, saver saveVendors) {
+func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16, uint16) string, saver saveVendors, metricsEngine metrics.MetricsEngine) {
 	versions := [2]struct {
 		specVersion      uint16
 		firstListVersion uint16
@@ -76,10 +77,10 @@ func preloadCache(ctx context.Context, client *http.Client, urlMaker func(uint16
 		},
 	}
 	for _, v := range versions {
-		latestVersion := saveOne(ctx, client, urlMaker(v.specVersion, 0), saver)
+		latestVersion := saveOne(ctx, client, urlMaker(v.specVersion, 0), saver, metricsEngine)
 
 		for i := v.firstListVersion; i < latestVersion; i++ {
-			saveOne(ctx, client, urlMaker(v.specVersion, i), saver)
+			saveOne(ctx, client, urlMaker(v.specVersion, i), saver, metricsEngine)
 		}
 	}
 }
@@ -98,24 +99,24 @@ func VendorListURLMaker(specVersion, listVersion uint16) string {
 // The goal here is to update quickly when new versions of the VendorList are released, but not wreck
 // server performance if a bad CMP starts sending us malformed consent strings that advertize a version
 // that doesn't exist yet.
-func newOccasionalSaver(timeout time.Duration) func(ctx context.Context, client *http.Client, url string, saver saveVendors) {
+func newOccasionalSaver(timeout time.Duration) func(ctx context.Context, client *http.Client, url string, saver saveVendors, metricsEngine metrics.MetricsEngine) {
 	lastSaved := &atomic.Value{}
 	lastSaved.Store(time.Time{})
 
-	return func(ctx context.Context, client *http.Client, url string, saver saveVendors) {
+	return func(ctx context.Context, client *http.Client, url string, saver saveVendors, metricsEngine metrics.MetricsEngine) {
 		now := time.Now()
 		timeSinceLastSave := now.Sub(lastSaved.Load().(time.Time))
 
 		if timeSinceLastSave.Minutes() > 10 {
 			withTimeout, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
-			saveOne(withTimeout, client, url, saver)
+			saveOne(withTimeout, client, url, saver, metricsEngine)
 			lastSaved.Store(now)
 		}
 	}
 }
 
-func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors) uint16 {
+func saveOne(ctx context.Context, client *http.Client, url string, saver saveVendors, metricsEngine metrics.MetricsEngine) uint16 {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		glog.Errorf("Failed to build GET %s request. Cookie syncs may be affected: %v", url, err)
@@ -136,8 +137,12 @@ func saveOne(ctx context.Context, client *http.Client, url string, saver saveVen
 	}
 	if resp.StatusCode != http.StatusOK {
 		glog.Errorf("GET %s returned %d. Cookie syncs may be affected.", url, resp.StatusCode)
+		//metricsEngine.RecordVendorListFetch(fail)
 		return 0
 	}
+	// log GVL fetch metric here
+	//metricsEngine.RecordVendorListFetch(success)
+
 	var newList api.VendorList
 	newList, err = vendorlist2.ParseEagerly(respBody)
 	if err != nil {

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -96,15 +96,17 @@ func TestFetcherThrottling(t *testing.T) {
 	})))
 	defer server.Close()
 
-	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), &metrics.MetricsEngineMock{}, testURLMaker(server))
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(3)
+	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), m, testURLMaker(server))
 
 	// Dynamically Load List 2 Successfully
-	_, errList1 := fetcher(context.Background(), 3, 2, &metrics.MetricsEngineMock{})
+	_, errList1 := fetcher(context.Background(), 3, 2, m)
 	assert.NoError(t, errList1)
 
 	// Fail To Load List 3 Due To Rate Limiting
 	// - The request is rate limited after dynamically list 2.
-	_, errList2 := fetcher(context.Background(), 3, 3, &metrics.MetricsEngineMock{})
+	_, errList2 := fetcher(context.Background(), 3, 3, m)
 	assert.EqualError(t, errList2, "gdpr vendor list spec version 3 list version 3 does not exist, or has not been loaded yet. Try again in a few minutes")
 }
 
@@ -119,8 +121,10 @@ func TestMalformedVendorlist(t *testing.T) {
 	})))
 	defer server.Close()
 
-	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), &metrics.MetricsEngineMock{}, testURLMaker(server))
-	_, err := fetcher(context.Background(), 3, 1, &metrics.MetricsEngineMock{})
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(3)
+	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), m, testURLMaker(server))
+	_, err := fetcher(context.Background(), 3, 1, m)
 
 	// Fetching should fail since vendor list could not be unmarshalled.
 	assert.Error(t, err)
@@ -132,8 +136,10 @@ func TestServerUrlInvalid(t *testing.T) {
 
 	invalidURLGenerator := func(uint16, uint16) string { return " http://invalid-url-has-leading-whitespace" }
 
-	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), &metrics.MetricsEngineMock{}, invalidURLGenerator)
-	_, err := fetcher(context.Background(), 3, 1, &metrics.MetricsEngineMock{})
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(2)
+	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), m, invalidURLGenerator)
+	_, err := fetcher(context.Background(), 3, 1, m)
 
 	assert.EqualError(t, err, "gdpr vendor list spec version 3 list version 1 does not exist, or has not been loaded yet. Try again in a few minutes")
 }
@@ -142,8 +148,10 @@ func TestServerUnavailable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	server.Close()
 
-	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), &metrics.MetricsEngineMock{}, testURLMaker(server))
-	_, err := fetcher(context.Background(), 3, 1, &metrics.MetricsEngineMock{})
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(2)
+	fetcher := NewVendorListFetcher(context.Background(), testConfig(), server.Client(), m, testURLMaker(server))
+	_, err := fetcher(context.Background(), 3, 1, m)
 
 	assert.EqualError(t, err, "gdpr vendor list spec version 3 list version 1 does not exist, or has not been loaded yet. Try again in a few minutes")
 }
@@ -254,7 +262,9 @@ func TestPreloadCache(t *testing.T) {
 	defer server.Close()
 
 	s := make(saver, 0, 5)
-	preloadCache(context.Background(), server.Client(), testURLMaker(server), s.saveVendorLists, &metrics.MetricsEngineMock{})
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(5)
+	preloadCache(context.Background(), server.Client(), testURLMaker(server), s.saveVendorLists, m)
 
 	expectedLoadedVersions := []versionInfo{
 		{specVersion: 2, listVersion: 2},
@@ -381,8 +391,10 @@ type testExpected struct {
 
 func runTest(t *testing.T, test test, server *httptest.Server) {
 	config := testConfig()
-	fetcher := NewVendorListFetcher(context.Background(), config, server.Client(), &metrics.MetricsEngineMock{}, testURLMaker(server))
-	vendorList, err := fetcher(context.Background(), test.setup.specVersion, test.setup.listVersion, &metrics.MetricsEngineMock{})
+	m := &metrics.MetricsEngineMock{}
+	m.On("RecordGvlListRequest").Times(3)
+	fetcher := NewVendorListFetcher(context.Background(), config, server.Client(), m, testURLMaker(server))
+	vendorList, err := fetcher(context.Background(), test.setup.specVersion, test.setup.listVersion, m)
 
 	if test.expected.errorMessage != "" {
 		assert.EqualError(t, err, test.expected.errorMessage, test.description+":error")

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -293,6 +293,12 @@ func (me *MultiMetricsEngine) RecordStoredResponse(pubId string) {
 	}
 }
 
+func (me *MultiMetricsEngine) RecordGvlListRequest() {
+	for _, thisME := range *me {
+		thisME.RecordGvlListRequest()
+	}
+}
+
 func (me *MultiMetricsEngine) RecordAdsCertReq(success bool) {
 	for _, thisME := range *me {
 		thisME.RecordAdsCertReq(success)
@@ -511,6 +517,9 @@ func (me *NilMetricsEngine) RecordDebugRequest(debugEnabled bool, pubId string) 
 }
 
 func (me *NilMetricsEngine) RecordStoredResponse(pubId string) {
+}
+
+func (me *NilMetricsEngine) RecordGvlListRequest() {
 }
 
 func (me *NilMetricsEngine) RecordAdsCertReq(success bool) {

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -35,6 +35,7 @@ type Metrics struct {
 	TLSHandshakeTimer              metrics.Timer
 	BidderServerResponseTimer      metrics.Timer
 	StoredResponsesMeter           metrics.Meter
+	GvlListRequestsMeter           metrics.Meter
 
 	// Metrics for OpenRTB requests specifically
 	RequestStatuses       map[RequestType]map[RequestStatus]metrics.Meter
@@ -182,6 +183,7 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []string, disabledMetr
 		SetUidStatusMeter:              make(map[SetUidStatus]metrics.Meter),
 		SyncerSetsMeter:                make(map[string]map[SyncerSetUidStatus]metrics.Meter),
 		StoredResponsesMeter:           blankMeter,
+		GvlListRequestsMeter:           blankMeter,
 
 		ImpsTypeBanner: blankMeter,
 		ImpsTypeVideo:  blankMeter,
@@ -301,6 +303,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.PrebidCacheRequestTimerSuccess = metrics.GetOrRegisterTimer("prebid_cache_request_time.ok", registry)
 	newMetrics.PrebidCacheRequestTimerError = metrics.GetOrRegisterTimer("prebid_cache_request_time.err", registry)
 	newMetrics.StoredResponsesMeter = metrics.GetOrRegisterMeter("stored_responses", registry)
+	newMetrics.GvlListRequestsMeter = metrics.GetOrRegisterMeter("gvl_list_requests", registry)
 	newMetrics.OverheadTimer = makeOverheadTimerMetrics(registry)
 	newMetrics.BidderServerResponseTimer = metrics.GetOrRegisterTimer("bidder_server_response_time_seconds", registry)
 
@@ -625,6 +628,10 @@ func (me *Metrics) RecordStoredResponse(pubId string) {
 	if pubId != PublisherUnknown && !me.MetricsDisabled.AccountStoredResponses {
 		me.getAccountMetrics(pubId).storedResponsesMeter.Mark(1)
 	}
+}
+
+func (me *Metrics) RecordGvlListRequest() {
+	me.GvlListRequestsMeter.Mark(1)
 }
 
 func (me *Metrics) RecordImps(labels ImpLabels) {

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -303,7 +303,7 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.PrebidCacheRequestTimerSuccess = metrics.GetOrRegisterTimer("prebid_cache_request_time.ok", registry)
 	newMetrics.PrebidCacheRequestTimerError = metrics.GetOrRegisterTimer("prebid_cache_request_time.err", registry)
 	newMetrics.StoredResponsesMeter = metrics.GetOrRegisterMeter("stored_responses", registry)
-	newMetrics.GvlListRequestsMeter = metrics.GetOrRegisterMeter("gvl_list_requests", registry)
+	newMetrics.GvlListRequestsMeter = metrics.GetOrRegisterMeter("gvl_requests", registry)
 	newMetrics.OverheadTimer = makeOverheadTimerMetrics(registry)
 	newMetrics.BidderServerResponseTimer = metrics.GetOrRegisterTimer("bidder_server_response_time_seconds", registry)
 

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -36,6 +36,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "setuid_requests.gdpr_blocked_host_cookie", m.SetUidStatusMeter[SetUidGDPRHostCookieBlocked])
 	ensureContains(t, registry, "setuid_requests.syncer_unknown", m.SetUidStatusMeter[SetUidSyncerUnknown])
 	ensureContains(t, registry, "stored_responses", m.StoredResponsesMeter)
+	ensureContains(t, registry, "stored_responses", m.GvlListRequestsMeter)
 
 	ensureContains(t, registry, "prebid_cache_request_time.ok", m.PrebidCacheRequestTimerSuccess)
 	ensureContains(t, registry, "prebid_cache_request_time.err", m.PrebidCacheRequestTimerError)

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -36,7 +36,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "setuid_requests.gdpr_blocked_host_cookie", m.SetUidStatusMeter[SetUidGDPRHostCookieBlocked])
 	ensureContains(t, registry, "setuid_requests.syncer_unknown", m.SetUidStatusMeter[SetUidSyncerUnknown])
 	ensureContains(t, registry, "stored_responses", m.StoredResponsesMeter)
-	ensureContains(t, registry, "stored_responses", m.GvlListRequestsMeter)
+	ensureContains(t, registry, "gvl_list_requests", m.GvlListRequestsMeter)
 
 	ensureContains(t, registry, "prebid_cache_request_time.ok", m.PrebidCacheRequestTimerSuccess)
 	ensureContains(t, registry, "prebid_cache_request_time.err", m.PrebidCacheRequestTimerError)

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -36,7 +36,7 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "setuid_requests.gdpr_blocked_host_cookie", m.SetUidStatusMeter[SetUidGDPRHostCookieBlocked])
 	ensureContains(t, registry, "setuid_requests.syncer_unknown", m.SetUidStatusMeter[SetUidSyncerUnknown])
 	ensureContains(t, registry, "stored_responses", m.StoredResponsesMeter)
-	ensureContains(t, registry, "gvl_list_requests", m.GvlListRequestsMeter)
+	ensureContains(t, registry, "gvl_requests", m.GvlListRequestsMeter)
 
 	ensureContains(t, registry, "prebid_cache_request_time.ok", m.PrebidCacheRequestTimerSuccess)
 	ensureContains(t, registry, "prebid_cache_request_time.err", m.PrebidCacheRequestTimerError)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -459,6 +459,7 @@ type MetricsEngine interface {
 	RecordAdapterGDPRRequestBlocked(adapterName openrtb_ext.BidderName)
 	RecordDebugRequest(debugEnabled bool, pubId string)
 	RecordStoredResponse(pubId string)
+	RecordGvlListRequest()
 	RecordAdsCertReq(success bool)
 	RecordAdsCertSignTime(adsCertSignTime time.Duration)
 	RecordBidValidationCreativeSizeError(adapter openrtb_ext.BidderName, account string)

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -175,6 +175,10 @@ func (me *MetricsEngineMock) RecordStoredResponse(pubId string) {
 	me.Called(pubId)
 }
 
+func (me *MetricsEngineMock) RecordGvlListRequest() {
+	me.Called()
+}
+
 func (me *MetricsEngineMock) RecordAdsCertReq(success bool) {
 	me.Called(success)
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -366,7 +366,7 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		"Count of total requests to Prebid Server that have stored responses")
 
 	metrics.gvlListRequests = newCounterWithoutLabels(cfg, reg,
-		"gvl_list_requests",
+		"gvl_requests",
 		"Count number of times GVL list is fetched")
 
 	metrics.adapterBids = newCounter(cfg, reg,

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -53,6 +53,7 @@ type Metrics struct {
 	privacyLMT                   *prometheus.CounterVec
 	privacyTCF                   *prometheus.CounterVec
 	storedResponses              prometheus.Counter
+	gvlListRequests              prometheus.Counter
 	storedResponsesFetchTimer    *prometheus.HistogramVec
 	storedResponsesErrors        *prometheus.CounterVec
 	adsCertRequests              *prometheus.CounterVec
@@ -363,6 +364,10 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	metrics.storedResponses = newCounterWithoutLabels(cfg, reg,
 		"stored_responses",
 		"Count of total requests to Prebid Server that have stored responses")
+
+	metrics.gvlListRequests = newCounterWithoutLabels(cfg, reg,
+		"gvl_list_requests",
+		"Count number of times GVL list is fetched")
 
 	metrics.adapterBids = newCounter(cfg, reg,
 		"adapter_bids",
@@ -698,6 +703,10 @@ func (m *Metrics) RecordStoredResponse(pubId string) {
 			accountLabel: pubId,
 		}).Inc()
 	}
+}
+
+func (m *Metrics) RecordGvlListRequest() {
+	m.gvlListRequests.Inc()
 }
 
 func (m *Metrics) RecordImps(labels metrics.ImpLabels) {

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1895,6 +1895,14 @@ func TestStoredResponsesMetric(t *testing.T) {
 	}
 }
 
+func TestRecordGvlListRequest(t *testing.T) {
+	m := createMetricsForTesting()
+
+	m.RecordGvlListRequest()
+
+	assertCounterValue(t, "Record instance of fetched GVL list", "success", m.gvlListRequests, 1.00)
+}
+
 func TestRecordAdsCertReqMetric(t *testing.T) {
 	testCases := []struct {
 		description                  string

--- a/router/router.go
+++ b/router/router.go
@@ -211,8 +211,8 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 	defReqJSON := readDefaultRequest(cfg.DefReqConfig)
 
 	gvlVendorIDs := cfg.BidderInfos.ToGVLVendorIDMap()
-	vendorListFetcher := gdpr.NewVendorListFetcher(context.Background(), cfg.GDPR, generalHttpClient, gdpr.VendorListURLMaker)
-	gdprPermsBuilder := gdpr.NewPermissionsBuilder(cfg.GDPR, gvlVendorIDs, vendorListFetcher)
+	vendorListFetcher := gdpr.NewVendorListFetcher(context.Background(), cfg.GDPR, generalHttpClient, r.MetricsEngine, gdpr.VendorListURLMaker)
+	gdprPermsBuilder := gdpr.NewPermissionsBuilder(cfg.GDPR, gvlVendorIDs, vendorListFetcher, r.MetricsEngine)
 	tcf2CfgBuilder := gdpr.NewTCF2Config
 
 	cacheClient := pbc.NewClient(cacheHttpClient, &cfg.CacheURL, &cfg.ExtCacheURL, r.MetricsEngine)


### PR DESCRIPTION
```
   pbs_sub_go_sync_mutex_wait_total_seconds_total 0.177076376
   # HELP pbs_sub_go_threads Number of OS threads created.
   # TYPE pbs_sub_go_threads gauge
   pbs_sub_go_threads 16
 + # HELP pbs_sub_gvl_list_requests Count number of times GVL list is fetched
 + # TYPE pbs_sub_gvl_list_requests counter
 + pbs_sub_gvl_list_requests 0
   # HELP pbs_sub_impressions_requests Count of requested impressions to Prebid Server labeled by type.
   # TYPE pbs_sub_impressions_requests counter
   pbs_sub_impressions_requests{audio="false",banner="false",native="false",video="false"} 0
```
