### PR TITLE
Log nested structures from the configuration

### DIFF
--- a/config/structlog.go
+++ b/config/structlog.go
@@ -37,6 +37,10 @@ func logGeneralWithLogger(v reflect.Value, prefix string, logger logMsg) {
 		logger("%s: %f", prefix, v.Float())
 	case reflect.Bool:
 		logger("%s: %t", prefix, v.Bool())
+	case reflect.Ptr:
+		if v.Elem().IsValid() {
+			logGeneralWithLogger(v.Elem(), prefix, logger)
+		}
 	default:
 		// logString, by using v.String(), will not fail, and indicate what additional cases we need to handle
 		logger("%s: %s", prefix, v.String())
@@ -45,7 +49,7 @@ func logGeneralWithLogger(v reflect.Value, prefix string, logger logMsg) {
 
 func logStructWithLogger(v reflect.Value, prefix string, logger logMsg) {
 	if v.Kind() != reflect.Struct {
-		glog.Fatalf("LogStruct called on type %s, whuch is not a struct!", v.Type().String())
+		glog.Fatalf("LogStruct called on type %s, which is not a struct!", v.Type().String())
 	}
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
@@ -60,7 +64,7 @@ func logStructWithLogger(v reflect.Value, prefix string, logger logMsg) {
 
 func logMapWithLogger(v reflect.Value, prefix string, logger logMsg) {
 	if v.Kind() != reflect.Map {
-		glog.Fatalf("LogMap called on type %s, whuch is not a map!", v.Type().String())
+		glog.Fatalf("LogMap called on type %s, which is not a map!", v.Type().String())
 	}
 	for _, k := range v.MapKeys() {
 		if k.Kind() == reflect.String && !allowedName(k.String()) {


### PR DESCRIPTION
Before
```
I0905 12:49:46.347520 1093850 structlog.go:46]   	adapters[rise].aliasOf: 
I0905 12:49:46.347524 1093850 structlog.go:39]   	adapters[rise].whiteLabelOnly: false
I0905 12:49:46.347528 1093850 structlog.go:39]   	adapters[rise].disabled: false
I0905 12:49:46.347532 1093850 structlog.go:46]   	adapters[rise].endpoint: https://pbs.yellowblue.io/pbs
I0905 12:49:46.347536 1093850 structlog.go:46]   	adapters[rise].extra_info: 
I0905 12:49:46.347540 1093850 structlog.go:46]   	adapters[rise].openrtb: <*config.OpenRTBInfo Value>
I0905 12:49:46.347543 1093850 structlog.go:46]   	adapters[rise].maintainer: <*config.MaintainerInfo Value>
I0905 12:49:46.347547 1093850 structlog.go:46]   	adapters[rise].capabilities: <*config.CapabilitiesInfo Value>
I0905 12:49:46.347552 1093850 structlog.go:39]   	adapters[rise].modifyingVastXmlAllowed: true
I0905 12:49:46.347555 1093850 structlog.go:46]   	adapters[rise].debug: <*config.DebugInfo Value>
I0905 12:49:46.347559 1093850 structlog.go:35]   	adapters[rise].gvlVendorID: 1043
I0905 12:49:46.347563 1093850 structlog.go:46]   	adapters[rise].userSync: <*config.Syncer Value>
I0905 12:49:46.347571 1093850 structlog.go:39]   	adapters[rise].experiment.adsCert.enabled: false
I0905 12:49:46.347577 1093850 structlog.go:46]   	adapters[rise].xapi.username: 
I0905 12:49:46.347580 1093850 structlog.go:60]   	adapters[rise].xapi.password: <REDACTED>
I0905 12:49:46.347584 1093850 structlog.go:46]   	adapters[rise].xapi.tracker: 
I0905 12:49:46.347588 1093850 structlog.go:46]   	adapters[rise].platform_id: 
I0905 12:49:46.347592 1093850 structlog.go:46]   	adapters[rise].app_secret: 
I0905 12:49:46.347596 1093850 structlog.go:46]   	adapters[rise].endpointCompression: gzip
```

With new changes:

```
I0905 12:51:02.933423 1094280 structlog.go:46]   	adapters[rise].aliasOf: 
I0905 12:51:02.933427 1094280 structlog.go:39]   	adapters[rise].whiteLabelOnly: false
I0905 12:51:02.933431 1094280 structlog.go:39]   	adapters[rise].disabled: false
I0905 12:51:02.933434 1094280 structlog.go:46]   	adapters[rise].endpoint: https://pbs.yellowblue.io/pbs
I0905 12:51:02.933438 1094280 structlog.go:46]   	adapters[rise].extra_info: 
I0905 12:51:02.933443 1094280 structlog.go:46]   	adapters[rise].maintainer.email: rise-prog-dev@risecodes.com
I0905 12:51:02.933449 1094280 structlog.go:46]   	adapters[rise].capabilities.app.mediaTypes: <[]openrtb_ext.BidType Value>
I0905 12:51:02.933454 1094280 structlog.go:46]   	adapters[rise].capabilities.site.mediaTypes: <[]openrtb_ext.BidType Value>
I0905 12:51:02.933459 1094280 structlog.go:39]   	adapters[rise].modifyingVastXmlAllowed: true
I0905 12:51:02.933464 1094280 structlog.go:35]   	adapters[rise].gvlVendorID: 1043
I0905 12:51:02.933469 1094280 structlog.go:46]   	adapters[rise].userSync.key: 
I0905 12:51:02.933475 1094280 structlog.go:46]   	adapters[rise].userSync.supports: <[]string Value>
I0905 12:51:02.933479 1094280 structlog.go:46]   	adapters[rise].userSync.iframe.url: https://pbs-cs.yellowblue.io/pbs-iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}
I0905 12:51:02.933483 1094280 structlog.go:46]   	adapters[rise].userSync.iframe.redirect_url: 
I0905 12:51:02.933486 1094280 structlog.go:46]   	adapters[rise].userSync.iframe.external_url: 
I0905 12:51:02.933490 1094280 structlog.go:46]   	adapters[rise].userSync.iframe.user_macro: [PBS_UID]
I0905 12:51:02.933494 1094280 structlog.go:46]   	adapters[rise].userSync.external_url: 
I0905 12:51:02.933499 1094280 structlog.go:46]   	adapters[rise].userSync.format_override: 
I0905 12:51:02.933507 1094280 structlog.go:39]   	adapters[rise].experiment.adsCert.enabled: false
I0905 12:51:02.933513 1094280 structlog.go:46]   	adapters[rise].xapi.username: 
I0905 12:51:02.933516 1094280 structlog.go:60]   	adapters[rise].xapi.password: <REDACTED>
I0905 12:51:02.933519 1094280 structlog.go:46]   	adapters[rise].xapi.tracker: 
I0905 12:51:02.933522 1094280 structlog.go:46]   	adapters[rise].platform_id: 
I0905 12:51:02.933526 1094280 structlog.go:46]   	adapters[rise].app_secret: 
I0905 12:51:02.933530 1094280 structlog.go:46]   	adapters[rise].endpointCompression: gzip
```