### PR TITLE
Intenze: Add region and placement bidder params

### DIFF
--- a/adapters/intenze/intenze.go
+++ b/adapters/intenze/intenze.go
@@ -3,20 +3,35 @@ package intenze
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"net/url"
+	"slices"
+	"strings"
 	"text/template"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/adapters"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/errortypes"
-	"github.com/prebid/prebid-server/v4/macros"
+	// "github.com/prebid/prebid-server/v4/macros"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/prebid/prebid-server/v4/util/jsonutil"
 )
 
 type adapter struct {
 	endpoint *template.Template
+}
+
+var exchangeSubdomainsRegions = map[string]string{
+	"us-east": "lb-east",
+	"eu":      "n2",
+	"apac":    "lb-apac",
+}
+var sspSubdomainsRegions = map[string]string{
+	"us-east": "us-east-ssp",
+	"eu":      "eu-ssp",
+	"apac":    "apac-ssp",
 }
 
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
@@ -55,6 +70,7 @@ func getHeaders(request *openrtb2.BidRequest) http.Header {
 }
 
 func (a *adapter) MakeRequests(openRTBRequest *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) (requestsToBidder []*adapters.RequestData, errs []error) {
+
 	impExt, err := getImpressionExt(&openRTBRequest.Imp[0])
 	if err != nil {
 		return nil, []error{err}
@@ -99,8 +115,45 @@ func getImpressionExt(imp *openrtb2.Imp) (*openrtb_ext.ExtIntenze, error) {
 }
 
 func (a *adapter) buildEndpointURL(params *openrtb_ext.ExtIntenze) (string, error) {
-	endpointParams := macros.EndpointTemplateParams{AccountID: params.AccountID}
-	return macros.ResolveMacros(a.endpoint, endpointParams)
+	if params.AccountID == nil && params.PlacementID == nil {
+		return "", &errortypes.BadInput{
+			Message: "either accountId or placementId expected",
+		}
+	}
+
+	var route = ""
+	var subdomain, queryKey, queryValue string
+	var regionMap map[string]string
+
+	if params.AccountID != nil {
+		subdomain = "lb-east"
+		queryKey = "pass"
+		queryValue = *params.AccountID
+		regionMap = exchangeSubdomainsRegions
+	} else {
+		subdomain = "us-east-ssp"
+		queryKey = "placementId"
+		route = "pbs-serve"
+		queryValue = *params.PlacementID
+		regionMap = sspSubdomainsRegions
+	}
+
+	if params.Region != nil {
+		var exists bool
+		subdomain, exists = regionMap[*params.Region]
+		if !exists {
+			keys := slices.Collect(maps.Keys(regionMap))
+			validRegions := strings.Join(keys, "\", \"")
+
+			return "", &errortypes.BadInput{
+				Message: fmt.Sprintf("invalid region: %s. Expected \"%s\"", *params.Region, validRegions),
+			}
+		}
+	}
+
+	endpoint := fmt.Sprintf("http://%s.intenze.co/%s?%s=%s", subdomain, route, queryKey, url.QueryEscape(queryValue))
+
+	return endpoint, nil
 }
 
 func checkResponseStatusCodes(response *adapters.ResponseData) error {

--- a/adapters/intenze/intenze.go
+++ b/adapters/intenze/intenze.go
@@ -3,18 +3,15 @@ package intenze
 import (
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/url"
-	"slices"
-	"strings"
 	"text/template"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/adapters"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/errortypes"
-	// "github.com/prebid/prebid-server/v4/macros"
+
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/prebid/prebid-server/v4/util/jsonutil"
 )
@@ -35,14 +32,7 @@ var sspSubdomainsRegions = map[string]string{
 }
 
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
-	template, err := template.New("endpointTemplate").Parse(config.Endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse endpoint url template: %v", err)
-	}
-
-	bidder := &adapter{
-		endpoint: template,
-	}
+	bidder := &adapter{}
 	return bidder, nil
 }
 
@@ -142,16 +132,13 @@ func (a *adapter) buildEndpointURL(params *openrtb_ext.ExtIntenze) (string, erro
 		var exists bool
 		subdomain, exists = regionMap[*params.Region]
 		if !exists {
-			keys := slices.Collect(maps.Keys(regionMap))
-			validRegions := strings.Join(keys, "\", \"")
-
 			return "", &errortypes.BadInput{
-				Message: fmt.Sprintf("invalid region: %s. Expected \"%s\"", *params.Region, validRegions),
+				Message: fmt.Sprintf("invalid region: %s. Expected us-east, eu or apac", *params.Region),
 			}
 		}
 	}
 
-	endpoint := fmt.Sprintf("http://%s.intenze.co/%s?%s=%s", subdomain, route, queryKey, url.QueryEscape(queryValue))
+	endpoint := fmt.Sprintf("https://%s.intenze.co/%s?%s=%s", subdomain, route, queryKey, url.QueryEscape(queryValue))
 
 	return endpoint, nil
 }

--- a/adapters/intenze/intenze_test.go
+++ b/adapters/intenze/intenze_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonSamples(t *testing.T) {
@@ -18,11 +17,4 @@ func TestJsonSamples(t *testing.T) {
 	}
 
 	adapterstest.RunJSONBidderTest(t, "intenzetest", bidder)
-}
-
-func TestEndpointTemplateMalformed(t *testing.T) {
-	_, buildErr := Builder(openrtb_ext.BidderIntenze, config.Adapter{
-		Endpoint: "{{Malformed}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-
-	assert.Error(t, buildErr)
 }

--- a/adapters/intenze/intenzetest/exemplary/banner-web.json
+++ b/adapters/intenze/intenzetest/exemplary/banner-web.json
@@ -66,7 +66,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/native-app.json
+++ b/adapters/intenze/intenzetest/exemplary/native-app.json
@@ -59,7 +59,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/native-web.json
+++ b/adapters/intenze/intenzetest/exemplary/native-web.json
@@ -53,7 +53,7 @@
             "2607:fb90:f27:4512:d800:cb23:a603:e245"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/simple-account-apac.json
+++ b/adapters/intenze/intenzetest/exemplary/simple-account-apac.json
@@ -33,6 +33,7 @@
         },
         "ext": {
           "bidder": {
+            "region": "apac",
             "accountId": "accountId"
           }
         }
@@ -59,7 +60,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "https://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-apac.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/simple-account-eu.json
+++ b/adapters/intenze/intenzetest/exemplary/simple-account-eu.json
@@ -33,6 +33,7 @@
         },
         "ext": {
           "bidder": {
+            "region": "eu",
             "accountId": "accountId"
           }
         }
@@ -59,7 +60,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "https://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://n2.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/simple-placement-apac.json
+++ b/adapters/intenze/intenzetest/exemplary/simple-placement-apac.json
@@ -33,7 +33,8 @@
         },
         "ext": {
           "bidder": {
-            "accountId": "accountId"
+            "region": "apac",
+            "placementId": "123"
           }
         }
       }
@@ -59,7 +60,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "https://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://apac-ssp.intenze.co/pbs-serve?placementId=123",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/simple-placement-default-us-east.json
+++ b/adapters/intenze/intenzetest/exemplary/simple-placement-default-us-east.json
@@ -33,7 +33,7 @@
         },
         "ext": {
           "bidder": {
-            "accountId": "accountId"
+            "placementId": "123"
           }
         }
       }
@@ -59,7 +59,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "https://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://us-east-ssp.intenze.co/pbs-serve?placementId=123",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/simple-placement-eu.json
+++ b/adapters/intenze/intenzetest/exemplary/simple-placement-eu.json
@@ -33,7 +33,8 @@
         },
         "ext": {
           "bidder": {
-            "accountId": "accountId"
+            "region": "eu",
+            "placementId": "123"
           }
         }
       }
@@ -59,7 +60,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "https://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://eu-ssp.intenze.co/pbs-serve?placementId=123",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/video-app.json
+++ b/adapters/intenze/intenzetest/exemplary/video-app.json
@@ -64,7 +64,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/exemplary/video-web.json
+++ b/adapters/intenze/intenzetest/exemplary/video-web.json
@@ -58,7 +58,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/supplemental/bad_media_type.json
+++ b/adapters/intenze/intenzetest/supplemental/bad_media_type.json
@@ -59,7 +59,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/supplemental/empty-seatbid-array.json
+++ b/adapters/intenze/intenzetest/supplemental/empty-seatbid-array.json
@@ -64,7 +64,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/supplemental/invalid-region.json
+++ b/adapters/intenze/intenzetest/supplemental/invalid-region.json
@@ -1,0 +1,36 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "invalid region: unknown. Expected us-east, eu or apac",
+      "comparison": "literal"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "tagid": "my-adcode",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480,
+          "minduration": 120,
+          "maxduration": 150
+        },
+        "ext": {
+          "bidder": {
+            "region": "unknown",
+            "placementId": "123"
+          }
+        }
+      }
+    ],
+    "site": {
+      "page": "test.com"
+    }
+  },
+  "httpCalls": []
+}

--- a/adapters/intenze/intenzetest/supplemental/invalid-response.json
+++ b/adapters/intenze/intenzetest/supplemental/invalid-response.json
@@ -59,7 +59,7 @@
             "123.123.123.123"
           ]
         },
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "device": {

--- a/adapters/intenze/intenzetest/supplemental/no-account-no-placement.json
+++ b/adapters/intenze/intenzetest/supplemental/no-account-no-placement.json
@@ -1,0 +1,33 @@
+{
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "either accountId or placementId expected",
+      "comparison": "literal"
+    }
+  ],
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "some-impression-id",
+        "tagid": "my-adcode",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480,
+          "minduration": 120,
+          "maxduration": 150
+        },
+        "ext": {
+          "bidder": {}
+        }
+      }
+    ],
+    "site": {
+      "page": "test.com"
+    }
+  },
+  "httpCalls": []
+}

--- a/adapters/intenze/intenzetest/supplemental/status-code-bad-request.json
+++ b/adapters/intenze/intenzetest/supplemental/status-code-bad-request.json
@@ -41,7 +41,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "imp": [

--- a/adapters/intenze/intenzetest/supplemental/status-code-no-content.json
+++ b/adapters/intenze/intenzetest/supplemental/status-code-no-content.json
@@ -35,7 +35,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "imp": [

--- a/adapters/intenze/intenzetest/supplemental/status-code-other-error.json
+++ b/adapters/intenze/intenzetest/supplemental/status-code-other-error.json
@@ -35,7 +35,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "imp": [

--- a/adapters/intenze/intenzetest/supplemental/status-code-service-unavailable.json
+++ b/adapters/intenze/intenzetest/supplemental/status-code-service-unavailable.json
@@ -35,7 +35,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://lb-east.intenze.co/?pass=accountId",
+        "uri": "https://lb-east.intenze.co/?pass=accountId",
         "body": {
           "id": "some-request-id",
           "imp": [

--- a/adapters/intenze/params_test.go
+++ b/adapters/intenze/params_test.go
@@ -9,6 +9,7 @@ import (
 
 var validParams = []string{
 	`{"accountId": "hash"}`,
+	`{"subdomain": "ssp-api", "placementId": "id"}`,
 }
 
 func TestValidParams(t *testing.T) {
@@ -31,9 +32,6 @@ var invalidParams = []string{
 	`5`,
 	`4.2`,
 	`[]`,
-	`{}`,
-	`{"adCode": "string", "seatCode": 5, "originalPublisherid": "string"}`,
-	`{  "accountid": "" }`,
 }
 
 func TestInvalidParams(t *testing.T) {

--- a/adapters/intenze/params_test.go
+++ b/adapters/intenze/params_test.go
@@ -9,7 +9,8 @@ import (
 
 var validParams = []string{
 	`{"accountId": "hash"}`,
-	`{"subdomain": "ssp-api", "placementId": "id"}`,
+	`{"placementId": "id"}`,
+	`{"region": "us-east", "placementId": "id"}`,
 }
 
 func TestValidParams(t *testing.T) {

--- a/openrtb_ext/imp_intenze.go
+++ b/openrtb_ext/imp_intenze.go
@@ -1,5 +1,7 @@
 package openrtb_ext
 
 type ExtIntenze struct {
-	AccountID string `json:"accountId"`
+	Region      *string `json:"region,omitempty"`
+	AccountID   *string `json:"accountId,omitempty"`
+	PlacementID *string `json:"placementId,omitempty"`
 }

--- a/static/bidder-params/intenze.json
+++ b/static/bidder-params/intenze.json
@@ -4,13 +4,20 @@
     "description": "A schema which validates params accepted by the Intenze adapter",
     "type": "object",
     "properties": {
+        "subdomain": {
+            "type": "string",
+            "description": "Specify regional/platform variated subdomain of SSP/Exchange. By default lb-east of ad exchange is used.",
+            "minLength": 1
+        },
         "accountId": {
             "type": "string",
-            "description": "Account id",
+            "description": "Use this for Account ID of Ad Exchange",
+            "minLength": 1
+        },
+        "placementId": {
+            "type": "string",
+            "description": "Use this for Placement ID of SSP",
             "minLength": 1
         }
-    },
-    "required": [
-        "accountId"
-    ]
+    }
 }

--- a/static/bidder-params/intenze.json
+++ b/static/bidder-params/intenze.json
@@ -4,9 +4,9 @@
     "description": "A schema which validates params accepted by the Intenze adapter",
     "type": "object",
     "properties": {
-        "subdomain": {
+        "region": {
             "type": "string",
-            "description": "Specify regional/platform variated subdomain of SSP/Exchange. By default lb-east of ad exchange is used.",
+            "description": "Target region traffic. By default us-east.",
             "minLength": 1
         },
         "accountId": {


### PR DESCRIPTION
We want to integrate prebid server integration to our new ssp.
Added the new following bid params for our adapter:
```region``` - optional target region of the world: ```us-east```(default), ```eu```, ```apac```
```placementId``` - optional, used when partner wants to integrate to our ssp
```accountId``` - this old parameter is optional now and used when partner wants to integrate to our exchange.