### PR TITLE
Add configurable dialer timeouts to HTTP clients

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -131,7 +131,7 @@ type HTTPClient struct {
 	IdleConnTimeout       int          `mapstructure:"idle_connection_timeout_seconds"`
 	TLSHandshakeTimeout   int          `mapstructure:"tls_handshake_timeout_seconds"`
 	ExpectContinueTimeout int          `mapstructure:"expect_continue_timeout_seconds"`
-	NetDialer             NetDialer    `mapstructure:"dialer"`
+	Dialer                Dialer       `mapstructure:"dialer"`
 	Throttle              HTTPThrottle `mapstructure:"throttle"`
 }
 
@@ -148,9 +148,9 @@ type HTTPThrottle struct {
 	ThrottleWindow int `mapstructure:"throttle_window"`
 }
 
-type NetDialer struct {
-	Timeout   int `mapstructure:"timeout_seconds"`
-	KeepAlive int `mapstructure:"keep_alive_seconds"`
+type Dialer struct {
+	TimeoutSeconds   int `mapstructure:"timeout_seconds"`
+	KeepAliveSeconds int `mapstructure:"keep_alive_seconds"`
 }
 
 func (cfg *Configuration) validate(v *viper.Viper) []error {
@@ -974,7 +974,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("http_client.tls_handshake_timeout_seconds", 10)
 	v.SetDefault("http_client.expect_continue_timeout_seconds", 1)
 	v.SetDefault("http_client.dialer.timeout_seconds", 30)
-	v.SetDefault("http_client.dialer.keep_alive_seconds", 30)
+	v.SetDefault("http_client.dialer.keep_alive_seconds", 15)
 	v.SetDefault("http_client.throttle.enable_throttling", false)
 	v.SetDefault("http_client.throttle.simulate_throttling_only", false)
 	v.SetDefault("http_client.throttle.long_queue_wait_threshold_ms", 50)
@@ -987,7 +987,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("http_client_cache.tls_handshake_timeout_seconds", 10)
 	v.SetDefault("http_client_cache.expect_continue_timeout_seconds", 1)
 	v.SetDefault("http_client_cache.dialer.timeout_seconds", 30)
-	v.SetDefault("http_client_cache.dialer.keep_alive_seconds", 30)
+	v.SetDefault("http_client_cache.dialer.keep_alive_seconds", 15)
 	// no metrics configured by default (metrics{host|database|username|password})
 	v.SetDefault("metrics.disabled_metrics.account_adapter_details", false)
 	v.SetDefault("metrics.disabled_metrics.account_debug", true)
@@ -1239,7 +1239,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("price_floors.fetcher.http_client.tls_handshake_timeout_seconds", 10)
 	v.SetDefault("price_floors.fetcher.http_client.expect_continue_timeout_seconds", 1)
 	v.SetDefault("price_floors.fetcher.http_client.dialer.timeout_seconds", 30)
-	v.SetDefault("price_floors.fetcher.http_client.dialer.keep_alive_seconds", 30)
+	v.SetDefault("price_floors.fetcher.http_client.dialer.keep_alive_seconds", 15)
 	v.SetDefault("price_floors.fetcher.max_retries", 10)
 
 	v.SetDefault("account_defaults.events_enabled", false)

--- a/router/router.go
+++ b/router/router.go
@@ -141,8 +141,8 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: defaultTransportDialContext(&net.Dialer{
-				Timeout:   time.Duration(cfg.Client.NetDialer.Timeout) * time.Second,
-				KeepAlive: time.Duration(cfg.Client.NetDialer.KeepAlive) * time.Second,
+				Timeout:   time.Duration(cfg.Client.Dialer.TimeoutSeconds) * time.Second,
+				KeepAlive: time.Duration(cfg.Client.Dialer.KeepAliveSeconds) * time.Second,
 			}),
 			MaxConnsPerHost:       cfg.Client.MaxConnsPerHost,
 			MaxIdleConns:          cfg.Client.MaxIdleConns,
@@ -158,8 +158,8 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: defaultTransportDialContext(&net.Dialer{
-				Timeout:   time.Duration(cfg.CacheClient.NetDialer.Timeout) * time.Second,
-				KeepAlive: time.Duration(cfg.CacheClient.NetDialer.KeepAlive) * time.Second,
+				Timeout:   time.Duration(cfg.CacheClient.Dialer.TimeoutSeconds) * time.Second,
+				KeepAlive: time.Duration(cfg.CacheClient.Dialer.KeepAliveSeconds) * time.Second,
 			}),
 			MaxConnsPerHost:       cfg.CacheClient.MaxConnsPerHost,
 			MaxIdleConns:          cfg.CacheClient.MaxIdleConns,
@@ -174,8 +174,8 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: defaultTransportDialContext(&net.Dialer{
-				Timeout:   time.Duration(cfg.PriceFloors.Fetcher.HttpClient.NetDialer.Timeout) * time.Second,
-				KeepAlive: time.Duration(cfg.PriceFloors.Fetcher.HttpClient.NetDialer.KeepAlive) * time.Second,
+				Timeout:   time.Duration(cfg.PriceFloors.Fetcher.HttpClient.Dialer.TimeoutSeconds) * time.Second,
+				KeepAlive: time.Duration(cfg.PriceFloors.Fetcher.HttpClient.Dialer.KeepAliveSeconds) * time.Second,
 			}),
 			MaxConnsPerHost:       cfg.PriceFloors.Fetcher.HttpClient.MaxConnsPerHost,
 			MaxIdleConns:          cfg.PriceFloors.Fetcher.HttpClient.MaxIdleConns,
@@ -311,7 +311,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 	return r, nil
 }
 
-// Grabbing the same dialer context as the default transport uses
+// defaultTransportDialContext returns the same dialer context as the default transport uses, copied from the library code.
 func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
 	return dialer.DialContext
 }


### PR DESCRIPTION
The default net/http Transport struct includes some dialer timeout configurations. Our Transports do not include these. This PR adds them, and gives the default Transport values as defaults.