### PR TITLE
Parameterize Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:22.04 AS build
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE} AS build
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends wget ca-certificates
@@ -26,7 +27,7 @@ ARG TEST="true"
 RUN if [ "$TEST" != "false" ]; then ./validate.sh ; fi
 RUN go build -mod=vendor -ldflags "-X github.com/prebid/prebid-server/v4/version.Ver=`git describe --tags | sed 's/^v//'` -X github.com/prebid/prebid-server/v4/version.Rev=`git rev-parse HEAD`" .
 
-FROM ubuntu:22.04 AS release
+FROM ${BASE_IMAGE} AS release
 LABEL maintainer="hans.hjort@xandr.com" 
 WORKDIR /usr/local/bin/
 COPY --from=build /app/prebid-server .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# BASE_IMAGE allows overriding the base image so the build can pull from an
+# internal mirror when docker.io is unreachable. Defaults to upstream ubuntu:22.04.
 ARG BASE_IMAGE=ubuntu:22.04
 FROM ${BASE_IMAGE} AS build
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
Adds a `BASE_IMAGE` build argument to the Dockerfile so the Ubuntu base image
can be sourced from an internal mirror registry instead of docker.io.

## Change
- Introduce a global `ARG BASE_IMAGE=ubuntu:22.04` referenced by both the
  `build` and `release` `FROM` stages.
- Default behavior is unchanged: builds still pull `ubuntu:22.04` from docker.io,
  keeping parity with the open-source Dockerfile.
- The host pipeline can override it to pull from the internal mirror.

## Usage
Internal pipeline build (pulls from mirror):
```bash
docker build \
  --build-arg BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:22.04 \
  -t prebid-server .