### PR TITLE
Actions: Add publish to docker hub workflow

### DIFF
--- a/.github/workflows/publishonly.yml
+++ b/.github/workflows/publishonly.yml
@@ -13,7 +13,6 @@ on:
     runs-on: ubuntu-latest
     steps:
       - name: Login to docker Hub
-        if: contains(inputs.debug, 'false')
         id: login
         uses: docker/login-action@v2.1.0
         with:


### PR DESCRIPTION
This pull request creates `.github/workflows/publishonly.yml` that adds a conditional before pushing an existing tag to Docker Hub. To verify success of the `docker/login-action` step we check the `steps.<step_name>.outcome`. According to documentation:

### Step Outcome
**Definition**: The outcome of a step is a machine-level status indicating whether the step actually succeeded or failed during execution.

**Possible values**:
- `success`: The step ran and completed without errors.
- `failure`: The step encountered an error and did not complete as intended.

**Technical Note**:
The outcome is determined immediately after the step finishes running.


### Step Conclusion
**Definition**: The conclusion of a step is a higher-level result that takes into account not just the execution status, but also conditions and controls that may have affected whether the step was allowed to run or how its result should be interpreted in the context of the workflow.

**Possible values**:
- `success`
- `failure`
- `skipped` (e.g., due to an if: condition evaluating to false)
- `cancelled` (e.g., the workflow or job was cancelled)
- `timed_out` (e.g., step exceeded its allowed time)
- `neutral` (e.g., step marked as neutral or not affecting the build)
- `action_required` (rare, but possible in some contexts)

**Technical Note**:
The conclusion may differ from the outcome if the step was skipped, cancelled, or otherwise did not run as planned.
