### PR TITLE
Adapter Code Coverage Workflow: Split into two stages

### DIFF
--- a/.github/workflows/adapter-code-coverage-report.yml
+++ b/.github/workflows/adapter-code-coverage-report.yml
@@ -1,0 +1,77 @@
+name: Adapter Code Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["Adapter Code Coverage"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  report-coverage:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Coverage Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-results
+          path: coverage-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR Metadata
+        id: pr_metadata
+        run: |
+          echo "pr_number=$(cat coverage-results/pr-metadata/pr_number)" >> $GITHUB_OUTPUT
+          echo "head_sha=$(cat coverage-results/pr-metadata/head_sha)" >> $GITHUB_OUTPUT
+          echo "directories=$(cat coverage-results/pr-metadata/directories.json)" >> $GITHUB_OUTPUT
+          echo "coverage_dir=$(pwd)/coverage-results" >> $GITHUB_OUTPUT
+
+      - name: Checkout Coverage Preview Branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: coverage-preview
+          repository: prebid/prebid-server
+          path: preview-repo
+
+      - name: Upload Coverage Results
+        id: commit_coverage
+        run: |
+          timestamp=$(date +%s)
+          directory=preview-repo/.github/preview/${{ github.event.workflow_run.id }}_${timestamp}
+          mkdir -p $directory
+          cp -r coverage-results/*.html $directory/
+          cd preview-repo
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/preview/*
+          git commit -m 'Add coverage files for run ${{ github.event.workflow_run.id }}'
+          git push origin coverage-preview
+          echo "remote_coverage_preview_dir=.github/preview/${{ github.event.workflow_run.id }}_${timestamp}" >> $GITHUB_OUTPUT
+
+      - name: Add Coverage Summary To Pull Request
+        if: steps.commit_coverage.outputs.remote_coverage_preview_dir != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
+            const helper = utils.coverageHelper({
+              github, context,
+              headSha: '${{ steps.pr_metadata.outputs.head_sha }}', 
+              tmpCoverageDir: '${{ steps.pr_metadata.outputs.coverage_dir }}', 
+              remoteCoverageDir: '${{ steps.commit_coverage.outputs.remote_coverage_preview_dir }}',
+              prNumber: ${{ steps.pr_metadata.outputs.pr_number }}
+            })
+            const adapterDirectories = JSON.parse('${{ steps.pr_metadata.outputs.directories }}')
+            await helper.AddCoverageSummary(adapterDirectories)

--- a/.github/workflows/adapter-code-coverage-report.yml
+++ b/.github/workflows/adapter-code-coverage-report.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: coverage-preview
-          repository: bsardo/prebid-server
+          repository: prebid/prebid-server
           path: preview-repo
 
       - name: Upload Coverage Results

--- a/.github/workflows/adapter-code-coverage-report.yml
+++ b/.github/workflows/adapter-code-coverage-report.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: coverage-preview
-          repository: prebid/prebid-server
+          repository: bsardo/prebid-server
           path: preview-repo
 
       - name: Upload Coverage Results

--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -1,12 +1,12 @@
 name: Adapter Code Coverage
 
 on:
-  pull_request_target:
+  pull_request:
     paths: ["adapters/*/*.go"]
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
+  pull-requests: read
 
 jobs:
   run-coverage:
@@ -21,8 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Discover Adapter Directories
         id: get_directories
@@ -66,46 +64,20 @@ jobs:
           done
           echo "coverage_dir=${temp_dir}" >> $GITHUB_OUTPUT
 
-          # remove pull request branch files
-          cd ..
-          rm -f -r ./*
-
-      - name: Checkout Coverage Preview Branch
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: coverage-preview
-          repository: prebid/prebid-server
-
-      - name: Upload Coverage Results
-        if: steps.run_coverage.outputs.coverage_dir != ''
-        id: commit_coverage
-        run: |
-          directory=.github/preview/${{ github.run_id }}_$(date +%s)
-          mkdir -p $directory
-          cp -r ${{ steps.run_coverage.outputs.coverage_dir }}/*.html ./$directory
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add $directory/*
-          git commit -m 'Add coverage files'
-          git push origin coverage-preview
-          echo "remote_coverage_preview_dir=${directory}" >> $GITHUB_OUTPUT
-
-      - name: Checkout Master Branch
+      - name: Save PR Metadata
         if: steps.get_directories.outputs.result != ''
-        run: git checkout master
+        run: |
+          mkdir -p ./pr-metadata
+          echo '${{ steps.get_directories.outputs.result }}' > ./pr-metadata/directories.json
+          echo '${{ github.event.pull_request.number }}' > ./pr-metadata/pr_number
+          echo '${{ github.event.pull_request.head.sha }}' > ./pr-metadata/head_sha
 
-      - name: Add Coverage Summary To Pull Request
-        if: steps.run_coverage.outputs.coverage_dir != '' && steps.commit_coverage.outputs.remote_coverage_preview_dir != ''
-        uses: actions/github-script@v7
+      - name: Upload Coverage Artifacts
+        if: steps.run_coverage.outputs.coverage_dir != ''
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
-            const helper = utils.coverageHelper({
-              github, context,
-              headSha: '${{ github.event.pull_request.head.sha }}', 
-              tmpCoverageDir: '${{ steps.run_coverage.outputs.coverage_dir }}', 
-              remoteCoverageDir: '${{ steps.commit_coverage.outputs.remote_coverage_preview_dir }}'
-            })
-            const adapterDirectories = JSON.parse('${{ steps.get_directories.outputs.result }}')
-            await helper.AddCoverageSummary(adapterDirectories)
+          name: coverage-results
+          path: |
+            ${{ steps.run_coverage.outputs.coverage_dir }}
+            ./pr-metadata
+          retention-days: 1

--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -64,20 +64,20 @@ jobs:
           done
           echo "coverage_dir=${temp_dir}" >> $GITHUB_OUTPUT
 
-      - name: Save PR Metadata
+      - name: Prepare Artifacts
         if: steps.get_directories.outputs.result != ''
         run: |
-          mkdir -p ./pr-metadata
-          echo '${{ steps.get_directories.outputs.result }}' > ./pr-metadata/directories.json
-          echo '${{ github.event.pull_request.number }}' > ./pr-metadata/pr_number
-          echo '${{ github.event.pull_request.head.sha }}' > ./pr-metadata/head_sha
+          mkdir -p ./coverage-artifacts/pr-metadata
+          cp ${{ steps.run_coverage.outputs.coverage_dir }}/*.html ./coverage-artifacts/ 2>/dev/null || true
+          cp ${{ steps.run_coverage.outputs.coverage_dir }}/*.txt ./coverage-artifacts/ 2>/dev/null || true
+          echo '${{ steps.get_directories.outputs.result }}' > ./coverage-artifacts/pr-metadata/directories.json
+          echo '${{ github.event.pull_request.number }}' > ./coverage-artifacts/pr-metadata/pr_number
+          echo '${{ github.event.pull_request.head.sha }}' > ./coverage-artifacts/pr-metadata/head_sha
 
       - name: Upload Coverage Artifacts
         if: steps.run_coverage.outputs.coverage_dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage-results
-          path: |
-            ${{ steps.run_coverage.outputs.coverage_dir }}
-            ./pr-metadata
+          path: ./coverage-artifacts
           retention-days: 1

--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -361,7 +361,7 @@ class coverageHelper {
     this.owner = input.context.repo.owner
     this.repo = input.context.repo.repo
     this.github = input.github
-    this.pullRequestNumber = input.context.payload.pull_request.number
+    this.pullRequestNumber = input.prNumber || input.context.payload.pull_request.number
     this.headSha = input.headSha
     this.previewBaseURL = `https://htmlpreview.github.io/?https://github.com/${this.owner}/${this.repo}/coverage-preview/${input.remoteCoverageDir}`
     this.tmpCoverDir = input.tmpCoverageDir


### PR DESCRIPTION
This PR splits the adapter code coverage workflow into two stages:
1) A code coverage workflow with read permissions that generates the code coverage artifacts
2) A code coverage report workflow with write permissions that download the code coverage artifacts posting the results to the corresponding PR

I tested it on my fork by switching the referenced repo from the main repo to my fork.