### PR TITLE
Fix: Preload Prometheus adapter connection dial metric labels when enabled

### DIFF
--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -185,13 +185,15 @@ func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[st
 			adapterLabel: adapterValues,
 		})
 
-		preloadLabelValuesForCounter(m.adapterConnectionDialErrors, map[string][]string{
-			adapterLabel: adapterValues,
-		})
+		if !m.metricsDisabled.AdapterConnectionDialMetrics {
+			preloadLabelValuesForCounter(m.adapterConnectionDialErrors, map[string][]string{
+				adapterLabel: adapterValues,
+			})
 
-		preloadLabelValuesForHistogram(m.adapterConnectionDialTime, map[string][]string{
-			adapterLabel: adapterValues,
-		})
+			preloadLabelValuesForHistogram(m.adapterConnectionDialTime, map[string][]string{
+				adapterLabel: adapterValues,
+			})
+		}
 	}
 
 	preloadLabelValuesForHistogram(m.adapterRequestsTimer, map[string][]string{


### PR DESCRIPTION
With Prometheus enabled 

```
metrics:
  prometheus:
    port: 9100
```

  and default option  `metrics.disabled_metrics.adapter_connection_dial_metrics = true` server crashes on startup as it tries to preload labels for non-initialized metrics