### PR TITLE
New Module: IntentIQ Identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/IABTechLab/adscert v0.34.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/WURFL/golang-wurfl v1.30.3
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/alitto/pond v1.8.3
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/benbjohnson/clock v1.3.0
@@ -31,6 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+	github.com/redis/go-redis/v9 v9.7.3
 	github.com/rs/cors v1.11.0
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/viper v1.12.0
@@ -51,6 +53,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -77,6 +80,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/alitto/pond v1.8.3 h1:ydIqygCLVPqIX/USe5EaV/aSRXTRXDEI9JwuDdu+/xs=
 github.com/alitto/pond v1.8.3/go.mod h1:CmvIIGd5jKLasGI3D87qDkQxjzChdKMmnXMg3fG6M6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -86,7 +88,10 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -123,6 +128,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -442,6 +449,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
@@ -523,6 +532,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prebid/prebid-server/v4/metrics"
 	prometheusmetrics "github.com/prebid/prebid-server/v4/metrics/prometheus"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prometheus/client_golang/prometheus"
 	gometrics "github.com/rcrowley/go-metrics"
 	influxdb "github.com/vrischmann/go-metrics-influxdb"
 )
@@ -61,6 +62,11 @@ type DetailedMetricsEngine struct {
 	metrics.MetricsEngine
 	GoMetrics         *metrics.Metrics
 	PrometheusMetrics *prometheusmetrics.Metrics
+	// ModuleMetricsGatherer holds the dedicated registry that hook modules register their own
+	// Prometheus collectors into (via ModuleDeps.MetricsRegisterer). Modules are built before this
+	// engine, so their registry cannot be the PBS core registry; the Prometheus listener gathers
+	// from both. May be nil when Prometheus is disabled or no module registered anything.
+	ModuleMetricsGatherer prometheus.Gatherer
 }
 
 // MultiMetricsEngine logs metrics to multiple metrics databases The can be useful in transitioning

--- a/modules/builder.go
+++ b/modules/builder.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	fiftyonedegreesDevicedetection "github.com/prebid/prebid-server/v4/modules/fiftyonedegrees/devicedetection"
+	intentiqIdentity "github.com/prebid/prebid-server/v4/modules/intentiq/identity"
 	prebidOrtb2blocking "github.com/prebid/prebid-server/v4/modules/prebid/ortb2blocking"
 	prebidRulesengine "github.com/prebid/prebid-server/v4/modules/prebid/rulesengine"
 	wurflDevicedetection "github.com/prebid/prebid-server/v4/modules/scientiamobile/wurfl_devicedetection"
@@ -14,6 +15,9 @@ func builders() ModuleBuilders {
 	return ModuleBuilders{
 		"fiftyonedegrees": {
 			"devicedetection": fiftyonedegreesDevicedetection.Builder,
+		},
+		"intentiq": {
+			"identity": intentiqIdentity.Builder,
 		},
 		"prebid": {
 			"ortb2blocking": prebidOrtb2blocking.Builder,

--- a/modules/intentiq/identity/README.md
+++ b/modules/intentiq/identity/README.md
@@ -12,7 +12,7 @@ This is the Go port of the prebid-server-java `extra/modules/intentiq-identity` 
 ## Operation Details
 
 The resolution request (`processed_auction_request`) sends the
-`at=39`/`mi=10`/`pt=17`/`dpn=1`/`srvrReq=true`/`source=pbsgo` constants plus `dpi` (= `partner-id`),
+`at=39`/`mi=10`/`pt=17`/`dpn=1`/`srvrReq=true`/`source=pbgo` constants plus `dpi` (= `partner-id`),
 and — when present on the request — `ip`, `ipv6`, `uas`, `uh` (UA client hints built from
 `device.sua`), `ref` (site domain/page or app bundle/name), `iiquid` (an existing `intentiq.com`
 eid), `pcid`+`idtype` from `device.ifa` (`idtype 4` for MAID/AAID, `idtype 8` for CTV with the id
@@ -140,7 +140,7 @@ by default). L2 failures are non-fatal — the hook falls through to a live API 
 
 When `reports-endpoint` is set and the `auction_response` hook is in the execution plan, the module
 reports each winning `seatbid[].bid[]` to the IntentIQ impression API — a fire-and-forget GET to
-`<reports-endpoint>?at=45&rtype=1&source=pbsgo&dpi=<partner-id>&rdata=<UTF-8 URL-encoded JSON>`. The
+`<reports-endpoint>?at=45&rtype=1&source=pbgo&dpi=<partner-id>&rdata=<UTF-8 URL-encoded JSON>`. The
 `rdata` carries `bidderCode`, `partnerId`, `cpm`, `currency`, `originalCpm`/`originalCurrency` (from
 the bid ext), `placementId`, `biddingPlatformId=4`, `vrref`, `prebidAuctionId`, `partnerAuctionId`,
 `abTestUuid`, `terminationCause`, `ip`, and `ua`. Because the Go `auction_response` payload exposes

--- a/modules/intentiq/identity/README.md
+++ b/modules/intentiq/identity/README.md
@@ -1,0 +1,202 @@
+## Overview
+
+The IntentIQ Identity module enriches an incoming OpenRTB request by adding resolved IDs to
+`user.eids`. At the `processed_auction_request` stage it calls the IntentIQ Bid Enhancement S2S API
+(`ProfilesEngineServlet`) and merges the eids from the response into `user.eids` before the request is
+sent to bidders. Optionally, at the `auction_response` stage it reports each winning bid to the
+IntentIQ impression API. Please contact your IntentIQ account manager to get a partner token.
+
+This is the Go port of the prebid-server-java `extra/modules/intentiq-identity` module. See the
+[S2S integration docs](https://s2s.documents.intentiq.com/) for the full API contract.
+
+## Operation Details
+
+The resolution request (`processed_auction_request`) sends the
+`at=39`/`mi=10`/`pt=17`/`dpn=1`/`srvrReq=true`/`source=pbsgo` constants plus `dpi` (= `partner-id`),
+and — when present on the request — `ip`, `ipv6`, `uas`, `uh` (UA client hints built from
+`device.sua`), `ref` (site domain/page or app bundle/name), `iiquid` (an existing `intentiq.com`
+eid), `pcid`+`idtype` from `device.ifa` (`idtype 4` for MAID/AAID, `idtype 8` for CTV with the id
+upper-cased; skipped when `device.lmt = 1`), and `gdpr`/`us_privacy`/`gpp`/`gpp_sid`. The TCF consent
+string is sent as the `gdpr-consent` request header. The response `data.eids` are merged into
+`user.eids`; on any failure the hook takes no action and the auction proceeds unchanged (fail-open).
+
+## Setup
+
+The module runs at two stages: `processed_auction_request` (enrich `user.eids`) and, optionally,
+`auction_response` (report winning bids to `reports-endpoint`). Enable the module and add the hook(s)
+to the execution plan.
+
+### Execution Plan
+
+```yaml
+hooks:
+  enabled: true
+  host_execution_plan:
+    endpoints:
+      /openrtb2/auction:
+        stages:
+          processed_auction_request:
+            groups:
+              - timeout: 1000
+                hook_sequence:
+                  - module_code: "intentiq.identity"
+                    hook_impl_code: "HandleProcessedAuctionHook"
+          auction_response:
+            groups:
+              - timeout: 100
+                hook_sequence:
+                  - module_code: "intentiq.identity"
+                    hook_impl_code: "HandleAuctionResponseHook"
+```
+
+### Global Config
+
+```yaml
+hooks:
+  modules:
+    intentiq:
+      identity:
+        api-endpoint: https://be-api-s2s.intentiq.com/profiles_engine/ProfilesEngineServlet
+        reports-endpoint: https://reports-s2s.intentiq.com/profiles_engine/ProfilesEngineServlet
+        partner-id: "1234567890"
+        timeout: 1000
+        cache-max-size: 33554432   # in-process (L1) byte budget; see "Caching"
+        metrics-enabled: true
+        cache:
+          enabled: true
+          ttlseconds: 43200
+          max-keys: 10
+          ttl-ceiling-first-party-seconds: 86400
+          ttl-ceiling-third-party-seconds: 43200
+          ttl-ceiling-device-seconds: 3600
+          negative-ttl-seconds: 120
+          in-progress-ttl-seconds: 1800
+        redis:
+          host: localhost
+          port: 6379
+          # password: ""
+```
+
+Use the region-specific `api-endpoint`: US `be-api-s2s.intentiq.com`, EU
+`be-api-s2s-gdpr.intentiq.com`, APAC `be-api-s2s-apac.intentiq.com`. When `api-endpoint` is empty the
+enrich hook is a no-op.
+
+### Account-Level Config
+
+Global config (above) provides defaults. Account-specific values can be set under the account's
+`hooks.modules.intentiq.identity` config and are merged over the global defaults per request — so
+`partner-id`, `timeout`, and `cache.*` can be tuned per account. `redis.*`, `cache-max-size`, and
+`metrics-enabled` are global-only.
+
+## Module Configuration Parameters
+
+| Param                                  | Level   | Required | Type    | Default | Description                                                        |
+|:---------------------------------------|:--------|:---------|:--------|:--------|:-------------------------------------------------------------------|
+| `api-endpoint`                         | global  | yes      | string  | none    | Bid Enhancement `ProfilesEngineServlet` URL (region-specific)      |
+| `reports-endpoint`                     | global  | no       | string  | none    | Impression-reporting URL; blank disables the impression hook       |
+| `partner-id`                           | account | yes      | string  | none    | Partner token from IntentIQ, sent as the `dpi` query parameter     |
+| `timeout`                              | account | no       | int     | 1000    | HTTP timeout (ms) for the resolution/report calls                  |
+| `cache.enabled`                        | account | no       | bool    | false   | Use the two-layer cache (requires `redis.*`)                       |
+| `cache.ttlseconds`                     | account | no       | int     | 43200   | Fallback positive TTL (s) when the response omits `cttl`           |
+| `cache.max-keys`                       | account | no       | int     | 10      | Max alias keys derived per request                                 |
+| `cache.ttl-ceiling-first-party-seconds`| account | no       | int     | 86400   | Upper bound on TTL for first-party id keys                         |
+| `cache.ttl-ceiling-third-party-seconds`| account | no       | int     | 43200   | Upper bound on TTL for third-party id keys (`intentiq.com`)        |
+| `cache.ttl-ceiling-device-seconds`     | account | no       | int     | 3600    | Upper bound on TTL for the probabilistic device-composite key      |
+| `cache.negative-ttl-seconds`           | account | no       | int     | 120     | TTL for the negative (unresolvable id) sentinel                    |
+| `cache.in-progress-ttl-seconds`        | account | no       | int     | 1800    | TTL for the IN_PROGRESS marker that dedups concurrent resolutions  |
+| `cache-max-size`                       | global  | no       | int     | 100000  | L1 (in-process) **byte** budget — see "Caching"                    |
+| `metrics-enabled`                      | global  | no       | bool    | true    | Emit the module's Prometheus metrics; `false` to opt out           |
+| `redis.host`                           | global  | cond.    | string  | none    | Redis host (required when caching)                                 |
+| `redis.port`                           | global  | cond.    | int     | none    | Redis port (required when caching)                                 |
+| `redis.password`                       | global  | no       | string  | none    | Redis password                                                     |
+
+## Caching
+
+When `cache.enabled` is true and `redis.*` is configured, resolved eids are cached in two layers:
+**L1** (in-process, [freecache](https://github.com/coocood/freecache)) backed by **L2** (shared, Redis
+by default). L2 failures are non-fatal — the hook falls through to a live API call.
+
+- **Multi-key (alias) caching.** Every relevant first-party id on the request becomes a namespaced
+  alias key, ordered by priority: `iiq:<id>` (`intentiq.com`), `pubcid:<id>`
+  (`pubcid.org`/`sharedid.org`), `maid:<ifa>` (upper-cased for CTV, skipped when `device.lmt = 1`),
+  `<source>:<id>` for any other eid, and a probabilistic `dev:<ifa_ua_ip>` composite (using a
+  *normalized* UA, not the raw string) as last resort. Keys are de-duplicated and capped at
+  `cache.max-keys`. On a lookup the highest-priority key with a live entry wins, and that entry is
+  **back-filled** under every other key that missed, so the alias graph grows over time. Differing
+  resolutions are never merged — only the single winning entry propagates.
+- **TTL.** The response `cttl` (or `cache.ttlseconds` when omitted) always wins, capped per id class by
+  the `ttl-ceiling-*` values.
+- **Negative caching.** When the API resolves no eids, a short-lived negative sentinel is written under
+  all candidate keys so unresolvable ids do not re-hit the S2S API every request.
+- **In-progress dedup.** On a full miss, an `IN_PROGRESS` marker is written under all candidate keys
+  before the live call; a concurrent request for the same id reads it and skips a duplicate call. It is
+  overwritten by the resolved/negative entry when the call completes, or expires otherwise.
+
+> **`cache-max-size` is a byte budget, not an entry count.** The Java module bounds L1 by entry count
+> (Caffeine); the Go L1 (freecache) is byte-budget bounded. Size it accordingly (e.g. `33554432` for
+> 32 MiB); values below freecache's 512 KiB floor are bumped up.
+
+## Impression Reporting
+
+When `reports-endpoint` is set and the `auction_response` hook is in the execution plan, the module
+reports each winning `seatbid[].bid[]` to the IntentIQ impression API — a fire-and-forget GET to
+`<reports-endpoint>?at=45&rtype=1&source=pbsgo&dpi=<partner-id>&rdata=<UTF-8 URL-encoded JSON>`. The
+`rdata` carries `bidderCode`, `partnerId`, `cpm`, `currency`, `originalCpm`/`originalCurrency` (from
+the bid ext), `placementId`, `biddingPlatformId=4`, `vrref`, `prebidAuctionId`, `partnerAuctionId`,
+`abTestUuid`, `terminationCause`, `ip`, and `ua`. Because the Go `auction_response` payload exposes
+only the bid response, the request-derived fields (`vrref`/`prebidAuctionId`/`ip`/`ua`) and the
+`abTestUuid`/`terminationCause` from the resolution response are stashed by the enrich hook in the
+module context and read here. With `reports-endpoint` blank the hook is a no-op. The bid response is
+never modified.
+
+## Metrics
+
+The hook framework already emits per-module `call`/`success.*`/`failure`/`timeout`/`execution-error`/
+`duration`. In addition this module registers its own **Prometheus** collectors into the server's
+scrape registry (threaded via `moduledeps.ModuleDeps.MetricsRegisterer`), exported on the server's
+`/metrics` endpoint. Recording is on by default; set `metrics-enabled: false` (global) to disable.
+
+The partner id is a Prometheus `partner` **label** (the Java module used a `_<dpi>` name suffix), and
+`layer` (`l1`/`l2`) and `keytype` (`first_party`/`third_party`/`device`) are labels. All series are
+prefixed `modules_module_intentiq_identity_custom_`:
+
+| Metric (suffix)                    | Type        | Labels                    | Meaning                                              |
+|:-----------------------------------|:------------|:--------------------------|:-----------------------------------------------------|
+| `cache_hit_total`                  | counter     | layer, keytype, partner   | positive entry served from cache                     |
+| `cache_miss_total`                 | counter     | keytype, partner          | full miss → API called                               |
+| `cache_negative_hit_total`         | counter     | layer, keytype, partner   | negative sentinel hit (counted as miss, no API call) |
+| `cache_in_progress_total`          | counter     | layer, keytype, partner   | in-flight marker hit; duplicate call skipped         |
+| `api_success_total`                | counter     | partner                   | resolution API responded and parsed                  |
+| `api_error_total`                  | counter     | partner                   | resolution API failed/timed out/unparseable          |
+| `api_latency_seconds`              | histogram   | partner                   | resolution API call duration                         |
+| `enriched_total`                   | counter     | partner                   | eids added to `user.eids`                            |
+| `eids_none_total`                  | counter     | partner                   | resolution produced no eids                          |
+| `skip_no_endpoint_total`           | counter     | partner                   | no `api-endpoint`; resolution skipped                |
+| `termination_cause_total`          | counter     | tc, partner               | one series per termination-cause id (0–199)          |
+| `flow_latency_seconds`             | histogram   | partner                   | whole-flow latency (enrich → bid release)            |
+| `impression_reported_total`        | counter     | partner                   | winning bid reported                                 |
+| `impression_error_total`           | counter     | partner                   | impression report call failed                        |
+| `l1_size` / `l1_eviction`          | gauge       | —                         | L1 entry count / cumulative evictions                |
+| `l2_size` / `l2_eviction`          | gauge       | —                         | Redis `DBSIZE` / `evicted_keys` (instance-wide)      |
+| `l1_get_error` / `l1_put_error`    | counter     | —                         | L1 read/write threw (≈never)                         |
+| `l2_get_latency_seconds` / `l2_put_latency_seconds` | histogram | —      | L2 GET/PUT duration                                  |
+| `l2_get_error` / `l2_put_error`    | counter     | —                         | L2 GET/PUT failed (GET → fail-open live call)        |
+
+The L1/L2 health series are process-wide, so they carry no `partner` label.
+
+## Running the demo
+
+1. Set `api-endpoint` and `partner-id` (and, for caching, a reachable `redis.*`) in
+   `sample/configs/prebid-config-with-intentiq.yaml`.
+2. Run the server with that config:
+   `go run . -v 1 -logtostderr --config sample/configs/prebid-config-with-intentiq.yaml`
+3. POST an OpenRTB request to `http://localhost:8000/openrtb2/auction` and observe `user.eids`
+   enriched in `ext.debug.resolvedrequest` (send `"test": 1` in the request to get debug output).
+4. Scrape the module's metrics at `http://localhost:9090/metrics`
+   (series prefixed `modules_module_intentiq_identity_custom_*`).
+
+## Maintainer contacts
+
+Any suggestions or questions can be directed to the IntentIQ team. Alternatively please open a new
+[issue](https://github.com/prebid/prebid-server/issues/new) or
+[pull request](https://github.com/prebid/prebid-server/pulls) in this repository.

--- a/modules/intentiq/identity/cache/coverage_test.go
+++ b/modules/intentiq/identity/cache/coverage_test.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyTypeToken(t *testing.T) {
+	assert.Equal(t, "first_party", FirstParty.Token())
+	assert.Equal(t, "third_party", ThirdParty.Token())
+	assert.Equal(t, "device", Device.Token())
+	assert.Equal(t, "unknown", KeyType(99).Token())
+}
+
+func TestLayerToken(t *testing.T) {
+	assert.Equal(t, "l1", LayerL1.Token())
+	assert.Equal(t, "l2", LayerL2.Token())
+	assert.Equal(t, "unknown", LayerNone.Token())
+}
+
+func TestCeilingFor(t *testing.T) {
+	p := TTLPolicy{
+		Default:           1 * time.Second,
+		FirstPartyCeiling: 2 * time.Second,
+		ThirdPartyCeiling: 3 * time.Second,
+		DeviceCeiling:     4 * time.Second,
+	}
+	assert.Equal(t, 2*time.Second, p.CeilingFor(FirstParty))
+	assert.Equal(t, 3*time.Second, p.CeilingFor(ThirdParty))
+	assert.Equal(t, 4*time.Second, p.CeilingFor(Device))
+	assert.Equal(t, 1*time.Second, p.CeilingFor(KeyType(99)), "unknown type falls back to Default")
+}
+
+func TestDecodeValid(t *testing.T) {
+	future := time.Now().Add(time.Hour).UnixMilli()
+
+	assert.Nil(t, decodeValid(nil), "empty -> nil")
+	assert.Nil(t, decodeValid([]byte(`{bad`)), "invalid JSON -> nil")
+
+	past, _ := json.Marshal(Entry{Exp: time.Now().Add(-time.Hour).UnixMilli()})
+	assert.Nil(t, decodeValid(past), "expired -> nil")
+
+	live, _ := json.Marshal(Entry{Negative: true, Exp: future})
+	got := decodeValid(live)
+	require.NotNil(t, got)
+	assert.True(t, got.Negative)
+}
+
+func TestToResult(t *testing.T) {
+	assert.Equal(t, InProgress, toResult(Entry{InProgress: true}, FirstParty, LayerL1).State)
+	assert.Equal(t, Negative, toResult(Entry{Negative: true}, FirstParty, LayerL1).State)
+
+	hit := toResult(Entry{}, ThirdParty, LayerL2)
+	assert.Equal(t, Hit, hit.State)
+	assert.Equal(t, ThirdParty, hit.KeyType)
+	assert.Equal(t, LayerL2, hit.Layer)
+}
+
+func TestEvictedKeysError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	store := NewRedisStore(client)
+	mr.Close() // force the INFO call to fail
+
+	_, err := store.EvictedKeys(context.Background())
+	assert.Error(t, err)
+}

--- a/modules/intentiq/identity/cache/identity_cache.go
+++ b/modules/intentiq/identity/cache/identity_cache.go
@@ -1,0 +1,272 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"time"
+
+	"github.com/coocood/freecache"
+	"github.com/prebid/openrtb/v20/openrtb2"
+)
+
+// minFreeCacheSize is freecache's minimum backing-buffer size (512 KiB). A smaller byte budget is
+// bumped up to this floor, matching freecache's own internal clamp.
+const minFreeCacheSize = 512 * 1024
+
+// IdentityCache is a dual-layer, multi-key (alias) cache for resolved eids: an in-process L1
+// (freecache) backed by a pluggable Store (L2, shared; Redis by default).
+//
+// A request yields an ordered list of Keys (one per first-party id present). On read, the
+// highest-priority key with a live entry wins and that entry is back-filled under every other key
+// that missed, so the alias graph grows over time and a later request carrying any of those ids
+// hits. On a full miss the caller fetches once and writes the entry under all keys.
+//
+// Entries carry the IntentIQ cttl capped by a per-KeyType ceiling (see TTLPolicy). Unresolvable ids
+// are cached as a short-lived negative sentinel so they do not re-hit the upstream API. L2 failures
+// are swallowed (fail-open) so the auction can fall through to a live call. Differing resolutions
+// are never merged — only the single winning entry propagates.
+type IdentityCache struct {
+	local   *freecache.Cache
+	store   Store
+	ttl     TTLPolicy
+	metrics Metrics
+	maxSize int
+}
+
+// NewIdentityCache builds the two-layer cache. maxSizeBytes bounds the in-process layer (freecache
+// is byte-budget bounded; the Java cache-max-size count becomes a byte budget in Go — document in
+// README). store is the L2 backend, ttl the TTL policy, metrics the health contract.
+func NewIdentityCache(maxSizeBytes int, ttl TTLPolicy, store Store, metrics Metrics) *IdentityCache {
+	size := maxSizeBytes
+	if size < minFreeCacheSize {
+		size = minFreeCacheSize
+	}
+	local := freecache.NewCache(size)
+	c := &IdentityCache{
+		local:   local,
+		store:   store,
+		ttl:     ttl,
+		metrics: metrics,
+		maxSize: size,
+	}
+	// L1 capacity gauges: current size (vs cache-max-size) and cumulative evictions.
+	c.metrics.RegisterL1Gauges(
+		func() int64 { return local.EntryCount() },
+		func() int64 { return local.EvacuateCount() },
+	)
+	return c
+}
+
+// Get sweeps keys in priority order and returns the first live outcome (see Result). A full miss
+// returns MissResult(). ctx bounds the L2 probes.
+func (c *IdentityCache) Get(ctx context.Context, keys []Key) Result {
+	if len(keys) == 0 {
+		return MissResult()
+	}
+
+	// L1 sweep in priority order. A resolved entry always wins; an in-progress marker is a fallback
+	// that short-circuits the L2 probe (this instance already knows a call is in flight) without
+	// firing a duplicate.
+	var inProgressType KeyType
+	inProgressFound := false
+	for i, k := range keys {
+		entry := c.l1Get(k.Key)
+		if entry == nil {
+			continue
+		}
+		if entry.InProgress {
+			if !inProgressFound {
+				inProgressType = k.Type
+				inProgressFound = true
+			}
+			continue
+		}
+		c.backfill(ctx, keys, i, *entry)
+		return toResult(*entry, k.Type, LayerL1)
+	}
+	if inProgressFound {
+		return InProgressResult(inProgressType, LayerL1)
+	}
+
+	// Full L1 miss: probe keys in L2 in priority order. Prefer the highest-priority resolved entry;
+	// fall back to an in-progress marker only if no resolved entry is found under any key. Every L2
+	// entry read is promoted into L1.
+	var l2InProgressType KeyType
+	l2InProgressFound := false
+	for i, k := range keys {
+		entry := c.l2Get(ctx, k.Key)
+		if entry == nil {
+			continue
+		}
+		if entry.InProgress {
+			if !l2InProgressFound {
+				c.l1Promote(k.Key, *entry)
+				l2InProgressType = k.Type
+				l2InProgressFound = true
+			}
+			continue
+		}
+		c.l1Promote(k.Key, *entry)
+		c.backfill(ctx, keys, i, *entry)
+		return toResult(*entry, k.Type, LayerL2)
+	}
+	if l2InProgressFound {
+		return InProgressResult(l2InProgressType, LayerL2)
+	}
+	return MissResult()
+}
+
+// Put writes a positive entry (the resolved eids) under every key, each capped by its ceiling.
+func (c *IdentityCache) Put(ctx context.Context, keys []Key, eids []openrtb2.EID, cttl time.Duration) {
+	for _, k := range keys {
+		ttl := c.ttl.EffectiveTTL(k.Type, cttl)
+		exp := time.Now().UnixMilli() + ttl.Milliseconds()
+		c.writeBoth(ctx, k.Key, Entry{Eids: eids, Exp: exp}, ttl)
+	}
+}
+
+// PutNegative writes a negative sentinel under every key with the negative TTL.
+func (c *IdentityCache) PutNegative(ctx context.Context, keys []Key, cttl time.Duration) {
+	ttl := c.ttl.NegativeTTLFor(cttl)
+	for _, k := range keys {
+		exp := time.Now().UnixMilli() + ttl.Milliseconds()
+		c.writeBoth(ctx, k.Key, Entry{Negative: true, Exp: exp}, ttl)
+	}
+}
+
+// PutInProgress marks a resolution as in flight: an IN_PROGRESS sentinel under every key with the
+// short in-progress TTL, so a concurrent request for the same id reads it and skips a duplicate
+// upstream call. Overwritten by Put/PutNegative when the call completes; expires otherwise.
+func (c *IdentityCache) PutInProgress(ctx context.Context, keys []Key) {
+	ttl := c.ttl.InProgressTTL
+	for _, k := range keys {
+		exp := time.Now().UnixMilli() + ttl.Milliseconds()
+		c.writeBoth(ctx, k.Key, Entry{InProgress: true, Exp: exp}, ttl)
+	}
+}
+
+// backfill propagates the winning entry under every other key that currently misses in L1, capped by
+// min(remaining, ceilingFor(type)). Faithful port of Java backfill.
+func (c *IdentityCache) backfill(ctx context.Context, keys []Key, hitIndex int, hit Entry) {
+	remaining := hit.Exp - time.Now().UnixMilli()
+	if remaining <= 0 {
+		return
+	}
+	for i, k := range keys {
+		if i == hitIndex {
+			continue
+		}
+		if c.l1Get(k.Key) != nil {
+			continue
+		}
+		ttlMs := remaining
+		if ceil := c.ttl.CeilingFor(k.Type).Milliseconds(); ceil < ttlMs {
+			ttlMs = ceil
+		}
+		exp := time.Now().UnixMilli() + ttlMs
+		entry := Entry{Eids: hit.Eids, Negative: hit.Negative, InProgress: hit.InProgress, Exp: exp}
+		c.writeBoth(ctx, k.Key, entry, time.Duration(ttlMs)*time.Millisecond)
+	}
+}
+
+// writeBoth writes the entry into L1 and L2. The entry lives in L1 even if the L2 write fails.
+func (c *IdentityCache) writeBoth(ctx context.Context, key string, entry Entry, ttl time.Duration) {
+	value, err := json.Marshal(entry)
+	if err != nil {
+		c.metrics.L1PutError()
+		return
+	}
+	c.l1Set(key, value, ttl)
+
+	start := time.Now()
+	putErr := c.store.Put(ctx, key, string(value), ttl)
+	c.metrics.L2PutLatency(time.Since(start))
+	if putErr != nil {
+		c.metrics.L2PutError()
+	}
+}
+
+// l1Set stores a pre-encoded value into freecache with a per-entry expiry (expireSeconds = ceil of
+// the TTL, min 1). L1 failures are counted and swallowed (fail open).
+func (c *IdentityCache) l1Set(key string, value []byte, ttl time.Duration) {
+	expireSeconds := int(math.Ceil(ttl.Seconds()))
+	if expireSeconds < 1 {
+		expireSeconds = 1
+	}
+	if err := c.local.Set([]byte(key), value, expireSeconds); err != nil {
+		c.metrics.L1PutError()
+	}
+}
+
+// l1Promote writes an entry read from L2 into L1, deriving the L1 TTL from the entry's absolute
+// expiry. A no-op if the entry has already expired.
+func (c *IdentityCache) l1Promote(key string, entry Entry) {
+	remaining := entry.Exp - time.Now().UnixMilli()
+	if remaining <= 0 {
+		return
+	}
+	value, err := json.Marshal(entry)
+	if err != nil {
+		c.metrics.L1PutError()
+		return
+	}
+	c.l1Set(key, value, time.Duration(remaining)*time.Millisecond)
+}
+
+// l1Get reads and decodes a live entry from L1, or nil when absent/expired. A pathological freecache
+// failure is counted and swallowed (fail open).
+func (c *IdentityCache) l1Get(key string) *Entry {
+	value, err := c.local.Get([]byte(key))
+	if err != nil {
+		if errors.Is(err, freecache.ErrNotFound) {
+			return nil
+		}
+		c.metrics.L1GetError()
+		return nil
+	}
+	return decodeValid(value)
+}
+
+// l2Get reads and decodes a live entry from L2, timing the GET. An L2 error is counted and treated
+// as a miss (fail open).
+func (c *IdentityCache) l2Get(ctx context.Context, key string) *Entry {
+	start := time.Now()
+	value, err := c.store.Get(ctx, key)
+	c.metrics.L2GetLatency(time.Since(start))
+	if err != nil {
+		c.metrics.L2GetError()
+		return nil
+	}
+	if value == "" {
+		return nil
+	}
+	return decodeValid([]byte(value))
+}
+
+// decodeValid decodes a serialized Entry and treats an entry at/after its absolute expiry as absent.
+func decodeValid(value []byte) *Entry {
+	if len(value) == 0 {
+		return nil
+	}
+	var entry Entry
+	if err := json.Unmarshal(value, &entry); err != nil {
+		return nil
+	}
+	if entry.Exp <= time.Now().UnixMilli() {
+		return nil
+	}
+	return &entry
+}
+
+// toResult maps a live entry to a Result for the given key type and serving layer.
+func toResult(entry Entry, keyType KeyType, layer Layer) Result {
+	if entry.InProgress {
+		return InProgressResult(keyType, layer)
+	}
+	if entry.Negative {
+		return NegativeResult(keyType, layer)
+	}
+	return HitResult(entry.Eids, keyType, layer)
+}

--- a/modules/intentiq/identity/cache/identity_cache_test.go
+++ b/modules/intentiq/identity/cache/identity_cache_test.go
@@ -1,0 +1,301 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingMetrics is a test-only cache.Metrics that counts calls and captures the registered gauges.
+type countingMetrics struct {
+	l1GetError   atomic.Int64
+	l1PutError   atomic.Int64
+	l2GetLatency atomic.Int64
+	l2PutLatency atomic.Int64
+	l2GetError   atomic.Int64
+	l2PutError   atomic.Int64
+
+	l1Size      func() int64
+	l1Evictions func() int64
+	l2Size      func() int64
+	l2Evictions func() int64
+}
+
+func (m *countingMetrics) L1GetError()                  { m.l1GetError.Add(1) }
+func (m *countingMetrics) L1PutError()                  { m.l1PutError.Add(1) }
+func (m *countingMetrics) L2GetLatency(d time.Duration) { m.l2GetLatency.Add(1) }
+func (m *countingMetrics) L2PutLatency(d time.Duration) { m.l2PutLatency.Add(1) }
+func (m *countingMetrics) L2GetError()                  { m.l2GetError.Add(1) }
+func (m *countingMetrics) L2PutError()                  { m.l2PutError.Add(1) }
+
+func (m *countingMetrics) RegisterL1Gauges(size, evictions func() int64) {
+	m.l1Size = size
+	m.l1Evictions = evictions
+}
+
+func (m *countingMetrics) RegisterL2Gauges(size, evictions func() int64) {
+	m.l2Size = size
+	m.l2Evictions = evictions
+}
+
+// testTTL is a policy with distinct, easily-asserted ceilings.
+func testTTL() TTLPolicy {
+	return TTLPolicy{
+		Default:           30 * time.Minute,
+		FirstPartyCeiling: time.Hour,
+		ThirdPartyCeiling: 10 * time.Minute,
+		DeviceCeiling:     5 * time.Minute,
+		NegativeTTL:       2 * time.Minute,
+		InProgressTTL:     15 * time.Second,
+	}
+}
+
+// newTestCache wires an IdentityCache over a real miniredis-backed L2.
+func newTestCache(t *testing.T) (*IdentityCache, *miniredis.Miniredis, *redis.Client, *countingMetrics) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	metrics := &countingMetrics{}
+	c := NewIdentityCache(1024*1024, testTTL(), NewRedisStore(client), metrics)
+	return c, mr, client, metrics
+}
+
+func eids(source string) []openrtb2.EID {
+	return []openrtb2.EID{{Source: source, UIDs: []openrtb2.UID{{ID: "abc"}}}}
+}
+
+func keysFor(pairs ...Key) []Key { return pairs }
+
+func TestNewIdentityCacheRegistersL1Gauges(t *testing.T) {
+	c, _, _, m := newTestCache(t)
+	require.NotNil(t, m.l1Size)
+	require.NotNil(t, m.l1Evictions)
+
+	assert.Equal(t, int64(0), m.l1Size())
+	c.Put(context.Background(), keysFor(Key{Key: "k1", Type: FirstParty}), eids("a.com"), 0)
+	assert.Equal(t, int64(1), m.l1Size())
+	assert.Equal(t, int64(0), m.l1Evictions())
+}
+
+func TestGetEmptyKeysIsMiss(t *testing.T) {
+	c, _, _, _ := newTestCache(t)
+	assert.Equal(t, Miss, c.Get(context.Background(), nil).State)
+	assert.Equal(t, Miss, c.Get(context.Background(), []Key{}).State)
+}
+
+func TestL1Hit(t *testing.T) {
+	c, _, _, m := newTestCache(t)
+	ctx := context.Background()
+	keys := keysFor(Key{Key: "fp", Type: FirstParty})
+	c.Put(ctx, keys, eids("a.com"), 0)
+
+	// Reset L2 latency counter from the Put so we can assert the hit served from L1.
+	before := m.l2GetLatency.Load()
+	res := c.Get(ctx, keys)
+	assert.Equal(t, Hit, res.State)
+	assert.Equal(t, LayerL1, res.Layer)
+	assert.Equal(t, FirstParty, res.KeyType)
+	require.Len(t, res.Eids, 1)
+	assert.Equal(t, "a.com", res.Eids[0].Source)
+	// L1 hit must not probe L2.
+	assert.Equal(t, before, m.l2GetLatency.Load())
+}
+
+func TestL2HitPromotesToL1(t *testing.T) {
+	c, _, client, m := newTestCache(t)
+	ctx := context.Background()
+	keys := keysFor(Key{Key: "fp", Type: FirstParty})
+
+	// Seed L2 directly (bypass L1) via the store, using a fresh cache's Put and then wiping L1 by
+	// building a second cache sharing the same redis.
+	seed := NewIdentityCache(1024*1024, testTTL(), NewRedisStore(client), &countingMetrics{})
+	seed.Put(ctx, keys, eids("b.com"), 0)
+
+	res := c.Get(ctx, keys)
+	assert.Equal(t, Hit, res.State)
+	assert.Equal(t, LayerL2, res.Layer)
+	require.Len(t, res.Eids, 1)
+	assert.Equal(t, "b.com", res.Eids[0].Source)
+	assert.GreaterOrEqual(t, m.l2GetLatency.Load(), int64(1))
+
+	// Now it must be promoted into L1: a second Get serves from L1 (no new L2 GET).
+	before := m.l2GetLatency.Load()
+	res2 := c.Get(ctx, keys)
+	assert.Equal(t, Hit, res2.State)
+	assert.Equal(t, LayerL1, res2.Layer)
+	assert.Equal(t, before, m.l2GetLatency.Load())
+}
+
+func TestAliasBackfill(t *testing.T) {
+	c, _, _, _ := newTestCache(t)
+	ctx := context.Background()
+	k0 := Key{Key: "primary", Type: FirstParty}
+	k1 := Key{Key: "secondary", Type: ThirdParty}
+
+	// Only k0 is populated.
+	c.Put(ctx, keysFor(k0), eids("a.com"), 0)
+
+	// A lookup carrying both keys hits under k0 and back-fills k1.
+	res := c.Get(ctx, keysFor(k0, k1))
+	assert.Equal(t, Hit, res.State)
+	assert.Equal(t, FirstParty, res.KeyType)
+
+	// A later lookup carrying only k1 now hits (from L1 backfill).
+	res2 := c.Get(ctx, keysFor(k1))
+	assert.Equal(t, Hit, res2.State)
+	assert.Equal(t, ThirdParty, res2.KeyType)
+	require.Len(t, res2.Eids, 1)
+	assert.Equal(t, "a.com", res2.Eids[0].Source)
+}
+
+func TestNegativeSentinel(t *testing.T) {
+	c, _, _, _ := newTestCache(t)
+	ctx := context.Background()
+	keys := keysFor(Key{Key: "neg", Type: ThirdParty})
+	c.PutNegative(ctx, keys, 0)
+
+	res := c.Get(ctx, keys)
+	assert.Equal(t, Negative, res.State)
+	assert.Equal(t, LayerL1, res.Layer)
+	assert.Equal(t, ThirdParty, res.KeyType)
+	assert.Nil(t, res.Eids)
+}
+
+func TestInProgressMarkerFallback(t *testing.T) {
+	c, _, _, _ := newTestCache(t)
+	ctx := context.Background()
+	k0 := Key{Key: "ip", Type: Device}
+	c.PutInProgress(ctx, keysFor(k0))
+
+	res := c.Get(ctx, keysFor(k0))
+	assert.Equal(t, InProgress, res.State)
+	assert.Equal(t, LayerL1, res.Layer)
+	assert.Equal(t, Device, res.KeyType)
+}
+
+func TestResolvedWinsOverInProgress(t *testing.T) {
+	c, _, _, _ := newTestCache(t)
+	ctx := context.Background()
+	k0 := Key{Key: "ipkey", Type: FirstParty}
+	k1 := Key{Key: "reskey", Type: ThirdParty}
+	c.PutInProgress(ctx, keysFor(k0))
+	c.Put(ctx, keysFor(k1), eids("a.com"), 0)
+
+	// k0 (in-progress) is higher priority but a resolved entry under k1 wins.
+	res := c.Get(ctx, keysFor(k0, k1))
+	assert.Equal(t, Hit, res.State)
+	assert.Equal(t, ThirdParty, res.KeyType)
+}
+
+func TestFullMiss(t *testing.T) {
+	c, _, _, m := newTestCache(t)
+	ctx := context.Background()
+	res := c.Get(ctx, keysFor(Key{Key: "nope", Type: FirstParty}, Key{Key: "nada", Type: Device}))
+	assert.Equal(t, Miss, res.State)
+	assert.Equal(t, LayerNone, res.Layer)
+	// Every key was probed in L2.
+	assert.GreaterOrEqual(t, m.l2GetLatency.Load(), int64(2))
+}
+
+func TestPositiveTTLCappedByCeiling(t *testing.T) {
+	c, _, client, _ := newTestCache(t)
+	ctx := context.Background()
+	// cttl far above the device ceiling (5m) -> capped at 5m.
+	k := Key{Key: "devkey", Type: Device}
+	c.Put(ctx, keysFor(k), eids("a.com"), 24*time.Hour)
+
+	ttl := client.PTTL(ctx, "devkey").Val()
+	assert.LessOrEqual(t, ttl, 5*time.Minute)
+	assert.Greater(t, ttl, 4*time.Minute)
+}
+
+func TestPositiveTTLUsesCttlWhenBelowCeiling(t *testing.T) {
+	c, _, client, _ := newTestCache(t)
+	ctx := context.Background()
+	// cttl below the first-party ceiling (1h) -> honored.
+	k := Key{Key: "fpkey", Type: FirstParty}
+	c.Put(ctx, keysFor(k), eids("a.com"), 3*time.Minute)
+
+	ttl := client.PTTL(ctx, "fpkey").Val()
+	assert.LessOrEqual(t, ttl, 3*time.Minute)
+	assert.Greater(t, ttl, 2*time.Minute)
+}
+
+func TestNegativeTTL(t *testing.T) {
+	c, _, client, _ := newTestCache(t)
+	ctx := context.Background()
+
+	// Without cttl -> configured NegativeTTL (2m).
+	c.PutNegative(ctx, keysFor(Key{Key: "n1", Type: ThirdParty}), 0)
+	ttl := client.PTTL(ctx, "n1").Val()
+	assert.LessOrEqual(t, ttl, 2*time.Minute)
+	assert.Greater(t, ttl, time.Minute)
+
+	// With cttl (below first-party ceiling) -> honored.
+	c.PutNegative(ctx, keysFor(Key{Key: "n2", Type: ThirdParty}), 30*time.Second)
+	ttl2 := client.PTTL(ctx, "n2").Val()
+	assert.LessOrEqual(t, ttl2, 30*time.Second)
+	assert.Greater(t, ttl2, 15*time.Second)
+
+	// With absurd cttl -> capped by first-party ceiling (1h).
+	c.PutNegative(ctx, keysFor(Key{Key: "n3", Type: ThirdParty}), 48*time.Hour)
+	ttl3 := client.PTTL(ctx, "n3").Val()
+	assert.LessOrEqual(t, ttl3, time.Hour)
+	assert.Greater(t, ttl3, 59*time.Minute)
+}
+
+func TestL2GetFailOpen(t *testing.T) {
+	c, mr, _, m := newTestCache(t)
+	ctx := context.Background()
+	keys := keysFor(Key{Key: "k", Type: FirstParty})
+
+	// Close L2: a Get for a key absent from L1 must fall through to a miss, and count an L2 error.
+	mr.Close()
+
+	res := c.Get(ctx, keys)
+	assert.Equal(t, Miss, res.State)
+	assert.GreaterOrEqual(t, m.l2GetError.Load(), int64(1))
+}
+
+func TestL2PutFailOpenStillLivesInL1(t *testing.T) {
+	c, mr, _, m := newTestCache(t)
+	ctx := context.Background()
+	keys := keysFor(Key{Key: "k", Type: FirstParty})
+
+	mr.Close()
+	c.Put(ctx, keys, eids("a.com"), 0)
+	assert.GreaterOrEqual(t, m.l2PutError.Load(), int64(1))
+
+	// Entry still lives in L1 despite the L2 write failure.
+	res := c.Get(ctx, keys)
+	assert.Equal(t, Hit, res.State)
+	assert.Equal(t, LayerL1, res.Layer)
+}
+
+func TestExpiredEntryTreatedAsAbsent(t *testing.T) {
+	c, _, client, _ := newTestCache(t)
+	ctx := context.Background()
+
+	// Write an entry directly to L2 whose absolute expiry is already in the past.
+	past := Entry{Eids: eids("a.com"), Exp: time.Now().UnixMilli() - 1000}
+	store := NewRedisStore(client)
+	value, err := json.Marshal(past)
+	require.NoError(t, err)
+	require.NoError(t, store.Put(ctx, "stale", string(value), time.Hour))
+
+	res := c.Get(ctx, keysFor(Key{Key: "stale", Type: FirstParty}))
+	assert.Equal(t, Miss, res.State)
+}

--- a/modules/intentiq/identity/cache/keys.go
+++ b/modules/intentiq/identity/cache/keys.go
@@ -1,0 +1,86 @@
+package cache
+
+import "time"
+
+// KeyType classifies a cache key by the kind of identifier it carries, so the TTL ceiling can be
+// applied per id class (see TTLPolicy). First-party ids are treated as longer-lived than
+// third-party / probabilistic ones. Note intentiq.com is treated as ThirdParty, matching how the
+// IntentIQ backend classifies the IntentIQ cookie id.
+type KeyType int
+
+const (
+	FirstParty KeyType = iota
+	ThirdParty
+	Device
+)
+
+// Token is the short, stable, lowercase metric token for a key type
+// (e.g. ThirdParty -> "third_party").
+func (t KeyType) Token() string {
+	switch t {
+	case FirstParty:
+		return "first_party"
+	case ThirdParty:
+		return "third_party"
+	case Device:
+		return "device"
+	default:
+		return "unknown"
+	}
+}
+
+// Key is a single namespaced cache key derived from a first-party identifier on the bid request,
+// together with its KeyType (used to pick the TTL ceiling). A request yields an ordered list of
+// these; the resolved identity is aliased across all of them.
+type Key struct {
+	Key  string
+	Type KeyType
+}
+
+// TTLPolicy governs TTLs for cached identity entries. The IntentIQ API cttl (or the configured
+// default when absent) always wins, but is capped by a per-KeyType ceiling — we cache the volatile
+// resolved eids, not the stable cookie mapping, so ceilings are upper bounds only and deliberately
+// far shorter than the IntentIQ backend's mapping TTLs. Negative (unresolvable) entries and the
+// in-progress marker each use a separate short TTL.
+type TTLPolicy struct {
+	Default           time.Duration
+	FirstPartyCeiling time.Duration
+	ThirdPartyCeiling time.Duration
+	DeviceCeiling     time.Duration
+	NegativeTTL       time.Duration
+	InProgressTTL     time.Duration
+}
+
+// CeilingFor returns the TTL ceiling for the given key type.
+func (p TTLPolicy) CeilingFor(t KeyType) time.Duration {
+	switch t {
+	case FirstParty:
+		return p.FirstPartyCeiling
+	case ThirdParty:
+		return p.ThirdPartyCeiling
+	case Device:
+		return p.DeviceCeiling
+	default:
+		return p.Default
+	}
+}
+
+// EffectiveTTL is the positive TTL for a key: min(cttl-or-default, ceiling(type)).
+func (p TTLPolicy) EffectiveTTL(t KeyType, cttl time.Duration) time.Duration {
+	base := p.Default
+	if cttl > 0 {
+		base = cttl
+	}
+	return min(base, p.CeilingFor(t))
+}
+
+// NegativeTTLFor is the suppression TTL for a negative (unresolvable) entry. On an empty/invalid
+// response the IntentIQ backend signals how long to suppress re-querying this user via cttl; honor
+// it when present (bounded by the first-party ceiling as a safety cap against absurd values), else
+// fall back to the configured default negative TTL.
+func (p TTLPolicy) NegativeTTLFor(cttl time.Duration) time.Duration {
+	if cttl > 0 {
+		return min(cttl, p.FirstPartyCeiling)
+	}
+	return p.NegativeTTL
+}

--- a/modules/intentiq/identity/cache/redis_store.go
+++ b/modules/intentiq/identity/cache/redis_store.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// evictedKeysField is the INFO stats line prefix carrying the cumulative evicted_keys counter.
+const evictedKeysField = "evicted_keys:"
+
+// RedisStore is the Redis-backed Store (the default L2 backend). Values are stored with a per-entry
+// TTL via SET key value PX <ttl>.
+type RedisStore struct {
+	client *redis.Client
+}
+
+// NewRedisStore builds a RedisStore from a go-redis client.
+func NewRedisStore(client *redis.Client) *RedisStore {
+	return &RedisStore{client: client}
+}
+
+// Get returns the value for key, or "" when absent.
+func (s *RedisStore) Get(ctx context.Context, key string) (string, error) {
+	value, err := s.client.Get(ctx, key).Result()
+	if errors.Is(err, redis.Nil) {
+		// Absent is not an error: fall through to a live API call.
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+// Put stores value under key with the given TTL.
+func (s *RedisStore) Put(ctx context.Context, key, value string, ttl time.Duration) error {
+	return s.client.Set(ctx, key, value, ttl).Err()
+}
+
+// DBSize is the current key count of the selected DB (DBSIZE). Instance-wide, not module-scoped.
+func (s *RedisStore) DBSize(ctx context.Context) (int64, error) {
+	return s.client.DBSize(ctx).Result()
+}
+
+// EvictedKeys is the cumulative evicted_keys from INFO stats. Instance-wide.
+func (s *RedisStore) EvictedKeys(ctx context.Context) (int64, error) {
+	info, err := s.client.Info(ctx, "stats").Result()
+	if err != nil {
+		return 0, err
+	}
+	return parseEvictedKeys(info), nil
+}
+
+// parseEvictedKeys extracts the evicted_keys counter from an INFO stats payload, returning 0 on a
+// missing or unparsable line (faithful to Java parseEvictedKeys).
+func parseEvictedKeys(info string) int64 {
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, evictedKeysField) {
+			raw := strings.TrimSpace(line[len(evictedKeysField):])
+			n, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil {
+				return 0
+			}
+			return n
+		}
+	}
+	return 0
+}

--- a/modules/intentiq/identity/cache/redis_store_test.go
+++ b/modules/intentiq/identity/cache/redis_store_test.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) (*RedisStore, *miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewRedisStore(client), mr, client
+}
+
+func TestRedisStoreGetAbsentReturnsEmptyNoError(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	value, err := store.Get(context.Background(), "missing")
+	assert.NoError(t, err)
+	assert.Equal(t, "", value)
+}
+
+func TestRedisStorePutGetRoundTrip(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Put(ctx, "k", "v", time.Minute))
+
+	value, err := store.Get(ctx, "k")
+	assert.NoError(t, err)
+	assert.Equal(t, "v", value)
+}
+
+func TestRedisStorePutSetsTTL(t *testing.T) {
+	store, mr, _ := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Put(ctx, "k", "v", 90*time.Second))
+	assert.Equal(t, 90*time.Second, mr.TTL("k"))
+}
+
+func TestRedisStoreGetError(t *testing.T) {
+	store, mr, _ := newTestStore(t)
+	mr.Close()
+	_, err := store.Get(context.Background(), "k")
+	assert.Error(t, err)
+}
+
+func TestRedisStoreDBSize(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Put(ctx, "a", "1", time.Minute))
+	require.NoError(t, store.Put(ctx, "b", "2", time.Minute))
+
+	n, err := store.DBSize(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+}
+
+func TestRedisStoreEvictedKeys(t *testing.T) {
+	store, mr, _ := newTestStore(t)
+	// miniredis INFO does not report evicted_keys, so a real poll yields 0 (missing field).
+	n, err := store.EvictedKeys(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	_ = mr
+}
+
+func TestParseEvictedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		info string
+		want int64
+	}{
+		{
+			name: "present crlf",
+			info: "# Stats\r\nkeyspace_hits:10\r\nevicted_keys:42\r\nkeyspace_misses:3\r\n",
+			want: 42,
+		},
+		{
+			name: "present lf",
+			info: "evicted_keys:7\n",
+			want: 7,
+		},
+		{
+			name: "present with whitespace",
+			info: "evicted_keys:  99  \n",
+			want: 99,
+		},
+		{
+			name: "missing field",
+			info: "keyspace_hits:10\nkeyspace_misses:3\n",
+			want: 0,
+		},
+		{
+			name: "unparsable value",
+			info: "evicted_keys:notanumber\n",
+			want: 0,
+		},
+		{
+			name: "empty",
+			info: "",
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseEvictedKeys(tc.info))
+		})
+	}
+}

--- a/modules/intentiq/identity/cache/result.go
+++ b/modules/intentiq/identity/cache/result.go
@@ -1,0 +1,73 @@
+package cache
+
+import "github.com/prebid/openrtb/v20/openrtb2"
+
+// State is the outcome of a multi-key cache lookup.
+type State int
+
+const (
+	// Miss — nothing cached; fetch from the API.
+	Miss State = iota
+	// Hit — a positive entry was found; Eids carries the resolved identity.
+	Hit
+	// Negative — a negative sentinel was found (the id is known-unresolvable); skip the upstream
+	// call and do not enrich.
+	Negative
+	// InProgress — a resolution call for this id is already in flight; skip the upstream call (do
+	// not fire a duplicate) and do not enrich.
+	InProgress
+)
+
+// Layer identifies which cache layer served the outcome: L1 (in-process) or L2 (Redis).
+type Layer int
+
+const (
+	// LayerNone is used for a full miss, where no layer matched.
+	LayerNone Layer = iota
+	// LayerL1 is the in-process layer (freecache).
+	LayerL1
+	// LayerL2 is the shared layer (Redis by default).
+	LayerL2
+)
+
+// Token is the short, stable, lowercase metric token for a layer ("l1"/"l2").
+func (l Layer) Token() string {
+	switch l {
+	case LayerL1:
+		return "l1"
+	case LayerL2:
+		return "l2"
+	default:
+		return "unknown"
+	}
+}
+
+// Result is the outcome of a multi-key cache lookup. KeyType is the type of the candidate key that
+// produced the outcome (Hit/Negative/InProgress); both KeyType and Layer are zero-valued for Miss,
+// where no key/layer matched.
+type Result struct {
+	State   State
+	Eids    []openrtb2.EID
+	KeyType KeyType
+	Layer   Layer
+}
+
+// HitResult builds a Hit result.
+func HitResult(eids []openrtb2.EID, keyType KeyType, layer Layer) Result {
+	return Result{State: Hit, Eids: eids, KeyType: keyType, Layer: layer}
+}
+
+// NegativeResult builds a Negative result.
+func NegativeResult(keyType KeyType, layer Layer) Result {
+	return Result{State: Negative, KeyType: keyType, Layer: layer}
+}
+
+// InProgressResult builds an InProgress result.
+func InProgressResult(keyType KeyType, layer Layer) Result {
+	return Result{State: InProgress, KeyType: keyType, Layer: layer}
+}
+
+// MissResult builds a Miss result.
+func MissResult() Result {
+	return Result{State: Miss}
+}

--- a/modules/intentiq/identity/cache/stats_reporter.go
+++ b/modules/intentiq/identity/cache/stats_reporter.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// statsPollTimeout bounds a single DBSIZE / INFO poll so a slow or stuck Redis instance cannot wedge
+// the poller goroutine.
+const statsPollTimeout = 2 * time.Second
+
+// RedisStatsReporter periodically polls Redis (L2) DBSIZE and INFO stats evicted_keys and exposes
+// them as the global l2.size / l2.eviction gauges. Redis stats are asynchronous and instance-wide,
+// so (unlike freecache's in-process L1 counters) they can't be read inside a synchronous gauge —
+// this caches the latest poll into atomics the gauges read. Both values are Redis-instance-wide,
+// not module-scoped.
+type RedisStatsReporter struct {
+	store        *RedisStore
+	metrics      Metrics
+	pollInterval time.Duration
+
+	size      atomic.Int64
+	evictions atomic.Int64
+
+	stop     chan struct{}
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// NewRedisStatsReporter builds the poller and registers the L2 gauges.
+func NewRedisStatsReporter(store *RedisStore, metrics Metrics, pollInterval time.Duration) *RedisStatsReporter {
+	r := &RedisStatsReporter{
+		store:        store,
+		metrics:      metrics,
+		pollInterval: pollInterval,
+		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
+	}
+	r.metrics.RegisterL2Gauges(
+		func() int64 { return r.size.Load() },
+		func() int64 { return r.evictions.Load() },
+	)
+	return r
+}
+
+// Start polls once, then launches the periodic poller goroutine. Returns the receiver for fluent
+// wiring.
+func (r *RedisStatsReporter) Start() *RedisStatsReporter {
+	r.poll()
+	go func() {
+		defer close(r.done)
+		ticker := time.NewTicker(r.pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.stop:
+				return
+			case <-ticker.C:
+				r.poll()
+			}
+		}
+	}()
+	return r
+}
+
+// Stop halts the poller goroutine. Safe to call multiple times.
+func (r *RedisStatsReporter) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stop)
+	})
+}
+
+// poll reads DBSIZE and evicted_keys and caches them into the gauge atomics. Failures are swallowed
+// (the previous value is retained) so a transient Redis blip does not zero the gauges.
+func (r *RedisStatsReporter) poll() {
+	ctx, cancel := context.WithTimeout(context.Background(), statsPollTimeout)
+	defer cancel()
+
+	if size, err := r.store.DBSize(ctx); err == nil {
+		r.size.Store(size)
+	}
+	if evictions, err := r.store.EvictedKeys(ctx); err == nil {
+		r.evictions.Store(evictions)
+	}
+}

--- a/modules/intentiq/identity/cache/stats_reporter_test.go
+++ b/modules/intentiq/identity/cache/stats_reporter_test.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsReporterRegistersL2Gauges(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	m := &countingMetrics{}
+	NewRedisStatsReporter(store, m, time.Minute)
+	require.NotNil(t, m.l2Size)
+	require.NotNil(t, m.l2Evictions)
+	// Before any poll the gauges read zero.
+	assert.Equal(t, int64(0), m.l2Size())
+	assert.Equal(t, int64(0), m.l2Evictions())
+}
+
+func TestStatsReporterPollsImmediatelyAndPeriodically(t *testing.T) {
+	store, _, client := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, client.Set(ctx, "a", "1", time.Minute).Err())
+	require.NoError(t, client.Set(ctx, "b", "2", time.Minute).Err())
+
+	m := &countingMetrics{}
+	r := NewRedisStatsReporter(store, m, 20*time.Millisecond)
+	r.Start()
+	t.Cleanup(r.Stop)
+
+	// The immediate poll in Start() should have populated the size gauge.
+	assert.Equal(t, int64(2), m.l2Size())
+
+	// A third key should be picked up by a later periodic poll.
+	require.NoError(t, client.Set(ctx, "c", "3", time.Minute).Err())
+	assert.Eventually(t, func() bool {
+		return m.l2Size() == 3
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestStatsReporterStopIsIdempotent(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	m := &countingMetrics{}
+	r := NewRedisStatsReporter(store, m, 10*time.Millisecond)
+	r.Start()
+
+	r.Stop()
+	// Second and third Stop must not panic (sync.Once).
+	assert.NotPanics(t, func() {
+		r.Stop()
+		r.Stop()
+	})
+
+	// The poller goroutine must have terminated.
+	select {
+	case <-r.done:
+	case <-time.After(time.Second):
+		t.Fatal("poller goroutine did not terminate after Stop")
+	}
+}
+
+func TestStatsReporterStopWithoutStart(t *testing.T) {
+	store, _, _ := newTestStore(t)
+	m := &countingMetrics{}
+	r := NewRedisStatsReporter(store, m, time.Minute)
+	// Stop before Start must be safe.
+	assert.NotPanics(t, r.Stop)
+}
+
+func TestStatsReporterPollSurvivesRedisFailure(t *testing.T) {
+	store, mr, client := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, client.Set(ctx, "a", "1", time.Minute).Err())
+
+	m := &countingMetrics{}
+	r := NewRedisStatsReporter(store, m, 20*time.Millisecond)
+	r.Start()
+	t.Cleanup(r.Stop)
+
+	assert.Equal(t, int64(1), m.l2Size())
+
+	// Kill Redis: the previously polled value must be retained (poll failures are swallowed).
+	mr.Close()
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, int64(1), m.l2Size())
+}

--- a/modules/intentiq/identity/cache/store.go
+++ b/modules/intentiq/identity/cache/store.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+)
+
+// Store is a generic, backend-agnostic key/value store used as the shared (L2) layer of
+// IdentityCache. The default implementation is Redis (RedisStore); a partner can provide a different
+// backend by supplying another implementation. Values are opaque strings (the cache handles
+// serialization), so the store stays decoupled from the eid model.
+type Store interface {
+	Get(ctx context.Context, key string) (string, error)
+	Put(ctx context.Context, key, value string, ttl time.Duration) error
+}
+
+// Entry is the serialized value held in both cache layers. The same JSON shape is stored in L1 and
+// L2 so the two layers stay uniform.
+//
+//   - a positive entry carries Eids, with Negative=false, InProgress=false
+//   - a negative sentinel has Negative=true (id known-unresolvable)
+//   - an in-progress marker has InProgress=true (a resolution call is in flight)
+//
+// Exp is the absolute expiry as Unix milliseconds; a read must treat an entry at/after Exp as absent.
+type Entry struct {
+	Eids       []openrtb2.EID `json:"eids,omitempty"`
+	Negative   bool           `json:"negative,omitempty"`
+	InProgress bool           `json:"inProgress,omitempty"`
+	Exp        int64          `json:"exp"`
+}
+
+// Metrics is the cache-layer health contract (implemented by the module's Prometheus metrics). It
+// is defined here, in the cache package, so the cache subsystem does not import the parent package
+// (which would create an import cycle). Business counters (hit/miss/negative/in_progress by
+// layer+keytype+partner) are recorded by the parent package from the Result, not here.
+type Metrics interface {
+	L1GetError()
+	L1PutError()
+	L2GetLatency(d time.Duration)
+	L2PutLatency(d time.Duration)
+	L2GetError()
+	L2PutError()
+	// RegisterL1Gauges wires the in-process capacity gauges (current size, cumulative evictions).
+	RegisterL1Gauges(size, evictions func() int64)
+	// RegisterL2Gauges wires the Redis capacity gauges (DBSIZE, cumulative evicted_keys).
+	RegisterL2Gauges(size, evictions func() int64)
+}

--- a/modules/intentiq/identity/config.go
+++ b/modules/intentiq/identity/config.go
@@ -1,0 +1,93 @@
+package identity
+
+import (
+	"time"
+
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+// Config is the effective module configuration. Host-level config is parsed in Builder (defaults
+// applied there); per request the account-level config is merged over it by resolve. JSON keys are
+// kebab-case to match the documented (Java) config surface so operators can reuse the same YAML.
+type Config struct {
+	APIEndpoint     string       `json:"api-endpoint"`
+	ReportsEndpoint string       `json:"reports-endpoint"`
+	PartnerID       string       `json:"partner-id"`
+	Timeout         int64        `json:"timeout"` // ms
+	Cache           CacheConfig  `json:"cache"`
+	Redis           *RedisConfig `json:"redis"`
+	CacheMaxSize    int          `json:"cache-max-size"` // in-process (L1) byte budget
+	MetricsEnabled  bool         `json:"metrics-enabled"`
+}
+
+// CacheConfig configures the two-layer identity cache.
+type CacheConfig struct {
+	Enabled                     bool `json:"enabled"`
+	TTLSeconds                  int  `json:"ttlseconds"`
+	MaxKeys                     int  `json:"max-keys"`
+	TTLCeilingFirstPartySeconds int  `json:"ttl-ceiling-first-party-seconds"`
+	TTLCeilingThirdPartySeconds int  `json:"ttl-ceiling-third-party-seconds"`
+	TTLCeilingDeviceSeconds     int  `json:"ttl-ceiling-device-seconds"`
+	NegativeTTLSeconds          int  `json:"negative-ttl-seconds"`
+	InProgressTTLSeconds        int  `json:"in-progress-ttl-seconds"`
+}
+
+// RedisConfig is the L2 backend connection. Host-level only (never overridden per account).
+type RedisConfig struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Password string `json:"password"`
+}
+
+// defaultConfig returns a Config pre-populated with the module defaults (mirrors the Java property
+// defaults). Builder unmarshals the host config over this, and resolve unmarshals account config
+// over the resolved host config.
+func defaultConfig() Config {
+	return Config{
+		Timeout:        1000,
+		CacheMaxSize:   100_000,
+		MetricsEnabled: true,
+		Cache: CacheConfig{
+			TTLSeconds:                  43_200,
+			MaxKeys:                     10,
+			TTLCeilingFirstPartySeconds: 86_400,
+			TTLCeilingThirdPartySeconds: 43_200,
+			TTLCeilingDeviceSeconds:     3_600,
+			NegativeTTLSeconds:          120,
+			InProgressTTLSeconds:        1_800,
+		},
+	}
+}
+
+// resolve merges the account-level module config over this (host-resolved) config and returns the
+// effective config for the request. Absent keys retain the host value; nested objects merge
+// field-by-field (Go unmarshal into an existing struct only overrides present keys). Account config
+// never carries redis.* (host-level only), so the shared Redis pointer is not deep-copied.
+func (c Config) resolve(accountConfig []byte) Config {
+	if len(accountConfig) == 0 {
+		return c
+	}
+	merged := c // value copy; nested structs copied by value
+	if err := jsonutil.Unmarshal(accountConfig, &merged); err != nil {
+		return c
+	}
+	return merged
+}
+
+func (c Config) timeout() time.Duration {
+	return time.Duration(c.Timeout) * time.Millisecond
+}
+
+// ttlPolicy builds the cache TTL policy from the (seconds-based) cache config.
+func (c Config) ttlPolicy() cache.TTLPolicy {
+	sec := func(s int) time.Duration { return time.Duration(s) * time.Second }
+	return cache.TTLPolicy{
+		Default:           sec(c.Cache.TTLSeconds),
+		FirstPartyCeiling: sec(c.Cache.TTLCeilingFirstPartySeconds),
+		ThirdPartyCeiling: sec(c.Cache.TTLCeilingThirdPartySeconds),
+		DeviceCeiling:     sec(c.Cache.TTLCeilingDeviceSeconds),
+		NegativeTTL:       sec(c.Cache.NegativeTTLSeconds),
+		InProgressTTL:     sec(c.Cache.InProgressTTLSeconds),
+	}
+}

--- a/modules/intentiq/identity/config_test.go
+++ b/modules/intentiq/identity/config_test.go
@@ -1,0 +1,70 @@
+package identity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	c := defaultConfig()
+	assert.Equal(t, int64(1000), c.Timeout)
+	assert.Equal(t, 100_000, c.CacheMaxSize)
+	assert.True(t, c.MetricsEnabled)
+	assert.Equal(t, 43_200, c.Cache.TTLSeconds)
+	assert.Equal(t, 10, c.Cache.MaxKeys)
+	assert.Equal(t, 86_400, c.Cache.TTLCeilingFirstPartySeconds)
+	assert.Equal(t, 1_800, c.Cache.InProgressTTLSeconds)
+	assert.False(t, c.Cache.Enabled)
+	assert.Nil(t, c.Redis)
+}
+
+func TestConfigResolve(t *testing.T) {
+	host := defaultConfig()
+	host.APIEndpoint = "http://host"
+	host.PartnerID = "host-partner"
+
+	t.Run("nil account returns host config unchanged", func(t *testing.T) {
+		assert.Equal(t, host, host.resolve(nil))
+	})
+
+	t.Run("empty account returns host config unchanged", func(t *testing.T) {
+		assert.Equal(t, host, host.resolve([]byte{}))
+	})
+
+	t.Run("account overrides only present keys, merges nested cache", func(t *testing.T) {
+		got := host.resolve([]byte(`{"partner-id":"acct","cache":{"ttlseconds":60}}`))
+		assert.Equal(t, "acct", got.PartnerID)          // overridden
+		assert.Equal(t, "http://host", got.APIEndpoint) // retained
+		assert.Equal(t, 60, got.Cache.TTLSeconds)       // nested override
+		assert.Equal(t, 10, got.Cache.MaxKeys)          // nested default retained
+		assert.Equal(t, int64(1000), got.Timeout)       // retained
+	})
+
+	t.Run("invalid JSON falls back to host config", func(t *testing.T) {
+		assert.Equal(t, host, host.resolve([]byte(`{not json`)))
+	})
+}
+
+func TestConfigTTLPolicy(t *testing.T) {
+	c := defaultConfig()
+	c.Cache.TTLSeconds = 100
+	c.Cache.TTLCeilingFirstPartySeconds = 200
+	c.Cache.TTLCeilingThirdPartySeconds = 300
+	c.Cache.TTLCeilingDeviceSeconds = 400
+	c.Cache.NegativeTTLSeconds = 5
+	c.Cache.InProgressTTLSeconds = 6
+
+	p := c.ttlPolicy()
+	assert.Equal(t, 100*time.Second, p.Default)
+	assert.Equal(t, 200*time.Second, p.FirstPartyCeiling)
+	assert.Equal(t, 300*time.Second, p.ThirdPartyCeiling)
+	assert.Equal(t, 400*time.Second, p.DeviceCeiling)
+	assert.Equal(t, 5*time.Second, p.NegativeTTL)
+	assert.Equal(t, 6*time.Second, p.InProgressTTL)
+}
+
+func TestConfigTimeout(t *testing.T) {
+	assert.Equal(t, 1500*time.Millisecond, Config{Timeout: 1500}.timeout())
+}

--- a/modules/intentiq/identity/enrich.go
+++ b/modules/intentiq/identity/enrich.go
@@ -1,0 +1,225 @@
+package identity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+// terminationCauseMetricMax bounds the tc values recorded as a metric (0 <= tc < 200); larger
+// values are IntentIQ diagnostic codes not tracked as a business counter.
+const terminationCauseMetricMax = 200
+
+// HandleProcessedAuctionHook enriches user.eids with IntentIQ-resolved ids. Faithful port of the Java
+// IntentiqIdentityProcessedAuctionRequestHook: it resolves identity (from the alias cache or a live
+// S2S call) and, on a hit, appends the resolved eids to user.eids. It is fail-open — any resolution
+// error leaves the request untouched. Flow state for the impression hook is always stashed in the
+// returned ModuleContext.
+func (m *Module) HandleProcessedAuctionHook(
+	ctx context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.ProcessedAuctionRequestPayload,
+) (hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload], error) {
+	start := time.Now()
+	cfg := m.cfg.resolve(miCtx.AccountConfig)
+	dpi := cfg.PartnerID
+
+	rw := payload.Request
+	var req *openrtb2.BidRequest
+	if rw != nil {
+		req = rw.BidRequest
+	}
+
+	// Baseline flow context: request-derived fields known regardless of the resolution outcome.
+	fc := flowContext{start: start}
+	if req != nil {
+		fc.auctionID = req.ID
+		fc.ref = resolveRef(req)
+		if device := req.Device; device != nil {
+			fc.ip = device.IP
+			if fc.ip == "" {
+				fc.ip = device.IPv6
+			}
+			fc.ua = device.UA
+		}
+	}
+
+	var result hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload]
+
+	if !notBlank(cfg.APIEndpoint) {
+		m.metrics.SkipNoEndpoint(dpi)
+		result.ModuleContext = setFlowContext(fc)
+		return result, nil
+	}
+	if req == nil {
+		result.ModuleContext = setFlowContext(fc)
+		return result, nil
+	}
+
+	res, err := m.resolveEids(ctx, cfg, rw)
+	if err != nil {
+		// Fail open: proceed without enrichment (abTestUuid/tc unknown on error).
+		m.metrics.APIError(dpi)
+		result.ModuleContext = setFlowContext(fc)
+		return result, nil
+	}
+
+	fc.abTestUUID = res.abTestUUID
+	fc.terminationCause = res.terminationCause
+	result.ModuleContext = setFlowContext(fc)
+
+	if len(res.eids) == 0 {
+		m.metrics.EidsNone(dpi)
+		return result, nil
+	}
+
+	m.metrics.Enriched(dpi)
+	eids := res.eids
+	result.ChangeSet.AddMutation(
+		func(p hookstage.ProcessedAuctionRequestPayload) (hookstage.ProcessedAuctionRequestPayload, error) {
+			enrichUserEids(p.Request, eids)
+			return p, nil
+		},
+		hookstage.MutationUpdate, "bidrequest", "user", "eids",
+	)
+
+	return result, nil
+}
+
+// resolveEids resolves identity for the request: either directly via the S2S call (caching disabled
+// or no candidate keys) or through the two-layer alias cache. Mirrors the Java resolveEids state
+// machine, recording the cache business counters as it goes.
+func (m *Module) resolveEids(ctx context.Context, cfg Config, rw *openrtb_ext.RequestWrapper) (resolution, error) {
+	dpi := cfg.PartnerID
+	req := rw.BidRequest
+
+	cacheEnabled := m.cache != nil && cfg.Cache.Enabled
+	var keys []cache.Key
+	if cacheEnabled {
+		keys = m.keyExtractor.CandidateKeys(req)
+	}
+	if len(keys) == 0 {
+		resp, err := m.fetch(ctx, cfg, rw)
+		if err != nil {
+			return resolution{}, err
+		}
+		return resolution{eids: resp.eids(), abTestUUID: resp.AbTestUUID, terminationCause: resp.Tc}, nil
+	}
+
+	// Cache counters are broken down by key type: the type of the key that actually matched for
+	// Hit/Negative/InProgress, and the request's primary (highest-priority) candidate type for a full
+	// Miss, where no key matched.
+	primaryType := keys[0].Type.Token()
+	res := m.cache.Get(ctx, keys)
+	switch res.State {
+	case cache.Hit:
+		m.metrics.CacheHit(res.Layer.Token(), res.KeyType.Token(), dpi)
+		return resolution{eids: res.Eids}, nil
+	case cache.Negative:
+		// A negative sentinel is a cached miss (id known-unresolvable): counts toward cache.miss, and
+		// the negative-specific counter distinguishes it from a true miss.
+		typ := res.KeyType.Token()
+		m.metrics.CacheMiss(typ, dpi)
+		m.metrics.CacheNegativeHit(res.Layer.Token(), typ, dpi)
+		return resolution{}, nil
+	case cache.InProgress:
+		// A resolution call for this id is already in flight; skip a duplicate and don't enrich.
+		m.metrics.CacheInProgress(res.Layer.Token(), res.KeyType.Token(), dpi)
+		return resolution{}, nil
+	default: // cache.Miss
+		m.metrics.CacheMiss(primaryType, dpi)
+		m.cache.PutInProgress(ctx, keys)
+		resp, err := m.fetch(ctx, cfg, rw)
+		if err != nil {
+			return resolution{}, err
+		}
+		eids := resp.eids()
+		if len(eids) > 0 {
+			m.cache.Put(ctx, keys, eids, resp.cttl())
+		} else {
+			m.cache.PutNegative(ctx, keys, resp.cttl())
+		}
+		return resolution{eids: eids, abTestUUID: resp.AbTestUUID, terminationCause: resp.Tc}, nil
+	}
+}
+
+// fetch performs the identity-resolution S2S GET (with the gdpr-consent header when present) under a
+// per-request timeout, parses the response leniently, and records the API metrics. APIError is left
+// to the caller's fail-open path so it is counted once per failed resolution (as in Java).
+func (m *Module) fetch(ctx context.Context, cfg Config, rw *openrtb_ext.RequestWrapper) (iiqResponse, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout())
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodGet, resolveURL(cfg, rw), nil)
+	if err != nil {
+		return iiqResponse{}, err
+	}
+	if consent := resolveConsent(rw); consent != "" {
+		httpReq.Header.Set(gdprConsentHeader, consent)
+	}
+
+	start := time.Now()
+	resp, err := m.httpClient.Do(httpReq)
+	m.metrics.APILatency(time.Since(start), cfg.PartnerID)
+	if err != nil {
+		return iiqResponse{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return iiqResponse{}, err
+	}
+
+	var parsed iiqResponse
+	if err := jsonutil.Unmarshal(body, &parsed); err != nil {
+		return iiqResponse{}, err
+	}
+
+	m.metrics.APISuccess(cfg.PartnerID)
+	if parsed.Tc != nil && *parsed.Tc >= 0 && *parsed.Tc < terminationCauseMetricMax {
+		m.metrics.TerminationCause(*parsed.Tc, cfg.PartnerID)
+	}
+	return parsed, nil
+}
+
+// eids leniently extracts the resolved eids from the response data. IntentIQ returns data as an
+// object on a hit but as an empty string ("") on an empty/invalid response, so a non-object data is
+// treated as absent rather than failing the parse.
+func (r iiqResponse) eids() []openrtb2.EID {
+	data := bytes.TrimSpace(r.Data)
+	if len(data) == 0 || data[0] != '{' {
+		return nil
+	}
+	var d struct {
+		Eids []openrtb2.EID `json:"eids"`
+	}
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil
+	}
+	return d.Eids
+}
+
+// enrichUserEids appends resolved eids to req.User.EIDs, creating User when absent (mirrors Java).
+func enrichUserEids(rw *openrtb_ext.RequestWrapper, resolved []openrtb2.EID) {
+	if rw == nil || rw.BidRequest == nil {
+		return
+	}
+	if rw.User == nil {
+		rw.User = &openrtb2.User{}
+	}
+	merged := make([]openrtb2.EID, 0, len(rw.User.EIDs)+len(resolved))
+	merged = append(merged, rw.User.EIDs...)
+	merged = append(merged, resolved...)
+	rw.User.EIDs = merged
+}

--- a/modules/intentiq/identity/enrich_test.go
+++ b/modules/intentiq/identity/enrich_test.go
@@ -1,0 +1,289 @@
+package identity
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+const eidsBody = `{"data":{"eids":[{"source":"intentiq.com","uids":[{"id":"abc","atype":1}]}]}}`
+const emptyBody = `{"data":{"eids":[]}}`
+
+// countMetrics is a counting Metrics stub for the enrich-hook tests.
+type countMetrics struct {
+	noopMetrics
+	apiSuccess     int
+	apiError       int
+	enriched       int
+	eidsNone       int
+	skipNoEndpoint int
+	tc             []int64
+}
+
+func (c *countMetrics) APISuccess(string)                   { c.apiSuccess++ }
+func (c *countMetrics) APIError(string)                     { c.apiError++ }
+func (c *countMetrics) Enriched(string)                     { c.enriched++ }
+func (c *countMetrics) EidsNone(string)                     { c.eidsNone++ }
+func (c *countMetrics) SkipNoEndpoint(string)               { c.skipNoEndpoint++ }
+func (c *countMetrics) TerminationCause(tc int64, _ string) { c.tc = append(c.tc, tc) }
+
+// capture records the URL/consent header the module sent to the fake IIQ backend.
+type capture struct {
+	rawQuery string
+	consent  string
+	hits     int
+}
+
+func newServer(t *testing.T, body string, cap *capture) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.hits++
+		cap.rawQuery = r.URL.RawQuery
+		cap.consent = r.Header.Get(gdprConsentHeader)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newModule(endpoint string, client *http.Client, metrics Metrics) *Module {
+	return &Module{
+		cfg:          Config{APIEndpoint: endpoint, PartnerID: "123", Timeout: 1000},
+		httpClient:   client,
+		keyExtractor: NewFirstPartyKeyExtractor(10),
+		metrics:      metrics,
+		cache:        nil, // no-cache direct path
+	}
+}
+
+func runHook(t *testing.T, m *Module, req *openrtb2.BidRequest) (hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload], hookstage.ProcessedAuctionRequestPayload) {
+	t.Helper()
+	payload := hookstage.ProcessedAuctionRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: req}}
+	res, err := m.HandleProcessedAuctionHook(context.Background(), hookstage.ModuleInvocationContext{}, payload)
+	require.NoError(t, err)
+	return res, payload
+}
+
+// applyMutations runs every mutation in the change set against the payload (as the framework would).
+func applyMutations(t *testing.T, res hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload], payload hookstage.ProcessedAuctionRequestPayload) hookstage.ProcessedAuctionRequestPayload {
+	t.Helper()
+	p := payload
+	for _, mut := range res.ChangeSet.Mutations() {
+		var err error
+		p, err = mut.Apply(p)
+		require.NoError(t, err)
+	}
+	return p
+}
+
+func flowFrom(t *testing.T, res hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload]) flowContext {
+	t.Helper()
+	fc, ok := getFlowContext(res.ModuleContext)
+	require.True(t, ok, "flow context must be set in ModuleContext")
+	return fc
+}
+
+func TestEnrichAppendsResolvedEids(t *testing.T) {
+	cap := &capture{}
+	m := newModule(newServer(t, eidsBody, cap).URL, http.DefaultClient, &countMetrics{})
+
+	res, payload := runHook(t, m, &openrtb2.BidRequest{})
+	require.Len(t, res.ChangeSet.Mutations(), 1)
+
+	updated := applyMutations(t, res, payload)
+	eids := updated.Request.User.EIDs
+	require.Len(t, eids, 1)
+	assert.Equal(t, "intentiq.com", eids[0].Source)
+	assert.Equal(t, "abc", eids[0].UIDs[0].ID)
+}
+
+func TestEnrichAppendsAfterExistingUserEids(t *testing.T) {
+	cap := &capture{}
+	m := newModule(newServer(t, eidsBody, cap).URL, http.DefaultClient, &countMetrics{})
+
+	req := &openrtb2.BidRequest{User: &openrtb2.User{EIDs: []openrtb2.EID{
+		{Source: "pubcid.org", UIDs: []openrtb2.UID{{ID: "existing-uid"}}},
+	}}}
+	res, payload := runHook(t, m, req)
+	updated := applyMutations(t, res, payload)
+
+	require.Len(t, updated.Request.User.EIDs, 2)
+	assert.Equal(t, "pubcid.org", updated.Request.User.EIDs[0].Source)
+	assert.Equal(t, "intentiq.com", updated.Request.User.EIDs[1].Source)
+}
+
+func TestEnrichEidsNoneWhenEmptyData(t *testing.T) {
+	cap := &capture{}
+	metrics := &countMetrics{}
+	m := newModule(newServer(t, emptyBody, cap).URL, http.DefaultClient, metrics)
+
+	res, _ := runHook(t, m, &openrtb2.BidRequest{})
+	assert.Empty(t, res.ChangeSet.Mutations())
+	assert.Equal(t, 1, metrics.eidsNone)
+	assert.Equal(t, 1, metrics.apiSuccess)
+	assert.Equal(t, 0, metrics.enriched)
+}
+
+// Lenient parse: data:"" (empty string, not an object) is a valid empty response, not an API error.
+func TestEnrichLenientEmptyStringData(t *testing.T) {
+	cap := &capture{}
+	metrics := &countMetrics{}
+	body := `{"adt":4,"ct":2,"data":"","cttl":600000,"tc":36}`
+	m := newModule(newServer(t, body, cap).URL, http.DefaultClient, metrics)
+
+	res, _ := runHook(t, m, &openrtb2.BidRequest{})
+	assert.Empty(t, res.ChangeSet.Mutations())
+	assert.Equal(t, 1, metrics.apiSuccess)
+	assert.Equal(t, 0, metrics.apiError)
+	assert.Equal(t, 1, metrics.eidsNone)
+	assert.Equal(t, []int64{36}, metrics.tc)
+}
+
+func TestEnrichSendsUrlParamsAndConsentHeader(t *testing.T) {
+	cap := &capture{}
+	m := newModule("", http.DefaultClient, &countMetrics{})
+	srv := newServer(t, emptyBody, cap)
+	m.cfg.APIEndpoint = srv.URL
+
+	gdpr := int8(1)
+	req := &openrtb2.BidRequest{
+		Device: &openrtb2.Device{IP: "1.2.3.4", UA: "Mozilla/5.0 (iPhone)"},
+		Regs:   &openrtb2.Regs{GDPR: &gdpr, USPrivacy: "1YNN"},
+		User:   &openrtb2.User{Consent: "CO-TCF-STRING"},
+	}
+	runHook(t, m, req)
+
+	require.Equal(t, 1, cap.hits)
+	// Raw query preserves the encoding (%20 for space).
+	assert.Contains(t, cap.rawQuery, "at=39")
+	assert.Contains(t, cap.rawQuery, "dpi=123")
+	assert.Contains(t, cap.rawQuery, "source=pbsgo")
+	assert.Contains(t, cap.rawQuery, "uas=Mozilla%2F5.0%20%28iPhone%29")
+	assert.Contains(t, cap.rawQuery, "gdpr=1")
+	assert.Contains(t, cap.rawQuery, "us_privacy=1YNN")
+
+	parsed, err := url.ParseQuery(cap.rawQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", parsed.Get("ip"))
+
+	// Consent travels in the header, not the query.
+	assert.Equal(t, "CO-TCF-STRING", cap.consent)
+	assert.NotContains(t, cap.rawQuery, "CO-TCF-STRING")
+}
+
+func TestEnrichNoConsentHeaderWhenAbsent(t *testing.T) {
+	cap := &capture{}
+	m := newModule(newServer(t, emptyBody, cap).URL, http.DefaultClient, &countMetrics{})
+
+	runHook(t, m, &openrtb2.BidRequest{})
+	assert.Equal(t, "", cap.consent)
+}
+
+func TestEnrichNoEndpointSkip(t *testing.T) {
+	metrics := &countMetrics{}
+	m := newModule("", http.DefaultClient, metrics)
+
+	res, payload := runHook(t, m, &openrtb2.BidRequest{ID: "auc-1"})
+	assert.Empty(t, res.ChangeSet.Mutations())
+	assert.Equal(t, 1, metrics.skipNoEndpoint)
+	assert.Equal(t, 0, metrics.apiSuccess)
+
+	// Flow context still set with the known start/auction fields.
+	fc := flowFrom(t, res)
+	assert.Equal(t, "auc-1", fc.auctionID)
+	assert.False(t, fc.start.IsZero())
+	// No mutation applied.
+	updated := applyMutations(t, res, payload)
+	assert.Nil(t, updated.Request.User)
+}
+
+func TestEnrichUpstreamErrorIsNoOp(t *testing.T) {
+	// Server that resets the connection / returns error: point the client at a closed server.
+	cap := &capture{}
+	srv := newServer(t, emptyBody, cap)
+	badURL := srv.URL
+	srv.Close() // force a connection error
+
+	metrics := &countMetrics{}
+	m := newModule(badURL, http.DefaultClient, metrics)
+
+	res, payload := runHook(t, m, &openrtb2.BidRequest{})
+	assert.Empty(t, res.ChangeSet.Mutations())
+	assert.Equal(t, 1, metrics.apiError)
+	assert.Equal(t, 0, metrics.apiSuccess)
+
+	updated := applyMutations(t, res, payload)
+	assert.Nil(t, updated.Request.User)
+
+	// Flow context is still set (abTestUuid/tc unknown on error).
+	fc := flowFrom(t, res)
+	assert.False(t, fc.start.IsZero())
+	assert.Empty(t, fc.abTestUUID)
+	assert.Nil(t, fc.terminationCause)
+}
+
+func TestEnrichFlowContextCarriesTerminationCauseAndRequestFields(t *testing.T) {
+	cap := &capture{}
+	body := `{"data":{"eids":[{"source":"intentiq.com","uids":[{"id":"abc"}]}]},"abTestUuid":"ab-1","tc":5}`
+	m := newModule(newServer(t, body, cap).URL, http.DefaultClient, &countMetrics{})
+
+	req := &openrtb2.BidRequest{
+		ID:     "auction-9",
+		Site:   &openrtb2.Site{Domain: "example.com"},
+		Device: &openrtb2.Device{IP: "9.9.9.9", UA: "UA-X"},
+	}
+	res, _ := runHook(t, m, req)
+
+	fc := flowFrom(t, res)
+	assert.Equal(t, "auction-9", fc.auctionID)
+	assert.Equal(t, "example.com", fc.ref)
+	assert.Equal(t, "9.9.9.9", fc.ip)
+	assert.Equal(t, "UA-X", fc.ua)
+	assert.Equal(t, "ab-1", fc.abTestUUID)
+	require.NotNil(t, fc.terminationCause)
+	assert.Equal(t, int64(5), *fc.terminationCause)
+}
+
+func TestEnrichFlowContextIpFallsBackToIpv6(t *testing.T) {
+	cap := &capture{}
+	m := newModule(newServer(t, emptyBody, cap).URL, http.DefaultClient, &countMetrics{})
+
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IPv6: "2001:db8::1"}}
+	res, _ := runHook(t, m, req)
+
+	assert.Equal(t, "2001:db8::1", flowFrom(t, res).ip)
+}
+
+func TestResolveEidsDropsOutOfRangeTerminationCauseMetric(t *testing.T) {
+	cap := &capture{}
+	metrics := &countMetrics{}
+	body := `{"data":{"eids":[]},"tc":120088}`
+	m := newModule(newServer(t, body, cap).URL, http.DefaultClient, metrics)
+
+	res, _ := runHook(t, m, &openrtb2.BidRequest{})
+	// tc is out of [0,200): no metric recorded, but it still rides in the flow context.
+	assert.Empty(t, metrics.tc)
+	fc := flowFrom(t, res)
+	require.NotNil(t, fc.terminationCause)
+	assert.Equal(t, int64(120088), *fc.terminationCause)
+}
+
+func TestEidsLenientHelper(t *testing.T) {
+	assert.Nil(t, iiqResponse{Data: []byte(`""`)}.eids())
+	assert.Nil(t, iiqResponse{Data: nil}.eids())
+	assert.Nil(t, iiqResponse{Data: []byte(`  `)}.eids())
+
+	got := iiqResponse{Data: []byte(`{"eids":[{"source":"intentiq.com","uids":[{"id":"x"}]}]}`)}.eids()
+	require.Len(t, got, 1)
+	assert.Equal(t, "intentiq.com", got[0].Source)
+}

--- a/modules/intentiq/identity/enrich_test.go
+++ b/modules/intentiq/identity/enrich_test.go
@@ -167,7 +167,7 @@ func TestEnrichSendsUrlParamsAndConsentHeader(t *testing.T) {
 	// Raw query preserves the encoding (%20 for space).
 	assert.Contains(t, cap.rawQuery, "at=39")
 	assert.Contains(t, cap.rawQuery, "dpi=123")
-	assert.Contains(t, cap.rawQuery, "source=pbsgo")
+	assert.Contains(t, cap.rawQuery, "source=pbgo")
 	assert.Contains(t, cap.rawQuery, "uas=Mozilla%2F5.0%20%28iPhone%29")
 	assert.Contains(t, cap.rawQuery, "gdpr=1")
 	assert.Contains(t, cap.rawQuery, "us_privacy=1YNN")

--- a/modules/intentiq/identity/impression.go
+++ b/modules/intentiq/identity/impression.go
@@ -1,0 +1,211 @@
+package identity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+)
+
+// HandleAuctionResponseHook reports each winning bid to the IntentIQ impression API and records
+// whole-flow latency. The bid response is never modified.
+//
+// Faithful port of Java IntentiqIdentityAuctionResponseHook. Unlike the Java hook — which reaches the
+// bid request via AuctionContext — the Go auction-response payload exposes only the BidResponse, so
+// the request-derived report fields (vrref/prebidAuctionId/ip/ua) come from the flowContext the enrich
+// hook stashed in the module context.
+func (m *Module) HandleAuctionResponseHook(
+	_ context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.AuctionResponsePayload,
+) (hookstage.HookResult[hookstage.AuctionResponsePayload], error) {
+	var result hookstage.HookResult[hookstage.AuctionResponsePayload]
+
+	cfg := m.cfg.resolve(miCtx.AccountConfig)
+	dpi := cfg.PartnerID
+
+	fc, ok := getFlowContext(miCtx.ModuleContext)
+	// Whole-flow latency: enrich entry -> bid release, recorded once per auction regardless of
+	// whether an impression report is configured/sent.
+	if ok {
+		m.metrics.FlowLatency(time.Since(fc.start), dpi)
+	}
+
+	if cfg.ReportsEndpoint == "" || payload.BidResponse == nil {
+		return result, nil
+	}
+
+	bidResponse := payload.BidResponse
+	currency := bidResponse.Cur
+	if currency == "" {
+		currency = defaultCurrency
+	}
+
+	for i := range bidResponse.SeatBid {
+		seatBid := bidResponse.SeatBid[i]
+		for j := range seatBid.Bid {
+			m.report(cfg, seatBid.Seat, seatBid.Bid[j], currency, fc, ok)
+		}
+	}
+
+	return result, nil
+}
+
+// report builds the rdata payload for a single bid and fires a fire-and-forget GET to the reports
+// endpoint. The bid response is never touched.
+func (m *Module) report(cfg Config, bidderCode string, bid openrtb2.Bid, currency string, fc flowContext, haveFC bool) {
+	rdata := newOrderedMap()
+	rdata.put("bidderCode", bidderCode)
+	rdata.put("partnerId", cfg.PartnerID)
+	rdata.put("cpm", bid.Price)
+	rdata.put("currency", currency)
+	appendOriginalBid(rdata, bid.Ext)
+	rdata.put("placementId", bid.ImpID)
+	rdata.put("biddingPlatformId", biddingPlatformOpenRTB)
+
+	if haveFC {
+		putIfPresent(rdata, "vrref", fc.ref)
+		putIfPresent(rdata, "prebidAuctionId", fc.auctionID)
+		putIfPresent(rdata, "partnerAuctionId", fc.auctionID)
+		putIfPresent(rdata, "abTestUuid", fc.abTestUUID)
+		if fc.terminationCause != nil {
+			rdata.put("terminationCause", *fc.terminationCause)
+		}
+		putIfPresent(rdata, "ip", fc.ip)
+		putIfPresent(rdata, "ua", fc.ua)
+	}
+
+	reportURL := buildReportURL(cfg, rdata)
+	dpi := cfg.PartnerID
+	timeout := cfg.timeout()
+
+	// Fire-and-forget: use a fresh background context (the hook's request context is cancelled once
+	// the response is returned) bounded by the configured timeout. Recover so a stray panic in the
+	// detached goroutine can never take down the server.
+	go func() {
+		defer func() { _ = recover() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reportURL, nil)
+		if err != nil {
+			m.metrics.ImpressionError(dpi)
+			return
+		}
+		resp, err := m.httpClient.Do(req)
+		if err != nil {
+			m.metrics.ImpressionError(dpi)
+			return
+		}
+		// Drain and close so the connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		m.metrics.ImpressionReported(dpi)
+	}()
+}
+
+// buildReportURL assembles the reports-endpoint URL with the fixed query params plus the url-encoded
+// dpi and rdata JSON, mirroring the Java reportUrl/encodeComponent.
+func buildReportURL(cfg Config, rdata *orderedMap) string {
+	sep := "?"
+	if strings.Contains(cfg.ReportsEndpoint, "?") {
+		sep = "&"
+	}
+	rdataJSON, _ := rdata.MarshalJSON()
+
+	var b strings.Builder
+	b.WriteString(cfg.ReportsEndpoint)
+	b.WriteString(sep)
+	b.WriteString("at=45")
+	b.WriteString("&rtype=1")
+	b.WriteString("&source=" + sourcePBSGo)
+	b.WriteString("&dpi=" + encodeComponent(cfg.PartnerID))
+	b.WriteString("&rdata=" + encodeComponent(string(rdataJSON)))
+	return b.String()
+}
+
+// appendOriginalBid pulls origbidcpm (numeric) and origbidcur (non-blank string) from the bid ext,
+// adding originalCpm/originalCurrency to rdata. A non-numeric origbidcpm or unparseable ext is
+// silently skipped, matching the Java isNumber()/isNotBlank() guards.
+func appendOriginalBid(rdata *orderedMap, ext json.RawMessage) {
+	if len(ext) == 0 {
+		return
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(ext, &fields); err != nil {
+		return
+	}
+	if raw, ok := fields["origbidcpm"]; ok {
+		var num json.Number
+		if err := json.Unmarshal(raw, &num); err == nil && num != "" {
+			rdata.put("originalCpm", num)
+		}
+	}
+	if raw, ok := fields["origbidcur"]; ok {
+		var cur string
+		if err := json.Unmarshal(raw, &cur); err == nil && strings.TrimSpace(cur) != "" {
+			rdata.put("originalCurrency", cur)
+		}
+	}
+}
+
+// putIfPresent adds key only when value is non-blank (StringUtils.isNotBlank parity). Uses the shared
+// notBlank helper from params.go.
+func putIfPresent(rdata *orderedMap, key, value string) {
+	if notBlank(value) {
+		rdata.put(key, value)
+	}
+}
+
+// orderedMap is a minimal insertion-ordered string-keyed map that marshals to a JSON object in
+// insertion order, matching the Java LinkedHashMap-backed rdata so the produced JSON key order is
+// identical.
+type orderedMap struct {
+	keys   []string
+	values map[string]any
+}
+
+func newOrderedMap() *orderedMap {
+	return &orderedMap{values: make(map[string]any)}
+}
+
+// put sets key to value, appending to the order the first time the key is seen (later puts overwrite
+// the value but keep the original position, like LinkedHashMap).
+func (o *orderedMap) put(key string, value any) {
+	if _, exists := o.values[key]; !exists {
+		o.keys = append(o.keys, key)
+	}
+	o.values[key] = value
+}
+
+// MarshalJSON renders the object with keys in insertion order.
+func (o *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyJSON, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyJSON)
+		buf.WriteByte(':')
+		valJSON, err := json.Marshal(o.values[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valJSON)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}

--- a/modules/intentiq/identity/impression_test.go
+++ b/modules/intentiq/identity/impression_test.go
@@ -1,0 +1,205 @@
+package identity
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+)
+
+// impMetrics is a concurrency-safe Metrics stub for the impression hook (the report fires in a
+// detached goroutine).
+type impMetrics struct {
+	noopMetrics
+	reported atomic.Int64
+	errored  atomic.Int64
+	flow     atomic.Int64
+}
+
+func (m *impMetrics) ImpressionReported(string)         { m.reported.Add(1) }
+func (m *impMetrics) ImpressionError(string)            { m.errored.Add(1) }
+func (m *impMetrics) FlowLatency(time.Duration, string) { m.flow.Add(1) }
+
+func impModule(endpoint string, client *http.Client, metrics Metrics) *Module {
+	return &Module{
+		cfg:        Config{ReportsEndpoint: endpoint, PartnerID: "part-9", Timeout: 1000},
+		httpClient: client,
+		metrics:    metrics,
+	}
+}
+
+func miCtxWithFlow(fc flowContext) hookstage.ModuleInvocationContext {
+	return hookstage.ModuleInvocationContext{ModuleContext: setFlowContext(fc)}
+}
+
+func twoBidResponse() *openrtb2.BidResponse {
+	return &openrtb2.BidResponse{
+		Cur: "EUR",
+		SeatBid: []openrtb2.SeatBid{{
+			Seat: "bidderA",
+			Bid: []openrtb2.Bid{
+				{ImpID: "imp1", Price: 1.5},
+				{ImpID: "imp2", Price: 2.0, Ext: json.RawMessage(`{"origbidcpm":2.2,"origbidcur":"USD"}`)},
+			},
+		}},
+	}
+}
+
+func TestImpression_NoEndpoint_NoCall(t *testing.T) {
+	m := impModule("", http.DefaultClient, &impMetrics{})
+	res, err := m.HandleAuctionResponseHook(t.Context(),
+		miCtxWithFlow(flowContext{start: time.Now()}),
+		hookstage.AuctionResponsePayload{BidResponse: twoBidResponse()})
+	require.NoError(t, err)
+	assert.False(t, res.Reject)
+}
+
+func TestImpression_FlowLatencyRecordedEvenWithoutEndpoint(t *testing.T) {
+	metrics := &impMetrics{}
+	m := impModule("", http.DefaultClient, metrics)
+	_, err := m.HandleAuctionResponseHook(t.Context(),
+		miCtxWithFlow(flowContext{start: time.Now()}),
+		hookstage.AuctionResponsePayload{BidResponse: twoBidResponse()})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), metrics.flow.Load())
+}
+
+func TestImpression_NilResponse_NoPanic(t *testing.T) {
+	metrics := &impMetrics{}
+	m := impModule("https://reports.example/x", http.DefaultClient, metrics)
+	_, err := m.HandleAuctionResponseHook(t.Context(),
+		miCtxWithFlow(flowContext{start: time.Now()}),
+		hookstage.AuctionResponsePayload{BidResponse: nil})
+	require.NoError(t, err)
+}
+
+func TestImpression_ReportsOnePerBid(t *testing.T) {
+	type reqRec struct {
+		query string
+		rdata string
+	}
+	got := make(chan reqRec, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- reqRec{query: r.URL.RawQuery, rdata: r.URL.Query().Get("rdata")}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	metrics := &impMetrics{}
+	m := impModule(srv.URL, srv.Client(), metrics)
+
+	fc := flowContext{
+		start:      time.Now(),
+		abTestUUID: "ab-1",
+		auctionID:  "auc-1",
+		ref:        "example.com",
+		ip:         "5.6.7.8",
+		ua:         "UA/1",
+	}
+	_, err := m.HandleAuctionResponseHook(t.Context(), miCtxWithFlow(fc),
+		hookstage.AuctionResponsePayload{BidResponse: twoBidResponse()})
+	require.NoError(t, err)
+
+	// Two bids -> two fire-and-forget reports.
+	recs := make([]reqRec, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-got:
+			recs = append(recs, r)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for report %d", i+1)
+		}
+	}
+
+	// Fixed query params on every report.
+	for _, r := range recs {
+		q, err := url.ParseQuery(r.query)
+		require.NoError(t, err)
+		assert.Equal(t, "45", q.Get("at"))
+		assert.Equal(t, "1", q.Get("rtype"))
+		assert.Equal(t, sourcePBSGo, q.Get("source"))
+		assert.Equal(t, "part-9", q.Get("dpi"))
+	}
+
+	// Locate the imp2 report and assert its rdata JSON round-trips the expected fields (incl.
+	// original cpm/currency and the flow-context fields).
+	var imp2 map[string]any
+	for _, r := range recs {
+		var d map[string]any
+		require.NoError(t, json.Unmarshal([]byte(r.rdata), &d))
+		if d["placementId"] == "imp2" {
+			imp2 = d
+		}
+	}
+	require.NotNil(t, imp2, "expected a report for imp2")
+	assert.Equal(t, "bidderA", imp2["bidderCode"])
+	assert.Equal(t, "part-9", imp2["partnerId"])
+	assert.Equal(t, "EUR", imp2["currency"])
+	assert.Equal(t, biddingPlatformOpenRTB, imp2["biddingPlatformId"])
+	assert.EqualValues(t, 2.2, imp2["originalCpm"])
+	assert.Equal(t, "USD", imp2["originalCurrency"])
+	assert.Equal(t, "example.com", imp2["vrref"])
+	assert.Equal(t, "auc-1", imp2["prebidAuctionId"])
+	assert.Equal(t, "auc-1", imp2["partnerAuctionId"])
+	assert.Equal(t, "ab-1", imp2["abTestUuid"])
+	assert.Equal(t, "5.6.7.8", imp2["ip"])
+	assert.Equal(t, "UA/1", imp2["ua"])
+
+	assert.Eventually(t, func() bool { return metrics.reported.Load() == 2 }, 2*time.Second, 10*time.Millisecond)
+	assert.Equal(t, int64(1), metrics.flow.Load())
+}
+
+func TestImpression_DefaultCurrencyWhenAbsent(t *testing.T) {
+	got := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.URL.Query().Get("rdata")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := impModule(srv.URL, srv.Client(), &impMetrics{})
+	resp := &openrtb2.BidResponse{SeatBid: []openrtb2.SeatBid{{Seat: "s", Bid: []openrtb2.Bid{{ImpID: "i", Price: 1}}}}}
+	_, err := m.HandleAuctionResponseHook(t.Context(), miCtxWithFlow(flowContext{start: time.Now()}),
+		hookstage.AuctionResponsePayload{BidResponse: resp})
+	require.NoError(t, err)
+
+	select {
+	case rdata := <-got:
+		var d map[string]any
+		require.NoError(t, json.Unmarshal([]byte(rdata), &d))
+		assert.Equal(t, defaultCurrency, d["currency"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestImpression_ErrorCounted(t *testing.T) {
+	// Point at an unroutable endpoint so the GET fails; the error counter must increment.
+	metrics := &impMetrics{}
+	m := impModule("http://127.0.0.1:0/reports", &http.Client{Timeout: 500 * time.Millisecond}, metrics)
+	resp := &openrtb2.BidResponse{SeatBid: []openrtb2.SeatBid{{Seat: "s", Bid: []openrtb2.Bid{{ImpID: "i", Price: 1}}}}}
+	_, err := m.HandleAuctionResponseHook(t.Context(), miCtxWithFlow(flowContext{start: time.Now()}),
+		hookstage.AuctionResponsePayload{BidResponse: resp})
+	require.NoError(t, err)
+	assert.Eventually(t, func() bool { return metrics.errored.Load() == 1 }, 3*time.Second, 10*time.Millisecond)
+}
+
+// TestOrderedMapMarshalJSON verifies rdata preserves insertion order (matching Java LinkedHashMap).
+func TestOrderedMapMarshalJSON(t *testing.T) {
+	om := newOrderedMap()
+	om.put("b", 1)
+	om.put("a", "x")
+	om.put("b", 2) // overwrite value, keep position
+	out, err := om.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, `{"b":2,"a":"x"}`, string(out))
+}

--- a/modules/intentiq/identity/keyextractor.go
+++ b/modules/intentiq/identity/keyextractor.go
@@ -1,0 +1,157 @@
+package identity
+
+import (
+	"strings"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+)
+
+// FirstPartyKeyExtractor derives the ordered list of alias cache keys for a bid request. Each
+// relevant first-party id present becomes one namespaced key; the resolved identity is aliased across
+// all of them so a later request carrying any of those ids hits the cache.
+//
+// Faithful port of Java FirstPartyKeyExtractor.java. Priority (highest first): iiq:<id>
+// (intentiq.com), pubcid:<id> (pubcid.org/sharedid.org), maid:<ifa> (device.ifa; upper-cased for CTV
+// devicetype 3/7, skipped when device.lmt==1), <source>:<id> for any other eid, then a probabilistic
+// dev:<ifa_ua_ip> composite (ua via the deterministic normalizer in useragent.go). De-duplicate
+// (first occurrence wins) and cap at maxKeys.
+type FirstPartyKeyExtractor struct {
+	maxKeys int
+}
+
+// sharedSources are the eid sources treated as the shared/pubcid namespace.
+var sharedSources = map[string]bool{
+	"pubcid.org":   true,
+	"sharedid.org": true,
+}
+
+// NewFirstPartyKeyExtractor builds the extractor with the per-request key cap.
+func NewFirstPartyKeyExtractor(maxKeys int) *FirstPartyKeyExtractor {
+	return &FirstPartyKeyExtractor{maxKeys: maxKeys}
+}
+
+// CandidateKeys returns the ordered, de-duplicated, capped alias keys for the request.
+func (e *FirstPartyKeyExtractor) CandidateKeys(req *openrtb2.BidRequest) []cache.Key {
+	if req == nil {
+		return nil
+	}
+
+	var eids []openrtb2.EID
+	if req.User != nil {
+		eids = req.User.EIDs
+	}
+	device := req.Device
+
+	var keys []cache.Key
+	keys = addEidKeys(keys, eids, "iiq", cache.ThirdParty, func(s string) bool { return s == iiqSource })
+	keys = addEidKeys(keys, eids, "pubcid", cache.FirstParty, func(s string) bool { return sharedSources[s] })
+	keys = addMaidKey(keys, device)
+	keys = addOtherEidKeys(keys, eids)
+	keys = addDeviceComposite(keys, device)
+
+	return e.dedupAndCap(keys)
+}
+
+// addEidKeys appends "<namespace>:<id>" keys for every non-blank uid on eids whose source matches.
+func addEidKeys(keys []cache.Key, eids []openrtb2.EID, namespace string, keyType cache.KeyType, sourceMatch func(string) bool) []cache.Key {
+	for i := range eids {
+		eid := eids[i]
+		if eid.Source == "" || !sourceMatch(eid.Source) {
+			continue
+		}
+		for _, uid := range eid.UIDs {
+			if strings.TrimSpace(uid.ID) == "" {
+				continue
+			}
+			keys = append(keys, cache.Key{Key: namespace + ":" + uid.ID, Type: keyType})
+		}
+	}
+	return keys
+}
+
+// addMaidKey appends the "maid:<ifa>" key, skipping a blank ifa or an lmt==1 device and upper-casing
+// the ifa for CTV devices (devicetype 3 or 7) to match the resolution request's idtype-8 handling.
+func addMaidKey(keys []cache.Key, device *openrtb2.Device) []cache.Key {
+	if device == nil || strings.TrimSpace(device.IFA) == "" {
+		return keys
+	}
+	if device.Lmt != nil && *device.Lmt == 1 {
+		return keys
+	}
+	ifa := device.IFA
+	if dt := int(device.DeviceType); dt == 3 || dt == 7 {
+		ifa = strings.ToUpper(ifa)
+	}
+	return append(keys, cache.Key{Key: "maid:" + ifa, Type: cache.FirstParty})
+}
+
+// addOtherEidKeys appends "<source>:<id>" keys (lower-cased namespace) for every eid source that is
+// not the iiq or shared/pubcid source.
+func addOtherEidKeys(keys []cache.Key, eids []openrtb2.EID) []cache.Key {
+	for i := range eids {
+		eid := eids[i]
+		source := eid.Source
+		if source == "" {
+			continue
+		}
+		if source == iiqSource || sharedSources[source] {
+			continue
+		}
+		namespace := strings.ToLower(source)
+		for _, uid := range eid.UIDs {
+			if strings.TrimSpace(uid.ID) == "" {
+				continue
+			}
+			keys = append(keys, cache.Key{Key: namespace + ":" + uid.ID, Type: cache.FirstParty})
+		}
+	}
+	return keys
+}
+
+// addDeviceComposite appends the probabilistic "dev:<ifa_ua_ip>" composite key, joining the non-empty
+// [ifa, normalized-ua, ip||ipv6] fields with "_". The normalized UA (not the raw string) is used to
+// avoid fragmenting the cache per request.
+func addDeviceComposite(keys []cache.Key, device *openrtb2.Device) []cache.Key {
+	if device == nil {
+		return keys
+	}
+	ip := device.IP
+	if strings.TrimSpace(ip) == "" {
+		ip = device.IPv6
+	}
+	ua := strings.TrimSpace(normalizeUA(device.UA))
+
+	var fields []string
+	for _, f := range []string{device.IFA, ua, ip} {
+		if strings.TrimSpace(f) != "" {
+			fields = append(fields, f)
+		}
+	}
+	if len(fields) == 0 {
+		return keys
+	}
+	return append(keys, cache.Key{Key: "dev:" + strings.Join(fields, "_"), Type: cache.Device})
+}
+
+// dedupAndCap keeps the first occurrence of each key string (preserving order) and caps the result at
+// maxKeys.
+func (e *FirstPartyKeyExtractor) dedupAndCap(keys []cache.Key) []cache.Key {
+	if len(keys) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]cache.Key, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := seen[k.Key]; ok {
+			continue
+		}
+		seen[k.Key] = struct{}{}
+		out = append(out, k)
+		if e.maxKeys > 0 && len(out) >= e.maxKeys {
+			break
+		}
+	}
+	return out
+}

--- a/modules/intentiq/identity/keyextractor_test.go
+++ b/modules/intentiq/identity/keyextractor_test.go
@@ -1,0 +1,156 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+)
+
+func eid(source string, ids ...string) openrtb2.EID {
+	uids := make([]openrtb2.UID, 0, len(ids))
+	for _, id := range ids {
+		uids = append(uids, openrtb2.UID{ID: id})
+	}
+	return openrtb2.EID{Source: source, UIDs: uids}
+}
+
+func lmt(v int8) *int8 { return &v }
+
+func TestCandidateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxKeys int
+		req     *openrtb2.BidRequest
+		want    []cache.Key
+	}{
+		{
+			name: "nil request",
+			req:  nil,
+			want: nil,
+		},
+		{
+			name:    "priority order iiq, pubcid, maid, other, device",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				User: &openrtb2.User{EIDs: []openrtb2.EID{
+					eid("intentiq.com", "iiqid"),
+					eid("pubcid.org", "pub1"),
+					eid("uidapi.com", "uid2"),
+				}},
+				Device: &openrtb2.Device{IFA: "ifa-1", IP: "1.2.3.4"}, // no UA: composite is ifa_ip
+			},
+			want: []cache.Key{
+				{Key: "iiq:iiqid", Type: cache.ThirdParty},
+				{Key: "pubcid:pub1", Type: cache.FirstParty},
+				{Key: "maid:ifa-1", Type: cache.FirstParty},
+				{Key: "uidapi.com:uid2", Type: cache.FirstParty},
+				{Key: "dev:ifa-1_1.2.3.4", Type: cache.Device},
+			},
+		},
+		{
+			name:    "sharedid maps to pubcid namespace",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				User: &openrtb2.User{EIDs: []openrtb2.EID{eid("sharedid.org", "s1")}},
+			},
+			want: []cache.Key{{Key: "pubcid:s1", Type: cache.FirstParty}},
+		},
+		{
+			name:    "lmt=1 suppresses maid but keeps device composite off ifa? no - composite still uses ifa",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				Device: &openrtb2.Device{IFA: "ifa-x", Lmt: lmt(1)},
+			},
+			// maid key skipped; device composite still built from ifa (matches Java addDeviceComposite,
+			// which does not consult lmt).
+			want: []cache.Key{{Key: "dev:ifa-x", Type: cache.Device}},
+		},
+		{
+			name:    "CTV devicetype uppercases maid ifa",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				Device: &openrtb2.Device{IFA: "abc-DEF", DeviceType: 3},
+			},
+			want: []cache.Key{
+				{Key: "maid:ABC-DEF", Type: cache.FirstParty},
+				{Key: "dev:abc-DEF", Type: cache.Device},
+			},
+		},
+		{
+			name:    "blank uids skipped",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				User: &openrtb2.User{EIDs: []openrtb2.EID{eid("intentiq.com", "  ", "real")}},
+			},
+			want: []cache.Key{{Key: "iiq:real", Type: cache.ThirdParty}},
+		},
+		{
+			name:    "dedup keeps first occurrence",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				User: &openrtb2.User{EIDs: []openrtb2.EID{
+					eid("uidapi.com", "dup"),
+					eid("uidapi.com", "dup"),
+				}},
+			},
+			want: []cache.Key{{Key: "uidapi.com:dup", Type: cache.FirstParty}},
+		},
+		{
+			name:    "maxKeys cap",
+			maxKeys: 2,
+			req: &openrtb2.BidRequest{
+				User: &openrtb2.User{EIDs: []openrtb2.EID{
+					eid("intentiq.com", "a"),
+					eid("pubcid.org", "b"),
+					eid("uidapi.com", "c"),
+				}},
+			},
+			want: []cache.Key{
+				{Key: "iiq:a", Type: cache.ThirdParty},
+				{Key: "pubcid:b", Type: cache.FirstParty},
+			},
+		},
+		{
+			name:    "device composite ipv6 fallback when ip blank",
+			maxKeys: 10,
+			req: &openrtb2.BidRequest{
+				Device: &openrtb2.Device{IPv6: "::1"},
+			},
+			want: []cache.Key{{Key: "dev:::1", Type: cache.Device}},
+		},
+		{
+			name:    "no ids yields no keys",
+			maxKeys: 10,
+			req:     &openrtb2.BidRequest{},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewFirstPartyKeyExtractor(tt.maxKeys)
+			got := e.CandidateKeys(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCandidateKeysDeviceCompositeUsesNormalizedUA verifies the dev: composite embeds the normalized
+// UA (not the raw string), computed via normalizeUA so the assertion never couples to the parser's
+// exact output.
+func TestCandidateKeysDeviceCompositeUsesNormalizedUA(t *testing.T) {
+	ua := "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "ifa", UA: ua, IP: "9.9.9.9"}}
+
+	devKey := "dev:ifa_" + normalizeUA(ua) + "_9.9.9.9"
+	got := NewFirstPartyKeyExtractor(10).CandidateKeys(req)
+
+	assert.Equal(t, []cache.Key{
+		{Key: "maid:ifa", Type: cache.FirstParty},
+		{Key: devKey, Type: cache.Device},
+	}, got)
+	assert.NotContains(t, devKey, "Mozilla", "composite must use normalized UA, not the raw string")
+}

--- a/modules/intentiq/identity/metrics.go
+++ b/modules/intentiq/identity/metrics.go
@@ -1,0 +1,233 @@
+package identity
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// metricPrefix namespaces every module series so they group with the framework's
+// modules_module_intentiq_identity_* tree (the Prometheus rendering of the Java
+// modules.module.intentiq-identity.custom.* metrics). The Java per-partner "_<dpi>" name suffix
+// becomes a "partner" label, and the layer/keytype the Java names embedded become "layer"/"keytype"
+// labels — so the same per-partner dashboards apply while cardinality stays bounded.
+const metricPrefix = "modules_module_intentiq_identity_custom_"
+
+// l2LatencyBuckets is an ms-scaled bucket set for the Redis (L2) GET/PUT probes, which are typically
+// sub-millisecond to a few milliseconds — finer than the default second-scaled buckets.
+var l2LatencyBuckets = []float64{.0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1}
+
+// newMetrics returns the module metrics implementation. When reg is nil (Prometheus disabled) or
+// enabled is false, it returns a no-op so every call site is metric-agnostic.
+func newMetrics(reg prometheus.Registerer, enabled bool) Metrics {
+	if reg == nil || !enabled {
+		return noopMetrics{}
+	}
+	return newPromMetrics(reg)
+}
+
+// promMetrics is the Prometheus-backed Metrics implementation. Collectors are registered into the
+// supplied registry (the dedicated module registry threaded via ModuleDeps.MetricsRegisterer, which
+// the server gathers at /metrics). The capacity gauges are registered lazily by RegisterL1Gauges /
+// RegisterL2Gauges once the backing closures are known.
+type promMetrics struct {
+	reg prometheus.Registerer
+
+	// Cache outcome counters (recorded from the cache Result in the enrich hook).
+	cacheHit        *prometheus.CounterVec // {layer, keytype, partner}
+	cacheMiss       *prometheus.CounterVec // {keytype, partner}
+	cacheNegative   *prometheus.CounterVec // {layer, keytype, partner}
+	cacheInProgress *prometheus.CounterVec // {layer, keytype, partner}
+
+	// Per-partner business counters ({partner}).
+	apiSuccess         *prometheus.CounterVec
+	apiError           *prometheus.CounterVec
+	enriched           *prometheus.CounterVec
+	eidsNone           *prometheus.CounterVec
+	skipNoEndpoint     *prometheus.CounterVec
+	impressionReported *prometheus.CounterVec
+	impressionError    *prometheus.CounterVec
+	terminationCause   *prometheus.CounterVec // {tc, partner}
+
+	// Per-partner latency histograms ({partner}).
+	apiLatency  *prometheus.HistogramVec
+	flowLatency *prometheus.HistogramVec
+
+	// Global (unlabeled) L2 latency histograms.
+	l2GetLatency prometheus.Histogram
+	l2PutLatency prometheus.Histogram
+
+	// Global (unlabeled) cache health counters.
+	l1GetError prometheus.Counter
+	l1PutError prometheus.Counter
+	l2GetError prometheus.Counter
+	l2PutError prometheus.Counter
+
+	// Guards for the lazily-registered capacity gauges (RegisterL1Gauges/RegisterL2Gauges may be
+	// called more than once; only the first wins).
+	l1GaugesOnce sync.Once
+	l2GaugesOnce sync.Once
+}
+
+func newPromMetrics(reg prometheus.Registerer) *promMetrics {
+	f := promauto.With(reg)
+
+	counterVec := func(name, help string, labels ...string) *prometheus.CounterVec {
+		return f.NewCounterVec(prometheus.CounterOpts{Name: metricPrefix + name, Help: help}, labels)
+	}
+	counter := func(name, help string) prometheus.Counter {
+		return f.NewCounter(prometheus.CounterOpts{Name: metricPrefix + name, Help: help})
+	}
+	histVec := func(name, help string, buckets []float64, labels ...string) *prometheus.HistogramVec {
+		return f.NewHistogramVec(prometheus.HistogramOpts{Name: metricPrefix + name, Help: help, Buckets: buckets}, labels)
+	}
+	hist := func(name, help string, buckets []float64) prometheus.Histogram {
+		return f.NewHistogram(prometheus.HistogramOpts{Name: metricPrefix + name, Help: help, Buckets: buckets})
+	}
+
+	return &promMetrics{
+		reg: reg,
+
+		cacheHit:        counterVec("cache_hit_total", "Positive cache entries served, by layer/keytype/partner.", "layer", "keytype", "partner"),
+		cacheMiss:       counterVec("cache_miss_total", "Full cache misses (neither L1 nor L2) that triggered an API call, by keytype/partner.", "keytype", "partner"),
+		cacheNegative:   counterVec("cache_negative_hit_total", "Negative-sentinel cache hits (counted as miss, no API call), by layer/keytype/partner.", "layer", "keytype", "partner"),
+		cacheInProgress: counterVec("cache_in_progress_total", "In-progress-marker cache hits (duplicate API call skipped), by layer/keytype/partner.", "layer", "keytype", "partner"),
+
+		apiSuccess:         counterVec("api_success_total", "Resolution API responded and parsed OK, by partner.", "partner"),
+		apiError:           counterVec("api_error_total", "Resolution API failed/timed out/unparseable, by partner.", "partner"),
+		enriched:           counterVec("enriched_total", "Requests whose user.eids were enriched (a match), by partner.", "partner"),
+		eidsNone:           counterVec("eids_none_total", "Resolutions that produced no eids, by partner.", "partner"),
+		skipNoEndpoint:     counterVec("skip_no_endpoint_total", "Resolutions skipped because no api-endpoint is configured, by partner.", "partner"),
+		impressionReported: counterVec("impression_reported_total", "Winning bids reported to the reports-endpoint, by partner.", "partner"),
+		impressionError:    counterVec("impression_error_total", "Impression-report calls that failed, by partner.", "partner"),
+		terminationCause:   counterVec("termination_cause_total", "Enumerated termination-cause ids (0<=tc<200), by tc/partner.", "tc", "partner"),
+
+		apiLatency:  histVec("api_latency_seconds", "Resolution API call duration in seconds, by partner.", prometheus.DefBuckets, "partner"),
+		flowLatency: histVec("flow_latency_seconds", "Whole-flow latency (enrich hook to bid release) in seconds, by partner.", prometheus.DefBuckets, "partner"),
+
+		l2GetLatency: hist("l2_get_latency_seconds", "L2 (Redis) GET duration in seconds.", l2LatencyBuckets),
+		l2PutLatency: hist("l2_put_latency_seconds", "L2 (Redis) PUT duration in seconds.", l2LatencyBuckets),
+
+		l1GetError: counter("l1_get_error_total", "L1 (Caffeine-equivalent) read errors (treated as a miss)."),
+		l1PutError: counter("l1_put_error_total", "L1 write errors (entry did not land in L1)."),
+		l2GetError: counter("l2_get_error_total", "L2 (Redis) GET failures that fell through to a live API call."),
+		l2PutError: counter("l2_put_error_total", "L2 (Redis) PUT failures (entry still in L1, not in shared store)."),
+	}
+}
+
+// --- Cache outcome counters -----------------------------------------------------------------------
+
+func (m *promMetrics) CacheHit(layer, keyType, dpi string) {
+	m.cacheHit.WithLabelValues(layer, keyType, dpi).Inc()
+}
+
+func (m *promMetrics) CacheMiss(keyType, dpi string) {
+	m.cacheMiss.WithLabelValues(keyType, dpi).Inc()
+}
+
+func (m *promMetrics) CacheNegativeHit(layer, keyType, dpi string) {
+	m.cacheNegative.WithLabelValues(layer, keyType, dpi).Inc()
+}
+
+func (m *promMetrics) CacheInProgress(layer, keyType, dpi string) {
+	m.cacheInProgress.WithLabelValues(layer, keyType, dpi).Inc()
+}
+
+// --- Resolution / enrichment counters -------------------------------------------------------------
+
+func (m *promMetrics) APISuccess(dpi string) { m.apiSuccess.WithLabelValues(dpi).Inc() }
+func (m *promMetrics) APIError(dpi string)   { m.apiError.WithLabelValues(dpi).Inc() }
+func (m *promMetrics) Enriched(dpi string)   { m.enriched.WithLabelValues(dpi).Inc() }
+func (m *promMetrics) EidsNone(dpi string)   { m.eidsNone.WithLabelValues(dpi).Inc() }
+
+func (m *promMetrics) SkipNoEndpoint(dpi string) { m.skipNoEndpoint.WithLabelValues(dpi).Inc() }
+
+func (m *promMetrics) APILatency(d time.Duration, dpi string) {
+	m.apiLatency.WithLabelValues(dpi).Observe(d.Seconds())
+}
+
+func (m *promMetrics) FlowLatency(d time.Duration, dpi string) {
+	m.flowLatency.WithLabelValues(dpi).Observe(d.Seconds())
+}
+
+// TerminationCause records only 0<=tc<200 to bound label cardinality (matches the Java impl).
+func (m *promMetrics) TerminationCause(tc int64, dpi string) {
+	if tc >= 0 && tc < 200 {
+		m.terminationCause.WithLabelValues(strconv.FormatInt(tc, 10), dpi).Inc()
+	}
+}
+
+// --- Impression-report counters -------------------------------------------------------------------
+
+func (m *promMetrics) ImpressionReported(dpi string) { m.impressionReported.WithLabelValues(dpi).Inc() }
+func (m *promMetrics) ImpressionError(dpi string)    { m.impressionError.WithLabelValues(dpi).Inc() }
+
+// --- cache.Metrics: shared L1/L2 health -----------------------------------------------------------
+
+func (m *promMetrics) L1GetError() { m.l1GetError.Inc() }
+func (m *promMetrics) L1PutError() { m.l1PutError.Inc() }
+func (m *promMetrics) L2GetError() { m.l2GetError.Inc() }
+func (m *promMetrics) L2PutError() { m.l2PutError.Inc() }
+
+func (m *promMetrics) L2GetLatency(d time.Duration) { m.l2GetLatency.Observe(d.Seconds()) }
+func (m *promMetrics) L2PutLatency(d time.Duration) { m.l2PutLatency.Observe(d.Seconds()) }
+
+// RegisterL1Gauges wires the in-process (L1) capacity gauges. Idempotent: only the first call
+// registers, so a repeat call cannot trigger an AlreadyRegisteredError.
+func (m *promMetrics) RegisterL1Gauges(size, evictions func() int64) {
+	m.l1GaugesOnce.Do(func() {
+		m.registerGaugeFunc("l1_size", "Current L1 entry count (vs cache-max-size).", size)
+		m.registerGaugeFunc("l1_eviction", "Cumulative L1 evictions.", evictions)
+	})
+}
+
+// RegisterL2Gauges wires the Redis (L2) capacity gauges. Idempotent (see RegisterL1Gauges).
+func (m *promMetrics) RegisterL2Gauges(size, evictions func() int64) {
+	m.l2GaugesOnce.Do(func() {
+		m.registerGaugeFunc("l2_size", "Redis DBSIZE (instance-wide; polled).", size)
+		m.registerGaugeFunc("l2_eviction", "Redis cumulative evicted_keys (instance-wide; polled).", evictions)
+	})
+}
+
+// registerGaugeFunc registers a global GaugeFunc reading the supplied closure. An
+// AlreadyRegisteredError (e.g. two Metrics instances sharing a registry) is tolerated so the module
+// keeps working rather than panicking.
+func (m *promMetrics) registerGaugeFunc(name, help string, fn func() int64) {
+	g := prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: metricPrefix + name, Help: help}, func() float64 {
+		return float64(fn())
+	})
+	if err := m.reg.Register(g); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			panic(err)
+		}
+	}
+}
+
+// noopMetrics satisfies Metrics and does nothing. Used when metrics are disabled/unavailable.
+type noopMetrics struct{}
+
+func (noopMetrics) CacheHit(layer, keyType, dpi string)           {}
+func (noopMetrics) CacheMiss(keyType, dpi string)                 {}
+func (noopMetrics) CacheNegativeHit(layer, keyType, dpi string)   {}
+func (noopMetrics) CacheInProgress(layer, keyType, dpi string)    {}
+func (noopMetrics) APISuccess(dpi string)                         {}
+func (noopMetrics) APIError(dpi string)                           {}
+func (noopMetrics) APILatency(d time.Duration, dpi string)        {}
+func (noopMetrics) Enriched(dpi string)                           {}
+func (noopMetrics) EidsNone(dpi string)                           {}
+func (noopMetrics) SkipNoEndpoint(dpi string)                     {}
+func (noopMetrics) TerminationCause(tc int64, dpi string)         {}
+func (noopMetrics) FlowLatency(d time.Duration, dpi string)       {}
+func (noopMetrics) ImpressionReported(dpi string)                 {}
+func (noopMetrics) ImpressionError(dpi string)                    {}
+func (noopMetrics) L1GetError()                                   {}
+func (noopMetrics) L1PutError()                                   {}
+func (noopMetrics) L2GetLatency(d time.Duration)                  {}
+func (noopMetrics) L2PutLatency(d time.Duration)                  {}
+func (noopMetrics) L2GetError()                                   {}
+func (noopMetrics) L2PutError()                                   {}
+func (noopMetrics) RegisterL1Gauges(size, evictions func() int64) {}
+func (noopMetrics) RegisterL2Gauges(size, evictions func() int64) {}

--- a/modules/intentiq/identity/metrics_iface.go
+++ b/modules/intentiq/identity/metrics_iface.go
@@ -1,0 +1,41 @@
+package identity
+
+import (
+	"time"
+
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+)
+
+// Metrics is the full module metrics contract. It embeds the cache-layer health methods
+// (cache.Metrics) and adds the per-partner business counters recorded by the enrich and impression
+// hooks. The concrete Prometheus implementation lives in metrics.go (agent D); a no-op
+// implementation is used when metrics are disabled or no registry is available.
+//
+// dpi is the partner id (partner-facing data-provider id), attached as a Prometheus label rather
+// than the Java "_<dpi>" name suffix. layer is "l1"/"l2" (cache.Layer.Token()); keyType is
+// "first_party"/"third_party"/"device" (cache.KeyType.Token()).
+type Metrics interface {
+	cache.Metrics
+
+	// Cache outcome counters (recorded from the cache Result in the enrich hook).
+	CacheHit(layer, keyType, dpi string)
+	CacheMiss(keyType, dpi string)
+	CacheNegativeHit(layer, keyType, dpi string)
+	CacheInProgress(layer, keyType, dpi string)
+
+	// Resolution / enrichment counters.
+	APISuccess(dpi string)
+	APIError(dpi string)
+	APILatency(d time.Duration, dpi string)
+	Enriched(dpi string)
+	EidsNone(dpi string)
+	SkipNoEndpoint(dpi string)
+	TerminationCause(tc int64, dpi string)
+
+	// Whole-flow latency (enrich entry -> bid release), recorded once per auction.
+	FlowLatency(d time.Duration, dpi string)
+
+	// Impression-report counters.
+	ImpressionReported(dpi string)
+	ImpressionError(dpi string)
+}

--- a/modules/intentiq/identity/metrics_test.go
+++ b/modules/intentiq/identity/metrics_test.go
@@ -1,0 +1,180 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMetrics returns a promMetrics backed by a fresh registry for isolated assertions.
+func newTestMetrics(t *testing.T) (*promMetrics, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	m := newMetrics(reg, true)
+	pm, ok := m.(*promMetrics)
+	require.True(t, ok, "newMetrics(reg, true) must return the prometheus impl")
+	return pm, reg
+}
+
+func TestNewMetricsFallsBackToNoop(t *testing.T) {
+	assert.IsType(t, noopMetrics{}, newMetrics(nil, true), "nil registry -> noop")
+	assert.IsType(t, noopMetrics{}, newMetrics(prometheus.NewRegistry(), false), "disabled -> noop")
+	assert.IsType(t, &promMetrics{}, newMetrics(prometheus.NewRegistry(), true), "enabled -> prom")
+}
+
+func TestMetricsCacheOutcomeCounters(t *testing.T) {
+	m, _ := newTestMetrics(t)
+
+	m.CacheHit("l1", "third_party", "123")
+	m.CacheHit("l1", "third_party", "123")
+	m.CacheHit("l2", "first_party", "123")
+	m.CacheMiss("device", "123")
+	m.CacheNegativeHit("l2", "first_party", "999")
+	m.CacheInProgress("l1", "device", "123")
+
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.cacheHit.WithLabelValues("l1", "third_party", "123")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.cacheHit.WithLabelValues("l2", "first_party", "123")))
+	assert.Equal(t, 2, testutil.CollectAndCount(m.cacheHit), "two distinct label sets")
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.cacheMiss.WithLabelValues("device", "123")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.cacheNegative.WithLabelValues("l2", "first_party", "999")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.cacheInProgress.WithLabelValues("l1", "device", "123")))
+}
+
+func TestMetricsBusinessCounters(t *testing.T) {
+	m, _ := newTestMetrics(t)
+
+	m.APISuccess("p")
+	m.APIError("p")
+	m.APIError("p")
+	m.Enriched("p")
+	m.EidsNone("p")
+	m.SkipNoEndpoint("p")
+	m.ImpressionReported("p")
+	m.ImpressionError("p")
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.apiSuccess.WithLabelValues("p")))
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.apiError.WithLabelValues("p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.enriched.WithLabelValues("p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.eidsNone.WithLabelValues("p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.skipNoEndpoint.WithLabelValues("p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.impressionReported.WithLabelValues("p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.impressionError.WithLabelValues("p")))
+}
+
+func TestMetricsTerminationCauseBounds(t *testing.T) {
+	m, _ := newTestMetrics(t)
+
+	m.TerminationCause(0, "p")   // recorded (lower bound)
+	m.TerminationCause(199, "p") // recorded (upper bound)
+	m.TerminationCause(200, "p") // dropped
+	m.TerminationCause(-1, "p")  // dropped
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.terminationCause.WithLabelValues("0", "p")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.terminationCause.WithLabelValues("199", "p")))
+	assert.Equal(t, 2, testutil.CollectAndCount(m.terminationCause), "out-of-range tc must not create series")
+}
+
+func TestMetricsLatencyHistograms(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.APILatency(150*time.Millisecond, "p")
+	m.FlowLatency(2*time.Second, "p")
+	m.L2GetLatency(500 * time.Microsecond)
+	m.L2PutLatency(1 * time.Millisecond)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(m.apiLatency))
+	assert.Equal(t, 1, testutil.CollectAndCount(m.flowLatency))
+
+	// The latency histograms sum to the observed seconds and are named with the expected prefix.
+	got, err := reg.Gather()
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, mf := range got {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		metricPrefix + "api_latency_seconds",
+		metricPrefix + "flow_latency_seconds",
+		metricPrefix + "l2_get_latency_seconds",
+		metricPrefix + "l2_put_latency_seconds",
+	} {
+		assert.True(t, names[want], "missing histogram %s", want)
+	}
+
+	// L2 histograms are global (no partner/layer labels).
+	assert.Equal(t, 1, testutil.CollectAndCount(m.l2GetLatency))
+	assert.Equal(t, 1, testutil.CollectAndCount(m.l2PutLatency))
+}
+
+func TestMetricsGlobalErrorCounters(t *testing.T) {
+	m, _ := newTestMetrics(t)
+
+	m.L1GetError()
+	m.L1PutError()
+	m.L1PutError()
+	m.L2GetError()
+	m.L2PutError()
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.l1GetError))
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.l1PutError))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.l2GetError))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.l2PutError))
+}
+
+func TestMetricsGaugesLazyAndIdempotent(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	// Before registration the gauges must not exist.
+	assert.Equal(t, 0, countSeriesWithSuffix(t, reg, "l1_size"))
+
+	l1Size, l1Evict := int64(7), int64(3)
+	l2Size, l2Evict := int64(42), int64(11)
+	m.RegisterL1Gauges(func() int64 { return l1Size }, func() int64 { return l1Evict })
+	m.RegisterL2Gauges(func() int64 { return l2Size }, func() int64 { return l2Evict })
+
+	// A second call must not panic or double-register.
+	m.RegisterL1Gauges(func() int64 { return 100 }, func() int64 { return 100 })
+	m.RegisterL2Gauges(func() int64 { return 100 }, func() int64 { return 100 })
+
+	assert.Equal(t, 7.0, gaugeValue(t, reg, metricPrefix+"l1_size"))
+	assert.Equal(t, 3.0, gaugeValue(t, reg, metricPrefix+"l1_eviction"))
+	assert.Equal(t, 42.0, gaugeValue(t, reg, metricPrefix+"l2_size"))
+	assert.Equal(t, 11.0, gaugeValue(t, reg, metricPrefix+"l2_eviction"))
+
+	// GaugeFunc reads the live closure on each scrape.
+	l1Size = 9
+	assert.Equal(t, 9.0, gaugeValue(t, reg, metricPrefix+"l1_size"))
+}
+
+func countSeriesWithSuffix(t *testing.T, g prometheus.Gatherer, suffix string) int {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	n := 0
+	for _, mf := range mfs {
+		if strings.HasSuffix(mf.GetName(), suffix) {
+			n += len(mf.GetMetric())
+		}
+	}
+	return n
+}
+
+func gaugeValue(t *testing.T, g prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		require.Len(t, mf.GetMetric(), 1)
+		return mf.GetMetric()[0].GetGauge().GetValue()
+	}
+	t.Fatalf("gauge %s not found", name)
+	return 0
+}

--- a/modules/intentiq/identity/model.go
+++ b/modules/intentiq/identity/model.go
@@ -1,0 +1,98 @@
+package identity
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+)
+
+// Shared constants used across the enrich and impression hooks.
+const (
+	// iiqSource is the eid source of the IntentIQ cookie id.
+	iiqSource = "intentiq.com"
+	// sourcePBSGo identifies the request source to the IntentIQ S2S API as prebid-server-go.
+	sourcePBSGo = "pbsgo"
+	// biddingPlatformOpenRTB is the biddingPlatformId reported for OpenRTB impressions.
+	biddingPlatformOpenRTB = "4"
+	// defaultCurrency is used when the bid response omits a currency.
+	defaultCurrency = "USD"
+	// gdprConsentHeader carries the TCF consent string on the resolution request (per the GDPR S2S
+	// guide, consent is a header, not a query parameter).
+	gdprConsentHeader = "gdpr-consent"
+)
+
+// flowContextKey is the module-context key under which the enrich hook stashes state for the
+// impression hook within one auction.
+const flowContextKey = "intentiq.identity.flow"
+
+// flowContext carries state from the processed-auction-request (enrich) hook to the auction-response
+// (impression report) hook via hookstage.ModuleContext within one auction.
+//
+// The Go auction-response payload exposes only the BidResponse (no request), so the request-derived
+// fields the impression report needs (ref/ip/ua/auction id) are captured here by the enrich hook,
+// which does have the request.
+type flowContext struct {
+	// start is captured at enrich-hook entry; lets the impression hook record whole-flow latency.
+	start time.Time
+	// abTestUUID is the IIQ A/B test id returned by the resolution response, echoed on the report.
+	abTestUUID string
+	// terminationCause is the IIQ tc from the resolution response, if any.
+	terminationCause *int64
+	// auctionID is the bid request id (reported as prebidAuctionId / partnerAuctionId).
+	auctionID string
+	// ref is the site domain/page or app bundle/name (reported as vrref).
+	ref string
+	// ip is device.ip or device.ipv6.
+	ip string
+	// ua is device.ua.
+	ua string
+}
+
+// setFlowContext stores fc under flowContextKey in a fresh module context and returns it for
+// HookResult.ModuleContext.
+func setFlowContext(fc flowContext) *hookstage.ModuleContext {
+	mctx := hookstage.NewModuleContext()
+	mctx.Set(flowContextKey, fc)
+	return mctx
+}
+
+// getFlowContext retrieves the flow context stashed by the enrich hook, if present.
+func getFlowContext(mctx *hookstage.ModuleContext) (flowContext, bool) {
+	if mctx == nil {
+		return flowContext{}, false
+	}
+	v, ok := mctx.Get(flowContextKey)
+	if !ok {
+		return flowContext{}, false
+	}
+	fc, ok := v.(flowContext)
+	return fc, ok
+}
+
+// iiqResponse is the identity-resolution S2S response. data is decoded leniently: IntentIQ returns
+// it as an object on a hit but as an empty string ("") on an empty/invalid response, so a non-object
+// data is treated as absent rather than failing the whole parse. eids() applies that leniency.
+type iiqResponse struct {
+	Data       json.RawMessage `json:"data"`
+	Cttl       *int64          `json:"cttl"`
+	AbTestUUID string          `json:"abTestUuid"`
+	Tc         *int64          `json:"tc"`
+}
+
+// cttl returns the response cttl as a duration (seconds), or 0 when absent.
+func (r iiqResponse) cttl() time.Duration {
+	if r.Cttl == nil {
+		return 0
+	}
+	return time.Duration(*r.Cttl) * time.Second
+}
+
+// resolution is the outcome of identity resolution (from cache or a live call), carrying the eids to
+// merge plus the fields threaded to the impression hook.
+type resolution struct {
+	eids             []openrtb2.EID
+	abTestUUID       string
+	terminationCause *int64
+}

--- a/modules/intentiq/identity/model.go
+++ b/modules/intentiq/identity/model.go
@@ -13,7 +13,7 @@ const (
 	// iiqSource is the eid source of the IntentIQ cookie id.
 	iiqSource = "intentiq.com"
 	// sourcePBSGo identifies the request source to the IntentIQ S2S API as prebid-server-go.
-	sourcePBSGo = "pbsgo"
+	sourcePBSGo = "pbgo"
 	// biddingPlatformOpenRTB is the biddingPlatformId reported for OpenRTB impressions.
 	biddingPlatformOpenRTB = "4"
 	// defaultCurrency is used when the bid response omits a currency.

--- a/modules/intentiq/identity/model_test.go
+++ b/modules/intentiq/identity/model_test.go
@@ -1,0 +1,66 @@
+package identity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+)
+
+func TestIiqResponseCttl(t *testing.T) {
+	assert.Equal(t, time.Duration(0), iiqResponse{}.cttl(), "absent cttl -> 0")
+	v := int64(30)
+	assert.Equal(t, 30*time.Second, iiqResponse{Cttl: &v}.cttl())
+}
+
+func TestFlowContextRoundTrip(t *testing.T) {
+	fc := flowContext{start: time.Now(), abTestUUID: "ab", auctionID: "auc"}
+	got, ok := getFlowContext(setFlowContext(fc))
+	assert.True(t, ok)
+	assert.Equal(t, fc, got)
+}
+
+func TestGetFlowContextMissing(t *testing.T) {
+	_, ok := getFlowContext(nil)
+	assert.False(t, ok, "nil module context -> not present")
+
+	_, ok = getFlowContext(hookstage.NewModuleContext())
+	assert.False(t, ok, "empty module context -> not present")
+
+	mctx := hookstage.NewModuleContext()
+	mctx.Set(flowContextKey, "not a flowContext")
+	_, ok = getFlowContext(mctx)
+	assert.False(t, ok, "wrong type under key -> not present")
+}
+
+// TestNoopMetrics exercises every no-op method so the metric-agnostic fallback is covered and cannot
+// panic (it is used whenever Prometheus is disabled).
+func TestNoopMetrics(t *testing.T) {
+	var m Metrics = noopMetrics{}
+	assert.NotPanics(t, func() {
+		m.CacheHit("l1", "first_party", "p")
+		m.CacheMiss("first_party", "p")
+		m.CacheNegativeHit("l2", "device", "p")
+		m.CacheInProgress("l1", "third_party", "p")
+		m.APISuccess("p")
+		m.APIError("p")
+		m.APILatency(time.Second, "p")
+		m.Enriched("p")
+		m.EidsNone("p")
+		m.SkipNoEndpoint("p")
+		m.TerminationCause(1, "p")
+		m.FlowLatency(time.Second, "p")
+		m.ImpressionReported("p")
+		m.ImpressionError("p")
+		m.L1GetError()
+		m.L1PutError()
+		m.L2GetLatency(time.Second)
+		m.L2PutLatency(time.Second)
+		m.L2GetError()
+		m.L2PutError()
+		m.RegisterL1Gauges(func() int64 { return 0 }, func() int64 { return 0 })
+		m.RegisterL2Gauges(func() int64 { return 0 }, func() int64 { return 0 })
+	})
+}

--- a/modules/intentiq/identity/module.go
+++ b/modules/intentiq/identity/module.go
@@ -1,0 +1,90 @@
+// Package identity implements the IntentIQ Identity module for prebid-server.
+//
+// At the processed-auction-request stage it calls the IntentIQ Bid Enhancement S2S API and merges
+// the resolved eids into user.eids before the request is sent to bidders. Optionally, at the
+// auction-response stage it reports each winning bid to the IntentIQ impression API. A two-layer
+// (in-process + Redis) alias cache with negative caching and in-progress dedup fronts the resolution
+// call. This is a Go port of the prebid-server-java extra/modules/intentiq-identity module.
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+	"github.com/prebid/prebid-server/v4/modules/intentiq/identity/cache"
+	"github.com/prebid/prebid-server/v4/modules/moduledeps"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+// redisStatsPollInterval is how often the L2 size/eviction gauges are refreshed.
+const redisStatsPollInterval = 30 * time.Second
+
+// Module implements the processed-auction-request (enrich) and auction-response (impression) hooks.
+type Module struct {
+	cfg          Config
+	httpClient   *http.Client
+	keyExtractor *FirstPartyKeyExtractor
+	metrics      Metrics
+
+	// The following are non-nil only when caching is enabled and Redis is configured.
+	cache       *cache.IdentityCache
+	reporter    *cache.RedisStatsReporter
+	redisClient *redis.Client
+}
+
+var (
+	_ hookstage.ProcessedAuctionRequest = (*Module)(nil)
+	_ hookstage.AuctionResponse         = (*Module)(nil)
+)
+
+// Builder is the module entry point invoked by prebid-server to construct the module. Host-level
+// config defaults are applied here; account-level config is merged per request (see Config.resolve).
+func Builder(rawCfg json.RawMessage, deps moduledeps.ModuleDeps) (interface{}, error) {
+	cfg := defaultConfig()
+	if len(rawCfg) > 0 {
+		if err := jsonutil.Unmarshal(rawCfg, &cfg); err != nil {
+			return nil, fmt.Errorf("intentiq-identity: failed to parse config: %w", err)
+		}
+	}
+
+	metrics := newMetrics(deps.MetricsRegisterer, cfg.MetricsEnabled)
+
+	m := &Module{
+		cfg:          cfg,
+		httpClient:   deps.HTTPClient,
+		keyExtractor: NewFirstPartyKeyExtractor(cfg.Cache.MaxKeys),
+		metrics:      metrics,
+	}
+
+	if cfg.Cache.Enabled && cfg.Redis != nil && cfg.Redis.Host != "" {
+		client := redis.NewClient(&redis.Options{
+			Addr:     net.JoinHostPort(cfg.Redis.Host, strconv.Itoa(cfg.Redis.Port)),
+			Password: cfg.Redis.Password,
+		})
+		store := cache.NewRedisStore(client)
+		m.redisClient = client
+		m.cache = cache.NewIdentityCache(cfg.CacheMaxSize, cfg.ttlPolicy(), store, metrics)
+		m.reporter = cache.NewRedisStatsReporter(store, metrics, redisStatsPollInterval).Start()
+	}
+
+	return m, nil
+}
+
+// Shutdown stops the Redis stats poller and closes the Redis client. Detected structurally by the
+// framework's shutdown handling (modules.Shutdowner).
+func (m *Module) Shutdown() error {
+	if m.reporter != nil {
+		m.reporter.Stop()
+	}
+	if m.redisClient != nil {
+		return m.redisClient.Close()
+	}
+	return nil
+}

--- a/modules/intentiq/identity/module_test.go
+++ b/modules/intentiq/identity/module_test.go
@@ -1,0 +1,64 @@
+package identity
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prebid/prebid-server/v4/modules/moduledeps"
+)
+
+func TestBuilder_DefaultsNoCache(t *testing.T) {
+	raw := json.RawMessage(`{"api-endpoint":"http://x","partner-id":"p1"}`)
+	built, err := Builder(raw, moduledeps.ModuleDeps{})
+	require.NoError(t, err)
+
+	m, ok := built.(*Module)
+	require.True(t, ok)
+	assert.Equal(t, "http://x", m.cfg.APIEndpoint)
+	assert.Equal(t, int64(1000), m.cfg.Timeout) // default applied
+	assert.Nil(t, m.cache, "cache disabled by default")
+	assert.Nil(t, m.reporter)
+	assert.IsType(t, noopMetrics{}, m.metrics, "nil registerer -> noop metrics")
+
+	require.NoError(t, m.Shutdown()) // no reporter/redis -> nil
+}
+
+func TestBuilder_InvalidConfig(t *testing.T) {
+	_, err := Builder(json.RawMessage(`{bad`), moduledeps.ModuleDeps{})
+	require.Error(t, err)
+}
+
+func TestBuilder_MetricsRegistererYieldsPromMetrics(t *testing.T) {
+	built, err := Builder(json.RawMessage(`{"api-endpoint":"http://x"}`),
+		moduledeps.ModuleDeps{MetricsRegisterer: prometheus.NewRegistry()})
+	require.NoError(t, err)
+	assert.IsType(t, &promMetrics{}, built.(*Module).metrics)
+}
+
+func TestBuilder_CacheEnabledWithRedis(t *testing.T) {
+	mr := miniredis.RunT(t)
+	port, _ := strconv.Atoi(mr.Port())
+	cfg := map[string]any{
+		"api-endpoint": "http://x",
+		"partner-id":   "p1",
+		"cache":        map[string]any{"enabled": true},
+		"redis":        map[string]any{"host": mr.Host(), "port": port},
+	}
+	raw, _ := json.Marshal(cfg)
+
+	built, err := Builder(raw, moduledeps.ModuleDeps{MetricsRegisterer: prometheus.NewRegistry()})
+	require.NoError(t, err)
+
+	m := built.(*Module)
+	require.NotNil(t, m.cache, "cache should be built when enabled + redis configured")
+	require.NotNil(t, m.reporter)
+	require.NotNil(t, m.redisClient)
+
+	require.NoError(t, m.Shutdown()) // stops reporter + closes redis client
+}

--- a/modules/intentiq/identity/params.go
+++ b/modules/intentiq/identity/params.go
@@ -1,0 +1,317 @@
+package identity
+
+import (
+	"encoding/json"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+// IntentIQ S2S query-parameter names for the identity-resolution request (mirrors Java IiqParam).
+const (
+	paramAT        = "at"
+	paramMI        = "mi"
+	paramDPI       = "dpi"
+	paramPT        = "pt"
+	paramDPN       = "dpn"
+	paramSrvrReq   = "srvrReq"
+	paramSource    = "source"
+	paramIP        = "ip"
+	paramIPv6      = "ipv6"
+	paramUAS       = "uas"
+	paramUH        = "uh"
+	paramPCID      = "pcid"
+	paramIDType    = "idtype"
+	paramRef       = "ref"
+	paramIIQUID    = "iiquid"
+	paramGDPR      = "gdpr"
+	paramUSPrivacy = "us_privacy"
+	paramGPP       = "gpp"
+	paramGPPSID    = "gpp_sid"
+)
+
+// uaHintsHighEntropySource is the OpenRTB device.sua.source value the IntentIQ backend consumes
+// UA client hints for (high-entropy client hints).
+const uaHintsHighEntropySource = 2
+
+// resolveURL builds the identity-resolution request URL from the effective config and the request.
+// It faithfully mirrors the Java resolveUrl: fixed params first, then device/consent-derived params,
+// each URL-encoded and appended only when non-blank.
+func resolveURL(cfg Config, rw *openrtb_ext.RequestWrapper) string {
+	var b strings.Builder
+	b.WriteString(cfg.APIEndpoint)
+	if strings.Contains(cfg.APIEndpoint, "?") {
+		b.WriteByte('&')
+	} else {
+		b.WriteByte('?')
+	}
+	b.WriteString(paramAT)
+	b.WriteString("=39")
+
+	appendIfPresent(&b, paramMI, "10")
+	appendIfPresent(&b, paramDPI, cfg.PartnerID)
+	appendIfPresent(&b, paramPT, "17")
+	appendIfPresent(&b, paramDPN, "1")
+	appendIfPresent(&b, paramSrvrReq, "true")
+	appendIfPresent(&b, paramSource, sourcePBSGo)
+
+	req := rw.BidRequest
+	if device := req.Device; device != nil {
+		appendIfPresent(&b, paramIP, device.IP)
+		appendIfPresent(&b, paramIPv6, device.IPv6)
+		appendIfPresent(&b, paramUAS, device.UA)
+		appendIfPresent(&b, paramUH, buildUaHints(device.SUA))
+		appendDeviceID(&b, device)
+	}
+	appendIfPresent(&b, paramRef, resolveRef(req))
+	appendIfPresent(&b, paramIIQUID, resolveIiqUID(req.User))
+	appendConsent(&b, rw)
+
+	return b.String()
+}
+
+// appendConsent appends the gdpr / us_privacy / gpp / gpp_sid query params (consent itself is a
+// header, not a query param — see resolveConsent).
+func appendConsent(b *strings.Builder, rw *openrtb_ext.RequestWrapper) {
+	regs := rw.BidRequest.Regs
+	if regs == nil {
+		return
+	}
+	appendIfPresent(b, paramGDPR, resolveGDPR(rw, regs))
+	appendIfPresent(b, paramUSPrivacy, resolveUSPrivacy(rw, regs))
+	appendIfPresent(b, paramGPP, regs.GPP)
+	// Forwarded ahead of backend support so the GPP section ids are available if the backend adds it.
+	appendIfPresent(b, paramGPPSID, joinGPPSID(regs.GPPSID))
+}
+
+// resolveGDPR returns the GDPR flag from regs.gdpr, falling back to regs.ext.gdpr.
+func resolveGDPR(rw *openrtb_ext.RequestWrapper, regs *openrtb2.Regs) string {
+	if regs.GDPR != nil {
+		return strconv.Itoa(int(*regs.GDPR))
+	}
+	if regExt, err := rw.GetRegExt(); err == nil && regExt != nil {
+		if g := regExt.GetGDPR(); g != nil {
+			return strconv.Itoa(int(*g))
+		}
+	}
+	return ""
+}
+
+// resolveUSPrivacy returns us_privacy from regs.us_privacy, falling back to regs.ext.us_privacy.
+func resolveUSPrivacy(rw *openrtb_ext.RequestWrapper, regs *openrtb2.Regs) string {
+	if notBlank(regs.USPrivacy) {
+		return regs.USPrivacy
+	}
+	if regExt, err := rw.GetRegExt(); err == nil && regExt != nil {
+		return regExt.GetUSPrivacy()
+	}
+	return ""
+}
+
+// resolveConsent returns the TCF consent string from user.consent, falling back to user.ext.consent.
+// It is sent as the gdpr-consent request header (not a query param).
+func resolveConsent(rw *openrtb_ext.RequestWrapper) string {
+	user := rw.BidRequest.User
+	if user == nil {
+		return ""
+	}
+	if notBlank(user.Consent) {
+		return user.Consent
+	}
+	if userExt, err := rw.GetUserExt(); err == nil && userExt != nil {
+		if c := userExt.GetConsent(); c != nil {
+			return *c
+		}
+	}
+	return ""
+}
+
+// joinGPPSID joins the GPP section ids into a comma-separated string (empty when absent).
+func joinGPPSID(sids []int8) string {
+	if len(sids) == 0 {
+		return ""
+	}
+	parts := make([]string, len(sids))
+	for i, s := range sids {
+		parts[i] = strconv.Itoa(int(s))
+	}
+	return strings.Join(parts, ",")
+}
+
+// buildUaHints builds the `uh` UA client-hints JSON from OpenRTB device.sua, matching the IntentIQ
+// backend's numeric-keyed (0-8) UA-CH format: brands sorted, major vs full version. Returns "" when
+// there are no high-entropy hints to send.
+func buildUaHints(sua *openrtb2.UserAgent) string {
+	// The IntentIQ backend consumes hints only for high-entropy client hints (sua.source == 2).
+	if sua == nil || int(sua.Source) != uaHintsHighEntropySource {
+		return ""
+	}
+	hints := make(map[string]string)
+	appendBrowserHints(hints, sua.Browsers)
+	if sua.Mobile != nil {
+		hints["1"] = "?" + strconv.Itoa(int(*sua.Mobile))
+	}
+	appendPlatformHints(hints, sua.Platform)
+	putQuoted(hints, "3", sua.Architecture)
+	putQuoted(hints, "4", sua.Bitness)
+	putQuoted(hints, "5", sua.Model)
+	if len(hints) == 0 {
+		return ""
+	}
+	// encoding/json sorts string map keys, giving deterministic "0".."8" ordering.
+	encoded, err := json.Marshal(hints)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+// appendBrowserHints populates "0" (major versions) and "8" (full versions) from device.sua.browsers,
+// each a brand-sorted list of `"brand";v="version"` entries.
+func appendBrowserHints(hints map[string]string, browsers []openrtb2.BrandVersion) {
+	if browsers == nil {
+		return
+	}
+	majorByBrand := make(map[string]string)
+	fullByBrand := make(map[string]string)
+	for _, browser := range browsers {
+		if !notBlank(browser.Brand) || len(browser.Version) == 0 {
+			continue
+		}
+		fullVersion := strings.Join(browser.Version, ".")
+		if dot := strings.IndexByte(fullVersion, '.'); dot > 0 {
+			majorByBrand[browser.Brand] = fullVersion[:dot]
+		} else {
+			majorByBrand[browser.Brand] = fullVersion
+		}
+		fullByBrand[browser.Brand] = fullVersion
+	}
+	putBrandList(hints, "0", majorByBrand)
+	putBrandList(hints, "8", fullByBrand)
+}
+
+// putBrandList joins the brand->version map (sorted by brand) into a UA-CH brand list under key.
+func putBrandList(hints map[string]string, key string, brandToVersion map[string]string) {
+	if len(brandToVersion) == 0 {
+		return
+	}
+	brands := make([]string, 0, len(brandToVersion))
+	for brand := range brandToVersion {
+		brands = append(brands, brand)
+	}
+	sort.Strings(brands)
+	parts := make([]string, 0, len(brands))
+	for _, brand := range brands {
+		parts = append(parts, quote(brand)+";v="+quote(brandToVersion[brand]))
+	}
+	hints[key] = strings.Join(parts, ", ")
+}
+
+// appendPlatformHints populates "2" (platform brand) and "6" (platform version) from device.sua.platform.
+func appendPlatformHints(hints map[string]string, platform *openrtb2.BrandVersion) {
+	if platform == nil || !notBlank(platform.Brand) {
+		return
+	}
+	hints["2"] = quote(platform.Brand)
+	if len(platform.Version) > 0 {
+		hints["6"] = quote(strings.Join(platform.Version, "."))
+	}
+}
+
+// putQuoted stores a quoted value under key when value is non-blank.
+func putQuoted(hints map[string]string, key, value string) {
+	if notBlank(value) {
+		hints[key] = quote(value)
+	}
+}
+
+func quote(value string) string {
+	return "\"" + value + "\""
+}
+
+// appendDeviceID appends the pcid + idtype params derived from device.ifa. Skipped when ifa is blank
+// or lmt==1. CTV devices (devicetype 3/7) use an uppercased pcid and idtype 8; otherwise idtype 4.
+func appendDeviceID(b *strings.Builder, device *openrtb2.Device) {
+	ifa := device.IFA
+	if !notBlank(ifa) || (device.Lmt != nil && *device.Lmt == 1) {
+		return
+	}
+	ctv := device.DeviceType == 3 || device.DeviceType == 7
+	pcid := ifa
+	idtype := "4"
+	if ctv {
+		// CTV ids (idtype 8) must be uppercase; MAID/AAID (idtype 4) is case-insensitive.
+		pcid = strings.ToUpper(ifa)
+		idtype = "8"
+	}
+	b.WriteByte('&')
+	b.WriteString(paramPCID)
+	b.WriteByte('=')
+	b.WriteString(encodeComponent(pcid))
+	b.WriteByte('&')
+	b.WriteString(paramIDType)
+	b.WriteByte('=')
+	b.WriteString(idtype)
+}
+
+// resolveRef returns the referrer: site.domain||site.page, else app.bundle||app.name.
+func resolveRef(req *openrtb2.BidRequest) string {
+	if site := req.Site; site != nil {
+		if notBlank(site.Domain) {
+			return site.Domain
+		}
+		return site.Page
+	}
+	if app := req.App; app != nil {
+		if notBlank(app.Bundle) {
+			return app.Bundle
+		}
+		return app.Name
+	}
+	return ""
+}
+
+// resolveIiqUID returns the first non-blank uid id of the eid whose source is intentiq.com.
+func resolveIiqUID(user *openrtb2.User) string {
+	if user == nil {
+		return ""
+	}
+	for _, eid := range user.EIDs {
+		if eid.Source != iiqSource {
+			continue
+		}
+		for _, uid := range eid.UIDs {
+			if notBlank(uid.ID) {
+				return uid.ID
+			}
+		}
+	}
+	return ""
+}
+
+// appendIfPresent appends `&key=<encoded value>` when value is non-blank.
+func appendIfPresent(b *strings.Builder, key, value string) {
+	if !notBlank(value) {
+		return
+	}
+	b.WriteByte('&')
+	b.WriteString(key)
+	b.WriteByte('=')
+	b.WriteString(encodeComponent(value))
+}
+
+// encodeComponent URL-encodes a query-parameter value like Java's URLEncoder.encode(...).replace(
+// "+", "%20") — space becomes %20 rather than +.
+func encodeComponent(value string) string {
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+}
+
+// notBlank reports whether s has non-whitespace content (mirrors Java StringUtils.isNotBlank).
+func notBlank(s string) bool {
+	return strings.TrimSpace(s) != ""
+}

--- a/modules/intentiq/identity/params_test.go
+++ b/modules/intentiq/identity/params_test.go
@@ -1,0 +1,233 @@
+package identity
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+// baseURL is the fixed prefix every resolution URL starts with (partner id and source echoed in).
+const testEndpoint = "https://dev.example.com/resolve"
+
+func wrap(req *openrtb2.BidRequest) *openrtb_ext.RequestWrapper {
+	return &openrtb_ext.RequestWrapper{BidRequest: req}
+}
+
+func TestResolveURLConstantParams(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "partner-42"}
+	got := resolveURL(cfg, wrap(&openrtb2.BidRequest{}))
+
+	assert.Equal(t,
+		testEndpoint+"?at=39&mi=10&dpi=partner-42&pt=17&dpn=1&srvrReq=true&source=pbsgo",
+		got)
+}
+
+func TestResolveURLAppendsToExistingQuery(t *testing.T) {
+	cfg := Config{APIEndpoint: "https://dev.example.com/resolve?x=1", PartnerID: "p"}
+	got := resolveURL(cfg, wrap(&openrtb2.BidRequest{}))
+
+	assert.True(t, strings.HasPrefix(got, "https://dev.example.com/resolve?x=1&at=39&"), got)
+}
+
+func TestResolveURLDeviceIPIPv6AndUserAgentEncoding(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "383342646"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{
+		IP:   "125.253.50.47",
+		IPv6: "2001:db8::1",
+		UA:   "Mozilla/5.0 (iPhone)",
+	}}
+
+	got := resolveURL(cfg, wrap(req))
+
+	assert.Equal(t,
+		testEndpoint+"?at=39&mi=10&dpi=383342646&pt=17&dpn=1&srvrReq=true&source=pbsgo"+
+			"&ip=125.253.50.47&ipv6=2001%3Adb8%3A%3A1&uas=Mozilla%2F5.0%20%28iPhone%29",
+		got)
+}
+
+func TestResolveURLDeviceIfaMobileIdtype4(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "maid-AbC", DeviceType: 1}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&pcid=maid-AbC&idtype=4")
+}
+
+func TestResolveURLDeviceIfaCtvUppercasedIdtype8(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "rida-abc", DeviceType: 3}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&pcid=RIDA-ABC&idtype=8")
+}
+
+func TestResolveURLDeviceIfaCtvDeviceType7(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "rida-xyz", DeviceType: 7}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&pcid=RIDA-XYZ&idtype=8")
+}
+
+func TestResolveURLSkipsDeviceIdWhenLimitAdTracking(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	lmt := int8(1)
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "maid-1", Lmt: &lmt}}
+
+	got := resolveURL(cfg, wrap(req))
+	assert.NotContains(t, got, "pcid")
+	assert.NotContains(t, got, "idtype")
+}
+
+func TestResolveURLSkipsDeviceIdWhenIfaBlank(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{IFA: "   "}}
+
+	assert.NotContains(t, resolveURL(cfg, wrap(req)), "pcid")
+}
+
+func TestResolveURLRefFromSiteDomain(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Site: &openrtb2.Site{Domain: "example.com", Page: "https://example.com/p"}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&ref=example.com")
+}
+
+func TestResolveURLRefFallsBackToSitePage(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{Site: &openrtb2.Site{Page: "https://example.com/p"}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&ref=https%3A%2F%2Fexample.com%2Fp")
+}
+
+func TestResolveURLRefFromAppBundleThenName(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	assert.Contains(t, resolveURL(cfg, wrap(&openrtb2.BidRequest{App: &openrtb2.App{Bundle: "com.x.y"}})), "&ref=com.x.y")
+	assert.Contains(t, resolveURL(cfg, wrap(&openrtb2.BidRequest{App: &openrtb2.App{Name: "MyApp"}})), "&ref=MyApp")
+}
+
+func TestResolveURLIiqUidFromEid(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{User: &openrtb2.User{EIDs: []openrtb2.EID{
+		{Source: "other.com", UIDs: []openrtb2.UID{{ID: "x"}}},
+		{Source: iiqSource, UIDs: []openrtb2.UID{{ID: "IIQ-UID-1"}}},
+	}}}
+
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&iiquid=IIQ-UID-1")
+}
+
+func TestResolveURLConsentParamsFromTopLevelFields(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	gdpr := int8(1)
+	req := &openrtb2.BidRequest{
+		Regs: &openrtb2.Regs{GDPR: &gdpr, USPrivacy: "1YNN", GPP: "DBABMA~CONSENT", GPPSID: []int8{2, 6}},
+		User: &openrtb2.User{Consent: "CO-TCF-STRING"},
+	}
+
+	got := resolveURL(cfg, wrap(req))
+	assert.Contains(t, got, "&gdpr=1")
+	assert.Contains(t, got, "&us_privacy=1YNN")
+	// NOTE: url.QueryEscape leaves '~' unescaped (Java's URLEncoder emits %7E); see report.
+	assert.Contains(t, got, "&gpp=DBABMA~CONSENT")
+	assert.Contains(t, got, "&gpp_sid=2%2C6")
+	// Consent is a header, never a query param.
+	assert.NotContains(t, got, "CO-TCF-STRING")
+}
+
+func TestResolveURLConsentParamsFromRegsExtFallback(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	req := &openrtb2.BidRequest{
+		Regs: &openrtb2.Regs{Ext: json.RawMessage(`{"gdpr":1,"us_privacy":"1NYN"}`)},
+	}
+
+	got := resolveURL(cfg, wrap(req))
+	assert.Contains(t, got, "&gdpr=1")
+	assert.Contains(t, got, "&us_privacy=1NYN")
+}
+
+func TestResolveURLNoConsentParamsWhenAbsent(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	got := resolveURL(cfg, wrap(&openrtb2.BidRequest{}))
+
+	assert.NotContains(t, got, "gdpr")
+	assert.NotContains(t, got, "us_privacy")
+	assert.NotContains(t, got, "gpp")
+}
+
+func TestResolveConsentFromUserConsent(t *testing.T) {
+	req := &openrtb2.BidRequest{User: &openrtb2.User{Consent: "CO-TCF-STRING"}}
+	assert.Equal(t, "CO-TCF-STRING", resolveConsent(wrap(req)))
+}
+
+func TestResolveConsentFromUserExtFallback(t *testing.T) {
+	req := &openrtb2.BidRequest{User: &openrtb2.User{Ext: json.RawMessage(`{"consent":"EXT-TCF-STRING"}`)}}
+	assert.Equal(t, "EXT-TCF-STRING", resolveConsent(wrap(req)))
+}
+
+func TestResolveConsentEmptyWhenAbsent(t *testing.T) {
+	assert.Equal(t, "", resolveConsent(wrap(&openrtb2.BidRequest{})))
+}
+
+func TestBuildUaHintsFromDeviceSua(t *testing.T) {
+	mobile := int8(0)
+	sua := &openrtb2.UserAgent{
+		Source: 2,
+		Browsers: []openrtb2.BrandVersion{
+			{Brand: "Chromium", Version: []string{"108", "0", "5359", "125"}},
+			{Brand: "Google Chrome", Version: []string{"108", "0", "5359", "125"}},
+			{Brand: "Not?A_Brand", Version: []string{"8", "0", "0", "0"}},
+		},
+		Platform:     &openrtb2.BrandVersion{Brand: "Windows", Version: []string{"15", "0", "0"}},
+		Mobile:       &mobile,
+		Architecture: "x86",
+		Bitness:      "64",
+	}
+
+	var uh map[string]string
+	assert.NoError(t, json.Unmarshal([]byte(buildUaHints(sua)), &uh))
+
+	assert.Equal(t, `"Chromium";v="108", "Google Chrome";v="108", "Not?A_Brand";v="8"`, uh["0"])
+	assert.Equal(t, `"Chromium";v="108.0.5359.125", "Google Chrome";v="108.0.5359.125", "Not?A_Brand";v="8.0.0.0"`, uh["8"])
+	assert.Equal(t, "?0", uh["1"])
+	assert.Equal(t, `"Windows"`, uh["2"])
+	assert.Equal(t, `"x86"`, uh["3"])
+	assert.Equal(t, `"64"`, uh["4"])
+	assert.Equal(t, `"15.0.0"`, uh["6"])
+	_, has5 := uh["5"]
+	_, has7 := uh["7"]
+	assert.False(t, has5)
+	assert.False(t, has7)
+}
+
+func TestBuildUaHintsModelUnderKey5(t *testing.T) {
+	sua := &openrtb2.UserAgent{Source: 2, Model: "Pixel 7"}
+	var uh map[string]string
+	assert.NoError(t, json.Unmarshal([]byte(buildUaHints(sua)), &uh))
+	assert.Equal(t, `"Pixel 7"`, uh["5"])
+}
+
+func TestBuildUaHintsEmptyWhenNotHighEntropy(t *testing.T) {
+	sua := &openrtb2.UserAgent{Source: 1, Browsers: []openrtb2.BrandVersion{{Brand: "Chrome", Version: []string{"120"}}}}
+	assert.Equal(t, "", buildUaHints(sua))
+}
+
+func TestBuildUaHintsEmptyWhenNilOrNoData(t *testing.T) {
+	assert.Equal(t, "", buildUaHints(nil))
+	assert.Equal(t, "", buildUaHints(&openrtb2.UserAgent{Source: 2}))
+}
+
+func TestResolveURLUhParamPresentForHighEntropySua(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	sua := &openrtb2.UserAgent{Source: 2, Model: "Pixel"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{SUA: sua}}
+	assert.Contains(t, resolveURL(cfg, wrap(req)), "&uh=")
+}
+
+func TestResolveURLNoUhParamForLowEntropySua(t *testing.T) {
+	cfg := Config{APIEndpoint: testEndpoint, PartnerID: "123"}
+	sua := &openrtb2.UserAgent{Source: 1, Model: "Pixel"}
+	req := &openrtb2.BidRequest{Device: &openrtb2.Device{SUA: sua}}
+	assert.NotContains(t, resolveURL(cfg, wrap(req)), "uh=")
+}

--- a/modules/intentiq/identity/params_test.go
+++ b/modules/intentiq/identity/params_test.go
@@ -23,7 +23,7 @@ func TestResolveURLConstantParams(t *testing.T) {
 	got := resolveURL(cfg, wrap(&openrtb2.BidRequest{}))
 
 	assert.Equal(t,
-		testEndpoint+"?at=39&mi=10&dpi=partner-42&pt=17&dpn=1&srvrReq=true&source=pbsgo",
+		testEndpoint+"?at=39&mi=10&dpi=partner-42&pt=17&dpn=1&srvrReq=true&source=pbgo",
 		got)
 }
 
@@ -45,7 +45,7 @@ func TestResolveURLDeviceIPIPv6AndUserAgentEncoding(t *testing.T) {
 	got := resolveURL(cfg, wrap(req))
 
 	assert.Equal(t,
-		testEndpoint+"?at=39&mi=10&dpi=383342646&pt=17&dpn=1&srvrReq=true&source=pbsgo"+
+		testEndpoint+"?at=39&mi=10&dpi=383342646&pt=17&dpn=1&srvrReq=true&source=pbgo"+
 			"&ip=125.253.50.47&ipv6=2001%3Adb8%3A%3A1&uas=Mozilla%2F5.0%20%28iPhone%29",
 		got)
 }

--- a/modules/intentiq/identity/useragent.go
+++ b/modules/intentiq/identity/useragent.go
@@ -1,0 +1,127 @@
+package identity
+
+import (
+	"regexp"
+	"strings"
+)
+
+// normalizeUA reduces a raw User-Agent string to a compact, deterministic cache-key segment such as
+// "iOS17_MobileSafari17_iPhone": coarse OS (family+major), browser (family+major) and device (family)
+// tokens joined by "_". Empty tokens are dropped; a blank or wholly unrecognized UA returns "".
+//
+// This is an intentional lightweight adaptation of the Java DeviceUserAgent.normalize, which uses the
+// ua_parser library. We deliberately do NOT pull in that dependency: the segment's only job is to be a
+// stable, low-cardinality cache-key fragment, so exact ua_parser parity is not required. The single
+// hard requirement is determinism — the same input must always yield the same output — which a fixed
+// ordered heuristic table guarantees. Rendering engine and app-vs-browser distinctions are omitted,
+// matching the Java version's own omissions.
+func normalizeUA(ua string) string {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return ""
+	}
+
+	var parts []string
+	if t := osToken(ua); t != "" {
+		parts = append(parts, t)
+	}
+	if t := browserToken(ua); t != "" {
+		parts = append(parts, t)
+	}
+	if t := deviceToken(ua); t != "" {
+		parts = append(parts, t)
+	}
+	return strings.Join(parts, "_")
+}
+
+// uaRule pairs a detection regex with the family name emitted on a match. When the regex has a capture
+// group its first submatch is used as the major version; otherwise no version is appended.
+type uaRule struct {
+	re      *regexp.Regexp
+	family  string
+	version bool // whether re captures a major-version group at index 1
+}
+
+// osRules are evaluated in order; the first match wins. iOS is checked before Mac OS X because iPhone
+// UAs contain the "like Mac OS X" token.
+var osRules = []uaRule{
+	{regexp.MustCompile(`(?i)(?:iphone os|cpu os)\s+(\d+)`), "iOS", true},
+	{regexp.MustCompile(`(?i)mac os x\s+(\d+)`), "MacOSX", true},
+	{regexp.MustCompile(`(?i)android[\s/]+(\d+)`), "Android", true},
+	{regexp.MustCompile(`(?i)windows nt\s+(\d+)`), "Windows", true},
+	{regexp.MustCompile(`(?i)cros`), "ChromeOS", false},
+	{regexp.MustCompile(`(?i)linux`), "Linux", false},
+}
+
+// browserRules are evaluated in order; the first match wins. Wrapper browsers (Edge/Opera/Samsung)
+// must precede Chrome, and Chrome must precede Safari, because each later UA embeds the earlier
+// token.
+var browserRules = []uaRule{
+	{regexp.MustCompile(`(?i)edg(?:e|ios|a)?/(\d+)`), "Edge", true},
+	{regexp.MustCompile(`(?i)(?:opr|opera)/(\d+)`), "Opera", true},
+	{regexp.MustCompile(`(?i)samsungbrowser/(\d+)`), "SamsungBrowser", true},
+	{regexp.MustCompile(`(?i)(?:firefox|fxios)/(\d+)`), "Firefox", true},
+	{regexp.MustCompile(`(?i)(?:crios|chromium|chrome)/(\d+)`), "Chrome", true},
+	{regexp.MustCompile(`(?i)version/(\d+).*safari`), "Safari", true},
+}
+
+// deviceRules are evaluated in order; the first match wins.
+var deviceRules = []uaRule{
+	{regexp.MustCompile(`(?i)ipad`), "iPad", false},
+	{regexp.MustCompile(`(?i)ipod`), "iPod", false},
+	{regexp.MustCompile(`(?i)iphone`), "iPhone", false},
+	{regexp.MustCompile(`(?i)pixel\s+(\d+)`), "Pixel", true},
+	{regexp.MustCompile(`(?i)nexus\s+(\d+)`), "Nexus", true},
+	{regexp.MustCompile(`(?i)macintosh`), "Mac", false},
+}
+
+func osToken(ua string) string { return matchRules(ua, osRules) }
+
+func deviceToken(ua string) string { return matchRules(ua, deviceRules) }
+
+// browserToken mirrors ua_parser's mobile-aware families: Chrome and Safari become their "Mobile"
+// variants when the UA advertises "Mobile".
+func browserToken(ua string) string {
+	mobile := strings.Contains(strings.ToLower(ua), "mobile")
+	for _, r := range browserRules {
+		m := r.re.FindStringSubmatch(ua)
+		if m == nil {
+			continue
+		}
+		family := r.family
+		if mobile && (family == "Chrome" || family == "Safari") {
+			family = "Mobile" + family
+		}
+		version := ""
+		if r.version && len(m) > 1 {
+			version = m[1]
+		}
+		return token(family, version)
+	}
+	return ""
+}
+
+func matchRules(ua string, rules []uaRule) string {
+	for _, r := range rules {
+		m := r.re.FindStringSubmatch(ua)
+		if m == nil {
+			continue
+		}
+		version := ""
+		if r.version && len(m) > 1 {
+			version = m[1]
+		}
+		return token(r.family, version)
+	}
+	return ""
+}
+
+// whitespace collapses any run of whitespace so a family like "Mobile Safari" becomes "MobileSafari".
+var whitespace = regexp.MustCompile(`\s+`)
+
+// token joins a family with an optional major version, stripping all whitespace. It returns "" for a
+// blank family so callers can drop it.
+func token(family, version string) string {
+	value := whitespace.ReplaceAllString(family+version, "")
+	return value
+}

--- a/modules/intentiq/identity/useragent_test.go
+++ b/modules/intentiq/identity/useragent_test.go
@@ -1,0 +1,72 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeUA(t *testing.T) {
+	tests := []struct {
+		name string
+		ua   string
+		want string
+	}{
+		{"blank", "", ""},
+		{"whitespace only", "   ", ""},
+		{"unrecognized", "SomeRandomBot/1.0", ""},
+		{
+			name: "iphone safari mobile",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+			want: "iOS17_MobileSafari17_iPhone",
+		},
+		{
+			name: "android chrome mobile",
+			ua:   "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+			want: "Android14_MobileChrome120_Pixel8",
+		},
+		{
+			name: "windows desktop chrome",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+			want: "Windows10_Chrome120",
+		},
+		{
+			name: "mac safari desktop",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1 (KHTML, like Gecko) Version/17.0 Safari/605.1",
+			want: "MacOSX10_Safari17_Mac",
+		},
+		{
+			name: "edge precedes chrome",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+			want: "Windows10_Edge120",
+		},
+		{
+			name: "firefox",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+			want: "Windows10_Firefox121",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeUA(tt.ua))
+		})
+	}
+}
+
+// TestNormalizeUADeterministic is the one hard requirement: identical input always yields identical
+// output.
+func TestNormalizeUADeterministic(t *testing.T) {
+	uas := []string{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Version/17.0 Mobile Safari/604.1",
+		"Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/120.0.0.0 Mobile Safari/537.36",
+		"garbage",
+		"",
+	}
+	for _, ua := range uas {
+		first := normalizeUA(ua)
+		for i := 0; i < 5; i++ {
+			assert.Equal(t, first, normalizeUA(ua), "normalizeUA must be deterministic for %q", ua)
+		}
+	}
+}

--- a/modules/moduledeps/deps.go
+++ b/modules/moduledeps/deps.go
@@ -3,6 +3,8 @@ package moduledeps
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prebid/prebid-server/v4/currency"
 )
 
@@ -12,4 +14,8 @@ type ModuleDeps struct {
 	HTTPClient    *http.Client
 	RateConvertor *currency.RateConverter
 	Geoscope      map[string][]string
+	// MetricsRegisterer lets a module register its own Prometheus collectors into the registry the
+	// server scrapes at /metrics. May be nil (e.g. when Prometheus is disabled), in which case a
+	// module must treat metrics as a no-op.
+	MetricsRegisterer prometheus.Registerer
 }

--- a/router/router.go
+++ b/router/router.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/julienschmidt/httprouter"
 	_ "github.com/lib/pq"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 )
 
@@ -208,7 +209,11 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 	}
 
 	normalizedGeoscopes := getNormalizedGeoscopes(cfg.BidderInfos)
-	moduleDeps := moduledeps.ModuleDeps{HTTPClient: generalHttpClient, RateConvertor: rateConvertor, Geoscope: normalizedGeoscopes}
+	// Dedicated registry for collectors that hook modules register themselves. Modules are built
+	// before the metrics engine (which needs moduleStageNames from the build), so this cannot be the
+	// PBS core registry; the Prometheus listener gathers from both (see server/prometheus.go).
+	moduleMetricsRegistry := prometheus.NewRegistry()
+	moduleDeps := moduledeps.ModuleDeps{HTTPClient: generalHttpClient, RateConvertor: rateConvertor, Geoscope: normalizedGeoscopes, MetricsRegisterer: moduleMetricsRegistry}
 	repo, moduleStageNames, shutdownModules, err := modules.NewBuilder().Build(cfg.Hooks.Modules, moduleDeps)
 	if err != nil {
 		logger.Fatalf("Failed to init hook modules: %v", err)
@@ -216,6 +221,7 @@ func New(cfg *config.Configuration, rateConvertor *currency.RateConverter) (r *R
 
 	// Metrics engine
 	r.MetricsEngine = metricsConf.NewMetricsEngine(cfg, openrtb_ext.CoreBidderNames(), syncerKeys, moduleStageNames)
+	r.MetricsEngine.ModuleMetricsGatherer = moduleMetricsRegistry
 	shutdown, fetcher, ampFetcher, accounts, categoriesFetcher, videoFetcher, storedRespFetcher := storedRequestsConf.NewStoredRequests(cfg, r.MetricsEngine, generalHttpClient, r.Router)
 
 	analyticsRunner := analyticsBuild.New(&cfg.Analytics)

--- a/sample/configs/prebid-config-with-intentiq.yaml
+++ b/sample/configs/prebid-config-with-intentiq.yaml
@@ -1,0 +1,68 @@
+# Sample prebid-server (Go) configuration that enables the IntentIQ Identity module.
+# Mirrors the prebid-server-java sample (sample/configs/prebid-config-with-intentiq.yaml),
+# translated to the Go server's config schema.
+#
+# Run:
+#   go run . -v 1 -logtostderr --config sample/configs/prebid-config-with-intentiq.yaml
+# then POST an OpenRTB request to http://localhost:8000/openrtb2/auction and inspect the enriched
+# user.eids in ext.debug.resolvedrequest (send "test": 1 in the request to get debug output).
+
+status_response: "ok"
+host: localhost
+port: 8000
+admin_port: 6060
+
+gdpr:
+  default_value: "0"
+
+metrics:
+  # The module registers its own Prometheus collectors; enable the Prometheus endpoint to scrape them
+  # at http://localhost:9090/metrics (series prefixed modules_module_intentiq_identity_custom_*).
+  prometheus:
+    port: 9090
+    namespace: prebid
+    subsystem: server
+
+adapters:
+  generic:
+    enabled: true
+    endpoint: http://localhost:9099/bidder
+
+hooks:
+  enabled: true
+  modules:
+    intentiq:
+      identity:
+        # Region-specific Bid Enhancement endpoint (US shown); point at your mock during local dev.
+        api-endpoint: http://127.0.0.1:9098/profiles_engine/ProfilesEngineServlet
+        reports-endpoint: http://127.0.0.1:9098/profiles_engine/ProfilesEngineServlet
+        partner-id: "383342646"
+        timeout: 6000
+        cache-max-size: 33554432   # in-process (L1) byte budget (~32 MiB)
+        metrics-enabled: true
+        cache:
+          enabled: true
+          ttlseconds: 43200
+          # dev: keep the in-progress marker short so a timed-out resolution retries soon instead of
+          # poisoning the device key for 30 min (default 1800s) when the backend is slow/flapping.
+          in-progress-ttl-seconds: 30
+        redis:
+          host: 127.0.0.1
+          port: 6379
+          # password: ""
+  host_execution_plan:
+    endpoints:
+      /openrtb2/auction:
+        stages:
+          processed_auction_request:
+            groups:
+              - timeout: 6000
+                hook_sequence:
+                  - module_code: "intentiq.identity"
+                    hook_impl_code: "HandleProcessedAuctionHook"
+          auction_response:
+            groups:
+              - timeout: 6000
+                hook_sequence:
+                  - module_code: "intentiq.identity"
+                    hook_impl_code: "HandleAuctionResponseHook"

--- a/server/prometheus.go
+++ b/server/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/logger"
 	metricsconfig "github.com/prebid/prebid-server/v4/metrics/config"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -17,9 +18,17 @@ func newPrometheusServer(cfg *config.Configuration, metrics *metricsconfig.Detai
 	if proMetrics == nil {
 		logger.Fatalf("Prometheus metrics configured, but a Prometheus metrics engine was not found. Cannot set up a Prometheus listener.")
 	}
+
+	// Gather from the PBS core registry and, when present, the dedicated registry hook modules use
+	// for their own collectors so both are exported on /metrics.
+	var gatherer prometheus.Gatherer = proMetrics.Gatherer
+	if metrics.ModuleMetricsGatherer != nil {
+		gatherer = prometheus.Gatherers{proMetrics.Gatherer, metrics.ModuleMetricsGatherer}
+	}
+
 	return &http.Server{
 		Addr: cfg.Host + ":" + strconv.Itoa(cfg.Metrics.Prometheus.Port),
-		Handler: promhttp.HandlerFor(proMetrics.Gatherer, promhttp.HandlerOpts{
+		Handler: promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
 			ErrorLog:            loggerForPrometheus{},
 			MaxRequestsInFlight: 5,
 			Timeout:             cfg.Metrics.Prometheus.Timeout(),


### PR DESCRIPTION
### Summary

Adds a new host module, `intentiq.identity` — a Go port of the prebid-server-java `extra/modules/intentiq-identity` module. It enriches OpenRTB requests with IntentIQ-resolved identity and, optionally, reports winning bids to IntentIQ.

### What it does

- **`processed_auction_request`** — calls the IntentIQ Bid Enhancement S2S API (`ProfilesEngineServlet`) and merges the resolved eids into `user.eids` before the request reaches bidders. Fail-open: any resolution error leaves the request untouched.
- **`auction_response`** (optional) — fire-and-forget impression report of each winning bid to the configured `reports-endpoint`. The bid response is never modified.
- **Two-layer alias cache** (opt-in) — in-process L1 (freecache) backed by a shared L2 (Redis), with multi-key aliasing + back-fill, negative caching, and in-progress dedup of concurrent resolutions.
- **Metrics** — per-partner Prometheus counters/histograms/gauges, registered via a new `moduledeps.ModuleDeps.MetricsRegisterer` and exported on the server's existing `/metrics` endpoint.

### Framework changes

- `modules/moduledeps`: new `MetricsRegisterer prometheus.Registerer` field so a module can register its own collectors into the scrape registry.
- `router`, `metrics/config`, `server/prometheus`: thread a dedicated module-metrics registry to the Prometheus scrape handler (gathers alongside the core registry).
- `modules/builder.go`: register `intentiq.identity`.

### Config & docs

- `modules/intentiq/identity/README.md` — overview, setup/execution plan, parameters, caching, impression reporting, metrics, and a demo walkthrough.
- `sample/configs/prebid-config-with-intentiq.yaml` — runnable sample config.

### Testing

- Unit + integration tests for every component (enrich, impression, key extraction, UA normalization, two-layer cache with `miniredis`, metrics, config merge, builder/shutdown).
- `go build ./...`, `go vet`, and `gofmt` clean; tests pass under `-race`.
- Changed-code coverage: `modules/intentiq/identity` 91.5%, `.../cache` 91.1% (meets the 90% requirement).
