### PR TITLE
Mobkoi: Support aliased requests

### DIFF
--- a/adapters/mobkoi/mobkoi.go
+++ b/adapters/mobkoi/mobkoi.go
@@ -99,9 +99,7 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
 				Bid:     &seatBid.Bid[i],
 				BidType: openrtb_ext.BidTypeBanner,
-				Seat:    "mobkoi",
 			})
-
 		}
 	}
 	return bidResponse, nil

--- a/adapters/mobkoi/mobkoi_test.go
+++ b/adapters/mobkoi/mobkoi_test.go
@@ -1,11 +1,16 @@
 package mobkoi
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
 	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJsonSamples(t *testing.T) {
@@ -18,4 +23,23 @@ func TestJsonSamples(t *testing.T) {
 	}
 
 	adapterstest.RunJSONBidderTest(t, "mobkoitest", bidder)
+}
+
+func TestSeatLeftEmptyForAliasSupport(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderMobkoi, config.Adapter{
+		Endpoint: "http://dev.mobkoi.com/bid"},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	require.NoError(t, buildErr)
+
+	body := []byte(`{"id":"resp","cur":"USD","seatbid":[{"seat":"mobkoi","bid":[{"id":"1","impid":"imp1","price":1.5,"crid":"20"}]}]}`)
+	resp, errs := bidder.MakeBids(
+		&openrtb2.BidRequest{},
+		&adapters.RequestData{},
+		&adapters.ResponseData{StatusCode: http.StatusOK, Body: body},
+	)
+
+	require.Empty(t, errs)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Bids, 1)
+	assert.Empty(t, resp.Bids[0].Seat, "adapter must leave TypedBid.Seat empty so aliases pass the bidder-code-spoofing guard")
 }

--- a/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
@@ -138,7 +138,7 @@
             "nurl": "mobkoi/win"
           },
           "type": "banner",
-          "seat": "mobkoi"
+          "seat": ""
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
@@ -138,7 +138,7 @@
             "nurl": "mobkoi/win"
           },
           "type": "banner",
-          "seat": "mobkoi"
+          "seat": ""
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
@@ -134,7 +134,7 @@
             "nurl": "mobkoi/win"
           },
           "type": "banner",
-          "seat": "mobkoi"
+          "seat": ""
         }
       ]
     }


### PR DESCRIPTION
The adapter set `TypedBid.Seat="mobkoi"` on every bid. When the adapter is invoked under an alias (e.g. `mobkoi_s2s_alias`) the seat ("mobkoi") no longer matches the requested code and PBS rejects the bid.

Leave Seat empty so PBS labels the bid with the requested bidder code, which makes aliases work for every publisher without any publisher-side change.

Update JSON exemplars to expect an empty seat and add a regression test.