### PR TITLE
Trafficgate: Add TFC-EU Support

### DIFF
--- a/static/bidder-info/trafficgate.yaml
+++ b/static/bidder-info/trafficgate.yaml
@@ -2,6 +2,7 @@ endpoint: "http://{{.Host}}.bc-plugin.com/?c=o&m=rtb"
 maintainer:
   email: "support@bidscube.com"
 modifyingVastXmlAllowed: true
+gvlVendorID: 1272
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Change: Added TCF-EU (GDPR) support to the TrafficGate adapter in Prebid Server.
What was modified: A single line in static/bidder-info/trafficgate.yaml: gvlVendorID
