### PR TITLE
Adipolo: Add GVL Vendor ID

### DIFF
--- a/static/bidder-info/adipolo.yaml
+++ b/static/bidder-info/adipolo.yaml
@@ -2,6 +2,7 @@ aliasOf: xeworks
 endpoint: "http://rtb.adipolo.live?pid={{.SourceId}}&host={{.Host}}&pbs=1"
 maintainer:
   email: "smart@adipolo.com"
+gvlVendorID: 1456
 userSync:
   iframe:
     url: "https://sync.adipolo.live/static/adisync.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&cb={{.RedirectURL}}"


### PR DESCRIPTION
Updated the adapter configuration info file for Adipolo — added the gvlVendorID parameter with a value of 1456.