### PR TITLE
Metrics: Record HTTP connections wanted and obtained

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -735,6 +735,7 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 		// GetConn is called before a connection is created or retrieved from an idle pool
 		GetConn: func(hostPort string) {
 			connStart = time.Now()
+			bidder.me.RecordConnectionStart()
 		},
 		// GotConn is called after a successful connection is obtained
 		GotConn: func(info httptrace.GotConnInfo) {
@@ -752,6 +753,7 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 			}
 
 			bidder.me.RecordAdapterConnections(bidder.BidderName, info.Reused, connWaitTime)
+			bidder.me.RecordConnectionEnd()
 		},
 		// DNSStart is called when a DNS lookup begins.
 		DNSStart: func(info httptrace.DNSStartInfo) {

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -735,7 +735,7 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 		// GetConn is called before a connection is created or retrieved from an idle pool
 		GetConn: func(hostPort string) {
 			connStart = time.Now()
-			bidder.me.RecordConnectionStart()
+			bidder.me.RecordConnectionWant()
 		},
 		// GotConn is called after a successful connection is obtained
 		GotConn: func(info httptrace.GotConnInfo) {
@@ -753,7 +753,7 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 			}
 
 			bidder.me.RecordAdapterConnections(bidder.BidderName, info.Reused, connWaitTime)
-			bidder.me.RecordConnectionEnd()
+			bidder.me.RecordConnectionGot()
 		},
 		// DNSStart is called when a DNS lookup begins.
 		DNSStart: func(info httptrace.DNSStartInfo) {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2085,6 +2085,8 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
 	mockMetricEngine.On("RecordBidderServerResponseTime", mock.Anything).Once()
+	mockMetricEngine.On("RecordConnectionStart").Once()
+	mockMetricEngine.On("RecordConnectionEnd").Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2085,8 +2085,8 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
 	mockMetricEngine.On("RecordBidderServerResponseTime", mock.Anything).Once()
-	mockMetricEngine.On("RecordConnectionStart").Once()
-	mockMetricEngine.On("RecordConnectionEnd").Once()
+	mockMetricEngine.On("RecordConnectionWant").Once()
+	mockMetricEngine.On("RecordConnectionGot").Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -384,6 +384,18 @@ func (me *MultiMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderN
 	}
 }
 
+func (me *MultiMetricsEngine) RecordConnectionStart() {
+	for _, thisME := range *me {
+		thisME.RecordConnectionStart()
+	}
+}
+
+func (me *MultiMetricsEngine) RecordConnectionEnd() {
+	for _, thisME := range *me {
+		thisME.RecordConnectionEnd()
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -565,4 +577,10 @@ func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 
 // RecordAdapterThrottled as a noop
 func (me *NilMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
+}
+
+func (me *NilMetricsEngine) RecordConnectionStart() {
+}
+
+func (me *NilMetricsEngine) RecordConnectionEnd() {
 }

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -384,15 +384,15 @@ func (me *MultiMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderN
 	}
 }
 
-func (me *MultiMetricsEngine) RecordConnectionStart() {
+func (me *MultiMetricsEngine) RecordConnectionWant() {
 	for _, thisME := range *me {
-		thisME.RecordConnectionStart()
+		thisME.RecordConnectionWant()
 	}
 }
 
-func (me *MultiMetricsEngine) RecordConnectionEnd() {
+func (me *MultiMetricsEngine) RecordConnectionGot() {
 	for _, thisME := range *me {
-		thisME.RecordConnectionEnd()
+		thisME.RecordConnectionGot()
 	}
 }
 
@@ -579,8 +579,8 @@ func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 func (me *NilMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
 }
 
-func (me *NilMetricsEngine) RecordConnectionStart() {
+func (me *NilMetricsEngine) RecordConnectionWant() {
 }
 
-func (me *NilMetricsEngine) RecordConnectionEnd() {
+func (me *NilMetricsEngine) RecordConnectionGot() {
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -18,6 +18,8 @@ type Metrics struct {
 	TMaxTimeoutCounter             metrics.Counter
 	ConnectionAcceptErrorMeter     metrics.Meter
 	ConnectionCloseErrorMeter      metrics.Meter
+	ConnectionStartCounter         metrics.Counter
+	ConnectionEndCounter           metrics.Counter
 	ImpMeter                       metrics.Meter
 	AppRequestMeter                metrics.Meter
 	NoCookieMeter                  metrics.Meter
@@ -160,6 +162,8 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []string, disabledMetr
 		ConnectionCounter:              metrics.NilCounter{},
 		ConnectionAcceptErrorMeter:     blankMeter,
 		ConnectionCloseErrorMeter:      blankMeter,
+		ConnectionStartCounter:         metrics.NilCounter{},
+		ConnectionEndCounter:           metrics.NilCounter{},
 		ImpMeter:                       blankMeter,
 		AppRequestMeter:                blankMeter,
 		DebugRequestMeter:              blankMeter,
@@ -287,6 +291,8 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.TMaxTimeoutCounter = metrics.GetOrRegisterCounter("tmax_timeout", registry)
 	newMetrics.ConnectionAcceptErrorMeter = metrics.GetOrRegisterMeter("connection_accept_errors", registry)
 	newMetrics.ConnectionCloseErrorMeter = metrics.GetOrRegisterMeter("connection_close_errors", registry)
+	newMetrics.ConnectionStartCounter = metrics.GetOrRegisterCounter("connection_start", registry)
+	newMetrics.ConnectionEndCounter = metrics.GetOrRegisterCounter("connection_end", registry)
 	newMetrics.ImpMeter = metrics.GetOrRegisterMeter("imps_requested", registry)
 
 	newMetrics.ImpsTypeBanner = metrics.GetOrRegisterMeter("imp_banner", registry)
@@ -668,6 +674,14 @@ func (me *Metrics) RecordConnectionClose(success bool) {
 	} else {
 		me.ConnectionCloseErrorMeter.Mark(1)
 	}
+}
+
+func (me *Metrics) RecordConnectionStart() {
+	me.ConnectionStartCounter.Inc(1)
+}
+
+func (me *Metrics) RecordConnectionEnd() {
+	me.ConnectionEndCounter.Inc(1)
 }
 
 // RecordRequestTime implements a part of the MetricsEngine interface. The calling code is responsible

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -18,8 +18,8 @@ type Metrics struct {
 	TMaxTimeoutCounter             metrics.Counter
 	ConnectionAcceptErrorMeter     metrics.Meter
 	ConnectionCloseErrorMeter      metrics.Meter
-	ConnectionStartCounter         metrics.Counter
-	ConnectionEndCounter           metrics.Counter
+	ConnectionWantCounter          metrics.Counter
+	ConnectionGotCounter           metrics.Counter
 	ImpMeter                       metrics.Meter
 	AppRequestMeter                metrics.Meter
 	NoCookieMeter                  metrics.Meter
@@ -162,8 +162,8 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []string, disabledMetr
 		ConnectionCounter:              metrics.NilCounter{},
 		ConnectionAcceptErrorMeter:     blankMeter,
 		ConnectionCloseErrorMeter:      blankMeter,
-		ConnectionStartCounter:         metrics.NilCounter{},
-		ConnectionEndCounter:           metrics.NilCounter{},
+		ConnectionWantCounter:          metrics.NilCounter{},
+		ConnectionGotCounter:           metrics.NilCounter{},
 		ImpMeter:                       blankMeter,
 		AppRequestMeter:                blankMeter,
 		DebugRequestMeter:              blankMeter,
@@ -291,8 +291,8 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.TMaxTimeoutCounter = metrics.GetOrRegisterCounter("tmax_timeout", registry)
 	newMetrics.ConnectionAcceptErrorMeter = metrics.GetOrRegisterMeter("connection_accept_errors", registry)
 	newMetrics.ConnectionCloseErrorMeter = metrics.GetOrRegisterMeter("connection_close_errors", registry)
-	newMetrics.ConnectionStartCounter = metrics.GetOrRegisterCounter("connection_start", registry)
-	newMetrics.ConnectionEndCounter = metrics.GetOrRegisterCounter("connection_end", registry)
+	newMetrics.ConnectionWantCounter = metrics.GetOrRegisterCounter("connection_want", registry)
+	newMetrics.ConnectionGotCounter = metrics.GetOrRegisterCounter("connection_got", registry)
 	newMetrics.ImpMeter = metrics.GetOrRegisterMeter("imps_requested", registry)
 
 	newMetrics.ImpsTypeBanner = metrics.GetOrRegisterMeter("imp_banner", registry)
@@ -676,12 +676,12 @@ func (me *Metrics) RecordConnectionClose(success bool) {
 	}
 }
 
-func (me *Metrics) RecordConnectionStart() {
-	me.ConnectionStartCounter.Inc(1)
+func (me *Metrics) RecordConnectionWant() {
+	me.ConnectionWantCounter.Inc(1)
 }
 
-func (me *Metrics) RecordConnectionEnd() {
-	me.ConnectionEndCounter.Inc(1)
+func (me *Metrics) RecordConnectionGot() {
+	me.ConnectionGotCounter.Inc(1)
 }
 
 // RecordRequestTime implements a part of the MetricsEngine interface. The calling code is responsible

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -86,8 +86,8 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
 	ensureContains(t, registry, "bidder_server_response_time_seconds", m.BidderServerResponseTimer)
 	ensureContains(t, registry, "tmax_timeout", m.TMaxTimeoutCounter)
-	ensureContains(t, registry, "connection_start", m.ConnectionStartCounter)
-	ensureContains(t, registry, "connection_end", m.ConnectionEndCounter)
+	ensureContains(t, registry, "connection_want", m.ConnectionWantCounter)
+	ensureContains(t, registry, "connection_got", m.ConnectionGotCounter)
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -86,6 +86,8 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
 	ensureContains(t, registry, "bidder_server_response_time_seconds", m.BidderServerResponseTimer)
 	ensureContains(t, registry, "tmax_timeout", m.TMaxTimeoutCounter)
+	ensureContains(t, registry, "connection_start", m.ConnectionStartCounter)
+	ensureContains(t, registry, "connection_end", m.ConnectionEndCounter)
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -474,6 +474,6 @@ type MetricsEngine interface {
 	RecordModuleExecutionError(labels ModuleLabels)
 	RecordModuleTimeout(labels ModuleLabels)
 	RecordAdapterThrottled(adapterName openrtb_ext.BidderName)
-	RecordConnectionStart()
-	RecordConnectionEnd()
+	RecordConnectionWant()
+	RecordConnectionGot()
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -474,4 +474,6 @@ type MetricsEngine interface {
 	RecordModuleExecutionError(labels ModuleLabels)
 	RecordModuleTimeout(labels ModuleLabels)
 	RecordAdapterThrottled(adapterName openrtb_ext.BidderName)
+	RecordConnectionStart()
+	RecordConnectionEnd()
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -234,3 +234,11 @@ func (me *MetricsEngineMock) RecordModuleTimeout(labels ModuleLabels) {
 func (me *MetricsEngineMock) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	me.Called(adapterName)
 }
+
+func (me *MetricsEngineMock) RecordConnectionStart() {
+	me.Called()
+}
+
+func (me *MetricsEngineMock) RecordConnectionEnd() {
+	me.Called()
+}

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -235,10 +235,10 @@ func (me *MetricsEngineMock) RecordAdapterThrottled(adapterName openrtb_ext.Bidd
 	me.Called(adapterName)
 }
 
-func (me *MetricsEngineMock) RecordConnectionStart() {
+func (me *MetricsEngineMock) RecordConnectionWant() {
 	me.Called()
 }
 
-func (me *MetricsEngineMock) RecordConnectionEnd() {
+func (me *MetricsEngineMock) RecordConnectionGot() {
 	me.Called()
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -23,6 +23,8 @@ type Metrics struct {
 	connectionsClosed            prometheus.Counter
 	connectionsError             *prometheus.CounterVec
 	connectionsOpened            prometheus.Counter
+	connectionStarts             prometheus.Counter
+	connectionEnds               prometheus.Counter
 	cookieSync                   *prometheus.CounterVec
 	setUid                       *prometheus.CounterVec
 	impressions                  *prometheus.CounterVec
@@ -186,6 +188,14 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	metrics.connectionsOpened = newCounterWithoutLabels(cfg, reg,
 		"connections_opened",
 		"Count of successful connections opened to Prebid Server.")
+
+	metrics.connectionStarts = newCounterWithoutLabels(cfg, reg,
+		"connections_start",
+		"Count number of times a connection was started.")
+
+	metrics.connectionEnds = newCounterWithoutLabels(cfg, reg,
+		"connections_ends",
+		"Count number of times a connection was ended.")
 
 	metrics.tmaxTimeout = newCounterWithoutLabels(cfg, reg,
 		"tmax_timeout",
@@ -1109,4 +1119,12 @@ func (m *Metrics) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	m.adapterThrottled.With(prometheus.Labels{
 		adapterLabel: strings.ToLower(string(adapterName)),
 	}).Inc()
+}
+
+func (m *Metrics) RecordConnectionStart() {
+	m.connectionStarts.Inc()
+}
+
+func (m *Metrics) RecordConnectionEnd() {
+	m.connectionEnds.Inc()
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -23,8 +23,8 @@ type Metrics struct {
 	connectionsClosed            prometheus.Counter
 	connectionsError             *prometheus.CounterVec
 	connectionsOpened            prometheus.Counter
-	connectionStarts             prometheus.Counter
-	connectionEnds               prometheus.Counter
+	connectionWant               prometheus.Counter
+	connectionGot                prometheus.Counter
 	cookieSync                   *prometheus.CounterVec
 	setUid                       *prometheus.CounterVec
 	impressions                  *prometheus.CounterVec
@@ -189,13 +189,13 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 		"connections_opened",
 		"Count of successful connections opened to Prebid Server.")
 
-	metrics.connectionStarts = newCounterWithoutLabels(cfg, reg,
-		"connections_start",
-		"Count number of times a connection was started.")
+	metrics.connectionWant = newCounterWithoutLabels(cfg, reg,
+		"connections_want",
+		"Count number of times client trace calls GetConn.")
 
-	metrics.connectionEnds = newCounterWithoutLabels(cfg, reg,
-		"connections_ends",
-		"Count number of times a connection was ended.")
+	metrics.connectionGot = newCounterWithoutLabels(cfg, reg,
+		"connections_got",
+		"Count number of times client trace calls GotConn.")
 
 	metrics.tmaxTimeout = newCounterWithoutLabels(cfg, reg,
 		"tmax_timeout",
@@ -1121,10 +1121,10 @@ func (m *Metrics) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	}).Inc()
 }
 
-func (m *Metrics) RecordConnectionStart() {
-	m.connectionStarts.Inc()
+func (m *Metrics) RecordConnectionWant() {
+	m.connectionWant.Inc()
 }
 
-func (m *Metrics) RecordConnectionEnd() {
-	m.connectionEnds.Inc()
+func (m *Metrics) RecordConnectionGot() {
+	m.connectionGot.Inc()
 }

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -75,8 +75,8 @@ func TestConnectionMetrics(t *testing.T) {
 		expectedOpenedErrorCount float64
 		expectedClosedCount      float64
 		expectedClosedErrorCount float64
-		expectedConnectionStarts float64
-		expectedConnectionEnds   float64
+		expectedConnectionWant   float64
+		expectedConnectionGot    float64
 	}{
 		{
 			description: "Open Success",
@@ -119,18 +119,18 @@ func TestConnectionMetrics(t *testing.T) {
 			expectedClosedErrorCount: 1,
 		},
 		{
-			description: "connection-started",
+			description: "connection-want",
 			testCase: func(m *Metrics) {
-				m.RecordConnectionStart()
+				m.RecordConnectionWant()
 			},
-			expectedConnectionStarts: 1,
+			expectedConnectionWant: 1,
 		},
 		{
-			description: "connection-ended",
+			description: "connection-got",
 			testCase: func(m *Metrics) {
-				m.RecordConnectionEnd()
+				m.RecordConnectionGot()
 			},
-			expectedConnectionEnds: 1,
+			expectedConnectionGot: 1,
 		},
 	}
 
@@ -151,10 +151,10 @@ func TestConnectionMetrics(t *testing.T) {
 			test.expectedClosedErrorCount, prometheus.Labels{
 				connectionErrorLabel: connectionCloseError,
 			})
-		assertCounterValue(t, test.description, "connectionStarts", m.connectionStarts,
-			test.expectedConnectionStarts)
-		assertCounterValue(t, test.description, "connectionEnds", m.connectionEnds,
-			test.expectedConnectionEnds)
+		assertCounterValue(t, test.description, "connectionWant", m.connectionWant,
+			test.expectedConnectionWant)
+		assertCounterValue(t, test.description, "connectionGot", m.connectionGot,
+			test.expectedConnectionGot)
 	}
 }
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -75,6 +75,8 @@ func TestConnectionMetrics(t *testing.T) {
 		expectedOpenedErrorCount float64
 		expectedClosedCount      float64
 		expectedClosedErrorCount float64
+		expectedConnectionStarts float64
+		expectedConnectionEnds   float64
 	}{
 		{
 			description: "Open Success",
@@ -116,6 +118,20 @@ func TestConnectionMetrics(t *testing.T) {
 			expectedClosedCount:      0,
 			expectedClosedErrorCount: 1,
 		},
+		{
+			description: "connection-started",
+			testCase: func(m *Metrics) {
+				m.RecordConnectionStart()
+			},
+			expectedConnectionStarts: 1,
+		},
+		{
+			description: "connection-ended",
+			testCase: func(m *Metrics) {
+				m.RecordConnectionEnd()
+			},
+			expectedConnectionEnds: 1,
+		},
 	}
 
 	for _, test := range testCases {
@@ -135,6 +151,10 @@ func TestConnectionMetrics(t *testing.T) {
 			test.expectedClosedErrorCount, prometheus.Labels{
 				connectionErrorLabel: connectionCloseError,
 			})
+		assertCounterValue(t, test.description, "connectionStarts", m.connectionStarts,
+			test.expectedConnectionStarts)
+		assertCounterValue(t, test.description, "connectionEnds", m.connectionEnds,
+			test.expectedConnectionEnds)
 	}
 }
 


### PR DESCRIPTION
```
   # TYPE pbs_sub_connections_error counter
   pbs_sub_connections_error{connection_error="accept"} 0
   pbs_sub_connections_error{connection_error="close"} 0
 + # HELP pbs_sub_connections_got Count number of times client trace calls GotConn.
 + # TYPE pbs_sub_connections_got counter
 + pbs_sub_connections_got 0
   # HELP pbs_sub_connections_opened Count of successful connections opened to Prebid Server.
   # TYPE pbs_sub_connections_opened counter
   pbs_sub_connections_opened 1
 + # HELP pbs_sub_connections_want Count number of times client trace calls GetConn.
 + # TYPE pbs_sub_connections_want counter
 + pbs_sub_connections_want 0
   # HELP pbs_sub_cookie_sync_requests Count of cookie sync requests to Prebid Server.
   # TYPE pbs_sub_cookie_sync_requests counter
```
