### PR TITLE
Relevant Digital: Add useSourceBidderCode option

### DIFF
--- a/adapters/relevantdigital/params_test.go
+++ b/adapters/relevantdigital/params_test.go
@@ -35,8 +35,11 @@ func TestInvalidParams(t *testing.T) {
 
 var validParams = []string{
 	`{"accountId": "5fcf49f83a64ba6602b5be7e", "placementId" : "63b68275b4f35962c8eec9b1_5fcf49f83a64ba6602b5be9a", "pbsHost" : "some-host" }`,
+	`{"accountId": "5fcf49f83a64ba6602b5be7e", "placementId" : "63b68275b4f35962c8eec9b1_5fcf49f83a64ba6602b5be9a", "pbsHost" : "some-host", "useSourceBidderCode": true }`,
+	`{"accountId": "5fcf49f83a64ba6602b5be7e", "placementId" : "63b68275b4f35962c8eec9b1_5fcf49f83a64ba6602b5be9a", "pbsHost" : "some-host", "useSourceBidderCode": false }`,
 }
 
 var invalidParams = []string{
 	`{"accountId": 123, "placementId" : 123, "pbsHost" : ""}`,
+	`{"accountId": "5fcf49f83a64ba6602b5be7e", "placementId" : "63b68275b4f35962c8eec9b1_5fcf49f83a64ba6602b5be9a", "pbsHost" : "some-host", "useSourceBidderCode": "somethingInvalid" }`,
 }

--- a/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCode.json
+++ b/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCode.json
@@ -1,0 +1,131 @@
+{
+    "mockBidRequest": {
+        "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+        "imp": [
+            {
+                "id": "div-1",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "accountId": "620523ae7f4bbe1691bbb815",
+                        "pbsHost": "fakeHost",
+                        "placementId": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817",
+                        "useSourceBidderCode": true
+                    }
+                }
+            }
+        ],
+        "site": {
+            "domain": "somedomain.com",
+            "page": "https://somedomain.com"
+        },
+        "device": {
+            "ua": "userAgent",
+            "ip": "193.168.244.1"
+        }
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://fakeHost.relevant-digital.com/openrtb2/auction",
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "imp": [
+                        {
+                            "id": "div-1",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "prebid": {
+                                    "storedrequest": {
+                                        "id": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "site": {
+                        "domain": "somedomain.com",
+                        "page": "https://somedomain.com"
+                    },
+                    "device": {
+                        "ua": "userAgent",
+                        "ip": "193.168.244.1"
+                    },
+                    "ext": {
+                        "prebid": {
+                            "debug": false,
+                            "storedrequest": {
+                                "id": "620523ae7f4bbe1691bbb815"
+                            }
+                        },
+                        "relevant": {
+                            "adapterType": "server",
+                            "count": 1
+                        }
+                    },
+                    "tmax": 750
+                },
+                "impIDs": ["div-1"]
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "seatbid": [
+                        {
+                            "seat": "pubmatic",
+                            "bid": [
+                                {
+                                    "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                                    "impid": "div-1",
+                                    "price": 0.5,
+                                    "adm": "some-test-ad",
+                                    "crid": "crid_10",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "cur": "USD"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "USD",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                        "impid": "div-1",
+                        "price": 0.5,
+                        "adm": "some-test-ad",
+                        "crid": "crid_10",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner",
+                    "seat": "pubmatic"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeDisabled.json
+++ b/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeDisabled.json
@@ -1,0 +1,129 @@
+{
+    "mockBidRequest": {
+        "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+        "imp": [
+            {
+                "id": "div-1",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "accountId": "620523ae7f4bbe1691bbb815",
+                        "pbsHost": "fakeHost",
+                        "placementId": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                    }
+                }
+            }
+        ],
+        "site": {
+            "domain": "somedomain.com",
+            "page": "https://somedomain.com"
+        },
+        "device": {
+            "ua": "userAgent",
+            "ip": "193.168.244.1"
+        }
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://fakeHost.relevant-digital.com/openrtb2/auction",
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "imp": [
+                        {
+                            "id": "div-1",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "prebid": {
+                                    "storedrequest": {
+                                        "id": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "site": {
+                        "domain": "somedomain.com",
+                        "page": "https://somedomain.com"
+                    },
+                    "device": {
+                        "ua": "userAgent",
+                        "ip": "193.168.244.1"
+                    },
+                    "ext": {
+                        "prebid": {
+                            "debug": false,
+                            "storedrequest": {
+                                "id": "620523ae7f4bbe1691bbb815"
+                            }
+                        },
+                        "relevant": {
+                            "adapterType": "server",
+                            "count": 1
+                        }
+                    },
+                    "tmax": 750
+                },
+                "impIDs": ["div-1"]
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "seatbid": [
+                        {
+                            "seat": "pubmatic",
+                            "bid": [
+                                {
+                                    "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                                    "impid": "div-1",
+                                    "price": 0.5,
+                                    "adm": "some-test-ad",
+                                    "crid": "crid_10",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "cur": "USD"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "USD",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "8ee514f1-b2b8-4abb-89fd-084437d1e800",
+                        "impid": "div-1",
+                        "price": 0.5,
+                        "adm": "some-test-ad",
+                        "crid": "crid_10",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeDisabledMultipleSeatBids.json
+++ b/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeDisabledMultipleSeatBids.json
@@ -1,0 +1,157 @@
+{
+    "mockBidRequest": {
+        "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+        "imp": [
+            {
+                "id": "div-1",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "accountId": "620523ae7f4bbe1691bbb815",
+                        "pbsHost": "fakeHost",
+                        "placementId": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                    }
+                }
+            }
+        ],
+        "site": {
+            "domain": "somedomain.com",
+            "page": "https://somedomain.com"
+        },
+        "device": {
+            "ua": "userAgent",
+            "ip": "193.168.244.1"
+        }
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://fakeHost.relevant-digital.com/openrtb2/auction",
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "imp": [
+                        {
+                            "id": "div-1",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "prebid": {
+                                    "storedrequest": {
+                                        "id": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "site": {
+                        "domain": "somedomain.com",
+                        "page": "https://somedomain.com"
+                    },
+                    "device": {
+                        "ua": "userAgent",
+                        "ip": "193.168.244.1"
+                    },
+                    "ext": {
+                        "prebid": {
+                            "debug": false,
+                            "storedrequest": {
+                                "id": "620523ae7f4bbe1691bbb815"
+                            }
+                        },
+                        "relevant": {
+                            "adapterType": "server",
+                            "count": 1
+                        }
+                    },
+                    "tmax": 750
+                },
+                "impIDs": ["div-1"]
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "seatbid": [
+                        {
+                            "seat": "pubmatic",
+                            "bid": [
+                                {
+                                    "id": "bid-1",
+                                    "impid": "div-1",
+                                    "price": 0.5,
+                                    "adm": "pubmatic-ad",
+                                    "crid": "crid_1",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        },
+                        {
+                            "seat": "appnexus",
+                            "bid": [
+                                {
+                                    "id": "bid-2",
+                                    "impid": "div-1",
+                                    "price": 0.8,
+                                    "adm": "appnexus-ad",
+                                    "crid": "crid_2",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "cur": "USD"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "USD",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "bid-1",
+                        "impid": "div-1",
+                        "price": 0.5,
+                        "adm": "pubmatic-ad",
+                        "crid": "crid_1",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner"
+                },
+                {
+                    "bid": {
+                        "id": "bid-2",
+                        "impid": "div-1",
+                        "price": 0.8,
+                        "adm": "appnexus-ad",
+                        "crid": "crid_2",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeMultipleSeatBids.json
+++ b/adapters/relevantdigital/relevantdigitaltest/supplemental/useSourceBidderCodeMultipleSeatBids.json
@@ -1,0 +1,160 @@
+{
+    "mockBidRequest": {
+        "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+        "imp": [
+            {
+                "id": "div-1",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 250
+                        }
+                    ]
+                },
+                "ext": {
+                    "bidder": {
+                        "accountId": "620523ae7f4bbe1691bbb815",
+                        "pbsHost": "fakeHost",
+                        "placementId": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817",
+                        "useSourceBidderCode": true
+                    }
+                }
+            }
+        ],
+        "site": {
+            "domain": "somedomain.com",
+            "page": "https://somedomain.com"
+        },
+        "device": {
+            "ua": "userAgent",
+            "ip": "193.168.244.1"
+        }
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "https://fakeHost.relevant-digital.com/openrtb2/auction",
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "imp": [
+                        {
+                            "id": "div-1",
+                            "banner": {
+                                "format": [
+                                    {
+                                        "w": 300,
+                                        "h": 250
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "prebid": {
+                                    "storedrequest": {
+                                        "id": "620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "site": {
+                        "domain": "somedomain.com",
+                        "page": "https://somedomain.com"
+                    },
+                    "device": {
+                        "ua": "userAgent",
+                        "ip": "193.168.244.1"
+                    },
+                    "ext": {
+                        "prebid": {
+                            "debug": false,
+                            "storedrequest": {
+                                "id": "620523ae7f4bbe1691bbb815"
+                            }
+                        },
+                        "relevant": {
+                            "adapterType": "server",
+                            "count": 1
+                        }
+                    },
+                    "tmax": 750
+                },
+                "impIDs": ["div-1"]
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "3621f78b-abdf-4562-8eca-1c5e893387d0",
+                    "seatbid": [
+                        {
+                            "seat": "pubmatic",
+                            "bid": [
+                                {
+                                    "id": "bid-1",
+                                    "impid": "div-1",
+                                    "price": 0.5,
+                                    "adm": "pubmatic-ad",
+                                    "crid": "crid_1",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        },
+                        {
+                            "seat": "appnexus",
+                            "bid": [
+                                {
+                                    "id": "bid-2",
+                                    "impid": "div-1",
+                                    "price": 0.8,
+                                    "adm": "appnexus-ad",
+                                    "crid": "crid_2",
+                                    "w": 300,
+                                    "h": 250,
+                                    "mtype": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "cur": "USD"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "USD",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "bid-1",
+                        "impid": "div-1",
+                        "price": 0.5,
+                        "adm": "pubmatic-ad",
+                        "crid": "crid_1",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner",
+                    "seat": "pubmatic"
+                },
+                {
+                    "bid": {
+                        "id": "bid-2",
+                        "impid": "div-1",
+                        "price": 0.8,
+                        "adm": "appnexus-ad",
+                        "crid": "crid_2",
+                        "w": 300,
+                        "h": 250,
+                        "mtype": 1
+                    },
+                    "type": "banner",
+                    "seat": "appnexus"
+                }
+            ]
+        }
+    ]
+}

--- a/openrtb_ext/imp_relevantdigital.go
+++ b/openrtb_ext/imp_relevantdigital.go
@@ -1,8 +1,9 @@
 package openrtb_ext
 
 type ExtRelevantDigital struct {
-	AccountId   string `json:"accountId"`
-	PlacementId string `json:"placementId"`
-	Host        string `json:"pbsHost"`
-	PbsBufferMs int    `json:"pbsBufferMs"`
+	AccountId           string `json:"accountId"`
+	PlacementId         string `json:"placementId"`
+	Host                string `json:"pbsHost"`
+	PbsBufferMs         int    `json:"pbsBufferMs"`
+	UseSourceBidderCode bool   `json:"useSourceBidderCode,omitempty"`
 }

--- a/static/bidder-params/relevantdigital.json
+++ b/static/bidder-params/relevantdigital.json
@@ -19,6 +19,10 @@
         "pbsBufferMs": {
             "type": "number",
             "description": "TMax buffer, default is 250"
+        },
+        "useSourceBidderCode": {
+            "type": "boolean",
+            "description": "Use the bidder code of the actual server-side bidder in bid responses"
         }
     },
     "required": [


### PR DESCRIPTION
Add opt-in useSourceBidderCode bidder param that passes the upstream bidder's seat through in bid responses. This allows alternate bidder codes to work when relevantdigital is used as a server-side adapter.

Documented here https://docs.prebid.org/dev-docs/bidders/relevantdigital.html