### PR TITLE
Medianet: Add regional endpoint support

### DIFF
--- a/static/bidder-info/medianet.yaml
+++ b/static/bidder-info/medianet.yaml
@@ -1,5 +1,5 @@
-# Media.net's Prebid Server adapter supports regional endpoints.
-# Set the endpoint below to match the datacenter region where this config is deployed:
+# Media.net supports the following regional endpoint domains.
+# Kindly set the endpoint below to match the datacenter region where this config is deployed:
 #   US East  → https://prebid-adapter-useast.media.net/rtb/pb/prebids2s
 #   US West  → https://prebid-adapter-uswest.media.net/rtb/pb/prebids2s
 #   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s

--- a/static/bidder-info/medianet.yaml
+++ b/static/bidder-info/medianet.yaml
@@ -1,4 +1,12 @@
-endpoint: "https://prebid-adapter.media.net/rtb/pb/prebids2s"
+# Media.net's Prebid Server adapter supports regional endpoints.
+# Set the endpoint below to match the datacenter region where this config is deployed:
+#   US East  → https://prebid-adapter-useast.media.net/rtb/pb/prebids2s
+#   US West  → https://prebid-adapter-uswest.media.net/rtb/pb/prebids2s
+#   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s
+#   Europe   → https://prebid-adapter-eu.media.net/rtb/pb/prebids2s
+#
+# Replace REGION in the endpoint URL with: useast | uswest | asia | eu
+endpoint: "https://prebid-adapter-REGION.media.net/rtb/pb/prebids2s"
 extra_info: "https://medianet.golang.pbs.com"
 maintainer:
   email: "prebid-support@media.net"

--- a/static/bidder-info/medianet.yaml
+++ b/static/bidder-info/medianet.yaml
@@ -5,8 +5,8 @@
 #   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s
 #   Europe   → https://prebid-adapter-eu.media.net/rtb/pb/prebids2s
 #
-# Replace REGION in the endpoint URL with: useast | uswest | asia | eu
-endpoint: "https://prebid-adapter-REGION.media.net/rtb/pb/prebids2s"
+# Replace [REGION] in the endpoint URL with: useast | uswest | asia | eu
+endpoint: "https://prebid-adapter-[REGION].media.net/rtb/pb/prebids2s"
 extra_info: "https://medianet.golang.pbs.com"
 maintainer:
   email: "prebid-support@media.net"


### PR DESCRIPTION
Update the Media.net adapter endpoint to support datacenter-specific regional URLs (useast, uswest, asia, eu) with documentation comments.

[prebid-server-java MR](https://github.com/prebid/prebid-server-java/pull/4525/)