### PR TITLE
Yieldlab: Fixing a bug where the Adtype would be determined based on the request rather than the response.

### DIFF
--- a/adapters/yieldlab/const.go
+++ b/adapters/yieldlab/const.go
@@ -6,3 +6,6 @@ const adSourceBanner = "<script src=\"%v\"></script>"
 const adSourceURL = "https://ad.yieldlab.net/d/%v/%v/%v?%v"
 const vastMarkup = "<VAST version=\"2.0\"><Ad id=\"%v\"><Wrapper><AdSystem>Yieldlab</AdSystem><VASTAdTagURI><![CDATA[ %v ]]></VASTAdTagURI><Impression></Impression><Creatives></Creatives></Wrapper></Ad></VAST>"
 const creativeID = "%v%v%v"
+
+const adTypeBanner = "BANNER"
+const adTypeVideo = "VIDEO"

--- a/adapters/yieldlab/types.go
+++ b/adapters/yieldlab/types.go
@@ -12,6 +12,7 @@ type bidResponse struct {
 	Price      uint         `json:"price"`
 	Advertiser string       `json:"advertiser"`
 	Adsize     string       `json:"adsize"`
+	Adtype     string       `json:"adtype"`
 	Pid        uint64       `json:"pid"`
 	Did        uint64       `json:"did"`
 	Pvid       string       `json:"pvid"`

--- a/adapters/yieldlab/yieldlab.go
+++ b/adapters/yieldlab/yieldlab.go
@@ -376,15 +376,16 @@ func (a *YieldlabAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 
 			var bidType openrtb_ext.BidType
 			switch {
-			case strings.EqualFold(bid.Adtype, adTypeVideo):
+			case strings.EqualFold(bid.Adtype, adTypeVideo) && imp.Video != nil:
 				bidType = openrtb_ext.BidTypeVideo
 				responseBid.NURL = a.makeAdSourceURL(internalRequest, req, bid)
 				responseBid.AdM = a.makeVast(internalRequest, req, bid)
-			case strings.EqualFold(bid.Adtype, adTypeBanner):
+			case strings.EqualFold(bid.Adtype, adTypeBanner) && imp.Banner != nil:
 				bidType = openrtb_ext.BidTypeBanner
 				responseBid.AdM = a.makeBannerAdSource(internalRequest, req, bid)
 			default:
-				// Yieldlab adapter currently doesn't support Audio and Native ads
+				// Discard the bid if the returned adtype was not requested by the imp.
+				// Yieldlab adapter currently doesn't support Audio and Native ads.
 				continue
 			}
 

--- a/adapters/yieldlab/yieldlab.go
+++ b/adapters/yieldlab/yieldlab.go
@@ -375,14 +375,15 @@ func (a *YieldlabAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 			}
 
 			var bidType openrtb_ext.BidType
-			if imp.Video != nil {
+			switch {
+			case strings.EqualFold(bid.Adtype, adTypeVideo):
 				bidType = openrtb_ext.BidTypeVideo
 				responseBid.NURL = a.makeAdSourceURL(internalRequest, req, bid)
 				responseBid.AdM = a.makeVast(internalRequest, req, bid)
-			} else if imp.Banner != nil {
+			case strings.EqualFold(bid.Adtype, adTypeBanner):
 				bidType = openrtb_ext.BidTypeBanner
 				responseBid.AdM = a.makeBannerAdSource(internalRequest, req, bid)
-			} else {
+			default:
 				// Yieldlab adapter currently doesn't support Audio and Native ads
 				continue
 			}

--- a/adapters/yieldlab/yieldlabtest/exemplary/banner.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/banner.json
@@ -84,6 +84,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/dsa.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/dsa.json
@@ -108,6 +108,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5",

--- a/adapters/yieldlab/yieldlabtest/exemplary/gdpr.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/gdpr.json
@@ -88,6 +88,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/mixed_types.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/mixed_types.json
@@ -109,6 +109,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"
@@ -127,14 +128,13 @@
             "dealid": "1234",
             "id": "12345",
             "impid": "test-imp-id",
-            "nurl": "https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing",
-            "adm": "<VAST version=\"2.0\"><Ad id=\"12345\"><Wrapper><AdSystem>Yieldlab</AdSystem><VASTAdTagURI><![CDATA[ https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing ]]></VASTAdTagURI><Impression></Impression><Creatives></Creatives></Wrapper></Ad></VAST>",
+            "adm": "<script src=\"https://ad.yieldlab.net/d/12345/123456789/728x90?id=abc&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&pvid=40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5&ts=testing\"></script>",
             "price": 2.01,
             "w": 728,
             "h": 90,
             "adomain": ["yieldlab"]
           },
-          "type": "video"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/yieldlab/yieldlabtest/exemplary/multiple_impressions.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/multiple_impressions.json
@@ -102,6 +102,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"
@@ -111,6 +112,7 @@
             "price": 131,
             "advertiser": "yieldlab",
             "adsize": "300x250",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/schain.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/schain.json
@@ -104,6 +104,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/schain_multiple_nodes.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/schain_multiple_nodes.json
@@ -102,6 +102,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/video.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/video.json
@@ -97,6 +97,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "VIDEO",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/exemplary/video_app.json
+++ b/adapters/yieldlab/yieldlabtest/exemplary/video_app.json
@@ -97,6 +97,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "VIDEO",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"

--- a/adapters/yieldlab/yieldlabtest/supplemental/adtype_mismatch.json
+++ b/adapters/yieldlab/yieldlabtest/supplemental/adtype_mismatch.json
@@ -1,0 +1,98 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 728,
+              "h": 90
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "adslotId": "12345",
+            "supplyId": "123456789",
+            "targeting": {
+              "key1": "value1",
+              "key2": "value2"
+            },
+            "extId": "abc"
+          }
+        }
+      }
+    ],
+    "user": {
+      "buyeruid": "34a53e82-0dc3-4815-8b7e-b725ede0361c"
+    },
+    "device": {
+      "ifa": "hello-ads",
+      "devicetype": 4,
+      "connectiontype": 6,
+      "geo": {
+        "lat": 51.499488,
+        "lon": -0.128953
+      },
+      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
+      "ip": "169.254.13.37",
+      "h": 1098,
+      "w": 814
+    },
+    "site": {
+      "id": "fake-site-id",
+      "publisher": {
+        "id": "1"
+      },
+      "page": "http://localhost:9090/gdpr.html"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Cookie": [
+            "id=34a53e82-0dc3-4815-8b7e-b725ede0361c"
+          ],
+          "Referer": [
+            "http://localhost:9090/gdpr.html"
+          ],
+          "User-Agent": [
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"
+          ],
+          "X-Forwarded-For": [
+            "169.254.13.37"
+          ]
+        },
+        "uri": "https://ad.yieldlab.net/testing/12345?content=json&ids=ylid%3A34a53e82-0dc3-4815-8b7e-b725ede0361c&lat=51.499488&lon=-0.128953&pvid=true&sizes=12345%3A728x90&t=key1%3Dvalue1%26key2%3Dvalue2&ts=testing&yl_rtb_connectiontype=6&yl_rtb_devicetype=4&yl_rtb_ifa=hello-ads",
+        "impIDs":["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": [
+          {
+            "id": 12345,
+            "price": 201,
+            "advertiser": "yieldlab",
+            "adsize": "728x90",
+            "adtype": "VIDEO",
+            "pid": 1234,
+            "did": 5678,
+            "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5"
+          }
+        ]
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": []
+    }
+  ]
+}

--- a/adapters/yieldlab/yieldlabtest/supplemental/dsa_empty.json
+++ b/adapters/yieldlab/yieldlabtest/supplemental/dsa_empty.json
@@ -90,6 +90,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5",

--- a/adapters/yieldlab/yieldlabtest/supplemental/dsa_empty_transparency.json
+++ b/adapters/yieldlab/yieldlabtest/supplemental/dsa_empty_transparency.json
@@ -94,6 +94,7 @@
             "price": 201,
             "advertiser": "yieldlab",
             "adsize": "728x90",
+            "adtype": "BANNER",
             "pid": 1234,
             "did": 5678,
             "pvid": "40cb3251-1e1e-4cfd-8edc-7d32dc1a21e5",


### PR DESCRIPTION
Currently the bid type is determined by examining the request's Imp object which sometimes leads to the incorrect bid type being returned. This fixes this by applying the adtype returned by the response.