### PR TITLE
New Adapter: Realry

### DIFF
--- a/adapters/realry/params_test.go
+++ b/adapters/realry/params_test.go
@@ -1,0 +1,52 @@
+package realry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+// Validates static/bidder-params/realry.json — the JSON schema applied
+// to imp.ext.prebid.bidder.realry at request-parse time.
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+	for _, p := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderRealry, json.RawMessage(p)); err != nil {
+			t.Errorf("Schema rejected realry params: %s — %v", p, err)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+	for _, p := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderRealry, json.RawMessage(p)); err == nil {
+			t.Errorf("Schema allowed unexpected realry params: %s", p)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"placementId": "slot-1"}`,
+	`{"placementId": "slot-1", "sellerId": "seller-acme"}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`[]`,
+	`{}`,
+	`{"sellerId": "seller-acme"}`,
+	`{"placementId": ""}`,
+	`{"placementId": "slot-1", "sellerId": ""}`,
+}

--- a/adapters/realry/realry.go
+++ b/adapters/realry/realry.go
@@ -1,0 +1,120 @@
+// Package realry is the Prebid Server bidder adapter for the Realry
+// commerce DSP (https://bid.realry.com). The adapter is intentionally
+// thin — Realry's /bid/openrtb endpoint speaks standard OpenRTB 2.6
+// with Native 1.2 admObject support, so MakeRequests just forwards the
+// BidRequest and MakeBids walks the BidResponse seatbids.
+//
+// Bid type inference: Realry's endpoint does NOT set ext.prebid.type on
+// returned bids (it returns plain openrtb2.Bid). The adapter infers the
+// bid type from the matching imp's media types — imp.Native present →
+// native, otherwise banner. Realry does not currently bid on video.
+package realry
+
+import (
+	"net/http"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder constructs the Realry adapter. Per Prebid convention the
+// endpoint URL is wired from `pbs.yaml` config (`adapters.realry.endpoint`)
+// — we don't pin it in code so a host can repoint at a staging Realry
+// for integration testing.
+func Builder(_ openrtb_ext.BidderName, config config.Adapter, _ config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: config.Endpoint}, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	requestJSON, err := jsonutil.Marshal(request)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+	// X-SSP-Id is required by bid.realry.com — the Prebid Server host
+	// is the SSP from Realry's perspective, identified by a stable label.
+	// "prebid-server" is the default; host can override per-deployment
+	// via prebid-server config if Realry assigns a unique partner id.
+	headers.Add("X-SSP-Id", "prebid-server")
+	// Bearer token: while bid.realry.com is in OPEN MODE the value is
+	// not checked beyond non-empty. When Realry flips to closed mode
+	// (OPENRTB_SSPS set on their side) the host running prebid-server
+	// will need to inject the assigned token — see config.Adapter
+	// ExtraAdapterInfo for the wiring point.
+	headers.Add("Authorization", "Bearer prebid-server")
+
+	return []*adapters.RequestData{{
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    requestJSON,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+	}}, nil
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if responseData.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+	if responseData.StatusCode == http.StatusBadRequest {
+		return nil, []error{&errortypes.BadInput{
+			Message: "Realry: HTTP 400 from bid.realry.com (run with request.debug = 1 for more info).",
+		}}
+	}
+	if responseData.StatusCode != http.StatusOK {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: "Realry: unexpected status from bid.realry.com.",
+		}}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	// Build a quick impid → mediaType index so each returned bid's
+	// type can be inferred from the imp it answered.
+	mediaByImp := make(map[string]openrtb_ext.BidType, len(request.Imp))
+	for _, imp := range request.Imp {
+		switch {
+		case imp.Native != nil:
+			mediaByImp[imp.ID] = openrtb_ext.BidTypeNative
+		case imp.Banner != nil:
+			mediaByImp[imp.ID] = openrtb_ext.BidTypeBanner
+		default:
+			mediaByImp[imp.ID] = openrtb_ext.BidTypeBanner
+		}
+	}
+
+	bidResponse := adapters.NewBidderResponse()
+	bidResponse.Currency = response.Cur
+	var errs []error
+	for _, seat := range response.SeatBid {
+		for i := range seat.Bid {
+			bid := &seat.Bid[i]
+			bidType, ok := mediaByImp[bid.ImpID]
+			if !ok {
+				errs = append(errs, &errortypes.BadServerResponse{
+					Message: "Realry: bid for unknown impid " + bid.ImpID,
+				})
+				continue
+			}
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     bid,
+				BidType: bidType,
+			})
+		}
+	}
+	return bidResponse, errs
+}

--- a/adapters/realry/realry_test.go
+++ b/adapters/realry/realry_test.go
@@ -1,0 +1,19 @@
+package realry
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, err := Builder(openrtb_ext.BidderRealry, config.Adapter{
+		Endpoint: "https://bid.realry.com/bid/openrtb",
+	}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	if err != nil {
+		t.Fatalf("Builder returned unexpected error %v", err)
+	}
+	adapterstest.RunJSONBidderTest(t, "realrytest", bidder)
+}

--- a/adapters/realry/realrytest/exemplary/simple-banner.json
+++ b/adapters/realry/realrytest/exemplary/simple-banner.json
@@ -1,0 +1,102 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-banner-1",
+    "site": {
+      "id": "site-luxury-fashion",
+      "page": "https://publisher.example/articles/handbags"
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "geo": { "country": "US" }
+    },
+    "imp": [
+      {
+        "id": "test-imp-banner",
+        "tagid": "rail-300x250",
+        "banner": {
+          "format": [{ "w": 300, "h": 250 }]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "slot-pdp-1"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bid.realry.com/bid/openrtb",
+        "body": {
+          "id": "test-request-banner-1",
+          "site": {
+            "id": "site-luxury-fashion",
+            "page": "https://publisher.example/articles/handbags"
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "geo": { "country": "US" }
+          },
+          "imp": [
+            {
+              "id": "test-imp-banner",
+              "tagid": "rail-300x250",
+              "banner": {
+                "format": [{ "w": 300, "h": 250 }]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": "slot-pdp-1"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-banner"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-banner-1",
+          "cur": "USD",
+          "bidid": "bid-xyz",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-xyz",
+                  "impid": "test-imp-banner",
+                  "price": 1.25,
+                  "adm": "<a href=\"https://bid.realry.com/click?bid_id=bid-xyz\"><img src=\"https://cdn.example.com/bag.jpg\" /></a>",
+                  "nurl": "https://bid.realry.com/imp?bid_id=bid-xyz",
+                  "cid": "camp-1",
+                  "crid": "prod-42"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-xyz",
+            "impid": "test-imp-banner",
+            "price": 1.25,
+            "adm": "<a href=\"https://bid.realry.com/click?bid_id=bid-xyz\"><img src=\"https://cdn.example.com/bag.jpg\" /></a>",
+            "nurl": "https://bid.realry.com/imp?bid_id=bid-xyz",
+            "cid": "camp-1",
+            "crid": "prod-42"
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/realry/realrytest/exemplary/simple-native.json
+++ b/adapters/realry/realrytest/exemplary/simple-native.json
@@ -1,0 +1,104 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-native-1",
+    "site": {
+      "id": "site-luxury-fashion",
+      "page": "https://publisher.example/articles/handbags"
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "geo": { "country": "US" }
+    },
+    "imp": [
+      {
+        "id": "test-imp-native",
+        "tagid": "native-slot-1",
+        "native": {
+          "ver": "1.2",
+          "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":300,\"hmin\":250}},{\"id\":3,\"data\":{\"type\":1,\"len\":40}},{\"id\":4,\"data\":{\"type\":6}}]}"
+        },
+        "ext": {
+          "bidder": {
+            "placementId": "slot-pdp-1"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bid.realry.com/bid/openrtb",
+        "body": {
+          "id": "test-request-native-1",
+          "site": {
+            "id": "site-luxury-fashion",
+            "page": "https://publisher.example/articles/handbags"
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "geo": { "country": "US" }
+          },
+          "imp": [
+            {
+              "id": "test-imp-native",
+              "tagid": "native-slot-1",
+              "native": {
+                "ver": "1.2",
+                "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":300,\"hmin\":250}},{\"id\":3,\"data\":{\"type\":1,\"len\":40}},{\"id\":4,\"data\":{\"type\":6}}]}"
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": "slot-pdp-1"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-native"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-native-1",
+          "cur": "USD",
+          "bidid": "bid-abc",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-abc",
+                  "impid": "test-imp-native",
+                  "price": 0.85,
+                  "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"title\":{\"text\":\"Leather Crossbody Bag\"}},{\"id\":2,\"img\":{\"type\":3,\"url\":\"https://cdn.example.com/bag.jpg\"}},{\"id\":3,\"data\":{\"type\":1,\"value\":\"Acme Boutique\"}},{\"id\":4,\"data\":{\"type\":6,\"value\":\"USD 0.85\"}}],\"link\":{\"url\":\"https://bid.realry.com/click?bid_id=bid-abc\"}}",
+                  "nurl": "https://bid.realry.com/imp?bid_id=bid-abc",
+                  "cid": "camp-1",
+                  "crid": "prod-42"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-abc",
+            "impid": "test-imp-native",
+            "price": 0.85,
+            "adm": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"title\":{\"text\":\"Leather Crossbody Bag\"}},{\"id\":2,\"img\":{\"type\":3,\"url\":\"https://cdn.example.com/bag.jpg\"}},{\"id\":3,\"data\":{\"type\":1,\"value\":\"Acme Boutique\"}},{\"id\":4,\"data\":{\"type\":6,\"value\":\"USD 0.85\"}}],\"link\":{\"url\":\"https://bid.realry.com/click?bid_id=bid-abc\"}}",
+            "nurl": "https://bid.realry.com/imp?bid_id=bid-abc",
+            "cid": "camp-1",
+            "crid": "prod-42"
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/realry/realrytest/supplemental/204-no-bid.json
+++ b/adapters/realry/realrytest/supplemental/204-no-bid.json
@@ -1,0 +1,35 @@
+{
+  "mockBidRequest": {
+    "id": "test-no-bid",
+    "imp": [
+      {
+        "id": "test-imp-1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": "slot-x" } }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bid.realry.com/bid/openrtb",
+        "body": {
+          "id": "test-no-bid",
+          "imp": [
+            {
+              "id": "test-imp-1",
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": "slot-x" } }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-1"]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/realry/realrytest/supplemental/400-bad-input.json
+++ b/adapters/realry/realrytest/supplemental/400-bad-input.json
@@ -1,0 +1,40 @@
+{
+  "mockBidRequest": {
+    "id": "test-bad-input",
+    "imp": [
+      {
+        "id": "test-imp-1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": "slot-x" } }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bid.realry.com/bid/openrtb",
+        "body": {
+          "id": "test-bad-input",
+          "imp": [
+            {
+              "id": "test-imp-1",
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": "slot-x" } }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-1"]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": "missing OpenRTB id"
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Realry: HTTP 400 from bid.realry.com (run with request.debug = 1 for more info).",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/realry/realrytest/supplemental/500-server-error.json
+++ b/adapters/realry/realrytest/supplemental/500-server-error.json
@@ -1,0 +1,40 @@
+{
+  "mockBidRequest": {
+    "id": "test-server-err",
+    "imp": [
+      {
+        "id": "test-imp-1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "placementId": "slot-x" } }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://bid.realry.com/bid/openrtb",
+        "body": {
+          "id": "test-server-err",
+          "imp": [
+            {
+              "id": "test-imp-1",
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "placementId": "slot-x" } }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-1"]
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": "internal"
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Realry: unexpected status from bid.realry.com.",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -191,6 +191,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/pwbid"
 	"github.com/prebid/prebid-server/v4/adapters/qt"
 	"github.com/prebid/prebid-server/v4/adapters/readpeak"
+	"github.com/prebid/prebid-server/v4/adapters/realry"
 	"github.com/prebid/prebid-server/v4/adapters/rediads"
 	"github.com/prebid/prebid-server/v4/adapters/relevantdigital"
 	"github.com/prebid/prebid-server/v4/adapters/resetdigital"
@@ -464,6 +465,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderPWBid:             pwbid.Builder,
 		openrtb_ext.BidderQT:                qt.Builder,
 		openrtb_ext.BidderReadpeak:          readpeak.Builder,
+		openrtb_ext.BidderRealry:            realry.Builder,
 		openrtb_ext.BidderRediads:           rediads.Builder,
 		openrtb_ext.BidderRelevantDigital:   relevantdigital.Builder,
 		openrtb_ext.BidderResetDigital:      resetdigital.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -209,6 +209,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderPWBid,
 	BidderQT,
 	BidderReadpeak,
+	BidderRealry,
 	BidderRediads,
 	BidderRelevantDigital,
 	BidderResetDigital,
@@ -586,6 +587,7 @@ const (
 	BidderPWBid             BidderName = "pwbid"
 	BidderQT                BidderName = "qt"
 	BidderReadpeak          BidderName = "readpeak"
+	BidderRealry            BidderName = "realry"
 	BidderRediads           BidderName = "rediads"
 	BidderRelevantDigital   BidderName = "relevantdigital"
 	BidderResetDigital      BidderName = "resetdigital"

--- a/openrtb_ext/imp_realry.go
+++ b/openrtb_ext/imp_realry.go
@@ -1,0 +1,18 @@
+package openrtb_ext
+
+// ExtImpRealry is the bidder-specific imp ext passed by publishers in
+// `imp.ext.prebid.bidder.realry`. The adapter forwards the BidRequest
+// as-is to bid.realry.com, so publishers don't strictly need to set
+// these — they're there so a publisher can pin a placement to a known
+// account on the Realry side for reporting / quality assignment.
+type ExtImpRealry struct {
+	// PlacementId is the publisher-side identifier for the slot. Forwarded
+	// to the Realry bidder so impression/click logs can be diced per
+	// publisher placement without needing to parse site.id.
+	PlacementId string `json:"placementId"`
+
+	// SellerId is an optional realry-side advertiser id the publisher
+	// has been onboarded against. Omit unless explicitly assigned by
+	// the Realry partnerships team.
+	SellerId string `json:"sellerId,omitempty"`
+}

--- a/static/bidder-info/realry.yaml
+++ b/static/bidder-info/realry.yaml
@@ -1,0 +1,17 @@
+endpoint: "https://bid.realry.com/bid/openrtb"
+geoscope:
+  - global
+maintainer:
+  email: "steve@realry.com"
+openrtb:
+  version: 2.6
+  multiformat-supported: true
+capabilities:
+  site:
+    mediaTypes:
+      - banner
+      - native
+  app:
+    mediaTypes:
+      - banner
+      - native

--- a/static/bidder-params/realry.json
+++ b/static/bidder-params/realry.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Realry adapter params",
+    "description": "Validates params for ext.prebid.bidder.realry",
+    "type": "object",
+    "properties": {
+        "placementId": {
+            "type": "string",
+            "description": "Publisher-side identifier for the slot.",
+            "minLength": 1
+        },
+        "sellerId": {
+            "type": "string",
+            "description": "Optional Realry-side advertiser id assigned by partnerships team.",
+            "minLength": 1
+        }
+    },
+    "required": ["placementId"]
+}


### PR DESCRIPTION
## Summary

Adds the Realry bidder adapter. Realry is a commerce DSP focused on luxury
fashion product listings. Endpoint `https://bid.realry.com/bid/openrtb` speaks
OpenRTB 2.6 with Native 1.2 admObject + display banner — no video.

## Files

- `adapters/realry/realry.go` — MakeRequests/MakeBids; infers bid type from imp media (Native vs Banner).
- `adapters/realry/realry_test.go` — TestJsonSamples runner.
- `adapters/realry/params_test.go` — schema validation for `imp.ext.prebid.bidder.realry`.
- `adapters/realry/realrytest/exemplary/{simple-banner,simple-native}.json` — happy-path round-trip fixtures.
- `adapters/realry/realrytest/supplemental/{204-no-bid,400-bad-input,500-server-error}.json` — error-path coverage.
- `openrtb_ext/imp_realry.go` — ExtImpRealry struct (placementId required, sellerId optional).
- `static/bidder-info/realry.yaml` — endpoint, maintainer, capabilities (banner + native, site + app).
- `static/bidder-params/realry.json` — JSON schema.
- `exchange/adapter_builders.go` + `openrtb_ext/bidders.go` — registration (alphabetical between Readpeak and Rediads).

## Maintainer

`steve@realry.com` — see `static/bidder-info/realry.yaml`.

## Test plan

- [x] `go test ./adapters/realry/...` — TestJsonSamples (5 fixtures) + TestValidParams + TestInvalidParams pass.
- [x] `go test ./openrtb_ext/...` pass.
- [x] `go test ./exchange/...` pass.
- [x] Full repo `go test ./...` — 347/347 packages ok, 0 FAIL.
- [x] `gofmt -d` clean across all touched Go files.

## Companion docs PR

Submitted to [prebid/prebid.github.io](https://github.com/prebid/prebid.github.io)
adding `dev-docs/bidders/realry.md`.

## Notes

- No video support in this initial submission; banner + native only.
- No user-sync endpoint configured; can be added in a follow-up once Realry
  publishes one.
- No GVL Vendor ID — Realry has not registered with IAB Europe yet.
