### PR TITLE
Adapter Code Coverage workflow: Support Go version upgrades

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Run Coverage Tests
         id: run_coverage
         if: steps.get_directories.outputs.result != ''
+        env:
+          GOTOOLCHAIN: go1.26.1+auto
         run: |
           directories=$(echo '${{ steps.get_directories.outputs.result }}' | jq -r '.[]')
           go mod download

--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Run Coverage Tests
         id: run_coverage
         if: steps.get_directories.outputs.result != ''
-        env:
-          GOTOOLCHAIN: go1.26.1+auto
         run: |
           directories=$(echo '${{ steps.get_directories.outputs.result }}' | jq -r '.[]')
           go mod download

--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -12,17 +12,17 @@ jobs:
   run-coverage:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.0
-
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Discover Adapter Directories
         id: get_directories


### PR DESCRIPTION
```
## Problem

The `adapter-code-coverage.yml` workflow currently installs Go before checking out PR code:

```yaml
steps:
  - name: Install Go
    uses: actions/setup-go@v5
    with:
      go-version: 1.24.0       # hardcoded

  - name: Checkout Code        # PR code checked out after
```
 
Since this workflow uses pull_request_target, GitHub always runs the master branch's version of the workflow file. This means any PR that upgrades the Go version in go.mod will fail because:

1. Master installs Go 1.24.0
2. PR's go.mod declares a newer Go version (e.g., go 1.25 or go 1.26)
3. At build time, Go 1.24.0 auto-downloads the newer toolchain — but auto-downloaded toolchains are lightweight bundles missing the covdata tool
4. Tests fail with: go: no such tool "covdata"

This makes it impossible to upgrade Go via a PR — the adapter coverage check will always block it.

**Fix**
Swap the step order and use go-version-file to dynamically read the Go version from the checked-out PR code:
  
```
  steps:
  - name: Checkout Code        # checkout FIRST
    uses: actions/checkout@v4
    ...

  - name: Install Go           # then install based on go.mod
    uses: actions/setup-go@v5
    with:
      go-version-file: go.mod
```

This ensures actions/setup-go performs a full installation of whatever Go version the PR requires — no auto-download, no missing tools, no version mismatch.

**Impact**

- Zero risk for current PRs: master's go.mod declares go 1.23.0, so setup-go installs 1.23.x — same behavior as today.

- Unblocks future Go upgrades: version upgrades will work automatically without needing to update this workflow.
  