### PR TITLE
Support concat array merge for bidder config

### DIFF
--- a/config/account.go
+++ b/config/account.go
@@ -32,6 +32,21 @@ const (
 	RoundingModeUp        BidRoundingMode = "up"
 )
 
+// ArrayMergeMode controls how array fields in ext.prebid.bidderconfig are merged into the base request.
+type ArrayMergeMode string
+
+const (
+	// ArrayMergeModeConcat concatenates bidder config arrays with base request arrays.
+	ArrayMergeModeConcat ArrayMergeMode = "concat"
+	// ArrayMergeModeReplace replaces base request arrays with bidder config arrays (default behavior).
+	ArrayMergeModeReplace ArrayMergeMode = "replace"
+)
+
+// AccountBidderConfig defines account-level settings for ext.prebid.bidderconfig processing.
+type AccountBidderConfig struct {
+	ArrayMerge ArrayMergeMode `mapstructure:"array_merge" json:"array_merge,omitempty"`
+}
+
 // Account represents a publisher account configuration
 type Account struct {
 	ID                      string                                      `mapstructure:"id" json:"id"`
@@ -54,6 +69,7 @@ type Account struct {
 	Privacy                 AccountPrivacy                              `mapstructure:"privacy" json:"privacy"`
 	PreferredMediaType      openrtb_ext.PreferredMediaType              `mapstructure:"preferredmediatype" json:"preferredmediatype"`
 	TargetingPrefix         string                                      `mapstructure:"targeting_prefix" json:"targeting_prefix"`
+	BidderConfig            AccountBidderConfig                         `mapstructure:"bidderconfig" json:"bidderconfig,omitempty"`
 }
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -557,6 +557,8 @@ account_defaults:
           max_age_sec: 6000
           max_schema_dims: 10
     bid_rounding: up
+    bidderconfig:
+        array_merge: concat
     bidadjustments:
         mediatype:
             '*':
@@ -734,6 +736,7 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "account_defaults.price_floors.fetch.max_schema_dims", 10, cfg.AccountDefaults.PriceFloors.Fetcher.MaxSchemaDims)
 
 	assert.Equal(t, RoundingModeUp, cfg.AccountDefaults.BidRounding)
+	assert.Equal(t, ArrayMergeModeConcat, cfg.AccountDefaults.BidderConfig.ArrayMerge)
 
 	// Assert the DSA was correctly unmarshalled and DefaultUnpacked was built correctly
 	expectedDSA := AccountDSA{

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -299,7 +299,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 		r.RequestType == metrics.ReqTypeORTB2App ||
 		r.RequestType == metrics.ReqTypeAMP {
 		//Extract First party data for auction endpoint only
-		resolvedFPD, fpdErrors := firstpartydata.ExtractFPDForBidders(r.BidRequestWrapper)
+		resolvedFPD, fpdErrors := firstpartydata.ExtractFPDForBidders(r.BidRequestWrapper, r.Account.BidderConfig.ArrayMerge)
 		if len(fpdErrors) > 0 {
 			var errMessages []string
 			for _, fpdError := range fpdErrors {

--- a/firstpartydata/first_party_data.go
+++ b/firstpartydata/first_party_data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prebid/openrtb/v20/openrtb2"
 	jsonpatch "gopkg.in/evanphx/json-patch.v5"
 
+	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/errortypes"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/prebid/prebid-server/v4/util/jsonutil"
@@ -112,7 +113,7 @@ func ExtractOpenRtbGlobalFPD(bidRequest *openrtb2.BidRequest) map[string][]openr
 }
 
 // ResolveFPD consolidates First Party Data from different sources and returns valid FPD that will be applied to bidders later or returns errors
-func ResolveFPD(bidRequest *openrtb2.BidRequest, fpdBidderConfigData map[openrtb_ext.BidderName]*openrtb_ext.ORTB2, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, biddersWithGlobalFPD []string) (map[openrtb_ext.BidderName]*ResolvedFirstPartyData, []error) {
+func ResolveFPD(bidRequest *openrtb2.BidRequest, fpdBidderConfigData map[openrtb_ext.BidderName]*openrtb_ext.ORTB2, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, biddersWithGlobalFPD []string, arrayMergeMode config.ArrayMergeMode) (map[openrtb_ext.BidderName]*ResolvedFirstPartyData, []error) {
 	var errL []error
 
 	resolvedFpd := make(map[openrtb_ext.BidderName]*ResolvedFirstPartyData)
@@ -142,19 +143,19 @@ func ResolveFPD(bidRequest *openrtb2.BidRequest, fpdBidderConfigData map[openrtb
 
 		resolvedFpdConfig := &ResolvedFirstPartyData{}
 
-		newUser, err := resolveUser(fpdConfig, bidRequest.User, globalFPD, openRtbGlobalFPD, bidderName)
+		newUser, err := resolveUser(fpdConfig, bidRequest.User, globalFPD, openRtbGlobalFPD, bidderName, arrayMergeMode)
 		if err != nil {
 			errL = append(errL, err)
 		}
 		resolvedFpdConfig.User = newUser
 
-		newApp, err := resolveApp(fpdConfig, bidRequest.App, globalFPD, openRtbGlobalFPD, bidderName)
+		newApp, err := resolveApp(fpdConfig, bidRequest.App, globalFPD, openRtbGlobalFPD, bidderName, arrayMergeMode)
 		if err != nil {
 			errL = append(errL, err)
 		}
 		resolvedFpdConfig.App = newApp
 
-		newSite, err := resolveSite(fpdConfig, bidRequest.Site, globalFPD, openRtbGlobalFPD, bidderName)
+		newSite, err := resolveSite(fpdConfig, bidRequest.Site, globalFPD, openRtbGlobalFPD, bidderName, arrayMergeMode)
 		if err != nil {
 			errL = append(errL, err)
 		}
@@ -229,7 +230,7 @@ func validateDevice(device *openrtb2.Device) error {
 	return nil
 }
 
-func resolveUser(fpdConfig *openrtb_ext.ORTB2, bidRequestUser *openrtb2.User, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string) (*openrtb2.User, error) {
+func resolveUser(fpdConfig *openrtb_ext.ORTB2, bidRequestUser *openrtb2.User, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string, arrayMergeMode config.ArrayMergeMode) (*openrtb2.User, error) {
 	var fpdConfigUser json.RawMessage
 
 	if fpdConfig != nil && fpdConfig.User != nil {
@@ -264,15 +265,29 @@ func resolveUser(fpdConfig *openrtb_ext.ORTB2, bidRequestUser *openrtb2.User, gl
 		newUser.Data = openRtbGlobalFPD[userDataKey]
 	}
 	if fpdConfigUser != nil {
-		if err := jsonutil.MergeClone(newUser, fpdConfigUser); err != nil {
-			return nil, formatMergeCloneError(err)
+		if arrayMergeMode == config.ArrayMergeModeConcat {
+			// Nil out arrays before merge so MergeClone doesn't overwrite them,
+			// then manually concat base + bidderconfig additions
+			baseData := newUser.Data
+			baseEIDs := newUser.EIDs
+			newUser.Data = nil
+			newUser.EIDs = nil
+			if err := jsonutil.MergeClone(newUser, fpdConfigUser); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
+			newUser.Data = append(baseData, newUser.Data...)
+			newUser.EIDs = append(baseEIDs, newUser.EIDs...)
+		} else {
+			if err := jsonutil.MergeClone(newUser, fpdConfigUser); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
 		}
 	}
 
 	return newUser, nil
 }
 
-func resolveSite(fpdConfig *openrtb_ext.ORTB2, bidRequestSite *openrtb2.Site, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string) (*openrtb2.Site, error) {
+func resolveSite(fpdConfig *openrtb_ext.ORTB2, bidRequestSite *openrtb2.Site, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string, arrayMergeMode config.ArrayMergeMode) (*openrtb2.Site, error) {
 	var fpdConfigSite json.RawMessage
 
 	if fpdConfig != nil && fpdConfig.Site != nil {
@@ -319,8 +334,25 @@ func resolveSite(fpdConfig *openrtb_ext.ORTB2, bidRequestSite *openrtb2.Site, gl
 		newSite.Content.Data = openRtbGlobalFPD[siteContentDataKey]
 	}
 	if fpdConfigSite != nil {
-		if err := jsonutil.MergeClone(newSite, fpdConfigSite); err != nil {
-			return nil, formatMergeCloneError(err)
+		if arrayMergeMode == config.ArrayMergeModeConcat {
+			var baseContentData []openrtb2.Data
+			if newSite.Content != nil {
+				// Copy Content before modifying to avoid mutating the original request's Content.
+				contentCopy := *newSite.Content
+				newSite.Content = &contentCopy
+				baseContentData = newSite.Content.Data
+				newSite.Content.Data = nil
+			}
+			if err := jsonutil.MergeClone(newSite, fpdConfigSite); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
+			if newSite.Content != nil {
+				newSite.Content.Data = append(baseContentData, newSite.Content.Data...)
+			}
+		} else {
+			if err := jsonutil.MergeClone(newSite, fpdConfigSite); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
 		}
 
 		// Re-Validate Site
@@ -352,7 +384,7 @@ func formatMergeCloneError(err error) error {
 	return ErrBadFPD
 }
 
-func resolveApp(fpdConfig *openrtb_ext.ORTB2, bidRequestApp *openrtb2.App, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string) (*openrtb2.App, error) {
+func resolveApp(fpdConfig *openrtb_ext.ORTB2, bidRequestApp *openrtb2.App, globalFPD map[string][]byte, openRtbGlobalFPD map[string][]openrtb2.Data, bidderName string, arrayMergeMode config.ArrayMergeMode) (*openrtb2.App, error) {
 	var fpdConfigApp json.RawMessage
 
 	if fpdConfig != nil {
@@ -402,8 +434,25 @@ func resolveApp(fpdConfig *openrtb_ext.ORTB2, bidRequestApp *openrtb2.App, globa
 	}
 
 	if fpdConfigApp != nil {
-		if err := jsonutil.MergeClone(newApp, fpdConfigApp); err != nil {
-			return nil, formatMergeCloneError(err)
+		if arrayMergeMode == config.ArrayMergeModeConcat {
+			var baseContentData []openrtb2.Data
+			if newApp.Content != nil {
+				// Copy Content before modifying to avoid mutating the original request's Content.
+				contentCopy := *newApp.Content
+				newApp.Content = &contentCopy
+				baseContentData = newApp.Content.Data
+				newApp.Content.Data = nil
+			}
+			if err := jsonutil.MergeClone(newApp, fpdConfigApp); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
+			if newApp.Content != nil {
+				newApp.Content.Data = append(baseContentData, newApp.Content.Data...)
+			}
+		} else {
+			if err := jsonutil.MergeClone(newApp, fpdConfigApp); err != nil {
+				return nil, formatMergeCloneError(err)
+			}
 		}
 	}
 
@@ -453,7 +502,7 @@ func ExtractBidderConfigFPD(reqExt *openrtb_ext.RequestExt) (map[openrtb_ext.Bid
 }
 
 // ExtractFPDForBidders extracts FPD data from request if specified
-func ExtractFPDForBidders(req *openrtb_ext.RequestWrapper) (map[openrtb_ext.BidderName]*ResolvedFirstPartyData, []error) {
+func ExtractFPDForBidders(req *openrtb_ext.RequestWrapper, arrayMergeMode config.ArrayMergeMode) (map[openrtb_ext.BidderName]*ResolvedFirstPartyData, []error) {
 	reqExt, err := req.GetRequestExt()
 	if err != nil {
 		return nil, []error{err}
@@ -488,5 +537,5 @@ func ExtractFPDForBidders(req *openrtb_ext.RequestWrapper) (map[openrtb_ext.Bidd
 		openRtbGlobalFPD = ExtractOpenRtbGlobalFPD(req.BidRequest)
 	}
 
-	return ResolveFPD(req.BidRequest, fbdBidderConfigData, globalFpd, openRtbGlobalFPD, biddersWithGlobalFPD)
+	return ResolveFPD(req.BidRequest, fbdBidderConfigData, globalFpd, openRtbGlobalFPD, biddersWithGlobalFPD, arrayMergeMode)
 }

--- a/firstpartydata/first_party_data_test.go
+++ b/firstpartydata/first_party_data_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/errortypes"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/prebid/prebid-server/v4/util/jsonutil"
@@ -590,7 +591,7 @@ func TestResolveFPD(t *testing.T) {
 			}
 
 			// run test
-			resultFPD, errL := ResolveFPD(request, testFile.BidderConfigFPD, reqExtFPD, reqFPD, testFile.BiddersWithGlobalFPD)
+			resultFPD, errL := ResolveFPD(request, testFile.BidderConfigFPD, reqExtFPD, reqFPD, testFile.BiddersWithGlobalFPD, config.ArrayMergeModeReplace)
 
 			if len(errL) == 0 {
 				assert.Equal(t, request, originalRequest, "Original request should not be modified")
@@ -667,7 +668,7 @@ func TestExtractFPDForBidders(t *testing.T) {
 			err = jsonutil.UnmarshalValid(testFile.InputRequestData, resultRequest.BidRequest)
 			assert.NoError(t, err, "Error should be nil")
 
-			resultFPD, errL := ExtractFPDForBidders(resultRequest)
+			resultFPD, errL := ExtractFPDForBidders(resultRequest, config.ArrayMergeModeReplace)
 
 			if len(testFile.ValidationErrors) > 0 {
 				assert.Equal(t, len(testFile.ValidationErrors), len(errL), "Incorrect number of errors was returned")
@@ -859,7 +860,7 @@ func TestResolveUser(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			resultUser, err := resolveUser(test.fpdConfig, test.bidRequestUser, test.globalFPD, test.openRtbGlobalFPD, "bidderA")
+			resultUser, err := resolveUser(test.fpdConfig, test.bidRequestUser, test.globalFPD, test.openRtbGlobalFPD, "bidderA", config.ArrayMergeModeReplace)
 
 			if len(test.expectError) > 0 {
 				assert.EqualError(t, err, test.expectError)
@@ -1055,7 +1056,7 @@ func TestResolveSite(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			resultSite, err := resolveSite(test.fpdConfig, test.bidRequestSite, test.globalFPD, test.openRtbGlobalFPD, "bidderA")
+			resultSite, err := resolveSite(test.fpdConfig, test.bidRequestSite, test.globalFPD, test.openRtbGlobalFPD, "bidderA", config.ArrayMergeModeReplace)
 
 			if len(test.expectError) > 0 {
 				assert.EqualError(t, err, test.expectError)
@@ -1215,7 +1216,7 @@ func TestResolveApp(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			resultApp, err := resolveApp(test.fpdConfig, test.bidRequestApp, test.globalFPD, test.openRtbGlobalFPD, "bidderA")
+			resultApp, err := resolveApp(test.fpdConfig, test.bidRequestApp, test.globalFPD, test.openRtbGlobalFPD, "bidderA", config.ArrayMergeModeReplace)
 
 			if len(test.expectError) > 0 {
 				assert.EqualError(t, err, test.expectError)
@@ -1379,6 +1380,351 @@ func TestBuildExtData(t *testing.T) {
 	for _, test := range testCases {
 		actualRes := buildExtData(test.input)
 		assert.JSONEq(t, test.expectedRes, string(actualRes), "Incorrect result data")
+	}
+}
+
+func TestResolveUserConcatMode(t *testing.T) {
+	testCases := []struct {
+		description      string
+		fpdConfig        *openrtb_ext.ORTB2
+		bidRequestUser   *openrtb2.User
+		openRtbGlobalFPD map[string][]openrtb2.Data
+		expectedUser     *openrtb2.User
+		expectError      string
+	}{
+		{
+			description: "concat mode: user.data arrays are concatenated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{"data":[{"id":"bidder-seg","name":"Bidder Seg"}]}`),
+			},
+			bidRequestUser: &openrtb2.User{
+				ID: "user1",
+				Data: []openrtb2.Data{
+					{ID: "base-seg", Name: "Base Seg"},
+				},
+			},
+			expectedUser: &openrtb2.User{
+				ID: "user1",
+				Data: []openrtb2.Data{
+					{ID: "base-seg", Name: "Base Seg"},
+					{ID: "bidder-seg", Name: "Bidder Seg"},
+				},
+			},
+		},
+		{
+			description: "concat mode: user.eids arrays are concatenated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{"eids":[{"source":"bidder.com","uids":[{"id":"bidder-uid"}]}]}`),
+			},
+			bidRequestUser: &openrtb2.User{
+				ID: "user1",
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+				},
+			},
+			expectedUser: &openrtb2.User{
+				ID: "user1",
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+					{Source: "bidder.com", UIDs: []openrtb2.UID{{ID: "bidder-uid"}}},
+				},
+			},
+		},
+		{
+			description: "concat mode: both user.data and user.eids are concatenated simultaneously",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{
+				"data":[{"id":"bidder-data","name":"Bidder Data"}],
+				"eids":[{"source":"bidder.com","uids":[{"id":"bidder-uid"}]}]
+			}`),
+			},
+			bidRequestUser: &openrtb2.User{
+				ID: "user1",
+				Data: []openrtb2.Data{
+					{ID: "base-data", Name: "Base Data"},
+				},
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+				},
+			},
+			expectedUser: &openrtb2.User{
+				ID: "user1",
+				Data: []openrtb2.Data{
+					{ID: "base-data", Name: "Base Data"},
+					{ID: "bidder-data", Name: "Bidder Data"},
+				},
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+					{Source: "bidder.com", UIDs: []openrtb2.UID{{ID: "bidder-uid"}}},
+				},
+			},
+		},
+		{
+			description: "concat mode: nil base arrays result in bidder config arrays only",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{"eids":[{"source":"bidder.com","uids":[{"id":"bidder-uid"}]}]}`),
+			},
+			bidRequestUser: &openrtb2.User{ID: "user1"},
+			expectedUser: &openrtb2.User{
+				ID: "user1",
+				EIDs: []openrtb2.EID{
+					{Source: "bidder.com", UIDs: []openrtb2.UID{{ID: "bidder-uid"}}},
+				},
+			},
+		},
+		{
+			description: "concat mode: bidder config has no arrays, base arrays are preserved unchanged",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{"id":"overridden-id"}`),
+			},
+			bidRequestUser: &openrtb2.User{
+				ID: "original-id",
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+				},
+			},
+			expectedUser: &openrtb2.User{
+				ID: "overridden-id",
+				EIDs: []openrtb2.EID{
+					{Source: "base.com", UIDs: []openrtb2.UID{{ID: "base-uid"}}},
+				},
+			},
+		},
+		{
+			description: "concat mode: global FPD user.data followed by bidder config user.data are concatenated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				User: json.RawMessage(`{"data":[{"id":"bidder-seg","name":"Bidder Seg"}]}`),
+			},
+			bidRequestUser: &openrtb2.User{ID: "user1"},
+			openRtbGlobalFPD: map[string][]openrtb2.Data{
+				userDataKey: {
+					{ID: "global-seg", Name: "Global Seg"},
+				},
+			},
+			expectedUser: &openrtb2.User{
+				ID: "user1",
+				Data: []openrtb2.Data{
+					{ID: "global-seg", Name: "Global Seg"},
+					{ID: "bidder-seg", Name: "Bidder Seg"},
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			resultUser, err := resolveUser(test.fpdConfig, test.bidRequestUser, nil, test.openRtbGlobalFPD, "bidderA", config.ArrayMergeModeConcat)
+			if len(test.expectError) > 0 {
+				assert.EqualError(t, err, test.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedUser, resultUser)
+			}
+		})
+	}
+}
+
+func TestResolveSiteConcatMode(t *testing.T) {
+	testCases := []struct {
+		description    string
+		fpdConfig      *openrtb_ext.ORTB2
+		bidRequestSite *openrtb2.Site
+		expectedSite   *openrtb2.Site
+	}{
+		{
+			description: "concat mode: site.content.data arrays are concatenated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				Site: json.RawMessage(`{"content":{"data":[{"id":"bidder-cd","name":"Bidder CD"}]}}`),
+			},
+			bidRequestSite: &openrtb2.Site{
+				ID: "site1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+					},
+				},
+			},
+			expectedSite: &openrtb2.Site{
+				ID: "site1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+						{ID: "bidder-cd", Name: "Bidder CD"},
+					},
+				},
+			},
+		},
+		{
+			description: "concat mode: nil base content.data, bidder config data is used directly",
+			fpdConfig: &openrtb_ext.ORTB2{
+				Site: json.RawMessage(`{"content":{"data":[{"id":"bidder-cd","name":"Bidder CD"}]}}`),
+			},
+			bidRequestSite: &openrtb2.Site{
+				ID:   "site1",
+				Page: "http://example.com",
+			},
+			expectedSite: &openrtb2.Site{
+				ID:   "site1",
+				Page: "http://example.com",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "bidder-cd", Name: "Bidder CD"},
+					},
+				},
+			},
+		},
+		{
+			description: "concat mode: bidder config has no content.data, base data is preserved",
+			fpdConfig: &openrtb_ext.ORTB2{
+				Site: json.RawMessage(`{"id":"site2"}`),
+			},
+			bidRequestSite: &openrtb2.Site{
+				ID:   "site1",
+				Page: "http://example.com",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+					},
+				},
+			},
+			expectedSite: &openrtb2.Site{
+				ID:   "site2",
+				Page: "http://example.com",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+					},
+				},
+			},
+		},
+		{
+			description: "concat mode: original request site.content.data is not mutated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				Site: json.RawMessage(`{"content":{"data":[{"id":"bidder-cd","name":"Bidder CD"}]}}`),
+			},
+			bidRequestSite: &openrtb2.Site{
+				ID:   "site1",
+				Page: "http://example.com",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+					},
+				},
+			},
+			expectedSite: &openrtb2.Site{
+				ID:   "site1",
+				Page: "http://example.com",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-cd", Name: "Base CD"},
+						{ID: "bidder-cd", Name: "Bidder CD"},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			var originalContentData []openrtb2.Data
+			if test.bidRequestSite.Content != nil {
+				originalContentData = make([]openrtb2.Data, len(test.bidRequestSite.Content.Data))
+				copy(originalContentData, test.bidRequestSite.Content.Data)
+			}
+
+			resultSite, err := resolveSite(test.fpdConfig, test.bidRequestSite, nil, nil, "bidderA", config.ArrayMergeModeConcat)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedSite, resultSite)
+			// Verify original was not mutated
+			if test.bidRequestSite.Content != nil {
+				assert.Equal(t, originalContentData, test.bidRequestSite.Content.Data, "original site.content.data must not be mutated")
+			}
+		})
+	}
+}
+
+func TestResolveAppConcatMode(t *testing.T) {
+	testCases := []struct {
+		description   string
+		fpdConfig     *openrtb_ext.ORTB2
+		bidRequestApp *openrtb2.App
+		expectedApp   *openrtb2.App
+	}{
+		{
+			description: "concat mode: app.content.data arrays are concatenated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				App: json.RawMessage(`{"content":{"data":[{"id":"bidder-acd","name":"Bidder ACD"}]}}`),
+			},
+			bidRequestApp: &openrtb2.App{
+				ID: "app1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-acd", Name: "Base ACD"},
+					},
+				},
+			},
+			expectedApp: &openrtb2.App{
+				ID: "app1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-acd", Name: "Base ACD"},
+						{ID: "bidder-acd", Name: "Bidder ACD"},
+					},
+				},
+			},
+		},
+		{
+			description: "concat mode: nil base app.content.data, bidder config data is used directly",
+			fpdConfig: &openrtb_ext.ORTB2{
+				App: json.RawMessage(`{"content":{"data":[{"id":"bidder-acd","name":"Bidder ACD"}]}}`),
+			},
+			bidRequestApp: &openrtb2.App{ID: "app1"},
+			expectedApp: &openrtb2.App{
+				ID: "app1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "bidder-acd", Name: "Bidder ACD"},
+					},
+				},
+			},
+		},
+		{
+			description: "concat mode: original request app.content.data is not mutated",
+			fpdConfig: &openrtb_ext.ORTB2{
+				App: json.RawMessage(`{"content":{"data":[{"id":"bidder-acd","name":"Bidder ACD"}]}}`),
+			},
+			bidRequestApp: &openrtb2.App{
+				ID: "app1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-acd", Name: "Base ACD"},
+					},
+				},
+			},
+			expectedApp: &openrtb2.App{
+				ID: "app1",
+				Content: &openrtb2.Content{
+					Data: []openrtb2.Data{
+						{ID: "base-acd", Name: "Base ACD"},
+						{ID: "bidder-acd", Name: "Bidder ACD"},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			var originalContentData []openrtb2.Data
+			if test.bidRequestApp.Content != nil {
+				originalContentData = make([]openrtb2.Data, len(test.bidRequestApp.Content.Data))
+				copy(originalContentData, test.bidRequestApp.Content.Data)
+			}
+
+			resultApp, err := resolveApp(test.fpdConfig, test.bidRequestApp, nil, nil, "bidderA", config.ArrayMergeModeConcat)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedApp, resultApp)
+			if test.bidRequestApp.Content != nil {
+				assert.Equal(t, originalContentData, test.bidRequestApp.Content.Data, "original app.content.data must not be mutated")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Implements #4111 

Implements a new `concat` array merge mode for `ext.prebid.bidderconfig`.

Configurable via `account_defaults.bidderconfig.array_merge`. When set to `concat`, instead of overwriting base arrays with bidder-specific config, the bidder-specific entries are appended to the end of the base arrays.

Note on `dooh.content.data`:
Although `dooh` was mentioned in the original discussion, it is not supported in this implementation. The `openrtb_ext.ORTB2` struct does not have a DOOH field, and the `ResolveFPD()` flow does not handle it. It only operates with user, app, site and device. The dooh support may be a typo in the original spec or a divergence from pbs-java. If dooh support has business value, it should be tracked and implemented as a separate task.