### PR TITLE
Add unit tests for extractNurlVideoCrid

### DIFF
--- a/adapters/beachfront/beachfront_test.go
+++ b/adapters/beachfront/beachfront_test.go
@@ -60,3 +60,34 @@ func TestExtraInfoMalformed(t *testing.T) {
 
 	assert.Error(t, buildErr)
 }
+
+func TestExtractNurlVideoCrid(t *testing.T) {
+	tests := []struct {
+		name     string
+		nurl     string
+		expected string
+	}{
+		{
+			name:     "valid nurl",
+			nurl:     "https://useast.bfmio.com/getBids?aid=bid:70b99087-1b92-4e81-bc42-05c940fd6014:bid-id",
+			expected: "70b99087-1b92-4e81-bc42-05c940fd6014",
+		},
+		{
+			name: "nurl with no colons",
+			nurl: "short-nurl",
+		},
+		{
+			name: "nurl with one colon",
+			nurl: "short:nurl",
+		},
+		{
+			name: "empty nurl",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, extractNurlVideoCrid(test.nurl))
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Add coverage to prevent regressions around the off-by-one fix in `extractNurlVideoCrid` by verifying correct behavior for valid, short, and empty NURLs.

### Description
- Add `TestExtractNurlVideoCrid` to `adapters/beachfront/beachfront_test.go`, a table-driven unit test that asserts a valid NURL (≥3 colon-separated segments) returns the expected CRID, while NURLs with zero or one colon and an empty input return `""`.

### Testing
- Ran `gofmt -w adapters/beachfront/beachfront_test.go` and `go test ./adapters/beachfront`, both completed successfully.
- Ran `git diff --check` to ensure no formatting or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68f9a30344832b95206af9393c37c4)