### PR TITLE
Kargo: declare app capabilities in bidder YAML

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -9,6 +9,11 @@ capabilities:
       - banner
       - video
       - native
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
 userSync:
   redirect:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"


### PR DESCRIPTION
Enable app-based requests for the Kargo adapter by declaring app mediaTypes (banner, video, native) in the bidder-info config.