### PR TITLE
Fix: Change account disabled error status code to 403

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -209,7 +209,7 @@ func (deps *endpointDeps) AmpAuction(w http.ResponseWriter, r *http.Request, _ h
 		for _, er := range errL {
 			errCode := errortypes.ReadCode(er)
 			if errCode == errortypes.BlockedAppErrorCode || errCode == errortypes.AccountDisabledErrorCode {
-				httpStatus = http.StatusServiceUnavailable
+				httpStatus = http.StatusForbidden
 				metricsStatus = metrics.RequestStatusBlockedApp
 				break
 			}

--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -1920,12 +1920,12 @@ func writeError(errs []error, w http.ResponseWriter, labels *metrics.Labels) boo
 		httpStatus := http.StatusBadRequest
 		metricsStatus := metrics.RequestStatusBadInput
 		for _, err := range errs {
-			erVal := errortypes.ReadCode(err)
-			if erVal == errortypes.BlockedAppErrorCode || erVal == errortypes.AccountDisabledErrorCode {
-				httpStatus = http.StatusServiceUnavailable
+			switch errortypes.ReadCode(err) {
+			case errortypes.BlockedAppErrorCode, errortypes.AccountDisabledErrorCode:
+				httpStatus = http.StatusForbidden
 				metricsStatus = metrics.RequestStatusBlockedApp
 				break
-			} else if erVal == errortypes.MalformedAcctErrorCode {
+			case errortypes.MalformedAcctErrorCode:
 				httpStatus = http.StatusInternalServerError
 				metricsStatus = metrics.RequestStatusAccountConfigErr
 				break

--- a/endpoints/openrtb2/sample-requests/account-required/with-account/required-disabled-acct.json
+++ b/endpoints/openrtb2/sample-requests/account-required/with-account/required-disabled-acct.json
@@ -85,6 +85,6 @@
       }
     }
   },
-  "expectedReturnCode": 503,
+  "expectedReturnCode": 403,
   "expectedErrorMessage": "Invalid request: Prebid-server has disabled Account ID: disabled_acct, please reach out to the prebid server host.\n"
 }

--- a/endpoints/openrtb2/sample-requests/blocked/blocked-app.json
+++ b/endpoints/openrtb2/sample-requests/blocked/blocked-app.json
@@ -82,6 +82,6 @@
       }
     }
   },
-  "expectedReturnCode": 503,
+  "expectedReturnCode": 403,
   "expectedErrorMessage": "Invalid request: Prebid-server does not process requests from App ID: spam_app\n"
 }

--- a/endpoints/openrtb2/video_auction.go
+++ b/endpoints/openrtb2/video_auction.go
@@ -428,16 +428,16 @@ func handleError(labels *metrics.Labels, w http.ResponseWriter, errL []error, vo
 	var errors string
 	var status int = http.StatusInternalServerError
 	for _, er := range errL {
-		erVal := errortypes.ReadCode(er)
-		if erVal == errortypes.BlockedAppErrorCode || erVal == errortypes.AccountDisabledErrorCode {
-			status = http.StatusServiceUnavailable
+		switch errortypes.ReadCode(er) {
+		case errortypes.BlockedAppErrorCode, errortypes.AccountDisabledErrorCode:
+			status = http.StatusForbidden
 			labels.RequestStatus = metrics.RequestStatusBlockedApp
 			break
-		} else if erVal == errortypes.AcctRequiredErrorCode {
+		case errortypes.AcctRequiredErrorCode:
 			status = http.StatusBadRequest
 			labels.RequestStatus = metrics.RequestStatusBadInput
 			break
-		} else if erVal == errortypes.MalformedAcctErrorCode {
+		case errortypes.MalformedAcctErrorCode:
 			status = http.StatusInternalServerError
 			labels.RequestStatus = metrics.RequestStatusAccountConfigErr
 			break

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -817,7 +817,7 @@ func TestHandleError(t *testing.T) {
 			wantMetricsStatus: metrics.RequestStatusBlockedApp,
 		},
 		{
-			description: "Blocked app - return 503 with blocked metrics status",
+			description: "Blocked app - return 403 with blocked metrics status",
 			giveErrors: []error{
 				&errortypes.BlockedApp{},
 			},

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -813,7 +813,7 @@ func TestHandleError(t *testing.T) {
 			giveErrors: []error{
 				&errortypes.AccountDisabled{},
 			},
-			wantCode:          503,
+			wantCode:          http.StatusForbidden,
 			wantMetricsStatus: metrics.RequestStatusBlockedApp,
 		},
 		{
@@ -821,7 +821,7 @@ func TestHandleError(t *testing.T) {
 			giveErrors: []error{
 				&errortypes.BlockedApp{},
 			},
-			wantCode:          503,
+			wantCode:          http.StatusForbidden,
 			wantMetricsStatus: metrics.RequestStatusBlockedApp,
 		},
 		{


### PR DESCRIPTION
If the account is disabled, the server returns a 503 error, which isn't correct.
The 503 indicates a service outage or infra issue, not an app-level error.