### PR TITLE
New Adapter: Eskimi

### DIFF
--- a/adapters/eskimi/eskimi.go
+++ b/adapters/eskimi/eskimi.go
@@ -3,6 +3,7 @@ package eskimi
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/prebid/openrtb/v20/adcom1"
 	"github.com/prebid/openrtb/v20/openrtb2"
@@ -41,8 +42,12 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 
 	applyRequestParams(&outgoing, first)
 
-	impExts := make([]*openrtb_ext.ExtImpEskimi, len(outgoing.Imp))
-	impExts[0] = &first
+	// Imps whose ext fails to parse are dropped so malformed data is never
+	// forwarded upstream; the parse error is still reported to the caller.
+	imps := make([]openrtb2.Imp, 0, len(outgoing.Imp))
+	impExts := make([]*openrtb_ext.ExtImpEskimi, 0, len(outgoing.Imp))
+	imps = append(imps, outgoing.Imp[0])
+	impExts = append(impExts, &first)
 	var errs []error
 	for i := 1; i < len(outgoing.Imp); i++ {
 		ext, perr := parseImpExt(outgoing.Imp[i])
@@ -50,8 +55,10 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			errs = append(errs, perr)
 			continue
 		}
-		impExts[i] = &ext
+		imps = append(imps, outgoing.Imp[i])
+		impExts = append(impExts, &ext)
 	}
+	outgoing.Imp = imps
 
 	applyImpParams(&outgoing, impExts)
 
@@ -60,11 +67,16 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 		return nil, append(errs, err)
 	}
 
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+
 	return []*adapters.RequestData{{
-		Method: "POST",
-		Uri:    a.endpoint,
-		Body:   body,
-		ImpIDs: openrtb_ext.GetImpIDs(outgoing.Imp),
+		Method:  "POST",
+		Uri:     a.endpoint,
+		Body:    body,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(outgoing.Imp),
 	}}, errs
 }
 

--- a/adapters/eskimi/eskimi.go
+++ b/adapters/eskimi/eskimi.go
@@ -1,0 +1,247 @@
+package eskimi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the Eskimi adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: config.Endpoint}, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	if len(request.Imp) == 0 {
+		return nil, []error{&errortypes.BadInput{Message: "no impressions in the bid request"}}
+	}
+
+	outgoing := *request
+	outgoing.Imp = append([]openrtb2.Imp(nil), request.Imp...)
+
+	first, err := parseImpExt(outgoing.Imp[0])
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	if err := setPlacementID(&outgoing, first.PlacementID); err != nil {
+		return nil, []error{err}
+	}
+
+	applyRequestParams(&outgoing, first)
+
+	impExts := make([]*openrtb_ext.ExtImpEskimi, len(outgoing.Imp))
+	impExts[0] = &first
+	var errs []error
+	for i := 1; i < len(outgoing.Imp); i++ {
+		ext, perr := parseImpExt(outgoing.Imp[i])
+		if perr != nil {
+			errs = append(errs, perr)
+			continue
+		}
+		impExts[i] = &ext
+	}
+
+	applyImpParams(&outgoing, impExts)
+
+	body, err := jsonutil.Marshal(&outgoing)
+	if err != nil {
+		return nil, append(errs, err)
+	}
+
+	return []*adapters.RequestData{{
+		Method: "POST",
+		Uri:    a.endpoint,
+		Body:   body,
+		ImpIDs: openrtb_ext.GetImpIDs(outgoing.Imp),
+	}}, errs
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	var errs []error
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	if response.Cur != "" {
+		bidResponse.Currency = response.Cur
+	}
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bidType, typeErr := getMediaTypeForBid(request.Imp, seatBid.Bid[i])
+			if typeErr != nil {
+				errs = append(errs, typeErr)
+				continue
+			}
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: bidType,
+			})
+		}
+	}
+	return bidResponse, errs
+}
+
+func parseImpExt(imp openrtb2.Imp) (openrtb_ext.ExtImpEskimi, error) {
+	var bidderExt adapters.ExtImpBidder
+	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return openrtb_ext.ExtImpEskimi{}, &errortypes.BadInput{Message: fmt.Sprintf("invalid imp.ext for imp %s: %s", imp.ID, err)}
+	}
+	var eskimiExt openrtb_ext.ExtImpEskimi
+	if err := jsonutil.Unmarshal(bidderExt.Bidder, &eskimiExt); err != nil {
+		return openrtb_ext.ExtImpEskimi{}, &errortypes.BadInput{Message: fmt.Sprintf("invalid imp.ext.bidder for imp %s: %s", imp.ID, err)}
+	}
+	return eskimiExt, nil
+}
+
+// setPlacementID writes the placement ID to site.ext.placementId or app.ext.placementId,
+// preserving any other existing keys in the ext object.
+func setPlacementID(request *openrtb2.BidRequest, placementID int64) error {
+	patch := func(ext json.RawMessage) (json.RawMessage, error) {
+		fields := map[string]json.RawMessage{}
+		if len(ext) > 0 {
+			if err := jsonutil.Unmarshal(ext, &fields); err != nil {
+				return nil, err
+			}
+		}
+		id, err := jsonutil.Marshal(placementID)
+		if err != nil {
+			return nil, err
+		}
+		fields["placementId"] = id
+		return jsonutil.Marshal(fields)
+	}
+
+	switch {
+	case request.Site != nil:
+		site := *request.Site
+		ext, err := patch(site.Ext)
+		if err != nil {
+			return &errortypes.BadInput{Message: fmt.Sprintf("failed to set placementId on site.ext: %s", err)}
+		}
+		site.Ext = ext
+		request.Site = &site
+	case request.App != nil:
+		app := *request.App
+		ext, err := patch(app.Ext)
+		if err != nil {
+			return &errortypes.BadInput{Message: fmt.Sprintf("failed to set placementId on app.ext: %s", err)}
+		}
+		app.Ext = ext
+		request.App = &app
+	default:
+		return &errortypes.BadInput{Message: "request must contain either site or app"}
+	}
+	return nil
+}
+
+// applyRequestParams promotes request-level blocklists from the first imp's bidder ext
+// when the request doesn't already set them. Existing publisher/wrapper values win.
+func applyRequestParams(request *openrtb2.BidRequest, ext openrtb_ext.ExtImpEskimi) {
+	if len(request.BCat) == 0 && len(ext.Bcat) > 0 {
+		request.BCat = ext.Bcat
+	}
+	if len(request.BAdv) == 0 && len(ext.Badv) > 0 {
+		request.BAdv = ext.Badv
+	}
+	if len(request.BApp) == 0 && len(ext.Bapp) > 0 {
+		request.BApp = ext.Bapp
+	}
+}
+
+// applyImpParams applies per-imp params from the bidder ext: defaults imp.secure to 1,
+// fills bid floor when unset, and fans out battr to both banner.battr and video.battr.
+func applyImpParams(request *openrtb2.BidRequest, exts []*openrtb_ext.ExtImpEskimi) {
+	for i := range request.Imp {
+		if request.Imp[i].Secure == nil {
+			s := int8(1)
+			request.Imp[i].Secure = &s
+		}
+		ext := exts[i]
+		if ext == nil {
+			continue
+		}
+		if request.Imp[i].BidFloor == 0 && ext.BidFloor > 0 {
+			request.Imp[i].BidFloor = ext.BidFloor
+			if ext.BidFloorCur != "" {
+				request.Imp[i].BidFloorCur = ext.BidFloorCur
+			}
+		}
+		if len(ext.Battr) > 0 {
+			attrs := make([]adcom1.CreativeAttribute, len(ext.Battr))
+			for j, v := range ext.Battr {
+				attrs[j] = adcom1.CreativeAttribute(v)
+			}
+			if request.Imp[i].Banner != nil && len(request.Imp[i].Banner.BAttr) == 0 {
+				banner := *request.Imp[i].Banner
+				banner.BAttr = attrs
+				request.Imp[i].Banner = &banner
+			}
+			if request.Imp[i].Video != nil && len(request.Imp[i].Video.BAttr) == 0 {
+				video := *request.Imp[i].Video
+				video.BAttr = attrs
+				request.Imp[i].Video = &video
+			}
+		}
+	}
+}
+
+// getMediaTypeForBid resolves the bid's media type. When bid.mtype is set it is treated
+// as authoritative; an unsupported value returns an error rather than falling back to
+// imp inference. When bid.mtype is unset, the imp's media type is used; multi-format
+// imps without mtype cannot be disambiguated and return an error.
+func getMediaTypeForBid(imps []openrtb2.Imp, bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	if bid.MType != 0 {
+		switch bid.MType {
+		case openrtb2.MarkupBanner:
+			return openrtb_ext.BidTypeBanner, nil
+		case openrtb2.MarkupVideo:
+			return openrtb_ext.BidTypeVideo, nil
+		default:
+			return "", &errortypes.BadServerResponse{
+				Message: fmt.Sprintf("unsupported bid.mtype %d for impression %s (banner and video only)", bid.MType, bid.ImpID),
+			}
+		}
+	}
+	for _, imp := range imps {
+		if imp.ID != bid.ImpID {
+			continue
+		}
+		switch {
+		case imp.Banner != nil && imp.Video == nil:
+			return openrtb_ext.BidTypeBanner, nil
+		case imp.Video != nil && imp.Banner == nil:
+			return openrtb_ext.BidTypeVideo, nil
+		case imp.Banner != nil && imp.Video != nil:
+			return "", &errortypes.BadServerResponse{
+				Message: fmt.Sprintf("bid for multi-format imp %s requires bid.mtype to disambiguate", bid.ImpID),
+			}
+		}
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unsupported media type for impression %s (banner and video only)", bid.ImpID),
+		}
+	}
+	return "", &errortypes.BadServerResponse{
+		Message: fmt.Sprintf("unable to resolve media type for impression %s", bid.ImpID),
+	}
+}

--- a/adapters/eskimi/eskimi_test.go
+++ b/adapters/eskimi/eskimi_test.go
@@ -1,0 +1,157 @@
+package eskimi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+const testEndpoint = "https://ittr.eskimi.com/prebidjs"
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderEskimi, config.Adapter{
+		Endpoint: testEndpoint},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 814, DataCenter: "2"})
+
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	adapterstest.RunJSONBidderTest(t, "eskimitest", bidder)
+}
+
+func newAdapter() *adapter {
+	return &adapter{endpoint: testEndpoint}
+}
+
+func bannerImp(ext string) openrtb2.Imp {
+	return openrtb2.Imp{
+		ID:     "imp-1",
+		Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}},
+		Ext:    json.RawMessage(ext),
+	}
+}
+
+func TestMalformedSiteExt(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:   "req-1",
+		Imp:  []openrtb2.Imp{bannerImp(`{"bidder":{"placementId":625}}`)},
+		Site: &openrtb2.Site{ID: "271", Ext: json.RawMessage(`{invalid`)},
+	}
+	_, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "site.ext")
+}
+
+func TestMalformedAppExt(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:  "req-1",
+		Imp: []openrtb2.Imp{bannerImp(`{"bidder":{"placementId":625}}`)},
+		App: &openrtb2.App{ID: "app-1", Ext: json.RawMessage(`{invalid`)},
+	}
+	_, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "app.ext")
+}
+
+func TestImpSecureDefaultedToOne(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:   "req-1",
+		Imp:  []openrtb2.Imp{bannerImp(`{"bidder":{"placementId":625}}`)},
+		Site: &openrtb2.Site{ID: "271"},
+	}
+	reqData, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+	var out openrtb2.BidRequest
+	assert.NoError(t, json.Unmarshal(reqData[0].Body, &out))
+	assert.NotNil(t, out.Imp[0].Secure)
+	assert.EqualValues(t, 1, *out.Imp[0].Secure)
+}
+
+func TestImpSecureNotOverridden(t *testing.T) {
+	zero := int8(0)
+	imp := bannerImp(`{"bidder":{"placementId":625}}`)
+	imp.Secure = &zero
+	req := &openrtb2.BidRequest{
+		ID:   "req-1",
+		Imp:  []openrtb2.Imp{imp},
+		Site: &openrtb2.Site{ID: "271"},
+	}
+	reqData, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+	var out openrtb2.BidRequest
+	assert.NoError(t, json.Unmarshal(reqData[0].Body, &out))
+	assert.EqualValues(t, 0, *out.Imp[0].Secure)
+}
+
+// TestCallerRequestNotMutated asserts every copy-on-write surface in MakeRequests:
+// request.{BCat,BAdv,BApp}, request.{Site,App}.Ext, request.Imp[i].Secure,
+// request.Imp[i].{Banner,Video}.BAttr, and request.Imp[i].{BidFloor,BidFloorCur}.
+func TestCallerRequestNotMutated(t *testing.T) {
+	imp := openrtb2.Imp{
+		ID:     "imp-1",
+		Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}},
+		Video:  &openrtb2.Video{MIMEs: []string{"video/mp4"}, W: openrtb2.Int64Ptr(640), H: openrtb2.Int64Ptr(480)},
+		Ext: json.RawMessage(`{"bidder":{
+			"placementId":625,
+			"bcat":["IAB1"],"badv":["bad.com"],"bapp":["com.bad"],
+			"bidFloor":1.5,"bidFloorCur":"EUR",
+			"battr":[1,2]
+		}}`),
+	}
+	req := &openrtb2.BidRequest{
+		ID:   "req-1",
+		Imp:  []openrtb2.Imp{imp},
+		Site: &openrtb2.Site{ID: "271", Ext: json.RawMessage(`{"amp":0}`)},
+	}
+
+	_, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+
+	assert.Empty(t, req.BCat, "caller's request.BCat must not be mutated")
+	assert.Empty(t, req.BAdv, "caller's request.BAdv must not be mutated")
+	assert.Empty(t, req.BApp, "caller's request.BApp must not be mutated")
+	assert.JSONEq(t, `{"amp":0}`, string(req.Site.Ext), "caller's request.Site.Ext must not be mutated")
+	assert.Nil(t, req.Imp[0].Secure, "caller's imp[0].Secure must not be mutated")
+	assert.EqualValues(t, 0, req.Imp[0].BidFloor, "caller's imp[0].BidFloor must not be mutated")
+	assert.Empty(t, req.Imp[0].BidFloorCur, "caller's imp[0].BidFloorCur must not be mutated")
+	assert.Empty(t, req.Imp[0].Banner.BAttr, "caller's imp[0].Banner.BAttr must not be mutated")
+	assert.Empty(t, req.Imp[0].Video.BAttr, "caller's imp[0].Video.BAttr must not be mutated")
+}
+
+func TestCallerAppRequestNotMutated(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID:  "req-1",
+		Imp: []openrtb2.Imp{bannerImp(`{"bidder":{"placementId":625}}`)},
+		App: &openrtb2.App{ID: "app-1", Ext: json.RawMessage(`{"installed":1}`)},
+	}
+	_, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+	assert.JSONEq(t, `{"installed":1}`, string(req.App.Ext), "caller's request.App.Ext must not be mutated")
+}
+
+func TestLaterImpWithInvalidExtSurfacesError(t *testing.T) {
+	req := &openrtb2.BidRequest{
+		ID: "req-1",
+		Imp: []openrtb2.Imp{
+			bannerImp(`{"bidder":{"placementId":625,"bidFloor":1.5,"bidFloorCur":"EUR"}}`),
+			{ID: "imp-2", Banner: &openrtb2.Banner{}, Ext: json.RawMessage(`"not-an-object"`)},
+		},
+		Site: &openrtb2.Site{ID: "271"},
+	}
+	reqData, errs := newAdapter().MakeRequests(req, &adapters.ExtraRequestInfo{})
+	// First-imp request still goes out, but the bad later imp surfaces an error.
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "imp.ext")
+	assert.Len(t, reqData, 1)
+
+	var out openrtb2.BidRequest
+	assert.NoError(t, json.Unmarshal(reqData[0].Body, &out))
+	assert.EqualValues(t, 1.5, out.Imp[0].BidFloor)
+}

--- a/adapters/eskimi/eskimitest/exemplary/banner-web-with-buyeruid.json
+++ b/adapters/eskimi/eskimitest/exemplary/banner-web-with-buyeruid.json
@@ -1,0 +1,94 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com"
+    },
+    "user": {
+      "buyeruid": "eskimi-dmp-id-abc-123"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          },
+          "user": {
+            "buyeruid": "eskimi-dmp-id-abc-123"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 1.5,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 1.5,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/multi-imp-web.json
+++ b/adapters/eskimi/eskimitest/exemplary/multi-imp-web.json
@@ -1,0 +1,162 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "imp-banner",
+        "banner": {
+          "format": [
+            { "w": 300, "h": 250 }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      },
+      {
+        "id": "imp-video",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8],
+          "plcmt": 1
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 999
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com",
+      "page": "https://display.eskimi-creatives.com/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "imp-banner",
+              "secure": 1,
+              "banner": {
+                "format": [
+                  { "w": 300, "h": 250 }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            },
+            {
+              "id": "imp-video",
+              "secure": 1,
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8],
+                "plcmt": 1
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 999
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "page": "https://display.eskimi-creatives.com/",
+            "ext": {
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["imp-banner", "imp-video"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "imp-banner",
+                  "price": 1.25,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                },
+                {
+                  "id": "2",
+                  "impid": "imp-video",
+                  "price": 4.5,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine><Creatives><Creative><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+                  "crid": "video-creative-1",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "imp-banner",
+            "price": 1.25,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "id": "2",
+            "impid": "imp-video",
+            "price": 4.5,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine><Creatives><Creative><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "video-creative-1",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/optional-params.json
+++ b/adapters/eskimi/eskimitest/exemplary/optional-params.json
@@ -1,0 +1,120 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            { "w": 300, "h": 250 }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625,
+            "bidFloor": 1.5,
+            "bidFloorCur": "EUR",
+            "bcat": ["IAB1"],
+            "badv": ["bad.com"],
+            "bapp": ["com.bad.app"],
+            "battr": [1, 2]
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "bcat": ["IAB1"],
+          "badv": ["bad.com"],
+          "bapp": ["com.bad.app"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "bidfloor": 1.5,
+              "bidfloorcur": "EUR",
+              "banner": {
+                "format": [
+                  { "w": 300, "h": 250 }
+                ],
+                "battr": [1, 2]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625,
+                  "bidFloor": 1.5,
+                  "bidFloorCur": "EUR",
+                  "bcat": ["IAB1"],
+                  "badv": ["bad.com"],
+                  "bapp": ["com.bad.app"],
+                  "battr": [1, 2]
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": {
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 2.0,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 2.0,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/simple-banner-app.json
+++ b/adapters/eskimi/eskimitest/exemplary/simple-banner-app.json
@@ -1,0 +1,112 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            { "w": 320, "h": 50 }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "app-1",
+      "bundle": "com.eskimi.example",
+      "name": "Example App"
+    },
+    "device": {
+      "ifa": "00000000-0000-0000-0000-000000000000",
+      "os": "Android"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": {
+                "format": [
+                  { "w": 320, "h": 50 }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "app-1",
+            "bundle": "com.eskimi.example",
+            "name": "Example App",
+            "ext": {
+              "placementId": 625
+            }
+          },
+          "device": {
+            "ifa": "00000000-0000-0000-0000-000000000000",
+            "os": "Android"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 0.9,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 0.9,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/simple-banner-web.json
+++ b/adapters/eskimi/eskimitest/exemplary/simple-banner-web.json
@@ -1,0 +1,104 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            { "w": 300, "h": 250 }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com",
+      "page": "https://display.eskimi-creatives.com/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": {
+                "format": [
+                  { "w": 300, "h": 250 }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "page": "https://display.eskimi-creatives.com/",
+            "ext": {
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 1.25,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 1.25,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/simple-video-app.json
+++ b/adapters/eskimi/eskimitest/exemplary/simple-video-app.json
@@ -1,0 +1,116 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8],
+          "plcmt": 1
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      }
+    ],
+    "app": {
+      "id": "app-1",
+      "bundle": "com.eskimi.example",
+      "name": "Example App"
+    },
+    "device": {
+      "ifa": "00000000-0000-0000-0000-000000000000",
+      "os": "Android"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8],
+                "plcmt": 1
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            }
+          ],
+          "app": {
+            "id": "app-1",
+            "bundle": "com.eskimi.example",
+            "name": "Example App",
+            "ext": {
+              "placementId": 625
+            }
+          },
+          "device": {
+            "ifa": "00000000-0000-0000-0000-000000000000",
+            "os": "Android"
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 5.25,
+                  "nurl": "https://eskimi.com/win?bid=abc",
+                  "crid": "video-creative-1",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 5.25,
+            "nurl": "https://eskimi.com/win?bid=abc",
+            "crid": "video-creative-1",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/exemplary/simple-video-web.json
+++ b/adapters/eskimi/eskimitest/exemplary/simple-video-web.json
@@ -1,0 +1,108 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8],
+          "plcmt": 1
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com",
+      "page": "https://display.eskimi-creatives.com/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8],
+                "plcmt": 1
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "page": "https://display.eskimi-creatives.com/",
+            "ext": {
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 4.5,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine><Creatives><Creative><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+                  "crid": "video-creative-1",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 4.5,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine><Creatives><Creative><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "video-creative-1",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/app-ext-merge.json
+++ b/adapters/eskimi/eskimitest/supplemental/app-ext-merge.json
@@ -1,0 +1,71 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 320, "h": 50 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "app": {
+      "id": "app-1",
+      "bundle": "com.eskimi.example",
+      "ext": {
+        "installed": 1,
+        "data": { "category": "games" }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 320, "h": 50 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "app": {
+            "id": "app-1",
+            "bundle": "com.eskimi.example",
+            "ext": {
+              "installed": 1,
+              "data": { "category": "games" },
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 320, "h": 50, "mtype": 1 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 320, "h": 50, "mtype": 1 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/invalid-bidder-params.json
+++ b/adapters/eskimi/eskimitest/supplemental/invalid-bidder-params.json
@@ -1,0 +1,20 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid imp.ext.bidder for imp test-imp-id:.*",
+      "comparison": "regex"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": "not-an-object" }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": []
+}

--- a/adapters/eskimi/eskimitest/supplemental/invalid-imp-ext.json
+++ b/adapters/eskimi/eskimitest/supplemental/invalid-imp-ext.json
@@ -1,0 +1,20 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid imp.ext for imp test-imp-id:.*",
+      "comparison": "regex"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": "not-an-object"
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": []
+}

--- a/adapters/eskimi/eskimitest/supplemental/invalid-response-body.json
+++ b/adapters/eskimi/eskimitest/supplemental/invalid-response-body.json
@@ -1,0 +1,50 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": "this-should-be-an-array"
+        }
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": ".*",
+      "comparison": "regex"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/multi-format-imp-battr-dual-write.json
+++ b/adapters/eskimi/eskimitest/supplemental/multi-format-imp-battr-dual-write.json
@@ -1,0 +1,86 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625,
+            "battr": [13, 14]
+          }
+        }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": {
+                "format": [{ "w": 300, "h": 250 }],
+                "battr": [13, 14]
+              },
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8],
+                "battr": [13, 14]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625,
+                  "battr": [13, 14]
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 2.5, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480, "mtype": 2 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 2.5, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480, "mtype": 2 }, "type": "video" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/multi-format-imp-uses-mtype.json
+++ b/adapters/eskimi/eskimitest/supplemental/multi-format-imp-uses-mtype.json
@@ -1,0 +1,74 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8]
+        },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8]
+              },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "video-bid", "impid": "test-imp-id", "price": 4.0, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480, "mtype": 2 },
+                { "id": "banner-bid", "impid": "test-imp-id", "price": 1.5, "adm": "<div>ad</div>", "crid": "b-1", "w": 300, "h": 250, "mtype": 1 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "video-bid", "impid": "test-imp-id", "price": 4.0, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480, "mtype": 2 }, "type": "video" },
+        { "bid": { "id": "banner-bid", "impid": "test-imp-id", "price": 1.5, "adm": "<div>ad</div>", "crid": "b-1", "w": 300, "h": 250, "mtype": 1 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/multi-format-imp-without-mtype-errors.json
+++ b/adapters/eskimi/eskimitest/supplemental/multi-format-imp-without-mtype-errors.json
@@ -1,0 +1,76 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8]
+        },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8]
+              },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "ambiguous", "impid": "test-imp-id", "price": 2.0, "adm": "<div>?</div>", "crid": "c-1" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "bid for multi-format imp test-imp-id requires bid.mtype to disambiguate",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/multi-imp-asymmetry.json
+++ b/adapters/eskimi/eskimitest/supplemental/multi-imp-asymmetry.json
@@ -1,0 +1,103 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "imp-1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": {
+          "bidder": {
+            "placementId": 625,
+            "bcat": ["IAB-FROM-IMP-0"],
+            "bidFloor": 1.0
+          }
+        }
+      },
+      {
+        "id": "imp-2",
+        "banner": { "format": [{ "w": 728, "h": 90 }] },
+        "ext": {
+          "bidder": {
+            "placementId": 999,
+            "bcat": ["IAB-FROM-IMP-1"],
+            "bidFloor": 2.0,
+            "bidFloorCur": "EUR"
+          }
+        }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "bcat": ["IAB-FROM-IMP-0"],
+          "imp": [
+            {
+              "id": "imp-1",
+              "secure": 1,
+              "bidfloor": 1.0,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": {
+                "bidder": {
+                  "placementId": 625,
+                  "bcat": ["IAB-FROM-IMP-0"],
+                  "bidFloor": 1.0
+                }
+              }
+            },
+            {
+              "id": "imp-2",
+              "secure": 1,
+              "bidfloor": 2.0,
+              "bidfloorcur": "EUR",
+              "banner": { "format": [{ "w": 728, "h": 90 }] },
+              "ext": {
+                "bidder": {
+                  "placementId": 999,
+                  "bcat": ["IAB-FROM-IMP-1"],
+                  "bidFloor": 2.0,
+                  "bidFloorCur": "EUR"
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["imp-1", "imp-2"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "imp-1", "price": 1.5, "crid": "c1", "w": 300, "h": 250 },
+                { "id": "2", "impid": "imp-2", "price": 2.5, "crid": "c2", "w": 728, "h": 90 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "imp-1", "price": 1.5, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" },
+        { "bid": { "id": "2", "impid": "imp-2", "price": 2.5, "crid": "c2", "w": 728, "h": 90 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/multi-imp-invalid-second-dropped.json
+++ b/adapters/eskimi/eskimitest/supplemental/multi-imp-invalid-second-dropped.json
@@ -1,0 +1,79 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid imp.ext.bidder for imp imp-2:.*",
+      "comparison": "regex"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "imp-1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": {
+          "bidder": {
+            "placementId": 625
+          }
+        }
+      },
+      {
+        "id": "imp-2",
+        "banner": { "format": [{ "w": 728, "h": 90 }] },
+        "ext": { "bidder": "not-an-object" }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "imp-1",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": {
+                "bidder": {
+                  "placementId": 625
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["imp-1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "imp-1", "price": 1.5, "crid": "c1", "w": 300, "h": 250, "mtype": 1 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "imp-1", "price": 1.5, "crid": "c1", "w": 300, "h": 250, "mtype": 1 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/no-site-or-app.json
+++ b/adapters/eskimi/eskimitest/supplemental/no-site-or-app.json
@@ -1,0 +1,19 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "request must contain either site or app",
+      "comparison": "literal"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ]
+  },
+  "httpCalls": []
+}

--- a/adapters/eskimi/eskimitest/supplemental/pre-set-overrides-not-clobbered.json
+++ b/adapters/eskimi/eskimitest/supplemental/pre-set-overrides-not-clobbered.json
@@ -1,0 +1,96 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "bcat": ["IAB-EXISTING"],
+    "badv": ["existing-blocked.com"],
+    "bapp": ["com.existing.blocked"],
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "bidfloor": 5.0,
+        "bidfloorcur": "USD",
+        "banner": {
+          "format": [{ "w": 300, "h": 250 }],
+          "battr": [3]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625,
+            "bcat": ["IAB-FROM-EXT"],
+            "badv": ["ext-blocked.com"],
+            "bapp": ["com.ext.blocked"],
+            "bidFloor": 1.0,
+            "bidFloorCur": "EUR",
+            "battr": [1, 2]
+          }
+        }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "bcat": ["IAB-EXISTING"],
+          "badv": ["existing-blocked.com"],
+          "bapp": ["com.existing.blocked"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "bidfloor": 5.0,
+              "bidfloorcur": "USD",
+              "banner": {
+                "format": [{ "w": 300, "h": 250 }],
+                "battr": [3]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625,
+                  "bcat": ["IAB-FROM-EXT"],
+                  "badv": ["ext-blocked.com"],
+                  "bapp": ["com.ext.blocked"],
+                  "bidFloor": 1.0,
+                  "bidFloorCur": "EUR",
+                  "battr": [1, 2]
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 6.0, "crid": "c1", "w": 300, "h": 250 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 6.0, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/privacy-signals-pass-through.json
+++ b/adapters/eskimi/eskimitest/supplemental/privacy-signals-pass-through.json
@@ -1,0 +1,89 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" },
+    "user": {
+      "ext": {
+        "consent": "CO12345abcdefghijklmnopqrstuvwxyz"
+      }
+    },
+    "regs": {
+      "coppa": 1,
+      "us_privacy": "1YYY",
+      "gpp": "DBABMA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+      "gpp_sid": [7, 8],
+      "ext": {
+        "gdpr": 1
+      }
+    },
+    "device": {
+      "lmt": 1,
+      "dnt": 1
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          },
+          "user": {
+            "ext": { "consent": "CO12345abcdefghijklmnopqrstuvwxyz" }
+          },
+          "regs": {
+            "coppa": 1,
+            "us_privacy": "1YYY",
+            "gpp": "DBABMA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+            "gpp_sid": [7, 8],
+            "ext": { "gdpr": 1 }
+          },
+          "device": { "lmt": 1, "dnt": 1 }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/response-204.json
+++ b/adapters/eskimi/eskimitest/supplemental/response-204.json
@@ -1,0 +1,41 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/eskimi/eskimitest/supplemental/response-400.json
+++ b/adapters/eskimi/eskimitest/supplemental/response-400.json
@@ -1,0 +1,46 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 400
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/response-500.json
+++ b/adapters/eskimi/eskimitest/supplemental/response-500.json
@@ -1,0 +1,46 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 500
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/response-no-cur.json
+++ b/adapters/eskimi/eskimitest/supplemental/response-no-cur.json
@@ -1,0 +1,59 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/schain-pass-through.json
+++ b/adapters/eskimi/eskimitest/supplemental/schain-pass-through.json
@@ -1,0 +1,80 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" },
+    "source": {
+      "schain": {
+        "complete": 1,
+        "ver": "1.0",
+        "nodes": [
+          { "asi": "publisher.com", "sid": "pub-sid-1", "hp": 1 },
+          { "asi": "ssp.example", "sid": "ssp-sid-2", "hp": 1 }
+        ]
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          },
+          "source": {
+            "schain": {
+              "complete": 1,
+              "ver": "1.0",
+              "nodes": [
+                { "asi": "publisher.com", "sid": "pub-sid-1", "hp": 1 },
+                { "asi": "ssp.example", "sid": "ssp-sid-2", "hp": 1 }
+              ]
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/site-ext-merge.json
+++ b/adapters/eskimi/eskimitest/supplemental/site-ext-merge.json
@@ -1,0 +1,71 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": {
+      "id": "271",
+      "domain": "display.eskimi-creatives.com",
+      "ext": {
+        "amp": 0,
+        "data": { "category": "news" }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": {
+              "amp": 0,
+              "data": { "category": "news" },
+              "placementId": 625
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 1.0, "crid": "c1", "w": 300, "h": 250 }, "type": "banner" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/unmatched-bid-impid.json
+++ b/adapters/eskimi/eskimitest/supplemental/unmatched-bid-impid.json
@@ -1,0 +1,64 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "b1", "impid": "unknown-imp", "price": 1.0, "crid": "c1" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unable to resolve media type for impression unknown-imp",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/unsupported-bid-media-type.json
+++ b/adapters/eskimi/eskimitest/supplemental/unsupported-bid-media-type.json
@@ -1,0 +1,75 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": 625 } }
+      },
+      {
+        "id": "native-imp",
+        "native": { "request": "{}" },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": 625 } }
+            },
+            {
+              "id": "native-imp",
+              "secure": 1,
+              "native": { "request": "{}" },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id", "native-imp"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "native-imp", "price": 1.0, "crid": "c1" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unsupported media type for impression native-imp (banner and video only)",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/video-no-mtype-inferred.json
+++ b/adapters/eskimi/eskimitest/supplemental/video-no-mtype-inferred.json
@@ -1,0 +1,70 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480,
+          "protocols": [2, 3, 5, 6, 7, 8]
+        },
+        "ext": { "bidder": { "placementId": 625 } }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "protocols": [2, 3, 5, 6, 7, 8]
+              },
+              "ext": { "bidder": { "placementId": 625 } }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                { "id": "1", "impid": "test-imp-id", "price": 3.0, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        { "bid": { "id": "1", "impid": "test-imp-id", "price": 3.0, "adm": "<VAST/>", "crid": "v-1", "w": 640, "h": 480 }, "type": "video" }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/eskimitest/supplemental/video-outstream-web.json
+++ b/adapters/eskimi/eskimitest/supplemental/video-outstream-web.json
@@ -1,0 +1,104 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 360,
+          "protocols": [2, 3, 5, 6, 7, 8],
+          "plcmt": 4
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 625,
+            "battr": [13, 14]
+          }
+        }
+      }
+    ],
+    "site": { "id": "271", "domain": "display.eskimi-creatives.com" }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ittr.eskimi.com/prebidjs",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "secure": 1,
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 360,
+                "protocols": [2, 3, 5, 6, 7, 8],
+                "plcmt": 4,
+                "battr": [13, 14]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 625,
+                  "battr": [13, 14]
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "271",
+            "domain": "display.eskimi-creatives.com",
+            "ext": { "placementId": 625 }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "eskimi",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 3.5,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "outstream-1",
+                  "w": 640,
+                  "h": 360,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 3.5,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "outstream-1",
+            "w": 640,
+            "h": 360,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/eskimi/params_test.go
+++ b/adapters/eskimi/params_test.go
@@ -1,0 +1,56 @@
+package eskimi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json schema. %v", err)
+	}
+
+	for _, p := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderEskimi, json.RawMessage(p)); err != nil {
+			t.Errorf("Schema rejected valid params: %s", p)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json schema. %v", err)
+	}
+
+	for _, p := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderEskimi, json.RawMessage(p)); err == nil {
+			t.Errorf("Schema allowed invalid params: %s", p)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"placementId":625}`,
+	`{"placementId":625,"bidFloor":0.5,"bidFloorCur":"USD"}`,
+	`{"placementId":625,"bcat":["IAB1"],"badv":["bad.com"],"bapp":["com.bad.app"]}`,
+	`{"placementId":625,"battr":[1,2,17]}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`{}`,
+	`{"placementId":"625"}`,
+	`{"placementId":625.5}`,
+	`{"placementId":0}`,
+	`{"placementId":-1}`,
+	`{"bidFloor":0.5}`,
+	`{"placementId":625,"bcat":"IAB1"}`,
+	`{"placementId":625,"battr":[0]}`,
+	`{"placementId":625,"battr":[18]}`,
+	`{"placementId":625,"unknownField":"foo"}`,
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -104,6 +104,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/eplanning"
 	"github.com/prebid/prebid-server/v4/adapters/epom"
 	"github.com/prebid/prebid-server/v4/adapters/escalax"
+	"github.com/prebid/prebid-server/v4/adapters/eskimi"
 	"github.com/prebid/prebid-server/v4/adapters/exco"
 	"github.com/prebid/prebid-server/v4/adapters/feedad"
 	"github.com/prebid/prebid-server/v4/adapters/flatads"
@@ -373,6 +374,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderEPlanning:         eplanning.Builder,
 		openrtb_ext.BidderEpom:              epom.Builder,
 		openrtb_ext.BidderEscalax:           escalax.Builder,
+		openrtb_ext.BidderEskimi:            eskimi.Builder,
 		openrtb_ext.BidderExco:              exco.Builder,
 		openrtb_ext.BidderEVolution:         evolution.Builder,
 		openrtb_ext.BidderFeedAd:            feedad.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -120,6 +120,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderEPlanning,
 	BidderEpom,
 	BidderEscalax,
+	BidderEskimi,
 	BidderEVolution,
 	BidderExco,
 	BidderFeedAd,
@@ -496,6 +497,7 @@ const (
 	BidderEPlanning         BidderName = "eplanning"
 	BidderEpom              BidderName = "epom"
 	BidderEscalax           BidderName = "escalax"
+	BidderEskimi            BidderName = "eskimi"
 	BidderExco              BidderName = "exco"
 	BidderEVolution         BidderName = "e_volution"
 	BidderFeedAd            BidderName = "feedad"

--- a/openrtb_ext/imp_eskimi.go
+++ b/openrtb_ext/imp_eskimi.go
@@ -1,0 +1,14 @@
+package openrtb_ext
+
+// ExtImpEskimi defines the contract for bidrequest.imp[i].ext.prebid.bidder.eskimi.
+// COPPA and test flags are handled by PBS core via request.regs.coppa / request.test;
+// they are not duplicated as bidder params.
+type ExtImpEskimi struct {
+	PlacementID int64    `json:"placementId"`
+	BidFloor    float64  `json:"bidFloor,omitempty"`
+	BidFloorCur string   `json:"bidFloorCur,omitempty"`
+	Bcat        []string `json:"bcat,omitempty"`
+	Badv        []string `json:"badv,omitempty"`
+	Bapp        []string `json:"bapp,omitempty"`
+	Battr       []int64  `json:"battr,omitempty"`
+}

--- a/static/bidder-info/eskimi.yaml
+++ b/static/bidder-info/eskimi.yaml
@@ -1,0 +1,21 @@
+endpoint: "https://ittr.eskimi.com/prebidjs"
+maintainer:
+  email: prebid@eskimi.com
+gvlVendorID: 814
+modifyingVastXmlAllowed: false
+openrtb:
+  version: 2.6
+  gpp-supported: true
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+  site:
+    mediaTypes:
+      - banner
+      - video
+userSync:
+  redirect:
+    url: "https://ittpx.eskimi.com/sync?sp_id=137&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&dest={{.RedirectURL}}"
+    userMacro: "${USER_ID}"

--- a/static/bidder-params/eskimi.json
+++ b/static/bidder-params/eskimi.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Eskimi Adapter Params",
+  "description": "A schema which validates params accepted by the Eskimi adapter",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "placementId": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The Eskimi placement ID"
+    },
+    "bidFloor": {
+      "type": "number",
+      "minimum": 0,
+      "description": "The minimum bid floor (USD unless bidFloorCur is set)"
+    },
+    "bidFloorCur": {
+      "type": "string",
+      "description": "The currency of the bid floor"
+    },
+    "bcat": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Blocked IAB advertiser categories"
+    },
+    "badv": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Blocked advertiser domains"
+    },
+    "bapp": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Blocked app bundles"
+    },
+    "battr": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1, "maximum": 17 },
+      "description": "Blocked creative attributes (OpenRTB List 5.3)"
+    }
+  },
+  "required": ["placementId"]
+}


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter
- [ ] Bugfix
- [ ] Feature
- [ ] Updated bidder adapter
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI

## Overview

Hi Prebid maintainers,

This PR adds the **Eskimi** bidder adapter to prebid-server. Eskimi is a global
DSP/SSP and already ships a Prebid.js adapter (`bidder: eskimi`, GVL ID **814**) —
this PR brings the same demand to server-side header bidding so publishers using
PBS can buy Eskimi inventory without a client-side wrapper.

**Scope**
- Formats: banner, video (instream + outstream)
- Inventory: site (web) and app
- Cookie sync: redirect type
- OpenRTB 2.6 compliant; forwards `regs` (TCF v2, USP/CCPA, COPPA, GPP), `user.ext.consent`,
  `device.lmt`/`device.dnt`, and `source.schain` through unmodified — Eskimi's exchange
  normalizes these via its `BidRequestSanitizer` so spec-positioned signals are read directly.
- VAST handling: the adapter forwards `bid.adm` (inline VAST) and `bid.nurl` (VAST URL)
  through unchanged for video bids; PBS-side VAST caching is handled by PBS core when the
  bid is typed as video. `modifyingVastXmlAllowed: false` is declared explicitly.
- Long-form video (multi-ad pod via `/openrtb2/video`) is out of scope for this PR.

## Adapter behavior

- `imp[].ext.bidder.placementId` (integer ≥ 1, required) — the placement ID is read
  from the **first imp's** bidder ext and promoted to `site.ext.placementId` (web) or
  `app.ext.placementId` (app). Mirrors what Eskimi's backend reads
  (`bidRequest.site.orElse(app).ext.placementId`) — the contract the Prebid.js adapter
  has used in production for years.
- Existing `site.ext`/`app.ext` fields are preserved (merge, not overwrite).
- Optional bidder params: `bcat`, `badv`, `bapp` are promoted to request-level only
  when the request hasn't already set them (wrappers composing PBS still win);
  `bidFloor`, `bidFloorCur`, `battr` are applied per imp under the same guard.
- `imp.secure` defaults to 1 when unset, matching the Prebid.js adapter's
  secure-first behavior — many downstream demand partners require HTTPS-only
  creatives.
- COPPA and test flags are intentionally NOT bidder params: PBS core already
  propagates `request.regs.coppa` and `request.test` from the incoming oRTB request.
- Bid type resolution treats `bid.mtype` (OpenRTB 2.6) as authoritative when
  set — unsupported values (audio, native) surface a `BadServerResponse`. When
  `bid.mtype` is absent the imp's media type is used; multi-format imps
  (banner + video on the same imp) require `bid.mtype` to disambiguate and
  otherwise surface a `BadServerResponse`.

## Cookie sync

```yaml
userSync:
  redirect:
    url: "https://ittpx.eskimi.com/sync?sp_id=137&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&dest={{.RedirectURL}}"
    userMacro: "${USER_ID}"
```

Standard PBS redirect-type sync. `ittpx.eskimi.com` is Eskimi's dedicated
supply-side cookie-sync host (separate from the bidder endpoint to allow
independent CDN/TLS rotation; both terminate on Eskimi-owned infra). Our endpoint
substitutes `${USER_ID}` with the Eskimi user ID and 302s back to the PBS setuid
URL provided in `dest`.

## Hosting note for PBS operators

Eskimi serves bid + sync from regional hosts. The yaml ships **EU defaults**,
matching the live Prebid.js adapter's fallback when timezone detection is
ambiguous. PBS deployments outside Europe should override per their region:

| Region       | Bid endpoint                          | Sync URL host                   |
|--------------|---------------------------------------|---------------------------------|
| EU (default) | `https://ittr.eskimi.com/prebidjs`    | `https://ittpx.eskimi.com/sync` |
| US           | `https://ittr-us-e.eskimi.com/prebidjs` | `https://ittpx-us-e.eskimi.com/sync` |
| APAC         | `https://ittr-asia.eskimi.com/prebidjs` | `https://ittpx-asia.eskimi.com/sync` |

Override via standard PBS host config:

```yaml
adapters:
  eskimi:
    endpoint: "https://ittr-us-e.eskimi.com/prebidjs"
    usersync_url: "https://ittpx-us-e.eskimi.com/sync?sp_id=137&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&dest={{.RedirectURL}}"
```

## Tests

- `go test ./adapters/eskimi/...` — passes, **96.6% coverage**
- `go test ./openrtb_ext/... ./config/... ./router/...` — passes (validates bidder
  registration, params schema strictness, and info yaml capabilities)
- `./validate.sh --nofmt --cov` — passes
- 6 exemplary fixtures (banner-web, banner-app, video-web, video-app, optional
  params, post-sync `user.buyeruid`) + 21 supplemental fixtures covering:
  schain pass-through, full privacy-signal pass-through (TCF/USP/GPP/COPPA/LMT/DNT),
  pre-set bcat/badv/bapp/bidfloor/battr not clobbered by ext, multi-imp asymmetry,
  site.ext and app.ext field-preservation merge, video-outstream with battr,
  multi-format imp (banner+video) typed via `bid.mtype`, multi-format imp without
  mtype surfaces `BadServerResponse`, multi-format imp battr dual-write to both
  banner.battr and video.battr, video-only imp without mtype falls back to imp
  inference, response 204 / 400 / 500 / no `cur`, malformed imp.ext, malformed
  bidder params, malformed response body, missing site/app, unmatched bid impid,
  unsupported bid media type. White-box tests cover caller-request mutation
  safety (every COW surface), `imp.secure` default behavior, and app-side ext
  preservation.

## Docs

Companion docs PR on prebid/prebid.github.io: https://github.com/prebid/prebid.github.io/pull/6591

## Maintainer

`prebid@eskimi.com` (alias is verified live and monitored by the Eskimi exchange team).

Happy to iterate on review feedback — thanks for maintaining the project.
