### PR TITLE
Adagio: Remove hardcoded seat name

### DIFF
--- a/adapters/adagio/adagio.go
+++ b/adapters/adagio/adagio.go
@@ -102,7 +102,6 @@ func (a *adapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest
 				Bid:      &bid,
 				BidMeta:  meta,
 				BidVideo: video,
-				Seat:     openrtb_ext.BidderName(seatBid.Seat),
 				BidType:  bidType,
 			}
 			bidderResponse.Bids = append(bidderResponse.Bids, typedBid)

--- a/adapters/adagio/adagiotest/exemplary/banner-app.json
+++ b/adapters/adagio/adagiotest/exemplary/banner-app.json
@@ -181,7 +181,6 @@
             "h": 50,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/banner-web.json
+++ b/adapters/adagio/adagiotest/exemplary/banner-web.json
@@ -148,7 +148,6 @@
             "h": 50,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/multi-formats-app.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-formats-app.json
@@ -207,7 +207,6 @@
               "h": 50,
               "mtype": 1
             },
-            "seat": "adagio",
             "type": "banner"
           }
         ]

--- a/adapters/adagio/adagiotest/exemplary/multi-formats-web.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-formats-web.json
@@ -174,7 +174,6 @@
             "h": 50,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/multi-imps-app.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-imps-app.json
@@ -225,7 +225,6 @@
               "h": 50,
               "mtype": 1
             },
-            "seat": "adagio",
             "type": "banner"
           },
           {
@@ -242,7 +241,6 @@
               "h": 100,
               "mtype": 1
             },
-            "seat": "adagio",
             "type": "banner"
           }
         ]

--- a/adapters/adagio/adagiotest/exemplary/multi-imps-web.json
+++ b/adapters/adagio/adagiotest/exemplary/multi-imps-web.json
@@ -194,7 +194,6 @@
             "h": 50,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         },
         {
@@ -211,7 +210,6 @@
             "h": 100,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/native-app.json
+++ b/adapters/adagio/adagiotest/exemplary/native-app.json
@@ -152,7 +152,6 @@
             ],
             "mtype": 4
           },
-          "seat": "adagio",
           "type": "native"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/native-web.json
+++ b/adapters/adagio/adagiotest/exemplary/native-web.json
@@ -148,7 +148,6 @@
             "h": 50,
             "mtype": 4
           },
-          "seat": "adagio",
           "type": "native"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/request-with-rtd-module.json
+++ b/adapters/adagio/adagiotest/exemplary/request-with-rtd-module.json
@@ -226,7 +226,6 @@
             "h": 50,
             "mtype": 1
           },
-          "seat": "adagio",
           "type": "banner"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/video-app.json
+++ b/adapters/adagio/adagiotest/exemplary/video-app.json
@@ -165,7 +165,6 @@
             "h": 720,
             "mtype": 2
           },
-          "seat": "adagio",
           "type": "video"
         }
       ]

--- a/adapters/adagio/adagiotest/exemplary/video-web.json
+++ b/adapters/adagio/adagiotest/exemplary/video-web.json
@@ -158,7 +158,6 @@
             "h": 50,
             "mtype": 2
           },
-          "seat": "adagio",
           "type": "video"
         }
       ]


### PR DESCRIPTION
This PR updates the Adagio adapter’s MakeBids() function to stop hardcoding "adagio" as the seat name, which currently prevents the use of bidder aliases.
