### PR TITLE
New Adapter: m152

### DIFF
--- a/static/bidder-info/152media.yaml
+++ b/static/bidder-info/152media.yaml
@@ -1,2 +1,24 @@
-aliasOf: adkernel
-gvlVendorID: 1111
+# We have the following regional endpoint domains: 'east' - for US_EAST, 'eu' - for EU
+# Please deploy this config in each of your datacenters with the appropriate regional subdomain
+aliasOf: "teqblaze"
+endpoint: "https://#{REGION}#.152media-ssp.com/pserver"
+maintainer:
+  email: "info@152media.com"
+capabilities:
+  site:
+    mediaTypes:
+    - banner
+    - video
+    - native
+  app:
+    mediaTypes:
+    - banner
+    - video
+    - native
+userSync:
+  redirect:
+    url: "https://cs.152media-ssp.com/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"
+  iframe:
+    url: "https://cs.152media-ssp.com/pbserverIframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&pbserverUrl={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/152media.yaml
+++ b/static/bidder-info/152media.yaml
@@ -1,14 +1,2 @@
-# We have the following regional endpoint domains: 'east' - for US_EAST, 'eu' - for EU
-# Please deploy this config in each of your datacenters with the appropriate regional subdomain
-aliasOf: "teqblaze"
-endpoint: "https://#{REGION}#.152media-ssp.com/pserver"
-maintainer:
-  email: "info@152media.com"
+aliasOf: adkernel
 gvlVendorID: 1111
-userSync:
-  redirect:
-    url: "https://cs.152media-ssp.com/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"
-    userMacro: "[UID]"
-  iframe:
-    url: "https://cs.152media-ssp.com/pbserverIframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&pbserverUrl={{.RedirectURL}}"
-    userMacro: "[UID]"

--- a/static/bidder-info/152media.yaml
+++ b/static/bidder-info/152media.yaml
@@ -4,17 +4,7 @@ aliasOf: "teqblaze"
 endpoint: "https://#{REGION}#.152media-ssp.com/pserver"
 maintainer:
   email: "info@152media.com"
-capabilities:
-  site:
-    mediaTypes:
-    - banner
-    - video
-    - native
-  app:
-    mediaTypes:
-    - banner
-    - video
-    - native
+gvlVendorID: 1111
 userSync:
   redirect:
     url: "https://cs.152media-ssp.com/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"

--- a/static/bidder-info/m152.yaml
+++ b/static/bidder-info/m152.yaml
@@ -1,0 +1,14 @@
+# We have the following regional endpoint domains: 'east' - for US_EAST, 'eu' - for EU
+# Please deploy this config in each of your datacenters with the appropriate regional subdomain
+aliasOf: "teqblaze"
+endpoint: "https://#{REGION}#.152media-ssp.com/pserver"
+maintainer:
+  email: "info@152media.com"
+gvlVendorID: 1111
+userSync:
+  redirect:
+    url: "https://cs.152media-ssp.com/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"
+  iframe:
+    url: "https://cs.152media-ssp.com/pbserverIframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&pbserverUrl={{.RedirectURL}}"
+    userMacro: "[UID]"


### PR DESCRIPTION

New bidder adapter
Added 152media SSP bidder as a teqblaze alias with regional endpoints (east/eu), cookie sync configuration, and capabilities for banner, video, and native media types.

Doc MR: https://github.com/prebid/prebid.github.io/pull/6619