### PR TITLE
Drop supportCors user sync YAML config option

### DIFF
--- a/analytics/core.go
+++ b/analytics/core.go
@@ -82,9 +82,8 @@ type CookieSyncBidder struct {
 }
 
 type UsersyncInfo struct {
-	URL         string `json:"url,omitempty"`
-	Type        string `json:"type,omitempty"`
-	SupportCORS bool   `json:"supportCORS,omitempty"`
+	URL  string `json:"url,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
 // NotificationEvent object of a transaction at /event

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -127,9 +127,6 @@ type Syncer struct {
 	// ExternalURL is available as a macro to the RedirectURL template.
 	ExternalURL string `yaml:"externalUrl" mapstructure:"external_url"`
 
-	// SupportCORS identifies if CORS is supported for the user syncing endpoints.
-	SupportCORS *bool `yaml:"supportCors" mapstructure:"support_cors"`
-
 	// FormatOverride allows a bidder to override their callback type "b" for iframe, "i" for redirect
 	FormatOverride string `yaml:"formatOverride" mapstructure:"format_override"`
 
@@ -154,7 +151,6 @@ func (s *Syncer) Equal(other *Syncer) bool {
 		s.IFrame.Equal(other.IFrame) &&
 		s.Redirect.Equal(other.Redirect) &&
 		s.ExternalURL == other.ExternalURL &&
-		ptrutil.Equal(s.SupportCORS, other.SupportCORS) &&
 		s.FormatOverride == other.FormatOverride &&
 		ptrutil.Equal(s.Enabled, other.Enabled) &&
 		s.SkipWhen.Equal(other.SkipWhen)
@@ -264,7 +260,6 @@ func (s *Syncer) Defined() bool {
 		s.IFrame != nil ||
 		s.Redirect != nil ||
 		s.ExternalURL != "" ||
-		s.SupportCORS != nil ||
 		s.FormatOverride != "" ||
 		s.SkipWhen != nil
 }
@@ -803,10 +798,6 @@ func (s *Syncer) Override(original *Syncer) *Syncer {
 
 	if s.ExternalURL != "" {
 		copy.ExternalURL = s.ExternalURL
-	}
-
-	if s.SupportCORS != nil {
-		copy.SupportCORS = s.SupportCORS
 	}
 
 	return &copy

--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -73,7 +73,6 @@ aliasOf: bidderA
 func TestLoadBidderInfoFromDisk(t *testing.T) {
 	// should appear in result in mixed case
 	bidder := "stroeerCore"
-	trueValue := true
 
 	adapterConfigs := make(map[string]Adapter)
 	adapterConfigs[strings.ToLower(bidder)] = Adapter{}
@@ -115,7 +114,6 @@ func TestLoadBidderInfoFromDisk(t *testing.T) {
 					ExternalURL: "https://redirect.host",
 					UserMacro:   "#UID",
 				},
-				SupportCORS: &trueValue,
 			},
 		},
 	}
@@ -1402,11 +1400,6 @@ func TestBidderInfoValidationNegative(t *testing.T) {
 }
 
 func TestSyncerOverride(t *testing.T) {
-	var (
-		trueValue  = true
-		falseValue = false
-	)
-
 	testCases := []struct {
 		description   string
 		givenOriginal *Syncer
@@ -1466,12 +1459,6 @@ func TestSyncerOverride(t *testing.T) {
 			givenOriginal: &Syncer{ExternalURL: "original"},
 			givenOverride: &Syncer{ExternalURL: "override"},
 			expected:      &Syncer{ExternalURL: "override"},
-		},
-		{
-			description:   "Override SupportCORS",
-			givenOriginal: &Syncer{SupportCORS: &trueValue},
-			givenOverride: &Syncer{SupportCORS: &falseValue},
-			expected:      &Syncer{SupportCORS: &falseValue},
 		},
 		{
 			description:   "Override Partial - Other Fields Untouched",
@@ -1716,18 +1703,6 @@ func TestSyncerEqual(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "different-support-cors",
-			syncer1: &Syncer{
-				Key:         "key",
-				SupportCORS: ptrutil.ToPtr(true),
-			},
-			syncer2: &Syncer{
-				Key:         "key",
-				SupportCORS: ptrutil.ToPtr(false),
-			},
-			expected: false,
-		},
-		{
 			name: "different-format-override",
 			syncer1: &Syncer{
 				Key:            "key",
@@ -1782,7 +1757,6 @@ func TestSyncerEqual(t *testing.T) {
 					UserMacro: "$UID",
 				},
 				ExternalURL:    "https://external.com",
-				SupportCORS:    ptrutil.ToPtr(true),
 				FormatOverride: "i",
 				Enabled:        ptrutil.ToPtr(true),
 				SkipWhen: &SkipWhen{
@@ -1803,7 +1777,6 @@ func TestSyncerEqual(t *testing.T) {
 					UserMacro: "$UID",
 				},
 				ExternalURL:    "https://external.com",
-				SupportCORS:    ptrutil.ToPtr(true),
 				FormatOverride: "i",
 				Enabled:        ptrutil.ToPtr(true),
 				SkipWhen: &SkipWhen{
@@ -2071,11 +2044,6 @@ func TestSyncerDefined(t *testing.T) {
 		{
 			name:        "externalurl-only",
 			givenSyncer: &Syncer{ExternalURL: "anyURL"},
-			expected:    true,
-		},
-		{
-			name:        "supportscors-only",
-			givenSyncer: &Syncer{SupportCORS: ptrutil.ToPtr(false)},
 			expected:    true,
 		},
 		{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1019,8 +1019,6 @@ func TestMigrateConfigFromEnv(t *testing.T) {
 }
 
 func TestUserSyncFromEnv(t *testing.T) {
-	truePtr := true
-
 	// setup env vars for testing
 	if oldval, ok := os.LookupEnv("PBS_ADAPTERS_BIDDER1_USERSYNC_REDIRECT_URL"); ok {
 		defer os.Setenv("PBS_ADAPTERS_BIDDER1_USERSYNC_REDIRECT_URL", oldval)
@@ -1057,11 +1055,9 @@ func TestUserSyncFromEnv(t *testing.T) {
 	assert.Equal(t, "http://some.url/sync?redirect={{.RedirectURL}}", cfg.BidderInfos["bidder1"].Syncer.Redirect.URL)
 	assert.Equal(t, "[UID]", cfg.BidderInfos["bidder1"].Syncer.Redirect.UserMacro)
 	assert.Nil(t, cfg.BidderInfos["bidder1"].Syncer.IFrame)
-	assert.Equal(t, &truePtr, cfg.BidderInfos["bidder1"].Syncer.SupportCORS)
 
 	assert.Equal(t, "http://somedifferent.url/sync?redirect={{.RedirectURL}}", cfg.BidderInfos["bidder2"].Syncer.IFrame.URL)
 	assert.Nil(t, cfg.BidderInfos["bidder2"].Syncer.Redirect)
-	assert.Nil(t, cfg.BidderInfos["bidder2"].Syncer.SupportCORS)
 }
 
 func TestBidderInfoFromEnv(t *testing.T) {

--- a/config/test/bidder-info-valid/stroeerCore.yaml
+++ b/config/test/bidder-info-valid/stroeerCore.yaml
@@ -28,4 +28,3 @@ userSync:
     redirectUrl: "{{.ExternalURL}}/setuid/redirect"
     externalUrl: "https://redirect.host"
     userMacro: "#UID"
-  supportCors: true

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -466,9 +466,8 @@ func (c *cookieSyncEndpoint) handleResponse(w http.ResponseWriter, tf usersync.S
 			BidderCode: syncerChoice.Bidder,
 			NoCookie:   true,
 			UsersyncInfo: cookieSyncResponseSync{
-				URL:         sync.URL,
-				Type:        string(sync.Type),
-				SupportCORS: sync.SupportCORS,
+				URL:  sync.URL,
+				Type: string(sync.Type),
 			},
 		})
 	}
@@ -536,9 +535,8 @@ func mapBidderStatusToAnalytics(from []cookieSyncResponseBidder) []*analytics.Co
 			BidderCode: b.BidderCode,
 			NoCookie:   b.NoCookie,
 			UsersyncInfo: &analytics.UsersyncInfo{
-				URL:         b.UsersyncInfo.URL,
-				Type:        b.UsersyncInfo.Type,
-				SupportCORS: b.UsersyncInfo.SupportCORS,
+				URL:  b.UsersyncInfo.URL,
+				Type: b.UsersyncInfo.Type,
 			},
 		}
 	}
@@ -604,9 +602,8 @@ type cookieSyncResponseBidder struct {
 }
 
 type cookieSyncResponseSync struct {
-	URL         string `json:"url,omitempty"`
-	Type        string `json:"type,omitempty"`
-	SupportCORS bool   `json:"supportCORS,omitempty"`
+	URL  string `json:"url,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
 type cookieSyncResponseDebug struct {

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -114,7 +114,7 @@ func TestNewCookieSyncEndpoint(t *testing.T) {
 
 func TestCookieSyncHandle(t *testing.T) {
 	syncTypeExpected := []usersync.SyncType{usersync.SyncTypeIFrame, usersync.SyncTypeRedirect}
-	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect, SupportCORS: true}
+	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect}
 	syncer := MockSyncer{}
 	syncer.On("GetSync", syncTypeExpected, macros.UserSyncPrivacy{}).Return(sync, nil).Maybe()
 
@@ -144,7 +144,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -158,7 +158,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -176,7 +176,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"no_cookie","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -190,7 +190,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -277,7 +277,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`],"debug":[{"bidder":"a","error":"Already in sync"}]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -291,7 +291,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -313,7 +313,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			expectedStatusCode:              200,
 			expectedCookieDeprecationHeader: true,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -327,7 +327,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -1793,12 +1793,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 	privacyMacros := macros.UserSyncPrivacy{USPrivacy: "anyConsent"}
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: true}
+	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
 	syncerA := MockSyncer{}
 	syncerA.On("GetSync", syncTypeExpected, privacyMacros).Return(syncA, nil).Maybe()
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: false}
+	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
 	syncerB := MockSyncer{}
 	syncerB.On("GetSync", syncTypeExpected, privacyMacros).Return(syncB, nil).Maybe()
 
@@ -1837,7 +1837,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
 				Status: 200,
@@ -1845,7 +1845,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -1855,7 +1855,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}, {Bidder: "bar", Syncer: &syncerB}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}},` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}},` +
 				`{"bidder":"bar","no_cookie":true,"usersync":{"url":"https://syncB.com/sync?a=1&b=2","type":"redirect"}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
@@ -1864,12 +1864,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
 					},
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -1887,7 +1887,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -1956,14 +1956,14 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
 				},
 			},
 		},
@@ -1973,24 +1973,24 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType", SupportCORS: true},
+					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType"},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType", SupportCORS: true},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType"},
 				},
 			},
 		},
@@ -2621,15 +2621,15 @@ func createAccountJSON(priorityGroups [][]string, defaultCoopSync *bool) json.Ra
 func TestCookieSyncPriorityGroupsIntegration(t *testing.T) {
 	// Setup test syncers
 	syncerA := MockSyncer{}
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerA.On("Key").Return("appnexus").Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerB := MockSyncer{}
-	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerB.On("Key").Return("rubicon").Maybe()
 	syncerB.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerC := MockSyncer{}
-	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerC.On("Key").Return("pubmatic").Maybe()
 	syncerC.On("SupportsType", mock.Anything).Return(true).Maybe()
 	// Need to choose real bidder names because the standard chooser is hardcoded to validate against them
@@ -2788,7 +2788,7 @@ func TestCookieSyncPriorityGroupsEdgeCases(t *testing.T) {
 	// Setup basic syncers
 	syncerA := MockSyncer{}
 	syncerA.On("Key").Return("bidderA")
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 
 	syncersByBidder := map[string]usersync.Syncer{

--- a/static/bidder-info/imds.yaml
+++ b/static/bidder-info/imds.yaml
@@ -15,7 +15,6 @@ capabilities:
       - banner
       - video
 userSync:
-  supportCors: true
   iframe:
     url: "https://ad-cdn.technoratimedia.com/html/usersync.html?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gppsid={{.GPPSID}}&cb={{.RedirectURL}}"
     userMacro: "[USER_ID]"

--- a/static/bidder-info/orbidder.yaml
+++ b/static/bidder-info/orbidder.yaml
@@ -11,7 +11,6 @@ capabilities:
       - banner
       - native
 userSync:
-  supportCors: true
   redirect:
     url: "https://orbidder.otto.de/pbs-usersync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&redirect={{.RedirectURL}}"
     userMacro: "[ODN_ID]"

--- a/static/bidder-info/resetdigital.yaml
+++ b/static/bidder-info/resetdigital.yaml
@@ -21,4 +21,3 @@ usersync:
   redirect:
     url: "https://sync.resetdigital.co/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
     userMacro: "$UID"
-  supportCORS: true

--- a/static/bidder-info/sparteo.yaml
+++ b/static/bidder-info/sparteo.yaml
@@ -17,4 +17,3 @@ endpoint: "https://bid.sparteo.com/s2s-auction"
 userSync:
   iframe:
     url: "https://sync.sparteo.com/s2s_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect_url={{.RedirectURL}}"
-    supportCors: true

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -39,9 +39,8 @@ type Syncer interface {
 
 // Sync represents a user sync to be performed by the user's device.
 type Sync struct {
-	URL         string
-	Type        SyncType
-	SupportCORS bool
+	URL  string
+	Type SyncType
 }
 
 type standardSyncer struct {
@@ -49,7 +48,6 @@ type standardSyncer struct {
 	defaultSyncType SyncType
 	iframe          *template.Template
 	redirect        *template.Template
-	supportCORS     bool
 	formatOverride  string
 }
 
@@ -67,7 +65,6 @@ func NewSyncer(hostConfig config.UserSync, syncerConfig config.Syncer, bidder st
 	syncer := standardSyncer{
 		key:             syncerConfig.Key,
 		defaultSyncType: resolveDefaultSyncType(syncerConfig),
-		supportCORS:     syncerConfig.SupportCORS != nil && *syncerConfig.SupportCORS,
 		formatOverride:  syncerConfig.FormatOverride,
 	}
 
@@ -237,9 +234,8 @@ func (s standardSyncer) GetSync(syncTypes []SyncType, userSyncMacros macros.User
 	}
 
 	sync := Sync{
-		URL:         url,
-		Type:        syncType,
-		SupportCORS: s.supportCORS,
+		URL:  url,
+		Type: syncType,
 	}
 	return sync, nil
 }

--- a/usersync/syncer_test.go
+++ b/usersync/syncer_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestNewSyncer(t *testing.T) {
 	var (
-		supportCORS      = true
 		hostConfig       = config.UserSync{ExternalURL: "http://host.com", RedirectURL: "{{.ExternalURL}}/host"}
 		macroValues      = macros.UserSyncPrivacy{GDPR: "A", GDPRConsent: "B", USPrivacy: "C"}
 		iframeConfig     = &config.SyncerEndpoint{URL: "https://bidder.com/iframe?redirect={{.RedirectURL}}"}
@@ -107,7 +106,6 @@ func TestNewSyncer(t *testing.T) {
 	for _, test := range testCases {
 		syncerConfig := config.Syncer{
 			Key:         test.givenKey,
-			SupportCORS: &supportCORS,
 			IFrame:      test.givenIFrameConfig,
 			Redirect:    test.givenRedirectConfig,
 			ExternalURL: test.givenExternalURL,
@@ -120,7 +118,6 @@ func TestNewSyncer(t *testing.T) {
 			if assert.IsType(t, standardSyncer{}, result, test.description+":result_type") {
 				result := result.(standardSyncer)
 				assert.Equal(t, test.givenKey, result.key, test.description+":key")
-				assert.Equal(t, supportCORS, result.supportCORS, test.description+":cors")
 				assert.Equal(t, test.expectedDefault, result.defaultSyncType, test.description+":default_sync")
 
 				if test.expectedIFrame == "" {
@@ -682,14 +679,14 @@ func TestSyncerGetSync(t *testing.T) {
 			givenSyncer:    standardSyncer{iframe: iframeTemplate, redirect: redirectTemplate},
 			givenSyncTypes: []SyncType{SyncTypeIFrame},
 			givenMacros:    macros.UserSyncPrivacy{GDPR: "A", GDPRConsent: "B", USPrivacy: "C"},
-			expectedSync:   Sync{URL: "iframe,gdpr:A,gdprconsent:B,ccpa:C", Type: SyncTypeIFrame, SupportCORS: false},
+			expectedSync:   Sync{URL: "iframe,gdpr:A,gdprconsent:B,ccpa:C", Type: SyncTypeIFrame},
 		},
 		{
 			description:    "Redirect",
 			givenSyncer:    standardSyncer{iframe: iframeTemplate, redirect: redirectTemplate},
 			givenSyncTypes: []SyncType{SyncTypeRedirect},
 			givenMacros:    macros.UserSyncPrivacy{GDPR: "A", GDPRConsent: "B", USPrivacy: "C"},
-			expectedSync:   Sync{URL: "redirect,gdpr:A,gdprconsent:B,ccpa:C", Type: SyncTypeRedirect, SupportCORS: false},
+			expectedSync:   Sync{URL: "redirect,gdpr:A,gdprconsent:B,ccpa:C", Type: SyncTypeRedirect},
 		},
 		{
 			description:    "Macro Error",

--- a/usersync/syncersbuilder_test.go
+++ b/usersync/syncersbuilder_test.go
@@ -192,7 +192,6 @@ func TestShouldCreateSyncer(t *testing.T) {
 	var (
 		anySupports = []string{"iframe"}
 		anyEndpoint = &config.SyncerEndpoint{}
-		anyCORS     = true
 	)
 
 	testCases := []struct {
@@ -212,7 +211,7 @@ func TestShouldCreateSyncer(t *testing.T) {
 		},
 		{
 			description: "Enabled, Syncer - Fully Loaded",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint}},
 			expected:    true,
 		},
 		{
@@ -236,11 +235,6 @@ func TestShouldCreateSyncer(t *testing.T) {
 			expected:    true,
 		},
 		{
-			description: "Enabled, Syncer - Only SupportCORS",
-			given:       config.BidderInfo{Disabled: false, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
-			expected:    true,
-		},
-		{
 			description: "Disabled, No Syncer",
 			given:       config.BidderInfo{Disabled: true, Syncer: nil},
 			expected:    false,
@@ -252,7 +246,7 @@ func TestShouldCreateSyncer(t *testing.T) {
 		},
 		{
 			description: "Disabled, Syncer - Fully Loaded",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint}},
 			expected:    false,
 		},
 		{
@@ -276,11 +270,6 @@ func TestShouldCreateSyncer(t *testing.T) {
 			expected:    false,
 		},
 		{
-			description: "Disabled, Syncer - Only SupportCORS",
-			given:       config.BidderInfo{Disabled: true, Syncer: &config.Syncer{SupportCORS: &anyCORS}},
-			expected:    false,
-		},
-		{
 			description: "WhiteLabelOnly, No Syncer",
 			given:       config.BidderInfo{WhiteLabelOnly: true, Syncer: nil},
 			expected:    false,
@@ -292,7 +281,7 @@ func TestShouldCreateSyncer(t *testing.T) {
 		},
 		{
 			description: "WhiteLabelOnly, Syncer - Fully Loaded",
-			given:       config.BidderInfo{WhiteLabelOnly: true, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint, SupportCORS: &anyCORS}},
+			given:       config.BidderInfo{WhiteLabelOnly: true, Syncer: &config.Syncer{Key: "anyKey", Supports: anySupports, IFrame: anyEndpoint, Redirect: anyEndpoint}},
 			expected:    false,
 		},
 	}


### PR DESCRIPTION
Implements #4160.
Removing in 4.0 as described  #3861.