### PR TITLE
Fix: returnCreative handling by cache type

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -47,7 +47,24 @@ import (
 )
 
 type extCacheInstructions struct {
-	cacheBids, cacheVAST, returnCreative bool
+	cacheBids, cacheVAST                   bool
+	returnCreativeBids, returnCreativeVAST bool
+}
+
+func (c extCacheInstructions) shouldReturnCreative(bidType openrtb_ext.BidType) bool {
+	cacheApplies := false
+	returnCreative := false
+
+	if c.cacheBids {
+		cacheApplies = true
+		returnCreative = c.returnCreativeBids
+	}
+	if bidType == openrtb_ext.BidTypeVideo && c.cacheVAST {
+		cacheApplies = true
+		returnCreative = returnCreative || c.returnCreativeVAST
+	}
+
+	return !cacheApplies || returnCreative
 }
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
@@ -535,7 +552,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	e.bidValidationEnforcement.SetBannerCreativeMaxSize(r.Account.Validations)
 
 	// Build the response
-	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
+	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
 	bidResponse = adservertargeting.Apply(r.BidRequestWrapper, r.ResolvedBidRequest, bidResponse, r.QueryParams, bidResponseExt, r.Account.TruncateTargetAttribute)
 
 	bidResponse.Ext, err = encodeBidResponseExt(bidResponseExt)
@@ -954,7 +971,7 @@ func errsToBidderWarnings(errs []error) []openrtb_ext.ExtBidderMessage {
 }
 
 // This piece takes all the bids supplied by the adapters and crafts an openRTB response to send back to the requester
-func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterSeatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, bidRequest *openrtb_ext.RequestWrapper, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, pubID string, errList []error, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.BidResponse {
+func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterSeatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, bidRequest *openrtb_ext.RequestWrapper, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, cacheInstructions extCacheInstructions, impExtInfoMap map[string]ImpExtInfo, pubID string, errList []error, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.BidResponse {
 	bidResponse := new(openrtb2.BidResponse)
 
 	bidResponse.ID = bidRequest.ID
@@ -969,7 +986,7 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 	for a, adapterSeatBids := range adapterSeatBids {
 		//while processing every single bib, do we need to handle categories here?
 		if adapterSeatBids != nil && len(adapterSeatBids.Bids) > 0 {
-			sb := e.makeSeatBid(adapterSeatBids, a, adapterExtra, auc, returnCreative, impExtInfoMap, bidRequest, bidResponseExt, pubID, seatNonBidBuilder)
+			sb := e.makeSeatBid(adapterSeatBids, a, adapterExtra, auc, cacheInstructions, impExtInfoMap, bidRequest, bidResponseExt, pubID, seatNonBidBuilder)
 			seatBids = append(seatBids, *sb)
 			bidResponse.Cur = adapterSeatBids.Currency
 		}
@@ -1288,14 +1305,14 @@ func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*en
 
 // Return an openrtb seatBid for a bidder
 // buildBidResponse is responsible for ensuring nil bid seatbids are not included
-func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, pubID string, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.SeatBid {
+func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, cacheInstructions extCacheInstructions, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, pubID string, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.SeatBid {
 	seatBid := &openrtb2.SeatBid{
 		Seat:  adapter.String(),
 		Group: 0, // Prebid cannot support roadblocking
 	}
 
 	var errList []error
-	seatBid.Bid, errList = e.makeBid(adapterBid.Bids, auc, returnCreative, impExtInfoMap, bidRequest, bidResponseExt, adapter, pubID, seatNonBidBuilder)
+	seatBid.Bid, errList = e.makeBid(adapterBid.Bids, auc, cacheInstructions, impExtInfoMap, bidRequest, bidResponseExt, adapter, pubID, seatNonBidBuilder)
 	if len(errList) > 0 {
 		adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, errsToBidderErrors(errList)...)
 	}
@@ -1303,7 +1320,7 @@ func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter open
 	return seatBid
 }
 
-func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, adapter openrtb_ext.BidderName, pubID string, seatNonBidBuilder *SeatNonBidBuilder) ([]openrtb2.Bid, []error) {
+func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, cacheInstructions extCacheInstructions, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, adapter openrtb_ext.BidderName, pubID string, seatNonBidBuilder *SeatNonBidBuilder) ([]openrtb2.Bid, []error) {
 	result := make([]openrtb2.Bid, 0, len(bids))
 	errs := make([]error, 0, 1)
 
@@ -1362,7 +1379,7 @@ func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCrea
 			result = append(result, *bid.Bid)
 			resultBid := &result[len(result)-1]
 			resultBid.Ext = bidExtJSON
-			if !returnCreative {
+			if !cacheInstructions.shouldReturnCreative(bid.BidType) {
 				resultBid.AdM = ""
 			}
 		}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -52,19 +52,14 @@ type extCacheInstructions struct {
 }
 
 func (c extCacheInstructions) shouldReturnCreative(bidType openrtb_ext.BidType) bool {
-	cacheApplies := false
-	returnCreative := false
-
-	if c.cacheBids {
-		cacheApplies = true
-		returnCreative = c.returnCreativeBids
+	if c.cacheBids && !c.returnCreativeBids {
+		return false
 	}
-	if bidType == openrtb_ext.BidTypeVideo && c.cacheVAST {
-		cacheApplies = true
-		returnCreative = returnCreative || c.returnCreativeVAST
+	if bidType == openrtb_ext.BidTypeVideo && c.cacheVAST && !c.returnCreativeVAST {
+		return false
 	}
 
-	return !cacheApplies || returnCreative
+	return true
 }
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1415,10 +1415,10 @@ func TestBidReturnsCreative(t *testing.T) {
 			"",
 		},
 		{
-			"bids returnCreative true preserves video creative when VAST returnCreative is false",
+			"VAST returnCreative false removes video creative when bids returnCreative is true",
 			openrtb_ext.BidTypeVideo,
 			extCacheInstructions{cacheBids: true, cacheVAST: true, returnCreativeBids: true, returnCreativeVAST: false},
-			sampleAd,
+			"",
 		},
 		{
 			"bids returnCreative false removes banner creative when VAST returnCreative is true",
@@ -1427,10 +1427,10 @@ func TestBidReturnsCreative(t *testing.T) {
 			"",
 		},
 		{
-			"VAST returnCreative true preserves video creative when bids returnCreative is false",
+			"bids returnCreative false removes video creative when VAST returnCreative is true",
 			openrtb_ext.BidTypeVideo,
 			extCacheInstructions{cacheBids: true, cacheVAST: true, returnCreativeBids: false, returnCreativeVAST: true},
-			sampleAd,
+			"",
 		},
 	}
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -172,7 +172,7 @@ func TestCharacterEscape(t *testing.T) {
 	var errList []error
 
 	// 	4) Build bid response
-	bidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, true, nil, "", errList, &SeatNonBidBuilder{})
+	bidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, extCacheInstructions{}, nil, "", errList, &SeatNonBidBuilder{})
 
 	// 	5) Assert we have no errors and one '&' character as we are supposed to
 	if len(errList) > 0 {
@@ -1063,9 +1063,9 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 					sampleAd,
 				},
 				{
-					"Vast returnCreative set to false, don't return ad markup in response",
+					"Vast returnCreative set to false, return banner ad markup in response",
 					json.RawMessage(`{"prebid":{"cache":{"vastXml":{"returnCreative":false}}}}`),
-					"",
+					sampleAd,
 				},
 			},
 		},
@@ -1083,9 +1083,9 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 					sampleAd,
 				},
 				{
-					"Vast returnCreative is true, expect valid AdM",
+					"Bids returnCreative is false, expect empty banner AdM",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":true}}}}`),
-					sampleAd,
+					"",
 				},
 				{
 					"Both field's returnCreative set to true, expect valid AdM",
@@ -1346,7 +1346,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	var errList []error
 
 	// 	4) Build bid response
-	bid_resp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, true, nil, "", errList, &SeatNonBidBuilder{})
+	bid_resp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, extCacheInstructions{}, nil, "", errList, &SeatNonBidBuilder{})
 
 	expectedBidResponse := &openrtb2.BidResponse{
 		SeatBid: []openrtb2.SeatBid{
@@ -1386,18 +1386,51 @@ func TestBidReturnsCreative(t *testing.T) {
 	// Define test cases
 	testCases := []struct {
 		description            string
-		inReturnCreative       bool
+		bidType                openrtb_ext.BidType
+		cacheInstructions      extCacheInstructions
 		expectedCreativeMarkup string
 	}{
 		{
-			"returnCreative set to true, expect a full creative markup string in returned bid",
-			true,
+			"no cache instruction returns banner creative",
+			openrtb_ext.BidTypeBanner,
+			extCacheInstructions{},
 			sampleAd,
 		},
 		{
-			"returnCreative set to false, expect empty creative markup string in returned bid",
-			false,
+			"bids returnCreative false removes banner creative",
+			openrtb_ext.BidTypeBanner,
+			extCacheInstructions{cacheBids: true, returnCreativeBids: false},
 			"",
+		},
+		{
+			"VAST returnCreative false preserves banner creative",
+			openrtb_ext.BidTypeBanner,
+			extCacheInstructions{cacheVAST: true, returnCreativeVAST: false},
+			sampleAd,
+		},
+		{
+			"VAST returnCreative false removes video creative",
+			openrtb_ext.BidTypeVideo,
+			extCacheInstructions{cacheVAST: true, returnCreativeVAST: false},
+			"",
+		},
+		{
+			"bids returnCreative true preserves video creative when VAST returnCreative is false",
+			openrtb_ext.BidTypeVideo,
+			extCacheInstructions{cacheBids: true, cacheVAST: true, returnCreativeBids: true, returnCreativeVAST: false},
+			sampleAd,
+		},
+		{
+			"bids returnCreative false removes banner creative when VAST returnCreative is true",
+			openrtb_ext.BidTypeBanner,
+			extCacheInstructions{cacheBids: true, cacheVAST: true, returnCreativeBids: false, returnCreativeVAST: true},
+			"",
+		},
+		{
+			"VAST returnCreative true preserves video creative when bids returnCreative is false",
+			openrtb_ext.BidTypeVideo,
+			extCacheInstructions{cacheBids: true, cacheVAST: true, returnCreativeBids: false, returnCreativeVAST: true},
+			sampleAd,
 		},
 	}
 
@@ -1436,7 +1469,8 @@ func TestBidReturnsCreative(t *testing.T) {
 
 	//Run tests
 	for _, test := range testCases {
-		resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, test.inReturnCreative, nil, &openrtb_ext.RequestWrapper{}, nil, "", "", &SeatNonBidBuilder{})
+		sampleBids[0].BidType = test.bidType
+		resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, test.cacheInstructions, nil, &openrtb_ext.RequestWrapper{}, nil, "", "", &SeatNonBidBuilder{})
 
 		assert.Equal(t, 0, len(resultingErrs), "%s. Test should not return errors \n", test.description)
 		assert.Equal(t, test.expectedCreativeMarkup, resultingBids[0].AdM, "%s. Ad markup string doesn't match expected \n", test.description)
@@ -1721,7 +1755,7 @@ func TestBidResponseCurrency(t *testing.T) {
 	}
 	// Run tests
 	for i := range testCases {
-		actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, bidResponseExt, true, nil, "", errList, &SeatNonBidBuilder{})
+		actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, bidResponseExt, extCacheInstructions{}, nil, "", errList, &SeatNonBidBuilder{})
 		assert.Equalf(t, testCases[i].expectedBidResponse, actualBidResp, fmt.Sprintf("[TEST_FAILED] Objects must be equal for test: %s \n Expected: >>%s<< \n Actual: >>%s<< ", testCases[i].description, testCases[i].expectedBidResponse.Ext, actualBidResp.Ext))
 	}
 }
@@ -1789,7 +1823,7 @@ func TestBidResponseImpExtInfo(t *testing.T) {
 
 	expectedBidResponseExt := `{"origbidcpm":0,"prebid":{"meta":{"adaptercode":"appnexus"},"type":"video","passthrough":{"imp_passthrough_val":1}},"storedrequestattributes":{"h":480,"mimes":["video/mp4"]}}`
 
-	actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, nil, nil, nil, true, impExtInfo, "", errList, &SeatNonBidBuilder{})
+	actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, nil, nil, nil, extCacheInstructions{}, impExtInfo, "", errList, &SeatNonBidBuilder{})
 
 	resBidExt := string(actualBidResp.SeatBid[0].Bid[0].Ext)
 	assert.Equalf(t, expectedBidResponseExt, resBidExt, "Expected bid response extension is incorrect")
@@ -4930,7 +4964,7 @@ func TestMakeBidWithValidation(t *testing.T) {
 			e.bidValidationEnforcement = test.givenValidations
 			sampleBids := test.givenBids
 			nonBids := &SeatNonBidBuilder{}
-			resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, true, ImpExtInfoMap, bidRequest, bidExtResponse, test.givenSeat, "", nonBids)
+			resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, extCacheInstructions{}, ImpExtInfoMap, bidRequest, bidExtResponse, test.givenSeat, "", nonBids)
 
 			assert.Equal(t, 0, len(resultingErrs))
 			assert.Equal(t, test.expectedNumOfBids, len(resultingBids))

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -906,31 +906,23 @@ func randomizeList(list []openrtb_ext.BidderName) {
 }
 
 func getExtCacheInstructions(requestExtPrebid *openrtb_ext.ExtRequestPrebid) extCacheInstructions {
-	//returnCreative defaults to true
-	cacheInstructions := extCacheInstructions{returnCreative: true}
-	foundBidsRC := false
-	foundVastRC := false
+	// returnCreative defaults to true for each cache type.
+	cacheInstructions := extCacheInstructions{returnCreativeBids: true, returnCreativeVAST: true}
 
 	if requestExtPrebid != nil && requestExtPrebid.Cache != nil {
 		if requestExtPrebid.Cache.Bids != nil {
 			cacheInstructions.cacheBids = true
 			if requestExtPrebid.Cache.Bids.ReturnCreative != nil {
-				cacheInstructions.returnCreative = *requestExtPrebid.Cache.Bids.ReturnCreative
-				foundBidsRC = true
+				cacheInstructions.returnCreativeBids = *requestExtPrebid.Cache.Bids.ReturnCreative
 			}
 		}
 
 		if requestExtPrebid.Cache.VastXML != nil {
 			cacheInstructions.cacheVAST = true
 			if requestExtPrebid.Cache.VastXML.ReturnCreative != nil {
-				cacheInstructions.returnCreative = *requestExtPrebid.Cache.VastXML.ReturnCreative
-				foundVastRC = true
+				cacheInstructions.returnCreativeVAST = *requestExtPrebid.Cache.VastXML.ReturnCreative
 			}
 		}
-	}
-
-	if foundBidsRC && foundVastRC {
-		cacheInstructions.returnCreative = *requestExtPrebid.Cache.Bids.ReturnCreative || *requestExtPrebid.Cache.VastXML.ReturnCreative
 	}
 
 	return cacheInstructions

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -1753,9 +1753,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 			desc:             "Nil request ext, all cache flags false except for returnCreative that defaults to true",
 			requestExtPrebid: nil,
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1764,9 +1765,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				Cache: nil,
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1778,9 +1780,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1792,9 +1795,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: true, // default value
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1806,9 +1810,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: false,
 			},
 		},
 		{
@@ -1820,9 +1825,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1834,9 +1840,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: true, // default value
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1848,9 +1855,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnCreativeBids: false,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1862,9 +1870,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1876,9 +1885,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
@@ -1890,13 +1900,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets ReturnCreative to false, returnCreative = false",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets VAST ReturnCreative to false",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
@@ -1904,9 +1915,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: false,
 			},
 		},
 		{
@@ -1918,13 +1930,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets ReturnCreative to false, returnCreative = false",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets bids ReturnCreative to false",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
@@ -1932,13 +1945,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: false,
+				returnCreativeVAST: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids preserve different ReturnCreative values",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
@@ -1946,13 +1960,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: false,
+				returnCreativeVAST: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids preserve inverse ReturnCreative values",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
@@ -1960,9 +1975,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnCreativeBids: true,
+				returnCreativeVAST: false,
 			},
 		},
 	}
@@ -1970,9 +1986,7 @@ func TestGetExtCacheInstructions(t *testing.T) {
 	for _, test := range testCases {
 		cacheInstructions := getExtCacheInstructions(test.requestExtPrebid)
 
-		assert.Equal(t, test.outCacheInstructions.cacheBids, cacheInstructions.cacheBids, "%s. Unexpected shouldCacheBids value. \n", test.desc)
-		assert.Equal(t, test.outCacheInstructions.cacheVAST, cacheInstructions.cacheVAST, "%s. Unexpected shouldCacheVAST value. \n", test.desc)
-		assert.Equal(t, test.outCacheInstructions.returnCreative, cacheInstructions.returnCreative, "%s. Unexpected returnCreative value. \n", test.desc)
+		assert.Equal(t, test.outCacheInstructions, cacheInstructions, test.desc)
 	}
 }
 


### PR DESCRIPTION
## Problem observed

We observed successful banner bids that could not render after moving traffic to PBS-Go. The bidder raw OpenRTB response contained adm, but the final PBS-Go response did not. At the same time:

- nurl and lurl were still present
- GAM targeting such as hb_bidder and hb_price was still populated
- no client-side blocking was visible

This made the auction look successful in GAM, but without adm there was no creative to render. As a result, impression trackers contained in the creative were never executed and the bidders recorded no impressions.

The request did not ask PBS to suppress banner creative. It only configured ext.prebid.cache.vastxml.returnCreative=false, which should affect cached VAST for video bids.

## Root cause

PBS-Go collapsed cache.bids.returnCreative and cache.vastxml.returnCreative into one global boolean before building the response. When vastxml.returnCreative was false, makeBid therefore cleared adm for every returned bid, including banners.

This also made it impossible to vary returnCreative by media type as described in #2584.

## Expected behavior and PBS-Java parity

PBS-Java keeps the two cache targets independent when deciding whether to include adm:

- cache.bids applies to all bid types
- cache.vastxml applies only to video bids
- if an applicable cache target has returnCreative=false, adm is omitted for that bid
- a VAST-only returnCreative=false setting does not remove adm from banner bids

This means the observed request keeps banner adm while still removing video adm. Combined bids and vastxml settings now follow the same precedence as PBS-Java as well.

The corresponding PBS-Java behavior is implemented in [BidResponseCreator](https://github.com/prebid/prebid-server-java/blob/master/src/main/java/org/prebid/server/auction/BidResponseCreator.java#L1295-L1317) and covered by its [cache functional tests](https://github.com/prebid/prebid-server-java/blob/master/src/test/groovy/org/prebid/server/functional/tests/CacheSpec.groovy#L435-L484).

## Fix

- preserve the bids and VAST returnCreative values separately
- evaluate them after the bid media type is known
- apply VAST creative suppression only to video bids
- add regression coverage for banner, video, and combined cache settings

Fixes #2584

## Testing

- go test ./...
- go test ./exchange -count=1
- go vet ./exchange
- gofmt -s on changed files