### PR TITLE
Prebid Mobile: makes creative size transformation based on pxRatio

### DIFF
--- a/endpoints/openrtb2/interstitial.go
+++ b/endpoints/openrtb2/interstitial.go
@@ -2,6 +2,7 @@ package openrtb2
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/config"
@@ -11,35 +12,48 @@ import (
 
 func processInterstitials(req *openrtb_ext.RequestWrapper) error {
 	unmarshalled := true
-	for _, imp := range req.GetImp() {
-		if imp.Instl == 1 {
-			var prebid *openrtb_ext.ExtDevicePrebid
-			if unmarshalled {
-				if req.Device.Ext == nil {
-					// No special interstitial support requested, so bail as there is nothing to do
-					return nil
-				}
-				deviceExt, err := req.GetDeviceExt()
+	usePxRatioResolved := false
+	usePxRatio := false
 
-				if err != nil {
-					return err
-				}
-				prebid = deviceExt.GetPrebid()
-				if prebid == nil || prebid.Interstitial == nil {
-					// No special interstitial support requested, so bail as there is nothing to do
-					return nil
-				}
+	for _, imp := range req.GetImp() {
+		if imp.Instl != 1 {
+			continue
+		}
+
+		var prebid *openrtb_ext.ExtDevicePrebid
+		if unmarshalled {
+			if req.Device.Ext == nil {
+				// No special interstitial support requested, so bail as there is nothing to do
+				return nil
 			}
-			err := processInterstitialsForImp(imp, prebid, req.Device)
+			deviceExt, err := req.GetDeviceExt()
+
 			if err != nil {
 				return err
 			}
+			prebid = deviceExt.GetPrebid()
+			if prebid == nil || prebid.Interstitial == nil {
+				// No special interstitial support requested, so bail as there is nothing to do
+				return nil
+			}
+		}
+		if !usePxRatioResolved {
+			var err error
+			usePxRatio, err = usePxRatioForInterstitials(req)
+			if err != nil {
+				return err
+			}
+			usePxRatioResolved = true
+		}
+		err := processInterstitialsForImp(imp, prebid, req.Device, usePxRatio)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func processInterstitialsForImp(imp *openrtb_ext.ImpWrapper, devExtPrebid *openrtb_ext.ExtDevicePrebid, device *openrtb2.Device) error {
+func processInterstitialsForImp(imp *openrtb_ext.ImpWrapper, devExtPrebid *openrtb_ext.ExtDevicePrebid, device *openrtb2.Device, usePxRatio bool) error {
 	var maxWidth, maxHeight, minWidth, minHeight int64
 	if imp.Banner == nil {
 		// custom interstitial support is only available for banner requests.
@@ -56,6 +70,10 @@ func processInterstitialsForImp(imp *openrtb_ext.ImpWrapper, devExtPrebid *openr
 		}
 		maxWidth = device.W
 		maxHeight = device.H
+		if usePxRatio {
+			maxWidth = deviceSizeToDips(maxWidth, device.PxRatio)
+			maxHeight = deviceSizeToDips(maxHeight, device.PxRatio)
+		}
 	}
 	minWidth = (maxWidth * devExtPrebid.Interstitial.MinWidthPerc) / 100
 	minHeight = (maxHeight * devExtPrebid.Interstitial.MinHeightPerc) / 100
@@ -82,4 +100,26 @@ func genInterstitialFormat(minWidth, maxWidth, minHeight, maxHeight int64) []ope
 		formatList = append(formatList, openrtb2.Format{W: int64(size.Width), H: int64(size.Height)})
 	}
 	return formatList
+}
+
+func usePxRatioForInterstitials(req *openrtb_ext.RequestWrapper) (bool, error) {
+	requestExt, err := req.GetRequestExt()
+	if err != nil {
+		return false, err
+	}
+
+	requestPrebid := requestExt.GetPrebid()
+	return requestPrebid != nil && requestPrebid.Sdk != nil && requestPrebid.Sdk.UsePxRatio, nil
+}
+
+func deviceSizeToDips(size int64, pxRatio float64) int64 {
+	if pxRatio <= 0 {
+		return size
+	}
+
+	dips := int64(math.Round(float64(size) / pxRatio))
+	if dips < 1 {
+		return 1
+	}
+	return dips
 }

--- a/endpoints/openrtb2/interstitial.go
+++ b/endpoints/openrtb2/interstitial.go
@@ -11,8 +11,12 @@ import (
 )
 
 func processInterstitials(req *openrtb_ext.RequestWrapper) error {
-	unmarshalled := true
-	usePxRatioResolved := false
+	return processInterstitialsWithUsePxRatioResolver(req, usePxRatioForInterstitials)
+}
+
+func processInterstitialsWithUsePxRatioResolver(req *openrtb_ext.RequestWrapper, resolveUsePxRatio func(*openrtb_ext.RequestWrapper) bool) error {
+	var prebid *openrtb_ext.ExtDevicePrebid
+	resolved := false
 	usePxRatio := false
 
 	for _, imp := range req.GetImp() {
@@ -20,8 +24,10 @@ func processInterstitials(req *openrtb_ext.RequestWrapper) error {
 			continue
 		}
 
-		var prebid *openrtb_ext.ExtDevicePrebid
-		if unmarshalled {
+		if !resolved {
+			if req.Device == nil {
+				return &errortypes.BadInput{Message: fmt.Sprintf("Unable to read max interstitial size for Imp id=%s (No Device and no Format objects)", imp.ID)}
+			}
 			if req.Device.Ext == nil {
 				// No special interstitial support requested, so bail as there is nothing to do
 				return nil
@@ -36,17 +42,10 @@ func processInterstitials(req *openrtb_ext.RequestWrapper) error {
 				// No special interstitial support requested, so bail as there is nothing to do
 				return nil
 			}
+			usePxRatio = resolveUsePxRatio(req)
+			resolved = true
 		}
-		if !usePxRatioResolved {
-			var err error
-			usePxRatio, err = usePxRatioForInterstitials(req)
-			if err != nil {
-				return err
-			}
-			usePxRatioResolved = true
-		}
-		err := processInterstitialsForImp(imp, prebid, req.Device, usePxRatio)
-		if err != nil {
+		if err := processInterstitialsForImp(imp, prebid, req.Device, usePxRatio); err != nil {
 			return err
 		}
 	}
@@ -70,10 +69,10 @@ func processInterstitialsForImp(imp *openrtb_ext.ImpWrapper, devExtPrebid *openr
 		}
 		maxWidth = device.W
 		maxHeight = device.H
-		if usePxRatio {
-			maxWidth = deviceSizeToDips(maxWidth, device.PxRatio)
-			maxHeight = deviceSizeToDips(maxHeight, device.PxRatio)
-		}
+	}
+	if usePxRatio && device != nil {
+		maxWidth = deviceSizeToDips(maxWidth, device.PxRatio)
+		maxHeight = deviceSizeToDips(maxHeight, device.PxRatio)
 	}
 	minWidth = (maxWidth * devExtPrebid.Interstitial.MinWidthPerc) / 100
 	minHeight = (maxHeight * devExtPrebid.Interstitial.MinHeightPerc) / 100
@@ -102,18 +101,18 @@ func genInterstitialFormat(minWidth, maxWidth, minHeight, maxHeight int64) []ope
 	return formatList
 }
 
-func usePxRatioForInterstitials(req *openrtb_ext.RequestWrapper) (bool, error) {
+func usePxRatioForInterstitials(req *openrtb_ext.RequestWrapper) bool {
 	requestExt, err := req.GetRequestExt()
 	if err != nil {
-		return false, err
+		return false
 	}
 
 	requestPrebid := requestExt.GetPrebid()
-	return requestPrebid != nil && requestPrebid.Sdk != nil && requestPrebid.Sdk.UsePxRatio, nil
+	return requestPrebid != nil && requestPrebid.Sdk != nil && requestPrebid.Sdk.UsePxRatio
 }
 
 func deviceSizeToDips(size int64, pxRatio float64) int64 {
-	if pxRatio <= 0 {
+	if pxRatio <= 0 || math.IsNaN(pxRatio) {
 		return size
 	}
 

--- a/endpoints/openrtb2/interstitial_test.go
+++ b/endpoints/openrtb2/interstitial_test.go
@@ -121,3 +121,175 @@ func TestInterstitialWithoutPrebidDeviceExt(t *testing.T) {
 	}
 	assert.Equal(t, targetFormat, myRequest.Imp[0].Banner.Format)
 }
+
+func TestInterstitialUsesDeviceSizeInDipsWhenFormatIsAbsent(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  1,
+				Ext:    json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 60, "minheightperc": 60}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":true}}}`),
+	}
+
+	if err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}); err != nil {
+		t.Fatalf("Error processing interstitials: %v", err)
+	}
+
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 320, H: 480})
+	assert.NotContains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
+}
+
+func TestInterstitialUsesDeviceSizeInDipsWhenFormatIsOneByOne(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID: "my-imp-id",
+				Banner: &openrtb2.Banner{
+					Format: []openrtb2.Format{{W: 1, H: 1}},
+				},
+				Instl: 1,
+				Ext:   json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 60, "minheightperc": 60}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":true}}}`),
+	}
+
+	if err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}); err != nil {
+		t.Fatalf("Error processing interstitials: %v", err)
+	}
+
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 320, H: 480})
+	assert.NotContains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
+}
+
+func TestInterstitialDoesNotConvertExplicitFormatSizeUsingDevicePxRatio(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID: "my-imp-id",
+				Banner: &openrtb2.Banner{
+					Format: []openrtb2.Format{{W: 400, H: 600}},
+				},
+				Instl: 1,
+				Ext:   json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 80, "minheightperc": 80}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":true}}}`),
+	}
+
+	if err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}); err != nil {
+		t.Fatalf("Error processing interstitials: %v", err)
+	}
+
+	assert.Equal(t, []openrtb2.Format{
+		{W: 320, H: 480},
+		{W: 336, H: 544},
+		{W: 320, H: 568},
+		{W: 320, H: 500},
+		{W: 320, H: 481},
+	}, myRequest.Imp[0].Banner.Format)
+}
+
+func TestInterstitialKeepsCurrentDeviceSizeBehaviorWhenUsePxRatioIsTrueAndDevicePxRatioIsAbsent(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  1,
+				Ext:    json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:   1920,
+			W:   1080,
+			Ext: json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 1, "minheightperc": 1}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":true}}}`),
+	}
+
+	if err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}); err != nil {
+		t.Fatalf("Error processing interstitials: %v", err)
+	}
+
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
+}
+
+func TestInterstitialKeepsCurrentDeviceSizeBehaviorWhenUsePxRatioIsAbsent(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  1,
+				Ext:    json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 1, "minheightperc": 1}}}`),
+		},
+	}
+
+	if err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}); err != nil {
+		t.Fatalf("Error processing interstitials: %v", err)
+	}
+
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
+}
+
+func TestInterstitialDoesNotParseUsePxRatioWhenRequestHasNoInterstitialImps(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		ID: "some-id",
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  0,
+				Ext:    json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
+			},
+		},
+		Device: &openrtb2.Device{
+			H:   1920,
+			W:   1080,
+			Ext: json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 1, "minheightperc": 1}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":`),
+	}
+
+	assert.NoError(t, processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}))
+}
+
+func TestDeviceSizeToDips(t *testing.T) {
+	assert.Equal(t, int64(360), deviceSizeToDips(1080, 3))
+	assert.Equal(t, int64(1080), deviceSizeToDips(1080, 0))
+}

--- a/endpoints/openrtb2/interstitial_test.go
+++ b/endpoints/openrtb2/interstitial_test.go
@@ -2,9 +2,11 @@ package openrtb2
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/errortypes"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/stretchr/testify/assert"
 )
@@ -180,14 +182,14 @@ func TestInterstitialUsesDeviceSizeInDipsWhenFormatIsOneByOne(t *testing.T) {
 	assert.NotContains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
 }
 
-func TestInterstitialDoesNotConvertExplicitFormatSizeUsingDevicePxRatio(t *testing.T) {
+func TestInterstitialUsesExplicitFormatSizeInDips(t *testing.T) {
 	myRequest := &openrtb2.BidRequest{
 		ID: "some-id",
 		Imp: []openrtb2.Imp{
 			{
 				ID: "my-imp-id",
 				Banner: &openrtb2.Banner{
-					Format: []openrtb2.Format{{W: 400, H: 600}},
+					Format: []openrtb2.Format{{W: 1080, H: 1920}},
 				},
 				Instl: 1,
 				Ext:   json.RawMessage(`{"appnexus": {"placementId": 12883451}}`),
@@ -197,7 +199,7 @@ func TestInterstitialDoesNotConvertExplicitFormatSizeUsingDevicePxRatio(t *testi
 			H:       1920,
 			W:       1080,
 			PxRatio: 3,
-			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 80, "minheightperc": 80}}}`),
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 60, "minheightperc": 60}}}`),
 		},
 		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":true}}}`),
 	}
@@ -206,13 +208,8 @@ func TestInterstitialDoesNotConvertExplicitFormatSizeUsingDevicePxRatio(t *testi
 		t.Fatalf("Error processing interstitials: %v", err)
 	}
 
-	assert.Equal(t, []openrtb2.Format{
-		{W: 320, H: 480},
-		{W: 336, H: 544},
-		{W: 320, H: 568},
-		{W: 320, H: 500},
-		{W: 320, H: 481},
-	}, myRequest.Imp[0].Banner.Format)
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 320, H: 480})
+	assert.NotContains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
 }
 
 func TestInterstitialKeepsCurrentDeviceSizeBehaviorWhenUsePxRatioIsTrueAndDevicePxRatioIsAbsent(t *testing.T) {
@@ -289,7 +286,74 @@ func TestInterstitialDoesNotParseUsePxRatioWhenRequestHasNoInterstitialImps(t *t
 	assert.NoError(t, processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}))
 }
 
+func TestInterstitialIgnoresInvalidUsePxRatio(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  1,
+			},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 1, "minheightperc": 1}}}`),
+		},
+		Ext: json.RawMessage(`{"prebid":{"sdk":{"usepxratio":"true"}}}`),
+	}
+
+	assert.NoError(t, processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest}))
+	assert.Contains(t, myRequest.Imp[0].Banner.Format, openrtb2.Format{W: 768, H: 1024})
+}
+
+func TestInterstitialReturnsBadInputWhenDeviceIsMissing(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "my-imp-id",
+				Banner: &openrtb2.Banner{},
+				Instl:  1,
+			},
+		},
+	}
+
+	err := processInterstitials(&openrtb_ext.RequestWrapper{BidRequest: myRequest})
+
+	assert.IsType(t, &errortypes.BadInput{}, err)
+	assert.EqualError(t, err, "Unable to read max interstitial size for Imp id=my-imp-id (No Device and no Format objects)")
+}
+
+func TestInterstitialResolvesUsePxRatioOnceForMultipleImpressions(t *testing.T) {
+	myRequest := &openrtb2.BidRequest{
+		Imp: []openrtb2.Imp{
+			{ID: "imp-1", Banner: &openrtb2.Banner{}, Instl: 1},
+			{ID: "imp-2", Banner: &openrtb2.Banner{}, Instl: 1},
+		},
+		Device: &openrtb2.Device{
+			H:       1920,
+			W:       1080,
+			PxRatio: 3,
+			Ext:     json.RawMessage(`{"prebid": {"interstitial": {"minwidthperc": 60, "minheightperc": 60}}}`),
+		},
+	}
+	resolveCalls := 0
+	resolveUsePxRatio := func(*openrtb_ext.RequestWrapper) bool {
+		resolveCalls++
+		return true
+	}
+
+	err := processInterstitialsWithUsePxRatioResolver(
+		&openrtb_ext.RequestWrapper{BidRequest: myRequest},
+		resolveUsePxRatio)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, resolveCalls)
+}
+
 func TestDeviceSizeToDips(t *testing.T) {
 	assert.Equal(t, int64(360), deviceSizeToDips(1080, 3))
 	assert.Equal(t, int64(1080), deviceSizeToDips(1080, 0))
+	assert.Equal(t, int64(1080), deviceSizeToDips(1080, math.NaN()))
 }

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -356,6 +356,7 @@ type ExtRequestPrebidDataEidPermission struct {
 
 type ExtRequestSdk struct {
 	Renderers []ExtRequestSdkRenderer `json:"renderers,omitempty"`
+	UsePxRatio bool                   `json:"usepxratio,omitempty"`
 }
 
 type ExtRequestSdkRenderer struct {

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -355,8 +355,8 @@ type ExtRequestPrebidDataEidPermission struct {
 }
 
 type ExtRequestSdk struct {
-	Renderers []ExtRequestSdkRenderer `json:"renderers,omitempty"`
-	UsePxRatio bool                   `json:"usepxratio,omitempty"`
+	Renderers  []ExtRequestSdkRenderer `json:"renderers,omitempty"`
+	UsePxRatio bool                    `json:"usepxratio,omitempty"`
 }
 
 type ExtRequestSdkRenderer struct {


### PR DESCRIPTION
## Description

Fixes #4501

Prebid Server was not converting `device.w`/`device.h` from physical pixels to device-independent pixels (DIPs) when generating the list of candidate sizes for interstitial ads. According to the OpenRTB spec, `device.w`/`device.h` represent physical screen pixels, while `banner.format` sizes are expected in DIPs. On high-density screens this caused standard mobile interstitial sizes (e.g. 320x480) to be absent from the generated format list.

This change adds opt-in pxratio conversion controlled by a new field `ext.prebid.sdk.usepxratio`. When set to `true`, `device.w`/`device.h` are divided by `device.pxratio` before being used to calculate the interstitial size bounds. Conversion is only applied when falling back to device dimensions — explicit `banner.format` sizes are left untouched.

## Changes

- Added `UsePxRatio bool` field (`usepxratio`) to `ExtRequestSdk` in `openrtb_ext/request.go`
- Added `usePxRatioForInterstitials()` to read the flag from `ext.prebid.sdk` — evaluated lazily (only when an interstitial imp is encountered)
- Added `deviceSizeToDips()` helper: divides by `pxratio`, rounds to nearest integer, clamps to minimum 1; returns size unchanged when `pxratio` is 0 or not set
- Applied conversion in `processInterstitialsForImp()` only in the device-size fallback branch

## Testing

- `TestInterstitialUsesDeviceSizeInDipsWhenFormatIsAbsent` — device 1080×1920 @ pxratio 3 → expects 320×480 in results
- `TestInterstitialUsesDeviceSizeInDipsWhenFormatIsOneByOne` — same, with 1×1 sentinel format
- `TestInterstitialDoesNotConvertExplicitFormatSizeUsingDevicePxRatio` — explicit banner format is not converted
- `TestInterstitialKeepsCurrentDeviceSizeBehaviorWhenUsePxRatioIsAbsent` — no flag, no conversion (backward compatibility)
- `TestInterstitialKeepsCurrentDeviceSizeBehaviorWhenUsePxRatioIsTrueAndDevicePxRatioIsAbsent` — flag set but `pxratio` missing, sizes unchanged
- `TestInterstitialDoesNotParseUsePxRatioWhenRequestHasNoInterstitialImps` — malformed `ext` JSON does not cause an error when no interstitial imps are present
- `TestDeviceSizeToDips` — unit test for the conversion helper