### PR TITLE
DeepIntent: Add video media type support

### DIFF
--- a/adapters/deepintent/deepintent.go
+++ b/adapters/deepintent/deepintent.go
@@ -96,7 +96,7 @@ func (d *DeepintentAdapter) MakeBids(internalRequest *openrtb2.BidRequest, exter
 
 	for _, sb := range bidResp.SeatBid {
 		for i := range sb.Bid {
-			bidType, err := getMediaTypeForImp(sb.Bid[i].ImpID, internalRequest.Imp)
+			bidType, err := getMediaTypeForBid(&sb.Bid[i])
 			if err != nil {
 				errs = append(errs, err)
 			} else {
@@ -119,7 +119,7 @@ func (d *DeepintentAdapter) preprocess(request openrtb2.BidRequest) (*adapters.R
 
 	for _, imp := range request.Imp {
 
-		if err := buildImpBanner(&imp); err != nil {
+		if err := validateImp(&imp); err != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -148,14 +148,21 @@ func (d *DeepintentAdapter) preprocess(request openrtb2.BidRequest) (*adapters.R
 	}, errs
 }
 
-func buildImpBanner(imp *openrtb2.Imp) error {
-
-	if imp.Banner == nil {
+func validateImp(imp *openrtb2.Imp) error {
+	if imp.Banner == nil && imp.Video == nil {
 		return &errortypes.BadInput{
-			Message: "We need a Banner Object in the request",
+			Message: fmt.Sprintf("DeepIntent only supports Banner and Video media types. Ignoring ImpID=%s", imp.ID),
 		}
 	}
 
+	if imp.Banner != nil {
+		return buildImpBanner(imp)
+	}
+
+	return nil
+}
+
+func buildImpBanner(imp *openrtb2.Imp) error {
 	if imp.Banner.W == nil && imp.Banner.H == nil {
 		bannerCopy := *imp.Banner
 		banner := &bannerCopy
@@ -174,16 +181,15 @@ func buildImpBanner(imp *openrtb2.Imp) error {
 	return nil
 }
 
-func getMediaTypeForImp(impID string, imps []openrtb2.Imp) (openrtb_ext.BidType, error) {
-	mediaType := openrtb_ext.BidTypeBanner
-	for _, imp := range imps {
-		if imp.ID == impID {
-			return mediaType, nil
+func getMediaTypeForBid(bid *openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	default:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Unsupported MType %d for bid %s", bid.MType, bid.ImpID),
 		}
-	}
-
-	// This shouldnt happen. Lets handle it just incase by returning an error.
-	return "", &errortypes.BadInput{
-		Message: fmt.Sprintf("Failed to find impression %s ", impID),
 	}
 }

--- a/adapters/deepintent/deepintenttest/exemplary/multi-format.json
+++ b/adapters/deepintent/deepintenttest/exemplary/multi-format.json
@@ -1,0 +1,146 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 640,
+          "h": 480
+        },
+        "tagid": "16",
+        "displaymanager": "di_prebid",
+        "displaymanagerver": "2.0.0",
+        "ext": {
+          "bidder": {
+            "tagId": "16"
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "1",
+      "bundle": "com.wls.testwlsapplication"
+    },
+    "device": {
+      "ip": "123.123.123.123",
+      "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+    }
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://prebid.deepintent.com/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 640,
+                "h": 480
+              },
+              "tagid": "16",
+              "displaymanager": "di_prebid",
+              "displaymanagerver": "2.0.0",
+              "ext": {
+                "bidder": {
+                  "tagId": "16"
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "1",
+            "bundle": "com.wls.testwlsapplication"
+          },
+          "device": {
+            "ip": "123.123.123.123",
+            "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test_bid_id",
+                  "impid": "test-imp-id",
+                  "price": 0.50,
+                  "adm": "some-test-ad",
+                  "cid": "test_cid",
+                  "crid": "test_crid",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                }
+              ],
+              "seat": "deepintent"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test_bid_id",
+            "impid": "test-imp-id",
+            "price": 0.50,
+            "adm": "some-test-ad",
+            "cid": "test_cid",
+            "crid": "test_crid",
+            "w": 640,
+            "h": 480,
+            "mtype": 2,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/deepintent/deepintenttest/exemplary/simple-banner.json
+++ b/adapters/deepintent/deepintenttest/exemplary/simple-banner.json
@@ -97,6 +97,7 @@
                           "dealid": "test_dealid",
                           "w": 300,
                           "h": 250,
+                          "mtype": 1,
                           "ext": {
                               "prebid": {
                                   "type": "banner"
@@ -127,6 +128,7 @@
             "dealid": "test_dealid",
             "w": 300,
             "h": 250,
+            "mtype": 1,
             "ext": {
               "prebid": {
                 "type": "banner"

--- a/adapters/deepintent/deepintenttest/exemplary/simple-video.json
+++ b/adapters/deepintent/deepintenttest/exemplary/simple-video.json
@@ -1,0 +1,128 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 1024,
+          "h": 576
+        },
+        "tagid": "16",
+        "displaymanager": "di_prebid",
+        "displaymanagerver": "2.0.0",
+        "ext": {
+          "bidder": {
+            "tagId": "16"
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "1",
+      "bundle": "com.wls.testwlsapplication"
+    },
+    "device": {
+      "ip": "123.123.123.123",
+      "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+    }
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://prebid.deepintent.com/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 1024,
+                "h": 576
+              },
+              "tagid": "16",
+              "displaymanager": "di_prebid",
+              "displaymanagerver": "2.0.0",
+              "ext": {
+                "bidder": {
+                  "tagId": "16"
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "1",
+            "bundle": "com.wls.testwlsapplication"
+          },
+          "device": {
+            "ip": "123.123.123.123",
+            "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test_bid_id",
+                  "impid": "test-imp-id",
+                  "price": 0.27543,
+                  "adm": "some-test-ad",
+                  "cid": "test_cid",
+                  "crid": "test_crid",
+                  "w": 1024,
+                  "h": 576,
+                  "mtype": 2,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                }
+              ],
+              "seat": "deepintent"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test_bid_id",
+            "impid": "test-imp-id",
+            "price": 0.27543,
+            "adm": "some-test-ad",
+            "cid": "test_cid",
+            "crid": "test_crid",
+            "w": 1024,
+            "h": 576,
+            "mtype": 2,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/deepintent/deepintenttest/exemplary/simple-web-banner.json
+++ b/adapters/deepintent/deepintenttest/exemplary/simple-web-banner.json
@@ -95,6 +95,7 @@
                             "dealid": "test_dealid",
                             "w": 468,
                             "h": 60,
+                            "mtype": 1,
                             "ext": {
                                 "prebid": {
                                     "type": "banner"
@@ -125,6 +126,7 @@
                 "dealid": "test_dealid",
                 "w": 468,
                 "h": 60,
+                "mtype": 1,
                 "ext": {
                     "prebid": {
                         "type": "banner"

--- a/adapters/deepintent/deepintenttest/exemplary/simple-web-video.json
+++ b/adapters/deepintent/deepintenttest/exemplary/simple-web-video.json
@@ -1,0 +1,126 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [2, 5],
+          "w": 640,
+          "h": 480
+        },
+        "tagid": "1",
+        "displaymanager": "di_prebid",
+        "displaymanagerver": "2.0.0",
+        "ext": {
+          "bidder": {
+            "tagId": "1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "1",
+      "domain": "test.com"
+    },
+    "device": {
+      "ip": "123.123.123.123"
+    }
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://prebid.deepintent.com/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 5],
+                "w": 640,
+                "h": 480
+              },
+              "tagid": "1",
+              "displaymanager": "di_prebid",
+              "displaymanagerver": "2.0.0",
+              "ext": {
+                "bidder": {
+                  "tagId": "1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "1",
+            "domain": "test.com"
+          },
+          "device": {
+            "ip": "123.123.123.123"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test_bid_id",
+                  "impid": "test-imp-id",
+                  "price": 0.35,
+                  "adm": "some-test-ad",
+                  "cid": "test_cid",
+                  "crid": "test_crid",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                }
+              ],
+              "seat": "deepintent"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test_bid_id",
+            "impid": "test-imp-id",
+            "price": 0.35,
+            "adm": "some-test-ad",
+            "cid": "test_cid",
+            "crid": "test_crid",
+            "w": 640,
+            "h": 480,
+            "mtype": 2,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/deepintent/deepintenttest/supplemental/no_banner.json
+++ b/adapters/deepintent/deepintenttest/supplemental/no_banner.json
@@ -18,7 +18,7 @@
     },
     "expectedMakeRequestsErrors": [
       {
-        "value": "We need a Banner Object in the request",
+        "value": "DeepIntent only supports Banner and Video media types. Ignoring ImpID=test-banner-imp-id",
         "comparison": "literal"
       }
     ]

--- a/adapters/deepintent/deepintenttest/supplemental/no_media_type.json
+++ b/adapters/deepintent/deepintenttest/supplemental/no_media_type.json
@@ -1,0 +1,25 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "ext": {
+          "bidder": {
+            "tagId": "16"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "deepintent.com",
+      "page": "http://deepintent.com/"
+    }
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "DeepIntent only supports Banner and Video media types. Ignoring ImpID=test-imp-id",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/deepintent/deepintenttest/supplemental/unsupported_mtype.json
+++ b/adapters/deepintent/deepintenttest/supplemental/unsupported_mtype.json
@@ -1,0 +1,110 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "tagid": "16",
+        "displaymanager": "di_prebid",
+        "displaymanagerver": "2.0.0",
+        "ext": {
+          "bidder": {
+            "tagId": "16"
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "1",
+      "bundle": "com.wls.testwlsapplication"
+    },
+    "device": {
+      "ip": "123.123.123.123",
+      "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+    }
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://prebid.deepintent.com/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ],
+                "w": 300,
+                "h": 250
+              },
+              "tagid": "16",
+              "displaymanager": "di_prebid",
+              "displaymanagerver": "2.0.0",
+              "ext": {
+                "bidder": {
+                  "tagId": "16"
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "1",
+            "bundle": "com.wls.testwlsapplication"
+          },
+          "device": {
+            "ip": "123.123.123.123",
+            "ifa": "zxcjbzxmc-zxcbmz-zxbcz-zxczx"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test_bid_id",
+                  "impid": "test-imp-id",
+                  "price": 0.27543,
+                  "adm": "some-test-ad",
+                  "cid": "test_cid",
+                  "crid": "test_crid",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 99
+                }
+              ],
+              "seat": "deepintent"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [{"currency": "USD", "bids": []}],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unsupported MType 99 for bid test-imp-id",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/deepintent/deepintenttest/supplemental/wrongimp.json
+++ b/adapters/deepintent/deepintenttest/supplemental/wrongimp.json
@@ -115,7 +115,7 @@
     "expectedBidResponses": [{"currency":"USD","bids":[]}],
     "expectedMakeBidsErrors": [
         {
-          "value": "Failed to find impression test-imp-id1 ",
+          "value": "Unsupported MType 0 for bid test-imp-id1",
           "comparison": "literal"
         }
       ]

--- a/static/bidder-info/deepintent.yaml
+++ b/static/bidder-info/deepintent.yaml
@@ -6,9 +6,11 @@ capabilities:
   app:
     mediaTypes:
       - banner
+      - video
   site:
     mediaTypes:
       - banner
+      - video
 userSync:
   redirect:
     url: "https://match.deepintent.com/usersync/136?id=unk&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"


### PR DESCRIPTION
## Summary
- Add video impression support alongside existing banner in DeepintentBidAdapter
- Use `bid.MType` for media type detection following OpenRTB 2.6 standard
- Update bidder-info to declare video capability for app and site contexts
- Add exemplary and supplemental test fixtures for video scenarios

## Changes
- **`adapters/deepintent/deepintent.go`**: Added `validateImp()` to accept Banner or Video; replaced `getMediaTypeForImp()` with `getMediaTypeForBid()` using `bid.MType`
- **`static/bidder-info/deepintent.yaml`**: Added `video` to app and site media types
- **Test fixtures**: Updated existing banner tests with `mtype` field; added new video, multi-format, and error-handling test cases

## Test plan
- [x] All existing banner tests pass unchanged
- [x] New video exemplary tests (app + site contexts)
- [x] Multi-format (banner + video) test passes
- [x] Unsupported MType error handling verified
- [x] No media type rejection verified
- [x] `go test ./adapters/deepintent/...` passes
- [x] `make test adapter=deepintent` passes