### PR TITLE
New Adapter: Nexverse

### DIFF
--- a/adapters/nexverse/nexverse.go
+++ b/adapters/nexverse/nexverse.go
@@ -125,7 +125,7 @@ func getHeaders(request *openrtb2.BidRequest) http.Header {
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
-	headers.Add("X-Openrtb-Version", "2.5")
+	headers.Add("X-Openrtb-Version", "2.6")
 
 	if request.Device != nil {
 		if request.Device.UA != "" {
@@ -182,9 +182,19 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	return bidResponse, errs
 }
 
-// getMediaTypeForBid resolves the creative type. Nexverse signals it explicitly through
-// bid.ext.mediaType; otherwise fall back to the OpenRTB 2.6 bid.mtype field.
+// getMediaTypeForBid resolves the creative type. It relies on the authoritative OpenRTB 2.6
+// bid.mtype field and, only when that is not set, falls back to bid.ext.mediaType, which is
+// how Nexverse signals the type on responses that omit mtype. The type is never assumed.
 func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupNative:
+		return openrtb_ext.BidTypeNative, nil
+	}
+
 	if len(bid.Ext) > 0 {
 		var bidExt struct {
 			MediaType string `json:"mediaType"`
@@ -201,16 +211,7 @@ func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
 		}
 	}
 
-	switch bid.MType {
-	case openrtb2.MarkupBanner:
-		return openrtb_ext.BidTypeBanner, nil
-	case openrtb2.MarkupVideo:
-		return openrtb_ext.BidTypeVideo, nil
-	case openrtb2.MarkupNative:
-		return openrtb_ext.BidTypeNative, nil
-	default:
-		return "", &errortypes.BadServerResponse{
-			Message: fmt.Sprintf("Unable to determine media type for bid %s in imp %s", bid.ID, bid.ImpID),
-		}
+	return "", &errortypes.BadServerResponse{
+		Message: fmt.Sprintf("Unable to determine media type for bid %s in imp %s", bid.ID, bid.ImpID),
 	}
 }

--- a/adapters/nexverse/nexverse.go
+++ b/adapters/nexverse/nexverse.go
@@ -1,0 +1,216 @@
+package nexverse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the Nexverse adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{
+		endpoint: config.Endpoint,
+	}, nil
+}
+
+// MakeRequests builds one request per impression. The Nexverse endpoint identifies the
+// publisher/inventory through query parameters (uid, pub_id, pub_epid) which are supplied
+// per-impression, so impressions are not batched together.
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	var requests []*adapters.RequestData
+	var errs []error
+
+	requestCopy := *request
+	for _, imp := range request.Imp {
+		nexverseExt, err := parseImpExt(&imp)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// Nexverse expects bid floors in USD. Convert if a foreign currency is provided.
+		if imp.BidFloor > 0 && imp.BidFloorCur != "" && strings.ToUpper(imp.BidFloorCur) != "USD" {
+			convertedValue, err := reqInfo.ConvertCurrency(imp.BidFloor, imp.BidFloorCur, "USD")
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			imp.BidFloorCur = "USD"
+			imp.BidFloor = convertedValue
+		}
+
+		endpointURL, err := a.buildEndpointURL(nexverseExt)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		requestCopy.Imp = []openrtb2.Imp{imp}
+		body, err := json.Marshal(&requestCopy)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		requests = append(requests, &adapters.RequestData{
+			Method:  http.MethodPost,
+			Uri:     endpointURL,
+			Body:    body,
+			Headers: getHeaders(&requestCopy),
+			ImpIDs:  openrtb_ext.GetImpIDs(requestCopy.Imp),
+		})
+	}
+
+	return requests, errs
+}
+
+func parseImpExt(imp *openrtb2.Imp) (*openrtb_ext.ImpExtNexverse, error) {
+	var bidderExt adapters.ExtImpBidder
+	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return nil, &errortypes.BadInput{
+			Message: fmt.Sprintf("Failed to parse imp.ext for imp %s: %v", imp.ID, err),
+		}
+	}
+
+	var nexverseExt openrtb_ext.ImpExtNexverse
+	if err := jsonutil.Unmarshal(bidderExt.Bidder, &nexverseExt); err != nil {
+		return nil, &errortypes.BadInput{
+			Message: fmt.Sprintf("Failed to parse bidder params for imp %s: %v", imp.ID, err),
+		}
+	}
+
+	if nexverseExt.UID == "" || nexverseExt.PubID == "" || nexverseExt.PubEpid == "" {
+		return nil, &errortypes.BadInput{
+			Message: fmt.Sprintf("Missing required Nexverse params (uid, pubId, pubEpid) for imp %s", imp.ID),
+		}
+	}
+
+	return &nexverseExt, nil
+}
+
+func (a *adapter) buildEndpointURL(params *openrtb_ext.ImpExtNexverse) (string, error) {
+	endpointURL, err := url.Parse(a.endpoint)
+	if err != nil {
+		return "", &errortypes.BadInput{
+			Message: fmt.Sprintf("Failed to parse Nexverse endpoint: %v", err),
+		}
+	}
+
+	query := endpointURL.Query()
+	query.Set("uid", params.UID)
+	query.Set("pub_id", params.PubID)
+	query.Set("pub_epid", params.PubEpid)
+	if params.IsDebug {
+		query.Set("test", "1")
+	}
+	endpointURL.RawQuery = query.Encode()
+
+	return endpointURL.String(), nil
+}
+
+func getHeaders(request *openrtb2.BidRequest) http.Header {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+	headers.Add("X-Openrtb-Version", "2.5")
+
+	if request.Device != nil {
+		if request.Device.UA != "" {
+			headers.Add("User-Agent", request.Device.UA)
+		}
+		if request.Device.IP != "" {
+			headers.Add("X-Forwarded-For", request.Device.IP)
+		} else if request.Device.IPv6 != "" {
+			headers.Add("X-Forwarded-For", request.Device.IPv6)
+		}
+	}
+
+	return headers
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Failed to parse Nexverse response: %v", err),
+		}}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	if response.Cur != "" {
+		bidResponse.Currency = response.Cur
+	} else {
+		bidResponse.Currency = "USD"
+	}
+
+	var errs []error
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bidType, err := getMediaTypeForBid(seatBid.Bid[i])
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: bidType,
+			})
+		}
+	}
+
+	return bidResponse, errs
+}
+
+// getMediaTypeForBid resolves the creative type. Nexverse signals it explicitly through
+// bid.ext.mediaType; otherwise fall back to the OpenRTB 2.6 bid.mtype field.
+func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	if len(bid.Ext) > 0 {
+		var bidExt struct {
+			MediaType string `json:"mediaType"`
+		}
+		if err := jsonutil.Unmarshal(bid.Ext, &bidExt); err == nil {
+			switch bidExt.MediaType {
+			case "banner":
+				return openrtb_ext.BidTypeBanner, nil
+			case "video":
+				return openrtb_ext.BidTypeVideo, nil
+			case "native":
+				return openrtb_ext.BidTypeNative, nil
+			}
+		}
+	}
+
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupNative:
+		return openrtb_ext.BidTypeNative, nil
+	default:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Unable to determine media type for bid %s in imp %s", bid.ID, bid.ImpID),
+		}
+	}
+}

--- a/adapters/nexverse/nexverse_test.go
+++ b/adapters/nexverse/nexverse_test.go
@@ -1,0 +1,20 @@
+package nexverse
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderNexverse, config.Adapter{
+		Endpoint: "https://rtb.nexverse.ai"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	adapterstest.RunJSONBidderTest(t, "nexversetest", bidder)
+}

--- a/adapters/nexverse/nexversetest/exemplary/simple-banner.json
+++ b/adapters/nexverse/nexversetest/exemplary/simple-banner.json
@@ -1,0 +1,120 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "device": {
+      "ip": "123.123.123.123",
+      "ua": "test-user-agent"
+    },
+    "site": {
+      "page": "https://example.com"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent"
+          },
+          "site": {
+            "page": "https://example.com"
+          },
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "nexverse",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 1.5,
+                  "adm": "<div>banner ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1,
+                  "ext": {
+                    "mediaType": "banner"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 1.5,
+            "adm": "<div>banner ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1,
+            "ext": {
+              "mediaType": "banner"
+            }
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/nexverse/nexversetest/exemplary/simple-native.json
+++ b/adapters/nexverse/nexversetest/exemplary/simple-native.json
@@ -1,0 +1,108 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "device": {
+      "ip": "123.123.123.123",
+      "ua": "test-user-agent"
+    },
+    "app": {
+      "bundle": "com.example.app"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "native": {
+          "request": "{\"ver\":\"1.2\"}",
+          "ver": "1.2"
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent"
+          },
+          "app": {
+            "bundle": "com.example.app"
+          },
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "native": {
+                "request": "{\"ver\":\"1.2\"}",
+                "ver": "1.2"
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "nexverse",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 0.75,
+                  "adm": "{\"native\":{\"ver\":\"1.2\"}}",
+                  "crid": "creative-3",
+                  "mtype": 4,
+                  "ext": {
+                    "mediaType": "native"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 0.75,
+            "adm": "{\"native\":{\"ver\":\"1.2\"}}",
+            "crid": "creative-3",
+            "mtype": 4,
+            "ext": {
+              "mediaType": "native"
+            }
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/nexverse/nexversetest/exemplary/simple-video.json
+++ b/adapters/nexverse/nexversetest/exemplary/simple-video.json
@@ -1,0 +1,110 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "device": {
+      "ip": "123.123.123.123",
+      "ua": "test-user-agent"
+    },
+    "site": {
+      "page": "https://example.com"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "device": {
+            "ip": "123.123.123.123",
+            "ua": "test-user-agent"
+          },
+          "site": {
+            "page": "https://example.com"
+          },
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "nexverse",
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"3.0\"></VAST>",
+                  "crid": "creative-2",
+                  "mtype": 2,
+                  "ext": {
+                    "mediaType": "video"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<VAST version=\"3.0\"></VAST>",
+            "crid": "creative-2",
+            "mtype": 2,
+            "ext": {
+              "mediaType": "video"
+            }
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/nexverse/nexversetest/supplemental/debug-mode.json
+++ b/adapters/nexverse/nexversetest/supplemental/debug-mode.json
@@ -1,0 +1,101 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde",
+            "isDebug": true
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&test=1&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde",
+                  "isDebug": true
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "1",
+                  "impid": "test-imp-id",
+                  "price": 1.0,
+                  "adm": "<div>ad</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "1",
+            "impid": "test-imp-id",
+            "price": 1.0,
+            "adm": "<div>ad</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/nexverse/nexversetest/supplemental/missing-required-params.json
+++ b/adapters/nexverse/nexversetest/supplemental/missing-required-params.json
@@ -1,0 +1,30 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Missing required Nexverse params (uid, pubId, pubEpid) for imp test-imp-id",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/nexverse/nexversetest/supplemental/status-204.json
+++ b/adapters/nexverse/nexversetest/supplemental/status-204.json
@@ -1,0 +1,61 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/nexverse/nexversetest/supplemental/status-400.json
+++ b/adapters/nexverse/nexversetest/supplemental/status-400.json
@@ -1,0 +1,66 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "uid": "12345",
+            "pubId": "54321",
+            "pubEpid": "abcde"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://rtb.nexverse.ai?pub_epid=abcde&pub_id=54321&uid=12345",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "uid": "12345",
+                  "pubId": "54321",
+                  "pubEpid": "abcde"
+                }
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/nexverse/params_test.go
+++ b/adapters/nexverse/params_test.go
@@ -1,0 +1,56 @@
+package nexverse
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+var validParams = []string{
+	`{"uid": "12345", "pubId": "54321", "pubEpid": "abcde"}`,
+	`{"uid": "12345", "pubId": "54321", "pubEpid": "abcde", "isDebug": true}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`4.2`,
+	`[]`,
+	`{}`,
+	`{"uid": "12345"}`,
+	`{"uid": "12345", "pubId": "54321"}`,
+	`{"uid": "", "pubId": "54321", "pubEpid": "abcde"}`,
+	`{"uid": "12345", "pubId": "", "pubEpid": "abcde"}`,
+	`{"uid": "12345", "pubId": "54321", "pubEpid": ""}`,
+	`{"uid": 12345, "pubId": "54321", "pubEpid": "abcde"}`,
+	`{"uid": "12345", "pubId": "54321", "pubEpid": "abcde", "isDebug": "yes"}`,
+}
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderNexverse, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected Nexverse params: %s", validParam)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderNexverse, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -168,6 +168,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/nativery"
 	"github.com/prebid/prebid-server/v4/adapters/nativo"
 	"github.com/prebid/prebid-server/v4/adapters/nextmillennium"
+	"github.com/prebid/prebid-server/v4/adapters/nexverse"
 	"github.com/prebid/prebid-server/v4/adapters/nexx360"
 	"github.com/prebid/prebid-server/v4/adapters/nobid"
 	"github.com/prebid/prebid-server/v4/adapters/ogury"
@@ -443,6 +444,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderNativery:          nativery.Builder,
 		openrtb_ext.BidderNativo:            nativo.Builder,
 		openrtb_ext.BidderNextMillennium:    nextmillennium.Builder,
+		openrtb_ext.BidderNexverse:          nexverse.Builder,
 		openrtb_ext.BidderNexx360:           nexx360.Builder,
 		openrtb_ext.BidderNoBid:             nobid.Builder,
 		openrtb_ext.BidderOgury:             ogury.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -186,6 +186,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderNativery,
 	BidderNativo,
 	BidderNextMillennium,
+	BidderNexverse,
 	BidderNexx360,
 	BidderNoBid,
 	BidderOgury,
@@ -565,6 +566,7 @@ const (
 	BidderNativery          BidderName = "nativery"
 	BidderNativo            BidderName = "nativo"
 	BidderNextMillennium    BidderName = "nextmillennium"
+	BidderNexverse          BidderName = "nexverse"
 	BidderNexx360           BidderName = "nexx360"
 	BidderNoBid             BidderName = "nobid"
 	BidderOgury             BidderName = "ogury"

--- a/openrtb_ext/imp_nexverse.go
+++ b/openrtb_ext/imp_nexverse.go
@@ -1,0 +1,9 @@
+package openrtb_ext
+
+// ImpExtNexverse defines the contract for bidrequest.imp[i].ext.prebid.bidder.nexverse
+type ImpExtNexverse struct {
+	UID     string `json:"uid"`
+	PubID   string `json:"pubId"`
+	PubEpid string `json:"pubEpid"`
+	IsDebug bool   `json:"isDebug,omitempty"`
+}

--- a/static/bidder-info/nexverse.yaml
+++ b/static/bidder-info/nexverse.yaml
@@ -1,0 +1,14 @@
+endpoint: "https://rtb.nexverse.ai"
+maintainer:
+  email: "anand.kumar@nexverse.ai"
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - native

--- a/static/bidder-params/nexverse.json
+++ b/static/bidder-params/nexverse.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Nexverse Adapter Params",
+  "description": "A schema which validates params accepted by the Nexverse adapter",
+  "type": "object",
+  "properties": {
+    "uid": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique User ID assigned by Nexverse for the publisher"
+    },
+    "pubId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Publisher's unique identifier"
+    },
+    "pubEpid": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Publisher's endpoint identifier"
+    },
+    "isDebug": {
+      "type": "boolean",
+      "description": "Enables debug/test mode on the Nexverse endpoint"
+    }
+  },
+  "required": ["uid", "pubId", "pubEpid"]
+}


### PR DESCRIPTION
Add a server-side bid adapter for Nexverse (https://rtb.nexverse.ai).

The adapter identifies publisher inventory through the uid, pub_id, and pub_epid query parameters on the endpoint URL (required bidder params uid, pubId, pubEpid), sends one OpenRTB request per impression, converts foreign-currency bid floors to USD, and resolves the response media type from bid.ext.mediaType, falling back to bid.mtype. Banner, video, and native are supported.