### PR TITLE
Flipp: Update endpoint to not use cdn

### DIFF
--- a/static/bidder-info/flipp.yaml
+++ b/static/bidder-info/flipp.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://cdn-gateflipp.flippback.com/flyer-locator-service/prebid_campaigns"
+endpoint: "https://ads-flipp.com/flyer-locator-service/prebid_campaigns"
 maintainer:
   email: prebid@flipp.com
 capabilities:


### PR DESCRIPTION
We are changing the endpoint for prebid servers from `cdn-gateflipp.flippback.com` to `ads-flipp.com`
Doing the same changes on `Prebid.js` as well