### PR TITLE
Attekmi: Remove Vimayx alias

### DIFF
--- a/static/bidder-info/vimayx.yaml
+++ b/static/bidder-info/vimayx.yaml
@@ -1,2 +1,0 @@
-endpoint: "https://vimayx-prebid.attekmi.com/pbserver/?seat={{.AccountID}}&token={{.SourceId}}"
-aliasOf: "smarthub"


### PR DESCRIPTION
We have removed the alias Vimayx because we no longer use it.

Updated docs PR https://github.com/prebid/prebid.github.io/pull/6238