### PR TITLE
Pin trivy-action to v0.35.0 SHA for supply chain security

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
This PR pins `aquasecurity/trivy-action` to commit SHA (`57a97c7e7821a5776cebc9bb87c984fa69cba8f1`) instead of master.

In March 2026, Trivy's ecosystem was compromised in a supply chain attack ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23), [CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634)). Attackers hijacked version tags to inject credential-stealing malware. Our workflow was not affected as it ran after remediation, however pinning to an immutable SHA prevents exposure to similar attacks in the future.

We only had one run between March 6th and March 24th occurring on March 20th @2:43PM ET. The logs for that run indicate that we are indeed safe:
```
trivy-action SHA: 57a97c7e7821a5776cebc9bb87c984fa69cba8f1  ← Safe v0.35.0 commit
trivy version: v0.69.3 ← Safe version (not v0.69.4)
```