### PR TITLE
33across: Remove deprecated video.placement

### DIFF
--- a/adapters/33across/33across.go
+++ b/adapters/33across/33across.go
@@ -256,13 +256,7 @@ func validateVideoParams(video *openrtb2.Video, prod string) (*openrtb2.Video, e
 		}
 	}
 
-	if videoCopy.Placement == 0 {
-		videoCopy.Placement = 2
-	}
-
 	if prod == "instream" {
-		videoCopy.Placement = 1
-
 		if videoCopy.StartDelay == nil {
 			videoCopy.StartDelay = adcom1.StartDelay.Ptr(0)
 		}

--- a/adapters/33across/33acrosstest/exemplary/bidresponse-defaults.json
+++ b/adapters/33across/33acrosstest/exemplary/bidresponse-defaults.json
@@ -5,10 +5,10 @@
       {
         "id": "test-imp-id",
         "video": {
-          "w": 728, 
+          "w": 728,
           "h": 90,
           "protocols": [2],
-          "placement": 1,
+          "plcmt": 1,
           "startdelay": -2,
           "playbackmethod": [2],
           "mimes": ["foo", "bar"]
@@ -44,10 +44,10 @@
             {
               "id":"test-imp-id",
               "video": {
-                "w": 728, 
+                "w": 728,
                 "h": 90,
                 "protocols": [2],
-                "placement": 1,
+                "plcmt": 1,
                 "startdelay": -2,
                 "playbackmethod": [2],
                 "mimes": ["foo", "bar"]

--- a/adapters/33across/33acrosstest/exemplary/instream-video-defaults.json
+++ b/adapters/33across/33acrosstest/exemplary/instream-video-defaults.json
@@ -5,7 +5,7 @@
       {
         "id": "test-imp-id",
         "video": {
-          "w": 728, 
+          "w": 728,
           "h": 90,
           "protocols": [2],
           "playbackmethod": [2],
@@ -42,10 +42,9 @@
             {
               "id":"test-imp-id",
               "video": {
-                "w": 728, 
+                "w": 728,
                 "h": 90,
                 "protocols": [2],
-                "placement": 1,
                 "startdelay": 0,
                 "playbackmethod": [2],
                 "mimes": ["foo", "bar"]

--- a/adapters/33across/33acrosstest/exemplary/multi-format.json
+++ b/adapters/33across/33acrosstest/exemplary/multi-format.json
@@ -8,7 +8,7 @@
           "format": [{"w": 728, "h": 90}]
         },
         "video": {
-          "w": 728, 
+          "w": 728,
           "h": 90,
           "protocols": [2],
           "playbackmethod": [2],
@@ -48,10 +48,9 @@
                 "format": [{"w": 728, "h": 90}]
               },
               "video": {
-                "w": 728, 
+                "w": 728,
                 "h": 90,
                 "protocols": [2],
-                "placement": 2,
                 "playbackmethod": [2],
                 "mimes": ["foo", "bar"]
               },

--- a/adapters/33across/33acrosstest/exemplary/outstream-video-defaults.json
+++ b/adapters/33across/33acrosstest/exemplary/outstream-video-defaults.json
@@ -5,7 +5,7 @@
       {
         "id": "test-imp-id",
         "video": {
-          "w": 728, 
+          "w": 728,
           "h": 90,
           "protocols": [2],
           "playbackmethod": [2],
@@ -42,10 +42,9 @@
             {
               "id":"test-imp-id",
               "video": {
-                "w": 728, 
+                "w": 728,
                 "h": 90,
                 "protocols": [2],
-                "placement": 2,
                 "playbackmethod": [2],
                 "mimes": ["foo", "bar"]
               },

--- a/adapters/33across/33acrosstest/exemplary/site-video.json
+++ b/adapters/33across/33acrosstest/exemplary/site-video.json
@@ -5,10 +5,10 @@
       {
         "id": "test-imp-id",
         "video": {
-          "w": 728, 
+          "w": 728,
           "h": 90,
           "protocols": [2],
-          "placement": 1,
+          "plcmt": 1,
           "startdelay": -2,
           "playbackmethod": [2],
           "mimes": ["foo", "bar"]
@@ -44,10 +44,10 @@
             {
               "id":"test-imp-id",
               "video": {
-                "w": 728, 
+                "w": 728,
                 "h": 90,
                 "protocols": [2],
-                "placement": 1,
+                "plcmt": 1,
                 "startdelay": -2,
                 "playbackmethod": [2],
                 "mimes": ["foo", "bar"]


### PR DESCRIPTION
There's no need to set video.placement based on other RTB attributes, the attribute has been deprecated and the exchange will be in charge of populating the "new" placement attribute (plcmt) when it's not specified.