### PR TITLE
Mobilefuse: Add site media types

### DIFF
--- a/static/bidder-info/mobilefuse.yaml
+++ b/static/bidder-info/mobilefuse.yaml
@@ -12,6 +12,11 @@ capabilities:
       - banner
       - video
       - native
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - native
 endpointCompression: "GZIP"
 openrtb:
   version: 2.6


### PR DESCRIPTION
Added site media types to mobilefuse.yaml. Web is supported.