### PR TITLE
Ezoic: Add user sync

### DIFF
--- a/static/bidder-info/ezoic.yaml
+++ b/static/bidder-info/ezoic.yaml
@@ -5,6 +5,10 @@ endpoint: "https://g.ezoic.net/ezoic/prebid/adapter/ortb"
 maintainer:
   email: prebid@ezoic.com
 gvlVendorID: 347
+userSync:
+  iframe:
+    url: "https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
+    userMacro: "$UID"
 geoscope:
   - global
 openrtb:


### PR DESCRIPTION
Adds iframe user sync support for the Ezoic adapter (merged in #4823).

The sync frame is consent-aware (TCF v2 — GVL vendor 347 — and GPP are honored; no ID is written without consent where required) and returns an opaque, encrypted user token to the host's `/setuid` endpoint via the `$UID` macro.

Endpoint is live in production:

```
https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame
```

`./validate.sh` / config, usersync, endpoints, and router test suites pass locally.