### PR TITLE
New Adapter: Adelerate

### DIFF
--- a/adapters/adelerate/adelerate.go
+++ b/adapters/adelerate/adelerate.go
@@ -1,0 +1,166 @@
+package adelerate
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+const defaultCurrency = "USD"
+
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	bidder := &adapter{
+		endpoint: config.Endpoint,
+	}
+	return bidder, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	var errs []error
+	validImps := make([]openrtb2.Imp, 0, len(request.Imp))
+
+	for i := range request.Imp {
+		currImp := request.Imp[i]
+
+		var extImpBidder adapters.ExtImpBidder
+		if err := jsonutil.Unmarshal(currImp.Ext, &extImpBidder); err != nil {
+			errs = append(errs, &errortypes.BadInput{
+				Message: fmt.Sprintf("invalid imp.ext for impression %s: %s", currImp.ID, err.Error()),
+			})
+			continue
+		}
+
+		var bidderExt openrtb_ext.ImpExtAdelerate
+		if err := jsonutil.Unmarshal(extImpBidder.Bidder, &bidderExt); err != nil {
+			errs = append(errs, &errortypes.BadInput{
+				Message: fmt.Sprintf("invalid imp.ext for impression %s: %s", currImp.ID, err.Error()),
+			})
+			continue
+		}
+
+		if bidderExt.Floor > 0 && currImp.BidFloor == 0 {
+			floorCurrency := bidderExt.FloorCurrency
+			if floorCurrency == "" {
+				floorCurrency = defaultCurrency
+			}
+
+			floor := bidderExt.Floor
+			if floorCurrency != defaultCurrency {
+				convertedFloor, err := reqInfo.ConvertCurrency(floor, floorCurrency, defaultCurrency)
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				floor = convertedFloor
+			}
+
+			currImp.BidFloor = floor
+			currImp.BidFloorCur = defaultCurrency
+		}
+
+		currImp.Secure = openrtb2.Int8Ptr(1)
+
+		validImps = append(validImps, currImp)
+	}
+
+	if len(validImps) == 0 {
+		return nil, errs
+	}
+
+	reqCopy := *request
+	reqCopy.Imp = validImps
+
+	adapterReq, err := a.buildRequest(&reqCopy)
+	if err != nil {
+		return nil, append(errs, err)
+	}
+
+	return []*adapters.RequestData{adapterReq}, errs
+}
+
+func (a *adapter) buildRequest(request *openrtb2.BidRequest) (*adapters.RequestData, error) {
+	reqJSON, err := jsonutil.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+
+	return &adapters.RequestData{
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    reqJSON,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+	}, nil
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	if response.Cur != "" {
+		bidResponse.Currency = response.Cur
+	}
+
+	var errs []error
+
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bidType, err := getMediaTypeForBid(seatBid.Bid[i])
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			b := &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: bidType,
+			}
+			bidResponse.Bids = append(bidResponse.Bids, b)
+		}
+	}
+	return bidResponse, errs
+}
+
+func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupNative:
+		return openrtb_ext.BidTypeNative, nil
+	case 0:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("bid %s missing required mtype", bid.ID),
+		}
+	default:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unsupported mtype %d for bid %s", bid.MType, bid.ID),
+		}
+	}
+}

--- a/adapters/adelerate/adelerate_test.go
+++ b/adapters/adelerate/adelerate_test.go
@@ -1,0 +1,85 @@
+package adelerate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderAdelerate, config.Adapter{
+		Endpoint: "https://pbs.bidelerate.com/openrtb2/auction"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	adapterstest.RunJSONBidderTest(t, "adeleratetest", bidder)
+}
+
+func TestGetMediaTypeForBid(t *testing.T) {
+	tests := []struct {
+		name             string
+		bid              openrtb2.Bid
+		expectedBidType  openrtb_ext.BidType
+		expectedErrorMsg string
+	}{
+		{
+			name:            "banner",
+			bid:             openrtb2.Bid{ID: "banner-bid", MType: openrtb2.MarkupBanner},
+			expectedBidType: openrtb_ext.BidTypeBanner,
+		},
+		{
+			name:            "video",
+			bid:             openrtb2.Bid{ID: "video-bid", MType: openrtb2.MarkupVideo},
+			expectedBidType: openrtb_ext.BidTypeVideo,
+		},
+		{
+			name:            "native",
+			bid:             openrtb2.Bid{ID: "native-bid", MType: openrtb2.MarkupNative},
+			expectedBidType: openrtb_ext.BidTypeNative,
+		},
+		{
+			name:             "missing mtype",
+			bid:              openrtb2.Bid{ID: "missing-mtype-bid"},
+			expectedErrorMsg: "bid missing-mtype-bid missing required mtype",
+		},
+		{
+			name:             "unsupported mtype",
+			bid:              openrtb2.Bid{ID: "unsupported-mtype-bid", MType: 99},
+			expectedErrorMsg: "unsupported mtype 99 for bid unsupported-mtype-bid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bidType, err := getMediaTypeForBid(test.bid)
+			if test.expectedErrorMsg == "" {
+				if err != nil {
+					t.Fatalf("getMediaTypeForBid returned unexpected error: %v", err)
+				}
+				if bidType != test.expectedBidType {
+					t.Errorf("getMediaTypeForBid returned bid type %q, expected %q", bidType, test.expectedBidType)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("getMediaTypeForBid expected an error, got nil")
+			}
+			if err.Error() != test.expectedErrorMsg {
+				t.Errorf("getMediaTypeForBid returned error %q, expected %q", err.Error(), test.expectedErrorMsg)
+			}
+
+			var badServerResponse *errortypes.BadServerResponse
+			if !errors.As(err, &badServerResponse) {
+				t.Errorf("getMediaTypeForBid returned error type %T, expected *errortypes.BadServerResponse", err)
+			}
+		})
+	}
+}

--- a/adapters/adelerate/adeleratetest/exemplary/banner-with-existing-bidfloor.json
+++ b/adapters/adelerate/adeleratetest/exemplary/banner-with-existing-bidfloor.json
@@ -1,0 +1,109 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "bidfloor": 3.0,
+        "bidfloorcur": "GBP",
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1",
+            "floor": 1.5,
+            "floorCurrency": "EUR"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "bidfloor": 3.0,
+              "bidfloorcur": "GBP",
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1",
+                  "floor": 1.5,
+                  "floorCurrency": "EUR"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 4.0,
+                  "adm": "<div>test ad</div>",
+                  "crid": "creative-123",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 4.0,
+            "adm": "<div>test ad</div>",
+            "crid": "creative-123",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/banner-with-floor-default-currency.json
+++ b/adapters/adelerate/adeleratetest/exemplary/banner-with-floor-default-currency.json
@@ -1,0 +1,105 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1",
+            "floor": 2.0
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "bidfloor": 2.0,
+              "bidfloorcur": "USD",
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1",
+                  "floor": 2.0
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 3.0,
+                  "adm": "<div>test ad</div>",
+                  "crid": "creative-123",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 3.0,
+            "adm": "<div>test ad</div>",
+            "crid": "creative-123",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/banner-with-floor.json
+++ b/adapters/adelerate/adeleratetest/exemplary/banner-with-floor.json
@@ -1,0 +1,129 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1",
+            "floor": 1.0,
+            "floorCurrency": "EUR"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    },
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "EUR": {
+              "USD": 1.5
+            }
+          }
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "bidfloor": 1.5,
+              "bidfloorcur": "USD",
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1",
+                  "floor": 1.0,
+                  "floorCurrency": "EUR"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          },
+          "ext": {
+            "prebid": {
+              "currency": {
+                "rates": {
+                  "EUR": {
+                    "USD": 1.5
+                  }
+                }
+              }
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 2.0,
+                  "adm": "<div>test ad</div>",
+                  "crid": "creative-123",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 2.0,
+            "adm": "<div>test ad</div>",
+            "crid": "creative-123",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/multi-imp.json
+++ b/adapters/adelerate/adeleratetest/exemplary/multi-imp.json
@@ -1,0 +1,153 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "placement-1",
+            "publisherId": "publisher-1"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "banner": {
+          "format": [
+            {"w": 728, "h": 90}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "placement-2",
+            "publisherId": "publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "placement-1",
+                  "publisherId": "publisher-1"
+                }
+              }
+            },
+            {
+              "id": "test-imp-id-2",
+              "banner": {
+                "format": [
+                  {"w": 728, "h": 90}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "placement-2",
+                  "publisherId": "publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id-1", "test-imp-id-2"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-1",
+                  "impid": "test-imp-id-1",
+                  "price": 1.5,
+                  "adm": "<div>ad 1</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                },
+                {
+                  "id": "bid-2",
+                  "impid": "test-imp-id-2",
+                  "price": 2.0,
+                  "adm": "<div>ad 2</div>",
+                  "crid": "creative-2",
+                  "w": 728,
+                  "h": 90,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-1",
+            "impid": "test-imp-id-1",
+            "price": 1.5,
+            "adm": "<div>ad 1</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "id": "bid-2",
+            "impid": "test-imp-id-2",
+            "price": 2.0,
+            "adm": "<div>ad 2</div>",
+            "crid": "creative-2",
+            "w": 728,
+            "h": 90,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/simple-banner.json
+++ b/adapters/adelerate/adeleratetest/exemplary/simple-banner.json
@@ -1,0 +1,103 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250},
+            {"w": 728, "h": 90}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250},
+                  {"w": 728, "h": 90}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 1.5,
+                  "adm": "<div>test ad</div>",
+                  "crid": "creative-123",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 1.5,
+            "adm": "<div>test ad</div>",
+            "crid": "creative-123",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/simple-native.json
+++ b/adapters/adelerate/adeleratetest/exemplary/simple-native.json
@@ -1,0 +1,95 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "native": {
+          "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}}]}",
+          "ver": "1.2"
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "native": {
+                "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}}]}",
+                "ver": "1.2"
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 3.0,
+                  "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"title\":{\"text\":\"Test Title\"}}],\"link\":{\"url\":\"https://click.example.com\"}}",
+                  "crid": "native-creative-101",
+                  "mtype": 4
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 3.0,
+            "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"title\":{\"text\":\"Test Title\"}}],\"link\":{\"url\":\"https://click.example.com\"}}",
+            "crid": "native-creative-101",
+            "mtype": 4
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/exemplary/simple-video.json
+++ b/adapters/adelerate/adeleratetest/exemplary/simple-video.json
@@ -1,0 +1,103 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "protocols": [1, 2, 3],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/page"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [1, 2, 3],
+                "w": 640,
+                "h": 480
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/page"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 5.0,
+                  "adm": "<VAST version=\"3.0\"><Ad></Ad></VAST>",
+                  "crid": "video-creative-789",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "test-bid-id",
+            "impid": "test-imp-id",
+            "price": 5.0,
+            "adm": "<VAST version=\"3.0\"><Ad></Ad></VAST>",
+            "crid": "video-creative-789",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/bad-request.json
+++ b/adapters/adelerate/adeleratetest/supplemental/bad-request.json
@@ -1,0 +1,65 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/bad-server-response.json
+++ b/adapters/adelerate/adeleratetest/supplemental/bad-server-response.json
@@ -1,0 +1,65 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "invalid json"
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "expect { or n, but found .*",
+      "comparison": "regex"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/floor-currency-conversion-error.json
+++ b/adapters/adelerate/adeleratetest/supplemental/floor-currency-conversion-error.json
@@ -1,0 +1,106 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "invalid-floor-imp",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1",
+            "floor": 1.5,
+            "floorCurrency": "EUR"
+          }
+        }
+      },
+      {
+        "id": "valid-floor-imp",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-2",
+            "publisherId": "test-publisher-1",
+            "floor": 2.0
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    },
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "GBP": {
+              "USD": 1.3
+            }
+          }
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "valid-floor-imp",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "bidfloor": 2.0,
+              "bidfloorcur": "USD",
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-2",
+                  "publisherId": "test-publisher-1",
+                  "floor": 2.0
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          },
+          "ext": {
+            "prebid": {
+              "currency": {
+                "rates": {
+                  "GBP": {
+                    "USD": 1.3
+                  }
+                }
+              }
+            }
+          }
+        },
+        "impIDs": ["valid-floor-imp"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Currency conversion rate not found: 'EUR' => 'USD'",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/invalid-ext-with-valid-imp.json
+++ b/adapters/adelerate/adeleratetest/supplemental/invalid-ext-with-valid-imp.json
@@ -1,0 +1,76 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "invalid-ext-imp",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": "invalid"
+        }
+      },
+      {
+        "id": "valid-imp",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "valid-imp",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["valid-imp"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid imp.ext for impression invalid-ext-imp: .*",
+      "comparison": "regex"
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/adelerate/adeleratetest/supplemental/invalid-ext.json
+++ b/adapters/adelerate/adeleratetest/supplemental/invalid-ext.json
@@ -1,0 +1,27 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": "invalid"
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid imp.ext for impression test-imp-id: .*",
+      "comparison": "regex"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/mixed-valid-and-unsupported-media-type.json
+++ b/adapters/adelerate/adeleratetest/supplemental/mixed-valid-and-unsupported-media-type.json
@@ -1,0 +1,114 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "unsupported-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 1.0,
+                  "adm": "<div>unsupported ad</div>",
+                  "crid": "unsupported-creative",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 99
+                },
+                {
+                  "id": "valid-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 1.5,
+                  "adm": "<div>valid ad</div>",
+                  "crid": "valid-creative",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "valid-bid-id",
+            "impid": "test-imp-id",
+            "price": 1.5,
+            "adm": "<div>valid ad</div>",
+            "crid": "valid-creative",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unsupported mtype 99 for bid unsupported-bid-id",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/no-content.json
+++ b/adapters/adelerate/adeleratetest/supplemental/no-content.json
@@ -1,0 +1,60 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/adelerate/adeleratetest/supplemental/server-error.json
+++ b/adapters/adelerate/adeleratetest/supplemental/server-error.json
@@ -1,0 +1,65 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 503,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 503. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/adelerate/adeleratetest/supplemental/unknown-media-type.json
+++ b/adapters/adelerate/adeleratetest/supplemental/unknown-media-type.json
@@ -1,0 +1,91 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {"w": 300, "h": 250}
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "test-placement-1",
+            "publisherId": "test-publisher-1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbs.bidelerate.com/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {"w": 300, "h": 250}
+                ]
+              },
+              "secure": 1,
+              "ext": {
+                "bidder": {
+                  "placementId": "test-placement-1",
+                  "publisherId": "test-publisher-1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "test-bid-id",
+                  "impid": "test-imp-id",
+                  "price": 1.5,
+                  "adm": "<div>test ad</div>",
+                  "crid": "creative-123",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 0
+                }
+              ],
+              "seat": "adelerate"
+            }
+          ],
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "bid test-bid-id missing required mtype",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/adelerate/params_test.go
+++ b/adapters/adelerate/params_test.go
@@ -1,0 +1,54 @@
+package adelerate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+var validParams = []string{
+	`{"placementId":"123", "publisherId":"456"}`,
+	`{"placementId":"abc", "publisherId":"def", "floor": 1.5, "floorCurrency": "EUR"}`,
+	`{"placementId":"abc", "publisherId":"def", "floor": 0.5}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`[]`,
+	`{}`,
+	`{"placementId":"123"}`,
+	`{"publisherId":"456"}`,
+	`{"placementId":"", "publisherId":"456"}`,
+	`{"placementId":"123", "publisherId":""}`,
+	`{"some": "param"}`,
+}
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderAdelerate, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected adelerate params: %s", validParam)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderAdelerate, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/acuityads"
 	"github.com/prebid/prebid-server/v4/adapters/adagio"
 	"github.com/prebid/prebid-server/v4/adapters/adelement"
+	"github.com/prebid/prebid-server/v4/adapters/adelerate"
 	"github.com/prebid/prebid-server/v4/adapters/adf"
 	"github.com/prebid/prebid-server/v4/adapters/adgeneration"
 	"github.com/prebid/prebid-server/v4/adapters/adhese"
@@ -282,6 +283,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderAcuityAds:         acuityads.Builder,
 		openrtb_ext.BidderAdagio:            adagio.Builder,
 		openrtb_ext.BidderAdelement:         adelement.Builder,
+		openrtb_ext.BidderAdelerate:         adelerate.Builder,
 		openrtb_ext.BidderAdf:               adf.Builder,
 		openrtb_ext.BidderAdgeneration:      adgeneration.Builder,
 		openrtb_ext.BidderAdhese:            adhese.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -24,6 +24,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderAcuityAds,
 	BidderAdagio,
 	BidderAdelement,
+	BidderAdelerate,
 	BidderAdf,
 	BidderAdgeneration,
 	BidderAdhese,
@@ -405,6 +406,7 @@ const (
 	BidderAcuityAds         BidderName = "acuityads"
 	BidderAdagio            BidderName = "adagio"
 	BidderAdelement         BidderName = "adelement"
+	BidderAdelerate         BidderName = "adelerate"
 	BidderAdf               BidderName = "adf"
 	BidderAdgeneration      BidderName = "adgeneration"
 	BidderAdhese            BidderName = "adhese"

--- a/openrtb_ext/imp_adelerate.go
+++ b/openrtb_ext/imp_adelerate.go
@@ -1,0 +1,8 @@
+package openrtb_ext
+
+type ImpExtAdelerate struct {
+	PlacementID   string  `json:"placementId"`
+	PublisherID   string  `json:"publisherId"`
+	Floor         float64 `json:"floor,omitempty"`
+	FloorCurrency string  `json:"floorCurrency,omitempty"`
+}

--- a/static/bidder-info/adelerate.yaml
+++ b/static/bidder-info/adelerate.yaml
@@ -1,0 +1,21 @@
+endpoint: "https://pbs.bidelerate.com/openrtb2/auction"
+maintainer:
+  email: "support@adelerate.com"
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - native
+userSync:
+  iframe:
+    url: "https://pbs.bidelerate.com/cookie_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"
+  redirect:
+    url: "https://pbs.bidelerate.com/cookie_sync/pixel?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-params/adelerate.json
+++ b/static/bidder-params/adelerate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Adelerate Adapter Params",
+  "description": "A schema which validates params accepted by the Adelerate adapter",
+  "type": "object",
+  "properties": {
+    "placementId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The placement ID provided by Adelerate"
+    },
+    "publisherId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The publisher ID provided by Adelerate"
+    },
+    "floor": {
+      "type": "number",
+      "description": "Minimum CPM price. Use of Prebid Floors module is preferred."
+    },
+    "floorCurrency": {
+      "type": "string",
+      "description": "Currency for the floor param. Defaults to USD."
+    }
+  },
+  "required": [
+    "placementId",
+    "publisherId"
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds the Adelerate server-side bidder adapter.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

## Docs PR
[prebid/prebid.github.io#6623](https://github.com/prebid/prebid.github.io/pull/6623)
