### PR TITLE
Host Option To Use OS Certs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,8 @@ type Configuration struct {
 	AccountDefaults Account `mapstructure:"account_defaults"`
 	// accountDefaultsJSON is the internal serialized form of AccountDefaults used for json merge
 	accountDefaultsJSON json.RawMessage
+	// CertsUseSystem will use the host OS certificates instead of embedded certs.
+	CertsUseSystem bool `mapstructure:"certificates_use_system"`
 	// Local private file containing SSL certificates
 	PemCertsFile string `mapstructure:"certificates_file"`
 	// Custom headers to handle request timeouts from queueing infrastructure
@@ -1226,7 +1228,9 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("compression.response.enable_gzip", false)
 	v.SetDefault("compression.request.enable_gzip", false)
 
+	v.SetDefault("certificates_use_system", false)
 	v.SetDefault("certificates_file", "")
+
 	v.SetDefault("auto_gen_source_tid", true)
 	v.SetDefault("generate_bid_id", false)
 	v.SetDefault("generate_request_id", false)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -598,6 +598,7 @@ analytics:
     - code: agma-code
       publisher_id: publisher-id
       site_app_id: site-or-app-id
+certificates_use_system: true
 `)
 
 func cmpStrings(t *testing.T, key, expected, actual string) {
@@ -945,6 +946,7 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "analytics.agma.accounts.0.publisher_id", "publisher-id", cfg.Analytics.Agma.Accounts[0].PublisherId)
 	cmpStrings(t, "analytics.agma.accounts.0.code", "agma-code", cfg.Analytics.Agma.Accounts[0].Code)
 	cmpStrings(t, "analytics.agma.accounts.0.site_app_id", "site-or-app-id", cfg.Analytics.Agma.Accounts[0].SiteAppId)
+	cmpBools(t, "certificates_use_system", true, cfg.CertsUseSystem)
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -2,6 +2,7 @@ package pbs
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-server/v3/config"
-	"github.com/prebid/prebid-server/v3/server/ssl"
 	"github.com/prebid/prebid-server/v3/usersync"
 )
 
@@ -24,6 +24,7 @@ type UserSyncDeps struct {
 	RecaptchaSecret  string
 	HostCookieConfig *config.HostCookie
 	PriorityGroups   [][]string
+	CertPool         *x509.CertPool
 }
 
 // Struct for parsing json in google's response
@@ -35,7 +36,7 @@ type googleResponse struct {
 func (deps *UserSyncDeps) VerifyRecaptcha(response string) error {
 	ts := &http.Transport{
 		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{RootCAs: ssl.GetRootCAPool()},
+		TLSClientConfig: &tls.Config{RootCAs: deps.CertPool},
 	}
 
 	client := &http.Client{

--- a/router/router.go
+++ b/router/router.go
@@ -129,7 +129,11 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 
 	// For bid processing, we need both the hardcoded certificates and the certificates found in container's
 	// local file system
-	certPool := ssl.GetRootCAPool()
+	certPool, certPoolCreateErr := ssl.CreateCertPool(cfg.CertsUseSystem)
+	if certPoolCreateErr != nil {
+		glog.Infof("Could not load root certificates: %s \n", certPoolCreateErr.Error())
+	}
+
 	var readCertErr error
 	certPool, readCertErr = ssl.AppendPEMFileToRootCAPool(certPool, cfg.PemCertsFile)
 	if readCertErr != nil {
@@ -282,6 +286,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 		ExternalUrl:      cfg.ExternalURL,
 		RecaptchaSecret:  cfg.RecaptchaSecret,
 		PriorityGroups:   cfg.UserSync.PriorityGroups,
+		CertPool:         certPool,
 	}
 
 	r.GET("/setuid", endpoints.NewSetUIDEndpoint(cfg, syncersByBidder, gdprPermsBuilder, tcf2CfgBuilder, analyticsRunner, accounts, r.MetricsEngine))

--- a/server/ssl/ssl.go
+++ b/server/ssl/ssl.go
@@ -8,13 +8,18 @@ import (
 
 // from https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
 
-var pool *x509.CertPool
-
-func GetRootCAPool() *x509.CertPool {
-	if pool == nil {
-		pool = x509.NewCertPool()
-		pool.AppendCertsFromPEM(pemCerts)
+func CreateCertPool(useSystem bool) (*x509.CertPool, error) {
+	if useSystem {
+		return x509.SystemCertPool()
 	}
+
+	pool := createCertPoolFromEmbedded()
+	return pool, nil
+}
+
+func createCertPoolFromEmbedded() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(pemCerts)
 	return pool
 }
 

--- a/server/ssl/ssl_test.go
+++ b/server/ssl/ssl_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCertsFromFilePoolExists(t *testing.T) {
 	// Load hardcoded certificates found in ssl.go
-	certPool := GetRootCAPool()
+	certPool := createCertPoolFromEmbedded()
 
 	// Assert loaded certificates by looking at the length of the subjects array of strings
 	subjects := certPool.Subjects()

--- a/server/ssl/ssl_test.go
+++ b/server/ssl/ssl_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCertsFromFilePoolExists(t *testing.T) {
 	// Load hardcoded certificates found in ssl.go
-	certPool := createCertPoolFromEmbedded()
+	certPool, certErr := createCertPoolFromEmbedded()
+	require.NoError(t, certErr)
 
 	// Assert loaded certificates by looking at the length of the subjects array of strings
 	subjects := certPool.Subjects()


### PR DESCRIPTION
Following guidance from [this Medium article](https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07), the original developers of PBS embedded CA certificates in this project instead of using them from the OS. We've kept the embedded CA certificates updated to match the Ubuntu version targeted by the dockerfile.

This PR introduces the config option `certificates_use_system` will use the OS certs instead. It defaults to false, so PBS will continue to use the embedded certs by default.

Please let us know if you want to continue using the embedded certs or prefer to only use OS certs.