### PR TITLE
Add HTTP fetcher for stored responses

### DIFF
--- a/stored_requests/backends/http_fetcher/fetcher.go
+++ b/stored_requests/backends/http_fetcher/fetcher.go
@@ -97,7 +97,29 @@ func (fetcher *HttpFetcher) FetchRequests(ctx context.Context, requestIDs []stri
 }
 
 func (fetcher *HttpFetcher) FetchResponses(ctx context.Context, ids []string) (data map[string]json.RawMessage, errs []error) {
-	return nil, nil
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	httpReq, err := fetcher.buildResponseRequest(ids)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	httpResp, err := ctxhttp.Do(ctx, fetcher.client, httpReq)
+	if err != nil {
+		return nil, []error{err}
+	}
+	defer httpResp.Body.Close()
+
+	data, errs = unpackResponseData(httpResp, "Response")
+	for _, id := range ids {
+		if _, found := data[id]; !found {
+			errs = append(errs, stored_requests.NotFoundError{ID: id, DataType: "Response"})
+		}
+	}
+
+	return
 }
 
 // FetchAccounts retrieves account configurations
@@ -265,6 +287,18 @@ func (fetcher *HttpFetcher) buildRequest(requestIDs []string, impIDs []string) (
 	return http.NewRequest("GET", u.String(), nil)
 }
 
+func (fetcher *HttpFetcher) buildResponseRequest(ids []string) (*http.Request, error) {
+	u := *fetcher.EndpointURL
+
+	q := u.Query()
+
+	AddQueryParam(&q, "response-id", ids, fetcher.UseRfcCompliantBuilder)
+
+	u.RawQuery = q.Encode()
+
+	return http.NewRequest("GET", u.String(), nil)
+}
+
 func unpackResponse(resp *http.Response) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -305,6 +339,27 @@ func convertNullsToErrs(m map[string]json.RawMessage, dataType string, errs []er
 	return errs
 }
 
+func unpackResponseData(resp *http.Response, dataType string) (data map[string]json.RawMessage, errs []error) {
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, []error{fmt.Errorf("Error fetching Stored %ss via HTTP. Response code was %d", dataType, resp.StatusCode)}
+	}
+
+	var responseObj responseDataContract
+	if err := jsonutil.UnmarshalValid(respBytes, &responseObj); err != nil {
+		return nil, []error{err}
+	}
+
+	data = responseObj.Responses
+	errList := convertNullsToErrs(data, dataType, nil)
+
+	return data, errList
+}
+
 // responseContract is used to unmarshal  for the endpoint
 type responseContract struct {
 	Requests map[string]json.RawMessage `json:"requests"`
@@ -313,4 +368,8 @@ type responseContract struct {
 
 type accountsResponseContract struct {
 	Accounts map[string]json.RawMessage `json:"accounts"`
+}
+
+type responseDataContract struct {
+	Responses map[string]json.RawMessage `json:"responses"`
 }

--- a/stored_requests/backends/http_fetcher/fetcher_test.go
+++ b/stored_requests/backends/http_fetcher/fetcher_test.go
@@ -134,6 +134,42 @@ func TestMissingValues(t *testing.T) {
 	assert.Len(t, errs, 3, "Fetching 3 unknown reqs+imps should return 3 errors")
 }
 
+func TestFetchResponsesRfcCompliant(t *testing.T) {
+	fetcher, close := newTestResponseFetcher(t, []string{"resp-1", "resp-2"}, true)
+	defer close()
+
+	respData, errs := fetcher.FetchResponses(context.Background(), []string{"resp-1", "resp-2"})
+	assert.Empty(t, errs, "Unexpected errors fetching known responses")
+	assertMapKeys(t, respData, "resp-1", "resp-2")
+}
+
+func TestFetchResponses(t *testing.T) {
+	fetcher, close := newTestResponseFetcher(t, []string{"resp-1", "resp-2"}, false)
+	defer close()
+
+	respData, errs := fetcher.FetchResponses(context.Background(), []string{"resp-1", "resp-2"})
+	assert.Empty(t, errs, "Unexpected errors fetching known responses")
+	assertMapKeys(t, respData, "resp-1", "resp-2")
+}
+
+func TestFetchResponsesMissingValues(t *testing.T) {
+	fetcher, close := newPartialResponseFetcher(t, []string{"resp-1", "resp-2", "resp-3"}, []string{"resp-1"}, false)
+	defer close()
+
+	respData, errs := fetcher.FetchResponses(context.Background(), []string{"resp-1", "resp-2", "resp-3"})
+	assertMapKeys(t, respData, "resp-1")
+	assert.Len(t, errs, 2, "Fetching missing responses should return NotFound errors")
+}
+
+func TestFetchResponsesMissingValuesRfcCompliant(t *testing.T) {
+	fetcher, close := newPartialResponseFetcher(t, []string{"resp-1", "resp-2", "resp-3"}, []string{"resp-1"}, true)
+	defer close()
+
+	respData, errs := fetcher.FetchResponses(context.Background(), []string{"resp-1", "resp-2", "resp-3"})
+	assertMapKeys(t, respData, "resp-1")
+	assert.Len(t, errs, 2, "Fetching missing responses should return NotFound errors")
+}
+
 func TestFetchAccountsRfcCompliant(t *testing.T) {
 	fetcher, close := newTestAccountFetcher(t, []string{"acc-1", "acc-2"}, true)
 	defer close()
@@ -438,6 +474,53 @@ func newTestAccountFetcher(t *testing.T, expectAccIDs []string, useRfcCompliantB
 	handler := newAccountHandler(t, expectAccIDs, useRfcCompliantBuilder)
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	return NewFetcher(server.Client(), server.URL, useRfcCompliantBuilder), server.Close
+}
+
+func newTestResponseFetcher(t *testing.T, expectResponseIDs []string, useRfcCompliantBuilder bool) (fetcher *HttpFetcher, closer func()) {
+	handler := newResponseHandler(t, expectResponseIDs, expectResponseIDs, useRfcCompliantBuilder)
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	return NewFetcher(server.Client(), server.URL, useRfcCompliantBuilder), server.Close
+}
+
+func newPartialResponseFetcher(t *testing.T, expectResponseIDs []string, returnedResponseIDs []string, useRfcCompliantBuilder bool) (fetcher *HttpFetcher, closer func()) {
+	handler := newResponseHandler(t, expectResponseIDs, returnedResponseIDs, useRfcCompliantBuilder)
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	return NewFetcher(server.Client(), server.URL, useRfcCompliantBuilder), server.Close
+}
+
+func newResponseHandler(t *testing.T, expectResponseIDs []string, returnedResponseIDs []string, useRfcCompliantBuilder bool) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		var gotResponseIDs []string
+		if !useRfcCompliantBuilder {
+			gotResponseIDs = richSplit(query.Get("response-ids"))
+		} else {
+			gotResponseIDs = query["response-id"]
+		}
+
+		assertMatches(t, gotResponseIDs, expectResponseIDs)
+
+		responseIDSet := make(map[string]struct{}, len(returnedResponseIDs))
+		for _, responseID := range returnedResponseIDs {
+			responseIDSet[responseID] = struct{}{}
+		}
+
+		responseData := make(map[string]json.RawMessage, len(returnedResponseIDs))
+		for _, responseID := range gotResponseIDs {
+			if _, ok := responseIDSet[responseID]; ok && responseID != "" {
+				responseData[responseID] = jsonifyID(responseID)
+			}
+		}
+
+		respObj := responseDataContract{Responses: responseData}
+
+		if respBytes, err := jsonutil.Marshal(respObj); err != nil {
+			t.Errorf("failed to marshal responseDataContract in test:  %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.Write(respBytes)
+		}
+	}
 }
 
 func newAccountHandler(t *testing.T, expectAccIDs []string, useRfcCompliantBuilder bool) func(w http.ResponseWriter, r *http.Request) {

--- a/stored_requests/multifetcher.go
+++ b/stored_requests/multifetcher.go
@@ -37,7 +37,22 @@ func (mf MultiFetcher) FetchRequests(ctx context.Context, requestIDs []string, i
 }
 
 func (mf MultiFetcher) FetchResponses(ctx context.Context, ids []string) (data map[string]json.RawMessage, errs []error) {
-	return nil, nil
+	data = make(map[string]json.RawMessage, len(ids))
+
+	for _, f := range mf {
+		remainingIDs := filter(ids, data)
+		ids = remainingIDs
+
+		theseData, reserrs := f.FetchResponses(ctx, remainingIDs)
+		reserrs = dropMissingIDs(reserrs)
+		if len(reserrs) > 0 {
+			errs = append(errs, reserrs...)
+		}
+		addAll(data, theseData)
+	}
+
+	errs = appendNotFoundErrors("Response", ids, data, errs)
+	return
 }
 
 func (mf MultiFetcher) FetchAccount(ctx context.Context, accountDefaultJSON json.RawMessage, accountID string) (account json.RawMessage, errs []error) {

--- a/stored_requests/multifetcher_test.go
+++ b/stored_requests/multifetcher_test.go
@@ -126,6 +126,35 @@ func TestOtherError(t *testing.T) {
 	assert.JSONEq(t, `{"imp_id": "imp-1"}`, string(impData["imp-1"]), "MultiFetcher should return the right imp data")
 }
 
+func TestMultiFetcherResponses(t *testing.T) {
+	f1 := &mockFetcher{}
+	f2 := &mockFetcher{}
+	fetcher := &MultiFetcher{f1, f2}
+	ctx := context.Background()
+	ids := []string{"resp-1", "resp-2", "resp-3"}
+
+	f1.On("FetchResponses", ctx, ids).Return(
+		map[string]json.RawMessage{
+			"resp-1": json.RawMessage(`{"id":"resp-1"}`),
+		},
+		[]error{NotFoundError{"resp-2", "Response"}},
+	)
+	f2.On("FetchResponses", ctx, []string{"resp-2", "resp-3"}).Return(
+		map[string]json.RawMessage{
+			"resp-2": json.RawMessage(`{"id":"resp-2"}`),
+		},
+		[]error{},
+	)
+
+	respData, errs := fetcher.FetchResponses(ctx, ids)
+
+	f1.AssertExpectations(t)
+	f2.AssertExpectations(t)
+	assert.Len(t, respData, 2)
+	assert.Len(t, errs, 1)
+	assert.EqualError(t, errs[0], NotFoundError{"resp-3", "Response"}.Error())
+}
+
 func TestMultiFetcherAccountFoundInFirstFetcher(t *testing.T) {
 	f1 := &mockFetcher{}
 	f2 := &mockFetcher{}


### PR DESCRIPTION
Implemented support for fetching stored responses over HTTP by adding FetchResponses to the shared HTTP fetcher, including query construction (response-id/response-ids), response parsing from a responses JSON map, and proper missing-ID/non-200 error handling. 

Example pbs.yaml config: 
```yaml
stored_responses:
  http:
    endpoint: "https://yourendpoint.com/responses"
    use_rfc3986_compliant_request_builder: true
```