### PR TITLE
Revert "Metrics: Record HTTP connections wanted and obtained"

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -735,7 +735,6 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 		// GetConn is called before a connection is created or retrieved from an idle pool
 		GetConn: func(hostPort string) {
 			connStart = time.Now()
-			bidder.me.RecordConnectionWant()
 		},
 		// GotConn is called after a successful connection is obtained
 		GotConn: func(info httptrace.GotConnInfo) {
@@ -753,7 +752,6 @@ func (bidder *BidderAdapter) addClientTrace(ctx context.Context) context.Context
 			}
 
 			bidder.me.RecordAdapterConnections(bidder.BidderName, info.Reused, connWaitTime)
-			bidder.me.RecordConnectionGot()
 		},
 		// DNSStart is called when a DNS lookup begins.
 		DNSStart: func(info httptrace.DNSStartInfo) {

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -2085,8 +2085,6 @@ func TestCallRecordAdapterConnections(t *testing.T) {
 	mockMetricEngine.On("RecordAdapterConnections", expectedAdapterName, false, mock.MatchedBy(compareConnWaitTime)).Once()
 	mockMetricEngine.On("RecordOverheadTime", metrics.PreBidder, mock.Anything).Once()
 	mockMetricEngine.On("RecordBidderServerResponseTime", mock.Anything).Once()
-	mockMetricEngine.On("RecordConnectionWant").Once()
-	mockMetricEngine.On("RecordConnectionGot").Once()
 
 	// Run requestBid using an http.Client with a mock handler
 	bidder := AdaptBidder(bidderImpl, server.Client(), &config.Configuration{}, mockMetricEngine, openrtb_ext.BidderAppnexus, nil, "")

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -384,18 +384,6 @@ func (me *MultiMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderN
 	}
 }
 
-func (me *MultiMetricsEngine) RecordConnectionWant() {
-	for _, thisME := range *me {
-		thisME.RecordConnectionWant()
-	}
-}
-
-func (me *MultiMetricsEngine) RecordConnectionGot() {
-	for _, thisME := range *me {
-		thisME.RecordConnectionGot()
-	}
-}
-
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -577,10 +565,4 @@ func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 
 // RecordAdapterThrottled as a noop
 func (me *NilMetricsEngine) RecordAdapterThrottled(adapter openrtb_ext.BidderName) {
-}
-
-func (me *NilMetricsEngine) RecordConnectionWant() {
-}
-
-func (me *NilMetricsEngine) RecordConnectionGot() {
 }

--- a/metrics/go_metrics.go
+++ b/metrics/go_metrics.go
@@ -18,8 +18,6 @@ type Metrics struct {
 	TMaxTimeoutCounter             metrics.Counter
 	ConnectionAcceptErrorMeter     metrics.Meter
 	ConnectionCloseErrorMeter      metrics.Meter
-	ConnectionWantCounter          metrics.Counter
-	ConnectionGotCounter           metrics.Counter
 	ImpMeter                       metrics.Meter
 	AppRequestMeter                metrics.Meter
 	NoCookieMeter                  metrics.Meter
@@ -164,8 +162,6 @@ func NewBlankMetrics(registry metrics.Registry, exchanges []string, disabledMetr
 		ConnectionCounter:              metrics.NilCounter{},
 		ConnectionAcceptErrorMeter:     blankMeter,
 		ConnectionCloseErrorMeter:      blankMeter,
-		ConnectionWantCounter:          metrics.NilCounter{},
-		ConnectionGotCounter:           metrics.NilCounter{},
 		ImpMeter:                       blankMeter,
 		AppRequestMeter:                blankMeter,
 		DebugRequestMeter:              blankMeter,
@@ -299,8 +295,6 @@ func NewMetrics(registry metrics.Registry, exchanges []openrtb_ext.BidderName, d
 	newMetrics.TMaxTimeoutCounter = metrics.GetOrRegisterCounter("tmax_timeout", registry)
 	newMetrics.ConnectionAcceptErrorMeter = metrics.GetOrRegisterMeter("connection_accept_errors", registry)
 	newMetrics.ConnectionCloseErrorMeter = metrics.GetOrRegisterMeter("connection_close_errors", registry)
-	newMetrics.ConnectionWantCounter = metrics.GetOrRegisterCounter("connection_want", registry)
-	newMetrics.ConnectionGotCounter = metrics.GetOrRegisterCounter("connection_got", registry)
 	newMetrics.ImpMeter = metrics.GetOrRegisterMeter("imps_requested", registry)
 
 	newMetrics.ImpsTypeBanner = metrics.GetOrRegisterMeter("imp_banner", registry)
@@ -691,14 +685,6 @@ func (me *Metrics) RecordConnectionClose(success bool) {
 	} else {
 		me.ConnectionCloseErrorMeter.Mark(1)
 	}
-}
-
-func (me *Metrics) RecordConnectionWant() {
-	me.ConnectionWantCounter.Inc(1)
-}
-
-func (me *Metrics) RecordConnectionGot() {
-	me.ConnectionGotCounter.Inc(1)
 }
 
 // RecordRequestTime implements a part of the MetricsEngine interface. The calling code is responsible

--- a/metrics/go_metrics_test.go
+++ b/metrics/go_metrics_test.go
@@ -88,8 +88,6 @@ func TestNewMetrics(t *testing.T) {
 	ensureContains(t, registry, "request_over_head_time.make-bidder-requests", m.OverheadTimer[MakeBidderRequests])
 	ensureContains(t, registry, "bidder_server_response_time_seconds", m.BidderServerResponseTimer)
 	ensureContains(t, registry, "tmax_timeout", m.TMaxTimeoutCounter)
-	ensureContains(t, registry, "connection_want", m.ConnectionWantCounter)
-	ensureContains(t, registry, "connection_got", m.ConnectionGotCounter)
 
 	for module, stages := range moduleStageNames {
 		for _, stage := range stages {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -511,6 +511,4 @@ type MetricsEngine interface {
 	RecordModuleExecutionError(labels ModuleLabels)
 	RecordModuleTimeout(labels ModuleLabels)
 	RecordAdapterThrottled(adapterName openrtb_ext.BidderName)
-	RecordConnectionWant()
-	RecordConnectionGot()
 }

--- a/metrics/metrics_mock.go
+++ b/metrics/metrics_mock.go
@@ -234,11 +234,3 @@ func (me *MetricsEngineMock) RecordModuleTimeout(labels ModuleLabels) {
 func (me *MetricsEngineMock) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	me.Called(adapterName)
 }
-
-func (me *MetricsEngineMock) RecordConnectionWant() {
-	me.Called()
-}
-
-func (me *MetricsEngineMock) RecordConnectionGot() {
-	me.Called()
-}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -23,8 +23,6 @@ type Metrics struct {
 	connectionsClosed            prometheus.Counter
 	connectionsError             *prometheus.CounterVec
 	connectionsOpened            prometheus.Counter
-	connectionWant               prometheus.Counter
-	connectionGot                prometheus.Counter
 	cookieSync                   *prometheus.CounterVec
 	setUid                       *prometheus.CounterVec
 	impressions                  *prometheus.CounterVec
@@ -191,14 +189,6 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	metrics.connectionsOpened = newCounterWithoutLabels(cfg, reg,
 		"connections_opened",
 		"Count of successful connections opened to Prebid Server.")
-
-	metrics.connectionWant = newCounterWithoutLabels(cfg, reg,
-		"connections_want",
-		"Count number of times client trace calls GetConn.")
-
-	metrics.connectionGot = newCounterWithoutLabels(cfg, reg,
-		"connections_got",
-		"Count number of times client trace calls GotConn.")
 
 	metrics.tmaxTimeout = newCounterWithoutLabels(cfg, reg,
 		"tmax_timeout",
@@ -1134,12 +1124,4 @@ func (m *Metrics) RecordAdapterThrottled(adapterName openrtb_ext.BidderName) {
 	m.adapterThrottled.With(prometheus.Labels{
 		adapterLabel: strings.ToLower(string(adapterName)),
 	}).Inc()
-}
-
-func (m *Metrics) RecordConnectionWant() {
-	m.connectionWant.Inc()
-}
-
-func (m *Metrics) RecordConnectionGot() {
-	m.connectionGot.Inc()
 }

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -75,8 +75,6 @@ func TestConnectionMetrics(t *testing.T) {
 		expectedOpenedErrorCount float64
 		expectedClosedCount      float64
 		expectedClosedErrorCount float64
-		expectedConnectionWant   float64
-		expectedConnectionGot    float64
 	}{
 		{
 			description: "Open Success",
@@ -118,20 +116,6 @@ func TestConnectionMetrics(t *testing.T) {
 			expectedClosedCount:      0,
 			expectedClosedErrorCount: 1,
 		},
-		{
-			description: "connection-want",
-			testCase: func(m *Metrics) {
-				m.RecordConnectionWant()
-			},
-			expectedConnectionWant: 1,
-		},
-		{
-			description: "connection-got",
-			testCase: func(m *Metrics) {
-				m.RecordConnectionGot()
-			},
-			expectedConnectionGot: 1,
-		},
 	}
 
 	for _, test := range testCases {
@@ -151,10 +135,6 @@ func TestConnectionMetrics(t *testing.T) {
 			test.expectedClosedErrorCount, prometheus.Labels{
 				connectionErrorLabel: connectionCloseError,
 			})
-		assertCounterValue(t, test.description, "connectionWant", m.connectionWant,
-			test.expectedConnectionWant)
-		assertCounterValue(t, test.description, "connectionGot", m.connectionGot,
-			test.expectedConnectionGot)
 	}
 }
 


### PR DESCRIPTION
Reverts prebid/prebid-server#4518

EDIT: This metric was added and then removed in the next version because it was not measuring anything useful. The intent was to measure the size of the dialer queue, but this is not the way.