### PR TITLE
IMDS: Add advertising (advertising.com) alias to represent the rebranded entity

### DIFF
--- a/static/bidder-info/advertising.yaml
+++ b/static/bidder-info/advertising.yaml
@@ -1,0 +1,2 @@
+aliasOf: "imds"
+endpoint: "https://pbs.technoratimedia.com/openrtb/bids/{{.AccountID}}?src={{.SourceId}}&adapter=advertising"


### PR DESCRIPTION
Adds `advertising` as an alias of the `imds` bidder via the `aliasOf` directive, reflecting the ownership change from iMedia Digital Services to Advertising.com.

This replaces the closed #4258 (which did a full rename). Per feedback on that PR from @bsardo, @bretg and @ShriprasadM, this keeps full backwards compatibility: the existing `imds` and `synacormedia` bidder codes continue to work, and `advertising` is added as a non-breaking alias. 

Other related PRs: (all merged)
https://github.com/prebid/Prebid.js/pull/12878
https://github.com/prebid/prebid.github.io/pull/5943