### PR TITLE
Mobkoi: Always set TagID with placementID

### DIFF
--- a/adapters/mobkoi/mobkoi.go
+++ b/adapters/mobkoi/mobkoi.go
@@ -37,13 +37,11 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		return nil, []error{err}
 	}
 
-	if request.Imp[0].TagID == "" {
-		if ext.Bidder.PlacementID != "" {
-			request.Imp[0].TagID = ext.Bidder.PlacementID
-		} else {
-			return nil, []error{
-				errors.New("invalid because it comes with neither request.imp[0].tagId nor req.imp[0].ext.Bidder.placementId"),
-			}
+	if ext.Bidder.PlacementID != "" {
+		request.Imp[0].TagID = ext.Bidder.PlacementID
+	} else if request.Imp[0].TagID == "" {
+		return nil, []error{
+			errors.New("invalid because it comes with neither request.imp[0].tagId nor req.imp[0].ext.Bidder.placementId"),
 		}
 	}
 

--- a/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
@@ -1,0 +1,146 @@
+{
+  "mockBidRequest": {
+    "id": "some-request-id",
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "tmax": 1000,
+    "user": {
+      "buyeruid": "awesome-user",
+      "consent": "consent-string"
+    },
+    "site": {
+      "page": "test.com",
+      "publisher": {
+        "id": "123456789"
+      }
+    },
+    "imp": [
+      {
+        "id": "some-impression-id1",
+        "tagid": "originalTagId",
+        "banner": {
+          "w": 320,
+          "h": 50
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "placementId"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "http://dev.mobkoi.com/bid",
+        "body": {
+          "id": "some-request-id",
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "imp": [
+            {
+              "id": "some-impression-id1",
+              "tagid": "placementId",
+              "banner": {
+                "w": 320,
+                "h": 50
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": "placementId"
+                }
+              }
+            }
+          ],
+          "site": {
+            "page": "test.com",
+            "publisher": {
+              "id": "123456789"
+            }
+          },
+          "user": {
+            "buyeruid": "awesome-user",
+            "consent": "consent-string",
+            "ext": {
+              "consent": "consent-string"
+            }
+          },
+          "tmax": 1000
+        },
+        "impIDs": [
+          "some-impression-id1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "awesome-resp-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "some-impression-id1",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 320,
+                  "h": 50,
+                  "lurl": "mobkoi/loss",
+                  "nurl": "mobkoi/win"
+                }
+              ],
+              "type": "banner",
+              "seat": "mobkoi"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "some-impression-id1",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "crid": "20",
+            "adomain": [
+              "awesome.com"
+            ],
+            "w": 320,
+            "h": 50,
+            "lurl": "mobkoi/loss",
+            "nurl": "mobkoi/win"
+          },
+          "type": "banner",
+          "seat": "mobkoi"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We have a discrepancy between our Prebid Server and our Tag/PrebidJS integration. It’s not replacing the `bidrequest.Imp[0].TagID` with our internal value when a TagID is already present.

We are able to deliver because the value is set in the `bidrequest.Imp[0].Ext.placementID` field, but this creates discrepancies between the connectors, and it’s not ideal.