### PR TITLE
Insticator: Move DSP seat from TypedBid to Meta to prevent bid rejection

### DIFF
--- a/adapters/insticator/insticator.go
+++ b/adapters/insticator/insticator.go
@@ -240,9 +240,8 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 			b := &adapters.TypedBid{
 				Bid:      &seatBid.Bid[i],
 				BidType:  bidType,
-				BidMeta:  getBidMeta(bid, bidType),
+				BidMeta:  getBidMeta(bid, bidType, seatBid.Seat),
 				BidVideo: getBidVideo(bid, bidType),
-				Seat:     openrtb_ext.BidderName(seatBid.Seat),
 			}
 			bidResponse.Bids = append(bidResponse.Bids, b)
 		}
@@ -251,9 +250,10 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 }
 
 // getBidMeta extracts metadata from the bid for brand safety and reporting
-func getBidMeta(bid *openrtb2.Bid, bidType openrtb_ext.BidType) *openrtb_ext.ExtBidPrebidMeta {
+func getBidMeta(bid *openrtb2.Bid, bidType openrtb_ext.BidType, seat string) *openrtb_ext.ExtBidPrebidMeta {
 	meta := &openrtb_ext.ExtBidPrebidMeta{
 		MediaType: string(bidType),
+		Seat:      seat,
 	}
 
 	if len(bid.ADomain) > 0 {

--- a/adapters/insticator/insticatortest/exemplary/app-banner.json
+++ b/adapters/insticator/insticatortest/exemplary/app-banner.json
@@ -92,8 +92,12 @@
                   "impid": "test-imp-id",
                   "price": 0.5,
                   "adm": "some-test-ad",
-                  "adomain": ["insticator.com"],
-                  "cat": ["IAB1"],
+                  "adomain": [
+                    "insticator.com"
+                  ],
+                  "cat": [
+                    "IAB1"
+                  ],
                   "crid": "crid_10",
                   "h": 90,
                   "w": 728,
@@ -122,8 +126,12 @@
             "impid": "test-imp-id",
             "price": 0.5,
             "adm": "some-test-ad",
-            "adomain": ["insticator.com"],
-            "cat": ["IAB1"],
+            "adomain": [
+              "insticator.com"
+            ],
+            "cat": [
+              "IAB1"
+            ],
             "crid": "crid_10",
             "w": 728,
             "h": 90,
@@ -135,12 +143,13 @@
             }
           },
           "BidMeta": {
-            "advertiserDomains": ["insticator.com"],
+            "advertiserDomains": [
+              "insticator.com"
+            ],
             "mediaType": "banner",
             "primaryCatId": "IAB1"
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/exemplary/app-video.json
+++ b/adapters/insticator/insticatortest/exemplary/app-video.json
@@ -127,8 +127,12 @@
                   "impid": "test-imp-id",
                   "price": 0.5,
                   "adm": "some-test-vast-ad",
-                  "adomain": ["insticator.com"],
-                  "cat": ["IAB1-1"],
+                  "adomain": [
+                    "insticator.com"
+                  ],
+                  "cat": [
+                    "IAB1-1"
+                  ],
                   "dur": 30,
                   "mtype": 2,
                   "crid": "crid_10",
@@ -158,8 +162,12 @@
             "impid": "test-imp-id",
             "price": 0.5,
             "adm": "some-test-vast-ad",
-            "adomain": ["insticator.com"],
-            "cat": ["IAB1-1"],
+            "adomain": [
+              "insticator.com"
+            ],
+            "cat": [
+              "IAB1-1"
+            ],
             "dur": 30,
             "crid": "crid_10",
             "w": 728,
@@ -172,7 +180,9 @@
             }
           },
           "BidMeta": {
-            "advertiserDomains": ["insticator.com"],
+            "advertiserDomains": [
+              "insticator.com"
+            ],
             "mediaType": "video",
             "primaryCatId": "IAB1-1"
           },
@@ -180,8 +190,7 @@
             "duration": 30,
             "primary_category": "IAB1-1"
           },
-          "type": "video",
-          "seat": "insticator"
+          "type": "video"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/exemplary/multi-format.json
+++ b/adapters/insticator/insticatortest/exemplary/multi-format.json
@@ -138,8 +138,7 @@
             "w": 728,
             "h": 90
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/exemplary/multi-imps.json
+++ b/adapters/insticator/insticatortest/exemplary/multi-imps.json
@@ -308,8 +308,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         },
         {
           "bid": {
@@ -326,8 +325,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         },
         {
           "bid": {
@@ -344,8 +342,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     },
@@ -367,8 +364,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/exemplary/site-banner.json
+++ b/adapters/insticator/insticatortest/exemplary/site-banner.json
@@ -106,8 +106,12 @@
                   "impid": "test-imp-id",
                   "price": 0.5,
                   "adm": "some-test-ad",
-                  "adomain": ["insticator.com"],
-                  "cat": ["IAB1"],
+                  "adomain": [
+                    "insticator.com"
+                  ],
+                  "cat": [
+                    "IAB1"
+                  ],
                   "crid": "crid_10",
                   "h": 90,
                   "w": 728,
@@ -136,8 +140,12 @@
             "impid": "test-imp-id",
             "price": 0.5,
             "adm": "some-test-ad",
-            "adomain": ["insticator.com"],
-            "cat": ["IAB1"],
+            "adomain": [
+              "insticator.com"
+            ],
+            "cat": [
+              "IAB1"
+            ],
             "crid": "crid_10",
             "w": 728,
             "h": 90,
@@ -149,12 +157,13 @@
             }
           },
           "BidMeta": {
-            "advertiserDomains": ["insticator.com"],
+            "advertiserDomains": [
+              "insticator.com"
+            ],
             "mediaType": "banner",
             "primaryCatId": "IAB1"
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/exemplary/site-video.json
+++ b/adapters/insticator/insticatortest/exemplary/site-video.json
@@ -100,8 +100,12 @@
                   "impid": "test-imp-id",
                   "price": 0.5,
                   "adm": "some-test-vast-ad",
-                  "adomain": ["insticator.com"],
-                  "cat": ["IAB1-1"],
+                  "adomain": [
+                    "insticator.com"
+                  ],
+                  "cat": [
+                    "IAB1-1"
+                  ],
                   "dur": 30,
                   "mtype": 2,
                   "crid": "crid_10",
@@ -131,8 +135,12 @@
             "impid": "test-imp-id",
             "price": 0.5,
             "adm": "some-test-vast-ad",
-            "adomain": ["insticator.com"],
-            "cat": ["IAB1-1"],
+            "adomain": [
+              "insticator.com"
+            ],
+            "cat": [
+              "IAB1-1"
+            ],
             "dur": 30,
             "crid": "crid_10",
             "w": 728,
@@ -145,7 +153,9 @@
             }
           },
           "BidMeta": {
-            "advertiserDomains": ["insticator.com"],
+            "advertiserDomains": [
+              "insticator.com"
+            ],
             "mediaType": "video",
             "primaryCatId": "IAB1-1"
           },
@@ -153,8 +163,7 @@
             "duration": 30,
             "primary_category": "IAB1-1"
           },
-          "type": "video",
-          "seat": "insticator"
+          "type": "video"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/supplemental/app-pubid-absent.json
+++ b/adapters/insticator/insticatortest/supplemental/app-pubid-absent.json
@@ -123,8 +123,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/supplemental/currency-conversion.json
+++ b/adapters/insticator/insticatortest/supplemental/currency-conversion.json
@@ -144,8 +144,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/supplemental/device-validation.json
+++ b/adapters/insticator/insticatortest/supplemental/device-validation.json
@@ -160,8 +160,7 @@
               }
             }
           },
-          "type": "video",
-          "seat": "insticator"
+          "type": "video"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/supplemental/multi-imp-mixed-validation.json
+++ b/adapters/insticator/insticatortest/supplemental/multi-imp-mixed-validation.json
@@ -171,8 +171,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/insticator/insticatortest/supplemental/site-pubid-absent.json
+++ b/adapters/insticator/insticatortest/supplemental/site-pubid-absent.json
@@ -123,8 +123,7 @@
               }
             }
           },
-          "type": "banner",
-          "seat": "insticator"
+          "type": "banner"
         }
       ]
     }


### PR DESCRIPTION
The Seat field on TypedBid was being set to raw DSP seat strings (e.g. pubmatic_54229, criteo_46) which triggered the alternateBidderCodes validation in the PBS exchange, silently dropping 100% of bids for publishers without explicit config.

- Remove Seat from TypedBid to avoid alternateBidderCodes rejection
- Store DSP seat in ExtBidPrebidMeta.Seat for reporting (same approach as Rubicon adapter)
- Update test cases to reflect removed TypedBid.Seat