### PR TITLE
Disable iFrame-based syncing for specific bidders and account IDs

### DIFF
--- a/config/account.go
+++ b/config/account.go
@@ -58,11 +58,11 @@ type Account struct {
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.
 type CookieSync struct {
-	DefaultLimit          *int        `mapstructure:"default_limit" json:"default_limit"`
-	MaxLimit              *int        `mapstructure:"max_limit" json:"max_limit"`
-	DefaultCoopSync       *bool       `mapstructure:"default_coop_sync" json:"default_coop_sync"`
-	PriorityGroups        [][]string  `mapstructure:"priority_groups" json:"priority_groups"`
-	DisabledIFrameBidders interface{} `mapstructure:"disabled_iframe_bidders" json:"disabled_iframe_bidders"`
+	DefaultLimit          *int       `mapstructure:"default_limit" json:"default_limit"`
+	MaxLimit              *int       `mapstructure:"max_limit" json:"max_limit"`
+	DefaultCoopSync       *bool      `mapstructure:"default_coop_sync" json:"default_coop_sync"`
+	PriorityGroups        [][]string `mapstructure:"priority_groups" json:"priority_groups"`
+	DisabledIFrameBidders []string   `mapstructure:"disabled_iframe_bidders" json:"disabled_iframe_bidders"`
 }
 
 // AccountCCPA represents account-specific CCPA configuration

--- a/config/account.go
+++ b/config/account.go
@@ -58,10 +58,11 @@ type Account struct {
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.
 type CookieSync struct {
-	DefaultLimit    *int       `mapstructure:"default_limit" json:"default_limit"`
-	MaxLimit        *int       `mapstructure:"max_limit" json:"max_limit"`
-	DefaultCoopSync *bool      `mapstructure:"default_coop_sync" json:"default_coop_sync"`
-	PriorityGroups  [][]string `mapstructure:"priority_groups" json:"priority_groups"`
+	DefaultLimit          *int       `mapstructure:"default_limit" json:"default_limit"`
+	MaxLimit              *int       `mapstructure:"max_limit" json:"max_limit"`
+	DefaultCoopSync       *bool      `mapstructure:"default_coop_sync" json:"default_coop_sync"`
+	PriorityGroups        [][]string `mapstructure:"priority_groups" json:"priority_groups"`
+	DisabledIFrameBidders []string   `mapstructure:"disabled_iframe_bidders" json:"disabled_iframe_bidders"`
 }
 
 // AccountCCPA represents account-specific CCPA configuration

--- a/config/account.go
+++ b/config/account.go
@@ -58,11 +58,11 @@ type Account struct {
 
 // CookieSync represents the account-level defaults for the cookie sync endpoint.
 type CookieSync struct {
-	DefaultLimit          *int       `mapstructure:"default_limit" json:"default_limit"`
-	MaxLimit              *int       `mapstructure:"max_limit" json:"max_limit"`
-	DefaultCoopSync       *bool      `mapstructure:"default_coop_sync" json:"default_coop_sync"`
-	PriorityGroups        [][]string `mapstructure:"priority_groups" json:"priority_groups"`
-	DisabledIFrameBidders []string   `mapstructure:"disabled_iframe_bidders" json:"disabled_iframe_bidders"`
+	DefaultLimit          *int        `mapstructure:"default_limit" json:"default_limit"`
+	MaxLimit              *int        `mapstructure:"max_limit" json:"max_limit"`
+	DefaultCoopSync       *bool       `mapstructure:"default_coop_sync" json:"default_coop_sync"`
+	PriorityGroups        [][]string  `mapstructure:"priority_groups" json:"priority_groups"`
+	DisabledIFrameBidders interface{} `mapstructure:"disabled_iframe_bidders" json:"disabled_iframe_bidders"`
 }
 
 // AccountCCPA represents account-specific CCPA configuration

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/prebid/go-gdpr/consentconstants"
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/errortypes"
@@ -752,7 +753,11 @@ func (cfg *TimeoutNotification) validate(errs []error) []error {
 // New uses viper to get our server configurations.
 func New(v *viper.Viper, bidderInfos BidderInfos, normalizeBidderName openrtb_ext.BidderNameNormalizer) (*Configuration, error) {
 	var c Configuration
-	if err := v.Unmarshal(&c, viper.DecodeHook(AccountModulesHookFunc())); err != nil {
+	if err := v.Unmarshal(&c, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		AccountModulesHookFunc(),
+	))); err != nil {
 		return nil, fmt.Errorf("viper failed to unmarshal app config: %v", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1244,6 +1244,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("account_defaults.events_enabled", false)
 	v.BindEnv("account_defaults.privacy.dsa.default")
 	v.BindEnv("account_defaults.privacy.dsa.gdpr_only")
+	v.BindEnv("account_defaults.cookie_sync.disabled_iframe_bidders")
 	v.SetDefault("account_defaults.privacy.ipv6.anon_keep_bits", 56)
 	v.SetDefault("account_defaults.privacy.ipv4.anon_keep_bits", 24)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2031,3 +2031,48 @@ func TestUnpackDSADefault(t *testing.T) {
 		})
 	}
 }
+
+func TestDisabledIFrameBiddersEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVal   string
+		expected []string
+	}{
+		{
+			name:     "single-value",
+			envVal:   "openweb",
+			expected: []string{"openweb"},
+		},
+		{
+			name:     "comma-separated",
+			envVal:   "openweb,360playvid",
+			expected: []string{"openweb", "360playvid"},
+		},
+		{
+			name:     "wildcard",
+			envVal:   "*",
+			expected: []string{"*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := "PBS_ACCOUNT_DEFAULTS_COOKIE_SYNC_DISABLED_IFRAME_BIDDERS"
+			if old, ok := os.LookupEnv(key); ok {
+				defer os.Setenv(key, old)
+			} else {
+				defer os.Unsetenv(key)
+			}
+			os.Setenv(key, tt.envVal)
+
+			v := viper.New()
+			SetupViper(v, "", bidderInfos)
+			v.Set("gdpr.default_value", "0")
+			cfg, err := New(v, bidderInfos, mockNormalizeBidderName)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected, cfg.AccountDefaults.CookieSync.DisabledIFrameBidders,
+				"DisabledIFrameBidders should be parsed from env var %q", tt.envVal)
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2047,5 +2047,3 @@ func TestUnpackDSADefault(t *testing.T) {
 		})
 	}
 }
-
-

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2048,47 +2048,4 @@ func TestUnpackDSADefault(t *testing.T) {
 	}
 }
 
-func TestDisabledIFrameBiddersEnvVar(t *testing.T) {
-	tests := []struct {
-		name     string
-		envVal   string
-		expected []string
-	}{
-		{
-			name:     "single-value",
-			envVal:   "openweb",
-			expected: []string{"openweb"},
-		},
-		{
-			name:     "comma-separated",
-			envVal:   "openweb,360playvid",
-			expected: []string{"openweb", "360playvid"},
-		},
-		{
-			name:     "wildcard",
-			envVal:   "*",
-			expected: []string{"*"},
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			key := "PBS_ACCOUNT_DEFAULTS_COOKIE_SYNC_DISABLED_IFRAME_BIDDERS"
-			if old, ok := os.LookupEnv(key); ok {
-				defer os.Setenv(key, old)
-			} else {
-				defer os.Unsetenv(key)
-			}
-			os.Setenv(key, tt.envVal)
-
-			v := viper.New()
-			SetupViper(v, "", bidderInfos)
-			v.Set("gdpr.default_value", "0")
-			cfg, err := New(v, bidderInfos, mockNormalizeBidderName)
-			assert.NoError(t, err)
-
-			assert.Equal(t, tt.expected, cfg.AccountDefaults.CookieSync.DisabledIFrameBidders,
-				"DisabledIFrameBidders should be parsed from env var %q", tt.envVal)
-		})
-	}
-}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -637,6 +637,22 @@ func cmpNils(t *testing.T, key string, a interface{}) {
 	assert.Nilf(t, a, "%s: %t != nil", key, a)
 }
 
+func TestDisabledIFrameBiddersFromEnv(t *testing.T) {
+	os.Setenv("PBS_ACCOUNT_DEFAULTS_COOKIE_SYNC_DISABLED_IFRAME_BIDDERS", "openweb,360playvid")
+	defer os.Unsetenv("PBS_ACCOUNT_DEFAULTS_COOKIE_SYNC_DISABLED_IFRAME_BIDDERS")
+
+	v := viper.New()
+	SetupViper(v, "", bidderInfos)
+	v.Set("gdpr.default_value", "0")
+	v.SetConfigType("yaml")
+	cfg, err := New(v, bidderInfos, mockNormalizeBidderName)
+	assert.NoError(t, err)
+
+	bidders := cfg.AccountDefaults.CookieSync.DisabledIFrameBidders
+	t.Logf("DisabledIFrameBidders = %v (len=%d)", bidders, len(bidders))
+	assert.Equal(t, []string{"openweb", "360playvid"}, bidders)
+}
+
 func TestFullConfig(t *testing.T) {
 	int8One := int8(1)
 

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -344,46 +345,27 @@ func (c *cookieSyncEndpoint) findPriorityGroups(accountCookieSyncConfig config.C
 }
 
 // applyDisabledIFrameBidders enforces account-level iframe cookie sync restrictions.
-// The disabledBidders field supports two formats, matching the filterSettings convention:
-//   - "*" (string): disables iframe syncs for all bidders
-//   - ["bidderA", "bidderB"] (array): disables iframe syncs for specific bidders only
+// The disabledBidders slice supports:
+//   - nil or empty: no restriction applied
+//   - ["*"]: disables iframe syncs for all bidders
+//   - ["bidderA", "bidderB"]: disables iframe syncs for specific bidders only
 //
 // When specific bidders are disabled, a compositeFilter ANDs the request-level filter with the
 // account-level filter, ensuring the account config can only further restrict — never broaden —
 // what the request's filterSettings allows. Redirect syncs are never affected.
-func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders interface{}) usersync.SyncTypeFilter {
-	if disabledBidders == nil {
+func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders []string) usersync.SyncTypeFilter {
+	if len(disabledBidders) == 0 {
 		return syncTypeFilter
 	}
 
-	switch v := disabledBidders.(type) {
-	case string:
-		// "*" disables all iframe syncs, matching how filterSettings uses "*" for all bidders.
-		if v == "*" {
-			syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
-		}
-	case []string:
-		// Typed string slice: used when config is set programmatically or via mapstructure.
-		if len(v) > 0 {
-			syncTypeFilter.IFrame = compositeFilter{
-				requestFilter: syncTypeFilter.IFrame,
-				accountFilter: usersync.NewSpecificBidderFilter(v, usersync.BidderFilterModeExclude),
-			}
-		}
-	case []interface{}:
-		// Untyped slice: used when JSON unmarshal deserializes an array into interface{}.
-		bidders := make([]string, 0, len(v))
-		for _, b := range v {
-			if s, ok := b.(string); ok {
-				bidders = append(bidders, s)
-			}
-		}
-		if len(bidders) > 0 {
-			syncTypeFilter.IFrame = compositeFilter{
-				requestFilter: syncTypeFilter.IFrame,
-				accountFilter: usersync.NewSpecificBidderFilter(bidders, usersync.BidderFilterModeExclude),
-			}
-		}
+	if slices.Contains(disabledBidders, "*") {
+		syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
+		return syncTypeFilter
+	}
+
+	syncTypeFilter.IFrame = compositeFilter{
+		requestFilter: syncTypeFilter.IFrame,
+		accountFilter: usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude),
 	}
 
 	return syncTypeFilter

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -343,21 +343,36 @@ func (c *cookieSyncEndpoint) findPriorityGroups(accountCookieSyncConfig config.C
 	return c.config.UserSync.PriorityGroups
 }
 
-func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders []string) usersync.SyncTypeFilter {
-	if len(disabledBidders) == 0 {
+func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders interface{}) usersync.SyncTypeFilter {
+	if disabledBidders == nil {
 		return syncTypeFilter
 	}
 
-	for _, bidder := range disabledBidders {
-		if bidder == "*" {
+	switch v := disabledBidders.(type) {
+	case string:
+		if v == "*" {
 			syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
-			return syncTypeFilter
 		}
-	}
-
-	syncTypeFilter.IFrame = compositeFilter{
-		primary:   syncTypeFilter.IFrame,
-		secondary: usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude),
+	case []string:
+		if len(v) > 0 {
+			syncTypeFilter.IFrame = compositeFilter{
+				primary:   syncTypeFilter.IFrame,
+				secondary: usersync.NewSpecificBidderFilter(v, usersync.BidderFilterModeExclude),
+			}
+		}
+	case []interface{}:
+		bidders := make([]string, 0, len(v))
+		for _, b := range v {
+			if s, ok := b.(string); ok {
+				bidders = append(bidders, s)
+			}
+		}
+		if len(bidders) > 0 {
+			syncTypeFilter.IFrame = compositeFilter{
+				primary:   syncTypeFilter.IFrame,
+				secondary: usersync.NewSpecificBidderFilter(bidders, usersync.BidderFilterModeExclude),
+			}
+		}
 	}
 
 	return syncTypeFilter

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -345,10 +345,17 @@ func (c *cookieSyncEndpoint) findPriorityGroups(accountCookieSyncConfig config.C
 }
 
 // applyDisabledIFrameBidders enforces account-level iframe cookie sync restrictions.
-// The disabledBidders slice supports:
-//   - nil or empty: no restriction applied
-//   - ["*"]: disables iframe syncs for all bidders
-//   - ["bidderA", "bidderB"]: disables iframe syncs for specific bidders only
+// The disabledBidders field supports two formats, matching the filterSettings convention:
+// - "*" (string): disables iframe syncs for all bidders
+// - ["bidderA", "bidderB"] (array): disables iframe syncs for specific bidders only
+//
+// When specific bidders are disabled, a compositeFilter ANDs the request-level filter with the
+// account-level filter, ensuring the account config can only further restrict — never broaden —
+// what the request's filterSettings allows. Redirect syncs are never affected.
+// applyDisabledIFrameBidders enforces account-level iframe cookie sync restrictions.
+// The disabledBidders list supports:
+// - ["*"]: disables iframe syncs for all bidders
+// - ["bidderA", "bidderB"]: disables iframe syncs for specific bidders only
 //
 // When specific bidders are disabled, a compositeFilter ANDs the request-level filter with the
 // account-level filter, ensuring the account config can only further restrict — never broaden —
@@ -360,12 +367,11 @@ func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabled
 
 	if slices.Contains(disabledBidders, "*") {
 		syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
-		return syncTypeFilter
-	}
-
-	syncTypeFilter.IFrame = compositeFilter{
-		requestFilter: syncTypeFilter.IFrame,
-		accountFilter: usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude),
+	} else {
+		syncTypeFilter.IFrame = compositeFilter{
+			requestFilter: syncTypeFilter.IFrame,
+			accountFilter: usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude),
+		}
 	}
 
 	return syncTypeFilter

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -348,13 +348,30 @@ func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabled
 		return syncTypeFilter
 	}
 
-	if disabledBidders[0] == "*" {
-		syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
-	} else {
-		syncTypeFilter.IFrame = usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude)
+	for _, bidder := range disabledBidders {
+		if bidder == "*" {
+			syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
+			return syncTypeFilter
+		}
+	}
+
+	syncTypeFilter.IFrame = compositeFilter{
+		primary:   syncTypeFilter.IFrame,
+		secondary: usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude),
 	}
 
 	return syncTypeFilter
+}
+
+// compositeFilter implements usersync.BidderFilter by requiring both filters to allow a bidder.
+// This ensures account-level restrictions can only further restrict, never broaden, the request filter.
+type compositeFilter struct {
+	primary   usersync.BidderFilter
+	secondary usersync.BidderFilter
+}
+
+func (f compositeFilter) Allowed(bidder string) bool {
+	return f.primary.Allowed(bidder) && f.secondary.Allowed(bidder)
 }
 
 func parseTypeFilter(request *cookieSyncRequestFilterSettings) (usersync.SyncTypeFilter, error) {

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -167,6 +167,8 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, ma
 		return usersync.Request{}, macros.UserSyncPrivacy{}, account, err
 	}
 
+	syncTypeFilter = applyDisabledIFrameBidders(syncTypeFilter, account.CookieSync.DisabledIFrameBidders)
+
 	gdprRequestInfo := gdpr.RequestInfo{
 		Consent:    privacyMacros.GDPRConsent,
 		GDPRSignal: gdprSignal,
@@ -339,6 +341,20 @@ func (c *cookieSyncEndpoint) findPriorityGroups(accountCookieSyncConfig config.C
 		return accountCookieSyncConfig.PriorityGroups
 	}
 	return c.config.UserSync.PriorityGroups
+}
+
+func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders []string) usersync.SyncTypeFilter {
+	if len(disabledBidders) == 0 {
+		return syncTypeFilter
+	}
+
+	if disabledBidders[0] == "*" {
+		syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
+	} else {
+		syncTypeFilter.IFrame = usersync.NewSpecificBidderFilter(disabledBidders, usersync.BidderFilterModeExclude)
+	}
+
+	return syncTypeFilter
 }
 
 func parseTypeFilter(request *cookieSyncRequestFilterSettings) (usersync.SyncTypeFilter, error) {

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -343,6 +343,14 @@ func (c *cookieSyncEndpoint) findPriorityGroups(accountCookieSyncConfig config.C
 	return c.config.UserSync.PriorityGroups
 }
 
+// applyDisabledIFrameBidders enforces account-level iframe cookie sync restrictions.
+// The disabledBidders field supports two formats, matching the filterSettings convention:
+//   - "*" (string): disables iframe syncs for all bidders
+//   - ["bidderA", "bidderB"] (array): disables iframe syncs for specific bidders only
+//
+// When specific bidders are disabled, a compositeFilter ANDs the request-level filter with the
+// account-level filter, ensuring the account config can only further restrict — never broaden —
+// what the request's filterSettings allows. Redirect syncs are never affected.
 func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabledBidders interface{}) usersync.SyncTypeFilter {
 	if disabledBidders == nil {
 		return syncTypeFilter
@@ -350,17 +358,20 @@ func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabled
 
 	switch v := disabledBidders.(type) {
 	case string:
+		// "*" disables all iframe syncs, matching how filterSettings uses "*" for all bidders.
 		if v == "*" {
 			syncTypeFilter.IFrame = usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude)
 		}
 	case []string:
+		// Typed string slice: used when config is set programmatically or via mapstructure.
 		if len(v) > 0 {
 			syncTypeFilter.IFrame = compositeFilter{
-				primary:   syncTypeFilter.IFrame,
-				secondary: usersync.NewSpecificBidderFilter(v, usersync.BidderFilterModeExclude),
+				requestFilter: syncTypeFilter.IFrame,
+				accountFilter: usersync.NewSpecificBidderFilter(v, usersync.BidderFilterModeExclude),
 			}
 		}
 	case []interface{}:
+		// Untyped slice: used when JSON unmarshal deserializes an array into interface{}.
 		bidders := make([]string, 0, len(v))
 		for _, b := range v {
 			if s, ok := b.(string); ok {
@@ -369,8 +380,8 @@ func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabled
 		}
 		if len(bidders) > 0 {
 			syncTypeFilter.IFrame = compositeFilter{
-				primary:   syncTypeFilter.IFrame,
-				secondary: usersync.NewSpecificBidderFilter(bidders, usersync.BidderFilterModeExclude),
+				requestFilter: syncTypeFilter.IFrame,
+				accountFilter: usersync.NewSpecificBidderFilter(bidders, usersync.BidderFilterModeExclude),
 			}
 		}
 	}
@@ -381,12 +392,12 @@ func applyDisabledIFrameBidders(syncTypeFilter usersync.SyncTypeFilter, disabled
 // compositeFilter implements usersync.BidderFilter by requiring both filters to allow a bidder.
 // This ensures account-level restrictions can only further restrict, never broaden, the request filter.
 type compositeFilter struct {
-	primary   usersync.BidderFilter
-	secondary usersync.BidderFilter
+	requestFilter usersync.BidderFilter
+	accountFilter usersync.BidderFilter
 }
 
 func (f compositeFilter) Allowed(bidder string) bool {
-	return f.primary.Allowed(bidder) && f.secondary.Allowed(bidder)
+	return f.requestFilter.Allowed(bidder) && f.accountFilter.Allowed(bidder)
 }
 
 func parseTypeFilter(request *cookieSyncRequestFilterSettings) (usersync.SyncTypeFilter, error) {

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1109,39 +1109,6 @@ func TestCookieSyncParseRequest(t *testing.T) {
 			givenAccountRequired: true,
 		},
 		{
-			description: "IFrame Disabled For Specific Bidders Via Account Config",
-			givenBody: strings.NewReader(`{` +
-				`"bidders":["a", "b"],` +
-				`"account":"IFrameDisabledAccount"` +
-				`}`),
-			givenGDPRConfig:  config.GDPR{Enabled: true, DefaultValue: "0"},
-			givenCCPAEnabled: true,
-			givenConfig: config.UserSync{
-				PriorityGroups: [][]string{{"a", "b", "c"}},
-				Cooperative: config.UserSyncCooperative{
-					EnabledByDefault: false,
-				},
-			},
-			expectedPrivacy: macros.UserSyncPrivacy{},
-			expectedRequest: usersync.Request{
-				Bidders: []string{"a", "b"},
-				Cooperative: usersync.Cooperative{
-					Enabled:        true,
-					PriorityGroups: nil,
-				},
-				Limit: 20,
-				Privacy: usersyncPrivacy{
-					gdprPermissions: &fakePermissions{},
-					activityRequest: emptyActivityPoliciesRequest,
-					gdprSignal:      -1,
-				},
-				SyncTypeFilter: usersync.SyncTypeFilter{
-					IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
-					Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-				},
-			},
-		},
-		{
 			description: "IFrame Disabled For All Bidders Via Account Config Wildcard",
 			givenBody: strings.NewReader(`{` +
 				`"bidders":["a", "b"],` +
@@ -1697,58 +1664,119 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description    string
-		givenFilter    usersync.SyncTypeFilter
-		givenBidders   []string
-		expectedFilter usersync.SyncTypeFilter
+		description       string
+		givenFilter       usersync.SyncTypeFilter
+		givenBidders      []string
+		expectedIFrame    map[string]bool
+		expectedRedirect  map[string]bool
+		expectedExactSync *usersync.SyncTypeFilter
 	}{
 		{
-			description:    "Nil list - no change",
-			givenFilter:    allowAll,
-			givenBidders:   nil,
-			expectedFilter: allowAll,
+			description:  "Nil list - no change",
+			givenFilter:  allowAll,
+			givenBidders: nil,
+			expectedExactSync: &usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
 		},
 		{
-			description:    "Empty list - no change",
-			givenFilter:    allowAll,
-			givenBidders:   []string{},
-			expectedFilter: allowAll,
+			description:  "Empty list - no change",
+			givenFilter:  allowAll,
+			givenBidders: []string{},
+			expectedExactSync: &usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
 		},
 		{
 			description:  "Wildcard - excludes all iframe",
 			givenFilter:  allowAll,
 			givenBidders: []string{"*"},
-			expectedFilter: usersync.SyncTypeFilter{
+			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
 		{
-			description:  "Specific bidders - excludes only those",
+			description:  "Wildcard not first element - still excludes all iframe",
 			givenFilter:  allowAll,
-			givenBidders: []string{"bidderA", "bidderB"},
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewSpecificBidderFilter([]string{"bidderA", "bidderB"}, usersync.BidderFilterModeExclude),
+			givenBidders: []string{"a", "*"},
+			expectedExactSync: &usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
 		{
-			description: "Overrides existing request filter",
+			description:  "Specific bidders - excludes only those, allows others",
+			givenFilter:  allowAll,
+			givenBidders: []string{"bidderA", "bidderB"},
+			expectedIFrame: map[string]bool{
+				"biddera": false,
+				"bidderb": false,
+				"bidderc": true,
+			},
+			expectedRedirect: map[string]bool{
+				"biddera": true,
+			},
+		},
+		{
+			description: "Wildcard overrides existing request filter",
 			givenFilter: usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
 			},
 			givenBidders: []string{"*"},
-			expectedFilter: usersync.SyncTypeFilter{
+			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
+			},
+		},
+		{
+			description: "Account restricts further - request already excludes all iframe",
+			givenFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+			givenBidders: []string{"bidderA"},
+			expectedIFrame: map[string]bool{
+				"biddera": false,
+				"bidderb": false,
+			},
+		},
+		{
+			description: "Account restricts further - request includes specific bidders only",
+			givenFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewSpecificBidderFilter([]string{"bidderA", "bidderB"}, usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+			givenBidders: []string{"bidderA"},
+			expectedIFrame: map[string]bool{
+				"biddera": false,
+				"bidderb": true,
+				"bidderc": false,
 			},
 		},
 	}
 
 	for _, test := range testCases {
 		result := applyDisabledIFrameBidders(test.givenFilter, test.givenBidders)
-		assert.Equal(t, test.expectedFilter, result, test.description)
+
+		if test.expectedExactSync != nil {
+			assert.Equal(t, *test.expectedExactSync, result, test.description)
+		}
+
+		if test.expectedIFrame != nil {
+			for bidder, expected := range test.expectedIFrame {
+				assert.Equal(t, expected, result.IFrame.Allowed(bidder), "%s: IFrame.Allowed(%s)", test.description, bidder)
+			}
+		}
+
+		if test.expectedRedirect != nil {
+			for bidder, expected := range test.expectedRedirect {
+				assert.Equal(t, expected, result.Redirect.Allowed(bidder), "%s: Redirect.Allowed(%s)", test.description, bidder)
+			}
+		}
 	}
 }
 

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1173,7 +1173,7 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				"TestAccount":                   testAccountData,
 				"DisabledAccount":               json.RawMessage(`{"disabled":true}`),
 				"IFrameDisabledAccount":         json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["a"]}}`),
-				"IFrameDisabledAllAccount":      json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": "*"}}`),
+				"IFrameDisabledAllAccount":      json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["*"]}}`),
 				"ValidAccountInvalidActivities": json.RawMessage(`{"privacy":{"allowactivities":{"syncUser":{"rules":[{"condition":{"componentName": ["bidderA.bidderB.bidderC"]}}]}}}}`),
 			}},
 		}
@@ -1666,13 +1666,13 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 	testCases := []struct {
 		description       string
 		givenFilter       usersync.SyncTypeFilter
-		givenBidders      interface{}
+		givenBidders      []string
 		expectedIFrame    map[string]bool
 		expectedRedirect  map[string]bool
 		expectedExactSync *usersync.SyncTypeFilter
 	}{
 		{
-			description:  "Nil - no change",
+			description:  "Nil list - no change",
 			givenFilter:  allowAll,
 			givenBidders: nil,
 			expectedExactSync: &usersync.SyncTypeFilter{
@@ -1690,20 +1690,20 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 			},
 		},
 		{
-			description:  "Wildcard string - excludes all iframe",
+			description:  "Wildcard - excludes all iframe",
 			givenFilter:  allowAll,
-			givenBidders: "*",
+			givenBidders: []string{"*"},
 			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
 		{
-			description:  "Non-wildcard string - no change",
+			description:  "Wildcard with other bidders - still excludes all iframe",
 			givenFilter:  allowAll,
-			givenBidders: "bidderA",
+			givenBidders: []string{"a", "*"},
 			expectedExactSync: &usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
@@ -1726,7 +1726,7 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
 			},
-			givenBidders: "*",
+			givenBidders: []string{"*"},
 			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
@@ -1755,16 +1755,6 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 				"biddera": false,
 				"bidderb": true,
 				"bidderc": false,
-			},
-		},
-		{
-			description:  "JSON array ([]interface{}) - excludes specific bidders",
-			givenFilter:  allowAll,
-			givenBidders: []interface{}{"bidderA", "bidderB"},
-			expectedIFrame: map[string]bool{
-				"biddera": false,
-				"bidderb": false,
-				"bidderc": true,
 			},
 		},
 	}

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1108,6 +1108,72 @@ func TestCookieSyncParseRequest(t *testing.T) {
 			expectedError:        errCookieSyncAccountBlocked.Error(),
 			givenAccountRequired: true,
 		},
+		{
+			description: "IFrame Disabled For Specific Bidders Via Account Config",
+			givenBody: strings.NewReader(`{` +
+				`"bidders":["a", "b"],` +
+				`"account":"IFrameDisabledAccount"` +
+				`}`),
+			givenGDPRConfig:  config.GDPR{Enabled: true, DefaultValue: "0"},
+			givenCCPAEnabled: true,
+			givenConfig: config.UserSync{
+				PriorityGroups: [][]string{{"a", "b", "c"}},
+				Cooperative: config.UserSyncCooperative{
+					EnabledByDefault: false,
+				},
+			},
+			expectedPrivacy: macros.UserSyncPrivacy{},
+			expectedRequest: usersync.Request{
+				Bidders: []string{"a", "b"},
+				Cooperative: usersync.Cooperative{
+					Enabled:        true,
+					PriorityGroups: nil,
+				},
+				Limit: 20,
+				Privacy: usersyncPrivacy{
+					gdprPermissions: &fakePermissions{},
+					activityRequest: emptyActivityPoliciesRequest,
+					gdprSignal:      -1,
+				},
+				SyncTypeFilter: usersync.SyncTypeFilter{
+					IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
+					Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				},
+			},
+		},
+		{
+			description: "IFrame Disabled For All Bidders Via Account Config Wildcard",
+			givenBody: strings.NewReader(`{` +
+				`"bidders":["a", "b"],` +
+				`"account":"IFrameDisabledAllAccount"` +
+				`}`),
+			givenGDPRConfig:  config.GDPR{Enabled: true, DefaultValue: "0"},
+			givenCCPAEnabled: true,
+			givenConfig: config.UserSync{
+				PriorityGroups: [][]string{{"a", "b", "c"}},
+				Cooperative: config.UserSyncCooperative{
+					EnabledByDefault: false,
+				},
+			},
+			expectedPrivacy: macros.UserSyncPrivacy{},
+			expectedRequest: usersync.Request{
+				Bidders: []string{"a", "b"},
+				Cooperative: usersync.Cooperative{
+					Enabled:        true,
+					PriorityGroups: nil,
+				},
+				Limit: 20,
+				Privacy: usersyncPrivacy{
+					gdprPermissions: &fakePermissions{},
+					activityRequest: emptyActivityPoliciesRequest,
+					gdprSignal:      -1,
+				},
+				SyncTypeFilter: usersync.SyncTypeFilter{
+					IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
+					Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1139,6 +1205,8 @@ func TestCookieSyncParseRequest(t *testing.T) {
 			accountsFetcher: FakeAccountsFetcher{AccountData: map[string]json.RawMessage{
 				"TestAccount":                   testAccountData,
 				"DisabledAccount":               json.RawMessage(`{"disabled":true}`),
+				"IFrameDisabledAccount":         json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["a"]}}`),
+				"IFrameDisabledAllAccount":      json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["*"]}}`),
 				"ValidAccountInvalidActivities": json.RawMessage(`{"privacy":{"allowactivities":{"syncUser":{"rules":[{"condition":{"componentName": ["bidderA.bidderB.bidderC"]}}]}}}}`),
 			}},
 		}
@@ -1619,6 +1687,68 @@ func TestParseTypeFilter(t *testing.T) {
 			assert.EqualError(t, err, test.expectedError, test.description+":err")
 			assert.Empty(t, result, test.description+":result")
 		}
+	}
+}
+
+func TestApplyDisabledIFrameBidders(t *testing.T) {
+	allowAll := usersync.SyncTypeFilter{
+		IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+		Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+	}
+
+	testCases := []struct {
+		description     string
+		givenFilter     usersync.SyncTypeFilter
+		givenBidders    []string
+		expectedFilter  usersync.SyncTypeFilter
+	}{
+		{
+			description:  "Nil list - no change",
+			givenFilter:  allowAll,
+			givenBidders: nil,
+			expectedFilter: allowAll,
+		},
+		{
+			description:  "Empty list - no change",
+			givenFilter:  allowAll,
+			givenBidders: []string{},
+			expectedFilter: allowAll,
+		},
+		{
+			description:  "Wildcard - excludes all iframe",
+			givenFilter:  allowAll,
+			givenBidders: []string{"*"},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+		},
+		{
+			description:  "Specific bidders - excludes only those",
+			givenFilter:  allowAll,
+			givenBidders: []string{"bidderA", "bidderB"},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewSpecificBidderFilter([]string{"bidderA", "bidderB"}, usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+		},
+		{
+			description: "Overrides existing request filter",
+			givenFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
+			},
+			givenBidders: []string{"*"},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		result := applyDisabledIFrameBidders(test.givenFilter, test.givenBidders)
+		assert.Equal(t, test.expectedFilter, result, test.description)
 	}
 }
 

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -15,17 +15,17 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/prebid/prebid-server/v4/analytics"
-	"github.com/prebid/prebid-server/v4/config"
-	"github.com/prebid/prebid-server/v4/errortypes"
-	"github.com/prebid/prebid-server/v4/gdpr"
-	"github.com/prebid/prebid-server/v4/macros"
-	"github.com/prebid/prebid-server/v4/metrics"
-	"github.com/prebid/prebid-server/v4/openrtb_ext"
-	"github.com/prebid/prebid-server/v4/privacy"
-	"github.com/prebid/prebid-server/v4/privacy/ccpa"
-	"github.com/prebid/prebid-server/v4/usersync"
-	"github.com/prebid/prebid-server/v4/util/ptrutil"
+	"github.com/prebid/prebid-server/v3/analytics"
+	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/errortypes"
+	"github.com/prebid/prebid-server/v3/gdpr"
+	"github.com/prebid/prebid-server/v3/macros"
+	"github.com/prebid/prebid-server/v3/metrics"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/prebid/prebid-server/v3/privacy"
+	"github.com/prebid/prebid-server/v3/privacy/ccpa"
+	"github.com/prebid/prebid-server/v3/usersync"
+	"github.com/prebid/prebid-server/v3/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -114,7 +114,7 @@ func TestNewCookieSyncEndpoint(t *testing.T) {
 
 func TestCookieSyncHandle(t *testing.T) {
 	syncTypeExpected := []usersync.SyncType{usersync.SyncTypeIFrame, usersync.SyncTypeRedirect}
-	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect}
+	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect, SupportCORS: true}
 	syncer := MockSyncer{}
 	syncer.On("GetSync", syncTypeExpected, macros.UserSyncPrivacy{}).Return(sync, nil).Maybe()
 
@@ -144,7 +144,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -158,7 +158,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
 						},
 					},
 				}
@@ -176,7 +176,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"no_cookie","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -190,7 +190,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
 						},
 					},
 				}
@@ -277,7 +277,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
 				`],"debug":[{"bidder":"a","error":"Already in sync"}]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -291,7 +291,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
 						},
 					},
 				}
@@ -313,7 +313,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			expectedStatusCode:              200,
 			expectedCookieDeprecationHeader: true,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -327,7 +327,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
 						},
 					},
 				}
@@ -1672,7 +1672,7 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 		expectedExactSync *usersync.SyncTypeFilter
 	}{
 		{
-			description:  "Nil list - no change",
+			description:  "Nil - no change",
 			givenFilter:  allowAll,
 			givenBidders: nil,
 			expectedExactSync: &usersync.SyncTypeFilter{
@@ -1693,15 +1693,6 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 			description:  "Wildcard - excludes all iframe",
 			givenFilter:  allowAll,
 			givenBidders: []string{"*"},
-			expectedExactSync: &usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
-				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-			},
-		},
-		{
-			description:  "Wildcard with other bidders - still excludes all iframe",
-			givenFilter:  allowAll,
-			givenBidders: []string{"a", "*"},
 			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
@@ -1951,12 +1942,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 	privacyMacros := macros.UserSyncPrivacy{USPrivacy: "anyConsent"}
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
+	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: true}
 	syncerA := MockSyncer{}
 	syncerA.On("GetSync", syncTypeExpected, privacyMacros).Return(syncA, nil).Maybe()
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
+	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: false}
 	syncerB := MockSyncer{}
 	syncerB.On("GetSync", syncTypeExpected, privacyMacros).Return(syncB, nil).Maybe()
 
@@ -1995,7 +1986,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}}` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
 				Status: 200,
@@ -2003,7 +1994,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
 					},
 				},
 			},
@@ -2013,7 +2004,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}, {Bidder: "bar", Syncer: &syncerB}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}},` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}},` +
 				`{"bidder":"bar","no_cookie":true,"usersync":{"url":"https://syncB.com/sync?a=1&b=2","type":"redirect"}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
@@ -2022,12 +2013,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
 					},
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
 					},
 				},
 			},
@@ -2045,7 +2036,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
 					},
 				},
 			},
@@ -2114,14 +2105,14 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
 				},
 			},
 		},
@@ -2131,24 +2122,24 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType"},
+					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType", SupportCORS: true},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType"},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType", SupportCORS: true},
 				},
 			},
 		},
@@ -2779,15 +2770,15 @@ func createAccountJSON(priorityGroups [][]string, defaultCoopSync *bool) json.Ra
 func TestCookieSyncPriorityGroupsIntegration(t *testing.T) {
 	// Setup test syncers
 	syncerA := MockSyncer{}
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
 	syncerA.On("Key").Return("appnexus").Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerB := MockSyncer{}
-	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
+	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
 	syncerB.On("Key").Return("rubicon").Maybe()
 	syncerB.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerC := MockSyncer{}
-	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
+	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
 	syncerC.On("Key").Return("pubmatic").Maybe()
 	syncerC.On("SupportsType", mock.Anything).Return(true).Maybe()
 	// Need to choose real bidder names because the standard chooser is hardcoded to validate against them
@@ -2946,7 +2937,7 @@ func TestCookieSyncPriorityGroupsEdgeCases(t *testing.T) {
 	// Setup basic syncers
 	syncerA := MockSyncer{}
 	syncerA.On("Key").Return("bidderA")
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 
 	syncersByBidder := map[string]usersync.Syncer{

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1173,7 +1173,7 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				"TestAccount":                   testAccountData,
 				"DisabledAccount":               json.RawMessage(`{"disabled":true}`),
 				"IFrameDisabledAccount":         json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["a"]}}`),
-				"IFrameDisabledAllAccount":      json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": ["*"]}}`),
+				"IFrameDisabledAllAccount":      json.RawMessage(`{"cookie_sync": {"default_limit": 20, "max_limit": 30, "default_coop_sync": true, "disabled_iframe_bidders": "*"}}`),
 				"ValidAccountInvalidActivities": json.RawMessage(`{"privacy":{"allowactivities":{"syncUser":{"rules":[{"condition":{"componentName": ["bidderA.bidderB.bidderC"]}}]}}}}`),
 			}},
 		}
@@ -1666,13 +1666,13 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 	testCases := []struct {
 		description       string
 		givenFilter       usersync.SyncTypeFilter
-		givenBidders      []string
+		givenBidders      interface{}
 		expectedIFrame    map[string]bool
 		expectedRedirect  map[string]bool
 		expectedExactSync *usersync.SyncTypeFilter
 	}{
 		{
-			description:  "Nil list - no change",
+			description:  "Nil - no change",
 			givenFilter:  allowAll,
 			givenBidders: nil,
 			expectedExactSync: &usersync.SyncTypeFilter{
@@ -1690,20 +1690,20 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 			},
 		},
 		{
-			description:  "Wildcard - excludes all iframe",
+			description:  "Wildcard string - excludes all iframe",
 			givenFilter:  allowAll,
-			givenBidders: []string{"*"},
+			givenBidders: "*",
 			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
 		{
-			description:  "Wildcard not first element - still excludes all iframe",
+			description:  "Non-wildcard string - no change",
 			givenFilter:  allowAll,
-			givenBidders: []string{"a", "*"},
+			givenBidders: "bidderA",
 			expectedExactSync: &usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 			},
 		},
@@ -1726,7 +1726,7 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
 			},
-			givenBidders: []string{"*"},
+			givenBidders: "*",
 			expectedExactSync: &usersync.SyncTypeFilter{
 				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeExclude),
 				Redirect: usersync.NewSpecificBidderFilter([]string{"x"}, usersync.BidderFilterModeExclude),
@@ -1755,6 +1755,16 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 				"biddera": false,
 				"bidderb": true,
 				"bidderc": false,
+			},
+		},
+		{
+			description:  "JSON array ([]interface{}) - excludes specific bidders",
+			givenFilter:  allowAll,
+			givenBidders: []interface{}{"bidderA", "bidderB"},
+			expectedIFrame: map[string]bool{
+				"biddera": false,
+				"bidderb": false,
+				"bidderc": true,
 			},
 		},
 	}

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -15,17 +15,17 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/prebid/prebid-server/v3/analytics"
-	"github.com/prebid/prebid-server/v3/config"
-	"github.com/prebid/prebid-server/v3/errortypes"
-	"github.com/prebid/prebid-server/v3/gdpr"
-	"github.com/prebid/prebid-server/v3/macros"
-	"github.com/prebid/prebid-server/v3/metrics"
-	"github.com/prebid/prebid-server/v3/openrtb_ext"
-	"github.com/prebid/prebid-server/v3/privacy"
-	"github.com/prebid/prebid-server/v3/privacy/ccpa"
-	"github.com/prebid/prebid-server/v3/usersync"
-	"github.com/prebid/prebid-server/v3/util/ptrutil"
+	"github.com/prebid/prebid-server/v4/analytics"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/gdpr"
+	"github.com/prebid/prebid-server/v4/macros"
+	"github.com/prebid/prebid-server/v4/metrics"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/privacy"
+	"github.com/prebid/prebid-server/v4/privacy/ccpa"
+	"github.com/prebid/prebid-server/v4/usersync"
+	"github.com/prebid/prebid-server/v4/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -114,7 +114,7 @@ func TestNewCookieSyncEndpoint(t *testing.T) {
 
 func TestCookieSyncHandle(t *testing.T) {
 	syncTypeExpected := []usersync.SyncType{usersync.SyncTypeIFrame, usersync.SyncTypeRedirect}
-	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect, SupportCORS: true}
+	sync := usersync.Sync{URL: "aURL", Type: usersync.SyncTypeRedirect}
 	syncer := MockSyncer{}
 	syncer.On("GetSync", syncTypeExpected, macros.UserSyncPrivacy{}).Return(sync, nil).Maybe()
 
@@ -144,7 +144,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -158,7 +158,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -176,7 +176,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"no_cookie","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -190,7 +190,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -277,7 +277,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`],"debug":[{"bidder":"a","error":"Already in sync"}]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -291,7 +291,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -313,7 +313,7 @@ func TestCookieSyncHandle(t *testing.T) {
 			expectedStatusCode:              200,
 			expectedCookieDeprecationHeader: true,
 			expectedBody: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"a","no_cookie":true,"usersync":{"url":"aURL","type":"redirect"}}` +
 				`]}` + "\n",
 			setMetricsExpectations: func(m *metrics.MetricsEngineMock) {
 				m.On("RecordCookieSync", metrics.CookieSyncOK).Once()
@@ -327,7 +327,7 @@ func TestCookieSyncHandle(t *testing.T) {
 						{
 							BidderCode:   "a",
 							NoCookie:     true,
-							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect", SupportCORS: true},
+							UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "redirect"},
 						},
 					},
 				}
@@ -1572,91 +1572,6 @@ func TestCookieSyncWriteParseRequestErrorMetrics(t *testing.T) {
 	}
 }
 
-func TestParseTypeFilter(t *testing.T) {
-	testCases := []struct {
-		description    string
-		given          *cookieSyncRequestFilterSettings
-		expectedError  string
-		expectedFilter usersync.SyncTypeFilter
-	}{
-		{
-			description: "Nil",
-			given:       nil,
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-			},
-		},
-		{
-			description: "Nil Object",
-			given:       &cookieSyncRequestFilterSettings{},
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-			},
-		},
-		{
-			description: "Given IFrame Only",
-			given: &cookieSyncRequestFilterSettings{
-				IFrame: &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
-			},
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
-				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-			},
-		},
-		{
-			description: "Given Redirect Only",
-			given: &cookieSyncRequestFilterSettings{
-				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
-			},
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
-				Redirect: usersync.NewSpecificBidderFilter([]string{"b"}, usersync.BidderFilterModeExclude),
-			},
-		},
-		{
-			description: "Given Both",
-			given: &cookieSyncRequestFilterSettings{
-				IFrame:   &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
-				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
-			},
-			expectedFilter: usersync.SyncTypeFilter{
-				IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
-				Redirect: usersync.NewSpecificBidderFilter([]string{"b"}, usersync.BidderFilterModeExclude),
-			},
-		},
-		{
-			description: "IFrame Error",
-			given: &cookieSyncRequestFilterSettings{
-				IFrame:   &cookieSyncRequestFilter{Bidders: 42, Mode: "exclude"},
-				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
-			},
-			expectedError: "error parsing filtersettings.iframe: invalid bidders type. must either be a string '*' or a string array of bidders",
-		},
-		{
-			description: "Redirect Error",
-			given: &cookieSyncRequestFilterSettings{
-				IFrame:   &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
-				Redirect: &cookieSyncRequestFilter{Bidders: 42, Mode: "exclude"},
-			},
-			expectedError: "error parsing filtersettings.image: invalid bidders type. must either be a string '*' or a string array of bidders",
-		},
-	}
-
-	for _, test := range testCases {
-		result, err := parseTypeFilter(test.given)
-
-		if test.expectedError == "" {
-			assert.NoError(t, err, test.description+":err")
-			assert.Equal(t, test.expectedFilter, result, test.description+":result")
-		} else {
-			assert.EqualError(t, err, test.expectedError, test.description+":err")
-			assert.Empty(t, result, test.description+":result")
-		}
-	}
-}
-
 func TestApplyDisabledIFrameBidders(t *testing.T) {
 	allowAll := usersync.SyncTypeFilter{
 		IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
@@ -1767,6 +1682,91 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 			for bidder, expected := range test.expectedRedirect {
 				assert.Equal(t, expected, result.Redirect.Allowed(bidder), "%s: Redirect.Allowed(%s)", test.description, bidder)
 			}
+		}
+	}
+}
+
+func TestParseTypeFilter(t *testing.T) {
+	testCases := []struct {
+		description    string
+		given          *cookieSyncRequestFilterSettings
+		expectedError  string
+		expectedFilter usersync.SyncTypeFilter
+	}{
+		{
+			description: "Nil",
+			given:       nil,
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+		},
+		{
+			description: "Nil Object",
+			given:       &cookieSyncRequestFilterSettings{},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+		},
+		{
+			description: "Given IFrame Only",
+			given: &cookieSyncRequestFilterSettings{
+				IFrame: &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
+			},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+			},
+		},
+		{
+			description: "Given Redirect Only",
+			given: &cookieSyncRequestFilterSettings{
+				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
+			},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewUniformBidderFilter(usersync.BidderFilterModeInclude),
+				Redirect: usersync.NewSpecificBidderFilter([]string{"b"}, usersync.BidderFilterModeExclude),
+			},
+		},
+		{
+			description: "Given Both",
+			given: &cookieSyncRequestFilterSettings{
+				IFrame:   &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
+				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
+			},
+			expectedFilter: usersync.SyncTypeFilter{
+				IFrame:   usersync.NewSpecificBidderFilter([]string{"a"}, usersync.BidderFilterModeExclude),
+				Redirect: usersync.NewSpecificBidderFilter([]string{"b"}, usersync.BidderFilterModeExclude),
+			},
+		},
+		{
+			description: "IFrame Error",
+			given: &cookieSyncRequestFilterSettings{
+				IFrame:   &cookieSyncRequestFilter{Bidders: 42, Mode: "exclude"},
+				Redirect: &cookieSyncRequestFilter{Bidders: []interface{}{"b"}, Mode: "exclude"},
+			},
+			expectedError: "error parsing filtersettings.iframe: invalid bidders type. must either be a string '*' or a string array of bidders",
+		},
+		{
+			description: "Redirect Error",
+			given: &cookieSyncRequestFilterSettings{
+				IFrame:   &cookieSyncRequestFilter{Bidders: []interface{}{"a"}, Mode: "exclude"},
+				Redirect: &cookieSyncRequestFilter{Bidders: 42, Mode: "exclude"},
+			},
+			expectedError: "error parsing filtersettings.image: invalid bidders type. must either be a string '*' or a string array of bidders",
+		},
+	}
+
+	for _, test := range testCases {
+		result, err := parseTypeFilter(test.given)
+
+		if test.expectedError == "" {
+			assert.NoError(t, err, test.description+":err")
+			assert.Equal(t, test.expectedFilter, result, test.description+":result")
+		} else {
+			assert.EqualError(t, err, test.expectedError, test.description+":err")
+			assert.Empty(t, result, test.description+":result")
 		}
 	}
 }
@@ -1942,12 +1942,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 	privacyMacros := macros.UserSyncPrivacy{USPrivacy: "anyConsent"}
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: true}
+	syncA := usersync.Sync{URL: "https://syncA.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
 	syncerA := MockSyncer{}
 	syncerA.On("GetSync", syncTypeExpected, privacyMacros).Return(syncA, nil).Maybe()
 
 	// The & in the URL is necessary to test proper JSON encoding.
-	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect, SupportCORS: false}
+	syncB := usersync.Sync{URL: "https://syncB.com/sync?a=1&b=2", Type: usersync.SyncTypeRedirect}
 	syncerB := MockSyncer{}
 	syncerB.On("GetSync", syncTypeExpected, privacyMacros).Return(syncB, nil).Maybe()
 
@@ -1986,7 +1986,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}}` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
 				Status: 200,
@@ -1994,7 +1994,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -2004,7 +2004,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 			givenCookieHasSyncs: true,
 			givenSyncersChosen:  []usersync.SyncerChoice{{Bidder: "foo", Syncer: &syncerA}, {Bidder: "bar", Syncer: &syncerB}},
 			expectedJSON: `{"status":"ok","bidder_status":[` +
-				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect","supportCORS":true}},` +
+				`{"bidder":"foo","no_cookie":true,"usersync":{"url":"https://syncA.com/sync?a=1&b=2","type":"redirect"}},` +
 				`{"bidder":"bar","no_cookie":true,"usersync":{"url":"https://syncB.com/sync?a=1&b=2","type":"redirect"}}` +
 				`]}` + "\n",
 			expectedAnalytics: analytics.CookieSyncObject{
@@ -2013,12 +2013,12 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "foo",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect", SupportCORS: true},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncA.com/sync?a=1&b=2", Type: "redirect"},
 					},
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -2036,7 +2036,7 @@ func TestCookieSyncHandleResponse(t *testing.T) {
 					{
 						BidderCode:   "bar",
 						NoCookie:     true,
-						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect", SupportCORS: false},
+						UsersyncInfo: &analytics.UsersyncInfo{URL: "https://syncB.com/sync?a=1&b=2", Type: "redirect"},
 					},
 				},
 			},
@@ -2105,14 +2105,14 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
 				},
 			},
 		},
@@ -2122,24 +2122,24 @@ func TestMapBidderStatusToAnalytics(t *testing.T) {
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: cookieSyncResponseSync{URL: "aURL", Type: "aType"},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType", SupportCORS: true},
+					UsersyncInfo: cookieSyncResponseSync{URL: "bURL", Type: "bType"},
 				},
 			},
 			expected: []*analytics.CookieSyncBidder{
 				{
 					BidderCode:   "a",
 					NoCookie:     true,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType", SupportCORS: false},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "aURL", Type: "aType"},
 				},
 				{
 					BidderCode:   "b",
 					NoCookie:     false,
-					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType", SupportCORS: true},
+					UsersyncInfo: &analytics.UsersyncInfo{URL: "bURL", Type: "bType"},
 				},
 			},
 		},
@@ -2770,15 +2770,15 @@ func createAccountJSON(priorityGroups [][]string, defaultCoopSync *bool) json.Ra
 func TestCookieSyncPriorityGroupsIntegration(t *testing.T) {
 	// Setup test syncers
 	syncerA := MockSyncer{}
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerA.On("Key").Return("appnexus").Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerB := MockSyncer{}
-	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerB.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderB.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerB.On("Key").Return("rubicon").Maybe()
 	syncerB.On("SupportsType", mock.Anything).Return(true).Maybe()
 	syncerC := MockSyncer{}
-	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerC.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderC.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerC.On("Key").Return("pubmatic").Maybe()
 	syncerC.On("SupportsType", mock.Anything).Return(true).Maybe()
 	// Need to choose real bidder names because the standard chooser is hardcoded to validate against them
@@ -2937,7 +2937,7 @@ func TestCookieSyncPriorityGroupsEdgeCases(t *testing.T) {
 	// Setup basic syncers
 	syncerA := MockSyncer{}
 	syncerA.On("Key").Return("bidderA")
-	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect, SupportCORS: false}, nil).Maybe()
+	syncerA.On("GetSync", mock.Anything, mock.Anything).Return(usersync.Sync{URL: "https://sync.bidderA.com", Type: usersync.SyncTypeRedirect}, nil).Maybe()
 	syncerA.On("SupportsType", mock.Anything).Return(true).Maybe()
 
 	syncersByBidder := map[string]usersync.Syncer{

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -1697,21 +1697,21 @@ func TestApplyDisabledIFrameBidders(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description     string
-		givenFilter     usersync.SyncTypeFilter
-		givenBidders    []string
-		expectedFilter  usersync.SyncTypeFilter
+		description    string
+		givenFilter    usersync.SyncTypeFilter
+		givenBidders   []string
+		expectedFilter usersync.SyncTypeFilter
 	}{
 		{
-			description:  "Nil list - no change",
-			givenFilter:  allowAll,
-			givenBidders: nil,
+			description:    "Nil list - no change",
+			givenFilter:    allowAll,
+			givenBidders:   nil,
 			expectedFilter: allowAll,
 		},
 		{
-			description:  "Empty list - no change",
-			givenFilter:  allowAll,
-			givenBidders: []string{},
+			description:    "Empty list - no change",
+			givenFilter:    allowAll,
+			givenBidders:   []string{},
 			expectedFilter: allowAll,
 		},
 		{


### PR DESCRIPTION
Feature: Host and account-level control to disable iframe cookie syncs

Link: https://github.com/prebid/prebid-server/issues/4741

Summary
Adds a new account-level configuration field cookie_sync.disabled_iframe_bidders that allows Prebid Server hosts to disable iframe-based cookie syncs for specific bidders or all bidders, enforced server-side regardless of client-provided filterSettings.

Motivation
Prebid Server hosts may need to disable iframe-based cookie syncs for bidders whose sync endpoints point to domains that are restricted in the host's operating environment (e.g., sanctioned regions, compliance requirements). Today the only control is the client-side filterSettings parameter in the /cookie_sync request body, which does not protect against callers that don't set it.

Configuration
A new disabled_iframe_bidders field on the account-level cookie_sync config. Supports a list of bidder names or ["*"] wildcard to disable all iframe syncs.