### PR TITLE
Connection dial metrics

### DIFF
--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2085,6 +2085,8 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
 	mockMetricEngine.On("RecordBidderServerResponseTime", mock.Anything).Once()
+	mockMetricEngine.On("RecordConnectionDials").Once()
+	mockMetricEngine.On("RecordConnectionDialTime", mock.Anything).Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -378,6 +378,18 @@ func (me *MultiMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderN
 	}
 }
 
+func (me *MultiMetricsEngine) RecordConnectionDials() {
+	for _, thisME := range *me {
+		thisME.RecordConnectionDials()
+	}
+}
+
+func (me *MultiMetricsEngine) RecordConnectionDialTime(dialStartTime time.Duration) {
+	for _, thisME := range *me {
+		thisME.RecordConnectionDialTime(dialStartTime)
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -556,4 +568,10 @@ func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 
 // RecordAdapterThrottled as a noop
 func (me *NilMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
+}
+
+func (me *NilMetricsEngine) RecordConnectionDials() {
+}
+
+func (me *NilMetricsEngine) RecordConnectionDialTime(dialStartTime time.Duration) {
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -670,7 +670,7 @@ func (me *Metrics) RecordConnectionClose(success bool) {
 }
 
 func (me *Metrics) RecordConnectionDials() {
-	me.ConnectionDialCounter.Dec(1)
+	me.ConnectionDialCounter.Inc(1)
 }
 
 func (me *Metrics) RecordConnectionDialTime(dialStartTime time.Duration) {

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -18,6 +18,8 @@ type Metrics struct {
 	TMaxTimeoutCounter             metrics.Counter
 	ConnectionAcceptErrorMeter     metrics.Meter
 	ConnectionCloseErrorMeter      metrics.Meter
+	ConnectionDialCounter          metrics.Counter
+	ConnectionDialTimer            metrics.Timer
 	ImpMeter                       metrics.Meter
 	AppRequestMeter                metrics.Meter
 	NoCookieMeter                  metrics.Meter
@@ -159,6 +161,8 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []string, disabledMetr
 		ConnectionCounter:              metrics.NilCounter{},
 		ConnectionAcceptErrorMeter:     blankMeter,
 		ConnectionCloseErrorMeter:      blankMeter,
+		ConnectionDialCounter:          metrics.NilCounter{},
+		ConnectionDialTimer:            blankTimer,
 		ImpMeter:                       blankMeter,
 		AppRequestMeter:                blankMeter,
 		DebugRequestMeter:              blankMeter,
@@ -285,6 +289,8 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.TMaxTimeoutCounter = metrics.GetOrRegisterCounter("tmax_timeout", registry)
 	newMetrics.ConnectionAcceptErrorMeter = metrics.GetOrRegisterMeter("connection_accept_errors", registry)
 	newMetrics.ConnectionCloseErrorMeter = metrics.GetOrRegisterMeter("connection_close_errors", registry)
+	newMetrics.ConnectionDialCounter = metrics.GetOrRegisterCounter("connection_dial", registry)
+	newMetrics.ConnectionDialTimer = metrics.GetOrRegisterTimer("connection_dial_time_seconds", registry)
 	newMetrics.ImpMeter = metrics.GetOrRegisterMeter("imps_requested", registry)
 
 	newMetrics.ImpsTypeBanner = metrics.GetOrRegisterMeter("imp_banner", registry)
@@ -661,6 +667,14 @@ func (me *Metrics) RecordConnectionClose(success bool) {
 	} else {
 		me.ConnectionCloseErrorMeter.Mark(1)
 	}
+}
+
+func (me *Metrics) RecordConnectionDials() {
+	me.ConnectionDialCounter.Dec(1)
+}
+
+func (me *Metrics) RecordConnectionDialTime(dialStartTime time.Duration) {
+	me.ConnectionDialTimer.Update(dialStartTime)
 }
 
 // RecordRequestTime implements a part of the MetricsEngine interface. The calling code is responsible

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -85,6 +85,8 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
 	ensureContains(t, registry, "bidder_server_response_time_seconds", m.BidderServerResponseTimer)
 	ensureContains(t, registry, "tmax_timeout", m.TMaxTimeoutCounter)
+	ensureContains(t, registry, "connection_dial", m.ConnectionDialCounter)
+	ensureContains(t, registry, "connection_dial_time_seconds", m.ConnectionDialTimer)
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -473,4 +473,6 @@ type MetricsEngine interface {
 	RecordModuleExecutionError(labels ModuleLabels)
 	RecordModuleTimeout(labels ModuleLabels)
 	RecordAdapterThrottled(adapterName openrtb_ext.BidderName)
+	RecordConnectionDials()
+	RecordConnectionDialTime(dialStartTime time.Duration)
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -230,3 +230,11 @@ func (me *MetricsEngineMock) RecordModuleTimeout(labels ModuleLabels) {
 func (me *MetricsEngineMock) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	me.Called(adapterName)
 }
+
+func (me *MetricsEngineMock) RecordConnectionDials() {
+	me.Called()
+}
+
+func (me *MetricsEngineMock) RecordConnectionDialTime(dialStartTime time.Duration) {
+	me.Called(dialStartTime)
+}


### PR DESCRIPTION
```
    pbs_sub_bidder_server_response_time_seconds_sum 0
    pbs_sub_bidder_server_response_time_seconds_count 0
 +  # HELP pbs_sub_connection_dial_time_seconds Seconds connection dial lasted
 +  # TYPE pbs_sub_connection_dial_time_seconds histogram
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.05"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.1"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.15"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.2"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.25"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.3"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.4"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.5"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="0.75"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="1"} 0
 +  pbs_sub_connection_dial_time_seconds_bucket{le="+Inf"} 0
 +  pbs_sub_connection_dial_time_seconds_sum 0
 +  pbs_sub_connection_dial_time_seconds_count 0
    # HELP pbs_sub_connections_closed Count of successful connections closed to Prebid Server.
    # TYPE pbs_sub_connections_closed counter
    pbs_sub_connections_closed 1
 +  # HELP pbs_sub_connections_dials Count number of started dials to open a connection.
 +  # TYPE pbs_sub_connections_dials counter
 +  pbs_sub_connections_dials 0
    # HELP pbs_sub_connections_error Count of errors for connection open and close attempts to Prebid Server labeled by type.
    # TYPE pbs_sub_connections_error counter
    pbs_sub_connections_error{connection_error="accept"} 0
```
