### PR TITLE
33across: Make zoneId the preferred option

### DIFF
--- a/adapters/33across/params_test.go
+++ b/adapters/33across/params_test.go
@@ -40,15 +40,19 @@ func TestInvalidParams(t *testing.T) {
 }
 
 var validParams = []string{
+	`{"productId": "inview", "zoneId": "zone1"}`,
+	`{"productId": "siab", "zoneId": "fakezoneid2"}`,
+	`{"productId": "inview", "zoneId": "zone1", "siteId": "foo.ba"}`,
 	`{"productId": "inview", "siteId": "fakesiteid1"}`,
-	`{"productId": "siab", "siteId": "fakesiteid2"}`,
-	`{"productId": "inview", "siteId": "foo.ba", "zoneId": "zone1"}`,
 }
 
 var invalidParams = []string{
 	`{"productId": "inview"}`,
+	`{"zoneId": "fakezoneid2"}`,
 	`{"siteId": "fakesiteid2"}`,
+	`{"productId": 123, "zoneId": "fakesiteid2"}`,
 	`{"productId": 123, "siteId": "fakesiteid2"}`,
+	`{"productId": "siab", "zoneId": 123}`,
 	`{"productId": "siab", "siteId": 123}`,
-	`{"productId": "siab", "siteId": "fakesiteid2", "zoneId": 123}`,
+	`{"productId": "siab", "zoneId": 123, "siteId": "fakesiteid2"}`,
 }

--- a/openrtb_ext/imp_33across.go
+++ b/openrtb_ext/imp_33across.go
@@ -2,7 +2,7 @@ package openrtb_ext
 
 // ExtImp33across defines the contract for bidrequest.imp[i].ext.prebid.bidder.33across
 type ExtImp33across struct {
-	SiteId    string `json:"siteId"`
 	ZoneId    string `json:"zoneId,omitempty"`
+	SiteId    string `json:"siteId,omitempty"`
 	ProductId string `json:"productId,omitempty"`
 }

--- a/static/bidder-params/33across.json
+++ b/static/bidder-params/33across.json
@@ -19,5 +19,8 @@
         "description": "Zone Id"
       }
     },
-    "required": ["productId", "siteId"]
+    "anyOf": [
+      { "required": ["productId", "siteId"] },
+      { "required": ["productId", "zoneId"] }
+    ]
   }


### PR DESCRIPTION
zoneId is the preferred option to set the exchange id, siteId has been deprecated. 

Documentation:
https://github.com/prebid/prebid.github.io/pull/6254