### PR TITLE
Ogury: Allow inventory mapping for in-app traffic.

### DIFF
--- a/adapters/ogury/ogurytest/exemplary/app_banner_publisher.json
+++ b/adapters/ogury/ogurytest/exemplary/app_banner_publisher.json
@@ -1,0 +1,97 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "id": "1",
+      "bundle": "com.example",
+      "publisher": {
+        "id":  "pub-id"
+      }
+    },
+    "imp": [
+      {
+        "id": "imp-id",
+        "banner": {
+          "format": [{"w": 320, "h": 50}]
+        },
+        "ext": {
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://ogury.example.com",
+        "body": {
+          "app": {
+            "id": "1",
+            "bundle": "com.example",
+            "publisher": {
+              "id":  "pub-id"
+            }
+          },
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id":"imp-id",
+              "tagid": "imp-id",
+              "banner": {
+                "format": [{"w": 320, "h": 50}]
+              },
+              "ext": {
+              }
+            }
+          ]
+        },
+        "impIDs":["imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "seat",
+              "bid": [{
+                "id": "some-UUID",
+                "impid": "imp-id",
+                "price": 0.500000,
+                "nurl": "example nurl",
+                "adm": "adm string",
+                "crid": "crid_10",
+                "h": 100,
+                "w": 128,
+                "mtype": 1
+              }]
+            }
+          ]
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "some-UUID",
+            "impid": "imp-id",
+            "price": 0.5,
+            "nurl": "example nurl",
+            "adm": "adm string",
+            "crid": "crid_10",
+            "h": 100,
+            "w": 128,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ogury/ogurytest/supplemental/app_banner_invalid_request.json
+++ b/adapters/ogury/ogurytest/supplemental/app_banner_invalid_request.json
@@ -3,10 +3,7 @@
     "id": "test-request-id",
     "app": {
       "id": "1",
-      "bundle": "com.example",
-      "publisher": {
-        "id":  "pub-id"
-      }
+      "bundle": "com.example"
     },
     "imp": [
       {
@@ -26,7 +23,7 @@
 
   "expectedBidResponses": [],
   "expectedMakeRequestsErrors": [{
-    "value": "Invalid request. assetKey/adUnitId required",
+    "value": "Invalid request. assetKey/adUnitId or request.site/app.publisher.id required",
     "comparison": "literal"
   }]
 }

--- a/adapters/ogury/ogurytest/supplemental/site_banner_invalid_request.json
+++ b/adapters/ogury/ogurytest/supplemental/site_banner_invalid_request.json
@@ -22,7 +22,7 @@
   "httpCalls": [],
   "expectedBidResponses": [],
   "expectedMakeRequestsErrors": [{
-    "value": "Invalid request. assetKey/adUnitId or request.site.publisher.id required",
+    "value": "Invalid request. assetKey/adUnitId or request.site/app.publisher.id required",
     "comparison": "literal"
   }]
 }


### PR DESCRIPTION
We no longer require assetKey and adUnitId for in-app traffic, it can be handled with app.publisher.id with inventory mapping (like it did for web).

Doc update: https://github.com/prebid/prebid.github.io/pull/6371