### PR TITLE
Stroeercore: Use bid.ext as-is from the response

### DIFF
--- a/adapters/stroeerCore/stroeercoretest/exemplary/bid-ext.json
+++ b/adapters/stroeerCore/stroeercoretest/exemplary/bid-ext.json
@@ -144,19 +144,22 @@
               "ad": "advert",
               "crid": "wasd",
               "mtype": "banner",
-              "dsa": {
-                "behalf": "Advertiser A",
-                "paid": "Advertiser B",
-                "transparency": [
-                  {
-                    "domain": "example-domain.com",
-                    "dsaparams": [
-                      1,
-                      2
-                    ]
-                  }
-                ],
-                "adrender": 1
+              "ext": {
+                "other": "thing",
+                "dsa": {
+                  "behalf": "Advertiser A",
+                  "paid": "Advertiser B",
+                  "transparency": [
+                    {
+                      "domain": "example-domain.com",
+                      "dsaparams": [
+                        1,
+                        2
+                      ]
+                    }
+                  ],
+                  "adrender": 1
+                }
               }
             }
           ]
@@ -179,6 +182,7 @@
             "crid": "wasd",
             "mtype": 1,
             "ext": {
+              "other": "thing",
               "dsa": {
                 "behalf": "Advertiser A",
                 "paid": "Advertiser B",

--- a/adapters/stroeerCore/stroeercoretest/exemplary/deprecated-json-path-for-dsa.json
+++ b/adapters/stroeerCore/stroeercoretest/exemplary/deprecated-json-path-for-dsa.json
@@ -1,0 +1,207 @@
+{
+  "mockBidRequest": {
+    "id": "auction-id",
+    "cur": [
+      "EUR"
+    ],
+    "imp": [
+      {
+        "id": "1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sid": "123456"
+          }
+        }
+      }
+    ],
+    "device": {
+      "ip": "123.123.123.123"
+    },
+    "site": {
+      "domain": "www.publisher.com",
+      "page": "http://www.publisher.com/some/path"
+    },
+    "user": {
+      "buyeruid": "test-buyer-user-id"
+    },
+    "regs": {
+      "ext": {
+        "dsa": {
+          "dsarequired": 3,
+          "pubrender": 0,
+          "datatopub": 2,
+          "transparency": [
+            {
+              "domain": "example-platform.com",
+              "dsaparams": [
+                1
+              ]
+            },
+            {
+              "domain": "example-ssp.com",
+              "dsaparams": [
+                1,
+                2
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ]
+        },
+        "uri": "http://localhost/s2sdsh",
+        "body": {
+          "id": "auction-id",
+          "cur": [
+            "EUR"
+          ],
+          "imp": [
+            {
+              "id": "1",
+              "tagid": "123456",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "sid": "123456"
+                }
+              }
+            }
+          ],
+          "device": {
+            "ip": "123.123.123.123"
+          },
+          "site": {
+            "domain": "www.publisher.com",
+            "page": "http://www.publisher.com/some/path"
+          },
+          "user": {
+            "buyeruid": "test-buyer-user-id"
+          },
+          "regs": {
+            "ext": {
+              "dsa": {
+                "dsarequired": 3,
+                "pubrender": 0,
+                "datatopub": 2,
+                "transparency": [
+                  {
+                    "domain": "example-platform.com",
+                    "dsaparams": [
+                      1
+                    ]
+                  },
+                  {
+                    "domain": "example-ssp.com",
+                    "dsaparams": [
+                      1,
+                      2
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "impIDs":["1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "bids": [
+            {
+              "id": "1829273982920-01",
+              "bidId": "1",
+              "cpm": 2,
+              "width": 300,
+              "height": 600,
+              "ad": "advert",
+              "crid": "wasd",
+              "mtype": "banner",
+              "dsa": {
+                "behalf": "Advertiser A",
+                "paid": "Advertiser B",
+                "transparency": [
+                  {
+                    "domain": "example-domain.com",
+                    "dsaparams": [
+                      1,
+                      2
+                    ]
+                  }
+                ],
+                "adrender": 1
+              },
+              "ext": {
+                "something": "else"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "1829273982920-01",
+            "impid": "1",
+            "price": 2,
+            "adm": "advert",
+            "w": 300,
+            "h": 600,
+            "crid": "wasd",
+            "mtype": 1,
+            "ext": {
+              "dsa": {
+                "behalf": "Advertiser A",
+                "paid": "Advertiser B",
+                "transparency": [
+                  {
+                    "domain": "example-domain.com",
+                    "dsaparams": [
+                      1,
+                      2
+                    ]
+                  }
+                ],
+                "adrender": 1
+              },
+              "something": "else"
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Allows us to add to the bid ext without needing to update the adapter, which is especially convenient when adding fields for custom targeting. We intend to move dsa into ext in the near future, but we want to establish the PBS-Go version first.

Equivalent PBS-Java PR: https://github.com/prebid/prebid-server-java/pull/4317