### PR TITLE
Adapter Semgrep Workflow: Split into two stages

### DIFF
--- a/.github/workflows/helpers/pull-request-utils.js
+++ b/.github/workflows/helpers/pull-request-utils.js
@@ -231,7 +231,7 @@ class semgrepHelper {
     this.repo = input.context.repo.repo
     this.github = input.github
 
-    this.pullRequestNumber = input.context.payload.pull_request.number
+    this.pullRequestNumber = input.prNumber || input.context.payload.pull_request.number
     this.pullRequestEvent = input.event
 
     this.pullRequestDiff = input.diff.pullRequest.diff

--- a/.github/workflows/semgrep-report.yml
+++ b/.github/workflows/semgrep-report.yml
@@ -1,0 +1,73 @@
+name: Adapter Semgrep Report
+
+on:
+  workflow_run:
+    workflows: ["Adapter Semgrep Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report-semgrep:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Semgrep Artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: semgrep-results
+          path: semgrep-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR Metadata
+        id: pr_metadata
+        if: steps.download.outcome == 'success'
+        run: |
+          echo "pr_number=$(cat semgrep-results/pr-metadata/pr_number)" >> $GITHUB_OUTPUT
+          echo "head_sha=$(cat semgrep-results/pr-metadata/head_sha)" >> $GITHUB_OUTPUT
+          echo "event=$(cat semgrep-results/pr-metadata/event)" >> $GITHUB_OUTPUT
+
+      - name: Add Pull Request Comment
+        id: add_pull_request_comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const fs = require('fs')
+            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
+            const semgrepResult = JSON.parse(fs.readFileSync('semgrep-results/semgrep_result.json', 'utf8'))
+            const diff = JSON.parse(fs.readFileSync('semgrep-results/diff.json', 'utf8'))
+            const helper = utils.semgrepHelper({
+                github, context,
+                event: '${{ steps.pr_metadata.outputs.event }}',
+                semgrepResult,
+                diff,
+                headSha: '${{ steps.pr_metadata.outputs.head_sha }}',
+                prNumber: ${{ steps.pr_metadata.outputs.pr_number }}
+            })
+            const { previousScan, currentScan } = await helper.addReviewComments()
+            return previousScan.unAddressedComments + currentScan.newComments
+
+      - name: Check Results
+        if: steps.download.outcome == 'success'
+        run: |
+          if [ "${{steps.add_pull_request_comment.outputs.result}}" -ne "0" ]; then
+              echo 'Semgrep has found "${{steps.add_pull_request_comment.outputs.result}}" errors'
+              exit 1
+          else
+              echo 'Semgrep did not find any errors in the pull request changes'
+          fi

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,11 +1,12 @@
 name: Adapter Semgrep Check
 
 on:
-  pull_request_target:
+  pull_request:
     paths: ["adapters/*/*.go"]
 
-permissions: 
-    pull-requests: write
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   semgrep-check:
@@ -15,8 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Calculate Code Diff
         id: calculate_diff
@@ -49,32 +48,23 @@ jobs:
         if: contains(steps.should_run_semgrep.outputs.hasChanges, 'true')
         run: |
           unqouted_string=$(echo '${{ steps.calculate_diff.outputs.result }}' | jq .pullRequest.files | tr -d '"')
-          outputs=$(semgrep --gitlab-sast --config=.semgrep/adapter $unqouted_string  | jq '[.vulnerabilities[] | {"file": .location.file, "severity": .severity, "start": .location.start_line, "end": .location.end_line, "message": (.message | gsub("\\n"; "\n"))}]' | jq -c | jq -R)
-          echo "semgrep_result=${outputs}" >> "$GITHUB_OUTPUT"
+          outputs=$(semgrep --gitlab-sast --config=.semgrep/adapter $unqouted_string  | jq '[.vulnerabilities[] | {"file": .location.file, "severity": .severity, "start": .location.start_line, "end": .location.end_line, "message": (.message | gsub("\\n"; "\n"))}]' | jq -c)
+          echo "${outputs}" > semgrep_result.json
 
-      - name: Add Pull Request Comment
-        id: add_pull_request_comment
-        if: contains(steps.should_run_semgrep.outputs.hasChanges, 'true')
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            const utils = require('./.github/workflows/helpers/pull-request-utils.js')
-            const helper = utils.semgrepHelper({
-                github, context, event: "${{github.event.action}}", 
-                semgrepResult: JSON.parse(${{ steps.run_semgrep_tests.outputs.semgrep_result }}), 
-                diff: ${{ steps.calculate_diff.outputs.result }}, headSha: "${{github.event.pull_request.head.sha}}"
-            })
-            const { previousScan, currentScan } = await helper.addReviewComments()
-            return previousScan.unAddressedComments + currentScan.newComments
-
-      - name: Check Results
+      - name: Prepare Artifacts
         if: contains(steps.should_run_semgrep.outputs.hasChanges, 'true')
         run: |
-          if [ "${{steps.add_pull_request_comment.outputs.result}}" -ne "0" ]; then
-              echo 'Semgrep has found "${{steps.add_pull_request_comment.outputs.result}}" errors'
-              exit 1
-          else
-              echo 'Semgrep did not find any errors in the pull request changes'
-          fi
+          mkdir -p ./semgrep-artifacts/pr-metadata
+          cp semgrep_result.json ./semgrep-artifacts/semgrep_result.json
+          echo '${{ steps.calculate_diff.outputs.result }}' > ./semgrep-artifacts/diff.json
+          echo '${{ github.event.pull_request.number }}' > ./semgrep-artifacts/pr-metadata/pr_number
+          echo '${{ github.event.pull_request.head.sha }}' > ./semgrep-artifacts/pr-metadata/head_sha
+          echo '${{ github.event.action }}' > ./semgrep-artifacts/pr-metadata/event
+
+      - name: Upload Semgrep Artifacts
+        if: contains(steps.should_run_semgrep.outputs.hasChanges, 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-results
+          path: ./semgrep-artifacts
+          retention-days: 1


### PR DESCRIPTION
actions/checkout now refuses to check out fork PR code from a pull_request_target workflow ("pwn request" protection). Splits the semgrep check into an untrusted pull_request stage that runs semgrep and uploads results as an artifact, and a trusted workflow_run stage that downloads the artifact and posts review comments. Same pattern as #4775.