### PR TITLE
New adapter: Adferry

### DIFF
--- a/adapters/adferry/adferry.go
+++ b/adapters/adferry/adferry.go
@@ -1,0 +1,152 @@
+// Package adferry is the Prebid Server (Go) bidder adapter for Adferry.
+//
+// Server-to-server counterpart of the Prebid.js adapter: the host's Prebid
+// Server hands this adapter the bidder params under imp.ext.bidder, the
+// adapter copies placementId onto imp.tagid and POSTs the oRTB request to the
+// Adferry endpoint, one request per impression (the endpoint limits
+// concurrency per tag, so batching would queue placements behind each other).
+// The endpoint already resolves imp.ext.bidder.placementId itself, so a host
+// that forwards the raw request also works; tagid is set for clarity.
+//
+// Lives in the Adferry repo under sdk/prebid-server/ until it is submitted to
+// github.com/prebid/prebid-server (adapters/adferry/).
+package adferry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the Adferry adapter for the given bidder
+// with the given config. The endpoint comes from static/bidder-info/adferry.yaml.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: config.Endpoint}, nil
+}
+
+// ExtImpAdferry is the bidder params object: { placementId, bidFloor?, currency? }.
+type ExtImpAdferry struct {
+	PlacementID string  `json:"placementId"`
+	BidFloor    float64 `json:"bidFloor,omitempty"`
+	Currency    string  `json:"currency,omitempty"`
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	var requests []*adapters.RequestData
+	var errs []error
+
+	for i := range request.Imp {
+		imp := request.Imp[i]
+
+		var bidderExt adapters.ExtImpBidder
+		if err := json.Unmarshal(imp.Ext, &bidderExt); err != nil {
+			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("imp[%d].ext: %v", i, err)})
+			continue
+		}
+		var params ExtImpAdferry
+		if err := json.Unmarshal(bidderExt.Bidder, &params); err != nil {
+			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("imp[%d].ext.bidder: %v", i, err)})
+			continue
+		}
+		if params.PlacementID == "" {
+			errs = append(errs, &errortypes.BadInput{Message: fmt.Sprintf("imp[%d]: placementId is required", i)})
+			continue
+		}
+
+		// The join to the Adferry portal: placementId is the tag id.
+		imp.TagID = params.PlacementID
+		if params.BidFloor > 0 && imp.BidFloor <= 0 {
+			imp.BidFloor = params.BidFloor
+			if params.Currency != "" {
+				imp.BidFloorCur = params.Currency
+			}
+		}
+
+		// One request per impression.
+		reqCopy := *request
+		reqCopy.Imp = []openrtb2.Imp{imp}
+
+		body, err := json.Marshal(reqCopy)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		headers := http.Header{}
+		headers.Add("Content-Type", "application/json;charset=utf-8")
+		headers.Add("Accept", "application/json")
+		headers.Add("x-openrtb-version", "2.6")
+
+		requests = append(requests, &adapters.RequestData{
+			Method:  "POST",
+			Uri:     a.endpoint,
+			Body:    body,
+			Headers: headers,
+			ImpIDs:  []string{imp.ID},
+		})
+	}
+	return requests, errs
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := json.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(1)
+	if response.Cur != "" {
+		bidResponse.Currency = response.Cur
+	}
+
+	var errs []error
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bid := seatBid.Bid[i]
+			bidType, err := getMediaType(bid)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     &bid,
+				BidType: bidType,
+			})
+		}
+	}
+	return bidResponse, errs
+}
+
+// getMediaType uses the oRTB 2.6 bid.mtype (1 banner, 2 video, 3 audio) that
+// the Adferry endpoint always sets on every bid. Prebid Server expects the
+// media type to be stated on the response, so an unset/unknown mtype is an
+// explicit error rather than a guess from the impression.
+func getMediaType(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupAudio:
+		return openrtb_ext.BidTypeAudio, nil
+	default:
+		return "", &errortypes.BadServerResponse{Message: fmt.Sprintf("unsupported mtype %d for bid %s (imp %s)", bid.MType, bid.ID, bid.ImpID)}
+	}
+}

--- a/adapters/adferry/adferry_test.go
+++ b/adapters/adferry/adferry_test.go
@@ -1,0 +1,18 @@
+package adferry
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderAdferry, config.Adapter{
+		Endpoint: "https://rtb.adferry.co/api/ortb/prebid"}, config.Server{})
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+	adapterstest.RunJSONBidderTest(t, "adferrytest", bidder)
+}

--- a/adapters/adferry/adferrytest/exemplary/audio.json
+++ b/adapters/adferry/adferrytest/exemplary/audio.json
@@ -1,0 +1,66 @@
+{
+  "mockBidRequest": {
+    "id": "s2s_audio_1",
+    "imp": [{
+      "id": "audio-1",
+      "audio": { "mimes": ["audio/mp4"] },
+      "ext": { "bidder": { "placementId": "111c7fb088" } }
+    }],
+    "app": { "bundle": "com.example.radio" },
+    "device": { "ua": "Mozilla/5.0", "ip": "203.0.113.10" }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "headers": {
+        "Content-Type": ["application/json;charset=utf-8"],
+        "Accept": ["application/json"],
+        "X-Openrtb-Version": ["2.6"]
+      },
+      "body": {
+        "id": "s2s_audio_1",
+        "imp": [{
+          "id": "audio-1",
+          "tagid": "111c7fb088",
+          "audio": { "mimes": ["audio/mp4"] },
+          "ext": { "bidder": { "placementId": "111c7fb088" } }
+        }],
+        "app": { "bundle": "com.example.radio" },
+        "device": { "ua": "Mozilla/5.0", "ip": "203.0.113.10" }
+      },
+      "impIDs": ["audio-1"]
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "s2s_audio_1",
+        "cur": "USD",
+        "seatbid": [{
+          "seat": "adferry",
+          "bid": [{
+            "id": "b_audio",
+            "impid": "audio-1",
+            "price": 3.1,
+            "adm": "<VAST version=\"4.2\"><Ad><InLine/></Ad></VAST>",
+            "crid": "src-audio",
+            "mtype": 3
+          }]
+        }]
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [{
+      "bid": {
+        "id": "b_audio",
+        "impid": "audio-1",
+        "price": 3.1,
+        "adm": "<VAST version=\"4.2\"><Ad><InLine/></Ad></VAST>",
+        "crid": "src-audio",
+        "mtype": 3
+      },
+      "type": "audio"
+    }]
+  }]
+}

--- a/adapters/adferry/adferrytest/exemplary/banner.json
+++ b/adapters/adferry/adferrytest/exemplary/banner.json
@@ -1,0 +1,15 @@
+{
+  "mockBidRequest": {
+    "id": "s2s_banner", "imp": [{ "id": "banner-1", "banner": { "format": [{ "w": 300, "h": 250 }] }, "ext": { "bidder": { "placementId": "111c7fb088", "bidFloor": 1.5, "currency": "USD" } } }],
+    "site": { "page": "https://publisher.example/a" }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "s2s_banner", "imp": [{ "id": "banner-1", "tagid": "111c7fb088", "bidfloor": 1.5, "bidfloorcur": "USD", "banner": { "format": [{ "w": 300, "h": 250 }] }, "ext": { "bidder": { "placementId": "111c7fb088", "bidFloor": 1.5, "currency": "USD" } } }], "site": { "page": "https://publisher.example/a" } },
+      "impIDs": ["banner-1"]
+    },
+    "mockResponse": { "status": 200, "body": { "id": "s2s_banner", "cur": "USD", "seatbid": [{ "seat": "adferry", "bid": [{ "id": "bb", "impid": "banner-1", "price": 1.9, "adm": "<div>ad</div>", "crid": "c", "w": 300, "h": 250, "mtype": 1 }] }] } }
+  }],
+  "expectedBidResponses": [{ "currency": "USD", "bids": [{ "bid": { "id": "bb", "impid": "banner-1", "price": 1.9, "adm": "<div>ad</div>", "crid": "c", "w": 300, "h": 250, "mtype": 1 }, "type": "banner" }] }]
+}

--- a/adapters/adferry/adferrytest/exemplary/video.json
+++ b/adapters/adferry/adferrytest/exemplary/video.json
@@ -1,0 +1,70 @@
+{
+  "mockBidRequest": {
+    "id": "s2s_1",
+    "imp": [{
+      "id": "video-1",
+      "video": { "w": 640, "h": 480, "mimes": ["video/mp4"] },
+      "ext": { "bidder": { "placementId": "111c7fb088" } }
+    }],
+    "site": { "page": "https://publisher.example/article" },
+    "device": { "ua": "Mozilla/5.0", "ip": "203.0.113.10" }
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "headers": {
+        "Content-Type": ["application/json;charset=utf-8"],
+        "Accept": ["application/json"],
+        "X-Openrtb-Version": ["2.6"]
+      },
+      "body": {
+        "id": "s2s_1",
+        "imp": [{
+          "id": "video-1",
+          "tagid": "111c7fb088",
+          "video": { "w": 640, "h": 480, "mimes": ["video/mp4"] },
+          "ext": { "bidder": { "placementId": "111c7fb088" } }
+        }],
+        "site": { "page": "https://publisher.example/article" },
+        "device": { "ua": "Mozilla/5.0", "ip": "203.0.113.10" }
+      },
+      "impIDs": ["video-1"]
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "s2s_1",
+        "cur": "USD",
+        "seatbid": [{
+          "seat": "adferry",
+          "bid": [{
+            "id": "b1",
+            "impid": "video-1",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.2\"><Ad><InLine/></Ad></VAST>",
+            "crid": "src-1",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          }]
+        }]
+      }
+    }
+  }],
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [{
+      "bid": {
+        "id": "b1",
+        "impid": "video-1",
+        "price": 2.5,
+        "adm": "<VAST version=\"4.2\"><Ad><InLine/></Ad></VAST>",
+        "crid": "src-1",
+        "w": 640,
+        "h": 480,
+        "mtype": 2
+      },
+      "type": "video"
+    }]
+  }]
+}

--- a/adapters/adferry/adferrytest/supplemental/invalid-bidder-params.json
+++ b/adapters/adferry/adferrytest/supplemental/invalid-bidder-params.json
@@ -1,0 +1,7 @@
+{
+  "expectedMakeRequestsErrors": [
+    { "value": "imp[0].ext.bidder:", "comparison": "startswith" }
+  ],
+  "mockBidRequest": { "id": "r", "imp": [{ "id": "i", "banner": { "format": [{ "w": 300, "h": 250 }] }, "ext": { "bidder": "not-an-object" } }] },
+  "httpCalls": []
+}

--- a/adapters/adferry/adferrytest/supplemental/invalid-imp-ext.json
+++ b/adapters/adferry/adferrytest/supplemental/invalid-imp-ext.json
@@ -1,0 +1,7 @@
+{
+  "expectedMakeRequestsErrors": [
+    { "value": "imp[0].ext:", "comparison": "startswith" }
+  ],
+  "mockBidRequest": { "id": "r", "imp": [{ "id": "i", "banner": { "format": [{ "w": 300, "h": 250 }] }, "ext": "not-an-object" }] },
+  "httpCalls": []
+}

--- a/adapters/adferry/adferrytest/supplemental/missing-placementid.json
+++ b/adapters/adferry/adferrytest/supplemental/missing-placementid.json
@@ -1,0 +1,9 @@
+{
+  "expectedMakeRequestsErrors": [
+    { "value": "imp[0]: placementId is required", "comparison": "literal" }
+  ],
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": {} } }]
+  },
+  "httpCalls": []
+}

--- a/adapters/adferry/adferrytest/supplemental/status-204.json
+++ b/adapters/adferry/adferrytest/supplemental/status-204.json
@@ -1,0 +1,15 @@
+{
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }]
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "r", "imp": [{ "id": "i", "tagid": "111c7fb088", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }] },
+      "impIDs": ["i"]
+    },
+    "mockResponse": { "status": 204, "body": {} }
+  }],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": []
+}

--- a/adapters/adferry/adferrytest/supplemental/status-400.json
+++ b/adapters/adferry/adferrytest/supplemental/status-400.json
@@ -1,0 +1,16 @@
+{
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }]
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "r", "imp": [{ "id": "i", "tagid": "111c7fb088", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }] },
+      "impIDs": ["i"]
+    },
+    "mockResponse": { "status": 400, "body": "bad request" }
+  }],
+  "expectedMakeBidsErrors": [
+    { "value": "Unexpected status code: 400. Run with request.debug = 1 for more info", "comparison": "literal" }
+  ]
+}

--- a/adapters/adferry/adferrytest/supplemental/status-500.json
+++ b/adapters/adferry/adferrytest/supplemental/status-500.json
@@ -1,0 +1,16 @@
+{
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }]
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "r", "imp": [{ "id": "i", "tagid": "111c7fb088", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }] },
+      "impIDs": ["i"]
+    },
+    "mockResponse": { "status": 500, "body": "server error" }
+  }],
+  "expectedMakeBidsErrors": [
+    { "value": "Unexpected status code: 500. Run with request.debug = 1 for more info", "comparison": "literal" }
+  ]
+}

--- a/adapters/adferry/adferrytest/supplemental/unknown-media-type.json
+++ b/adapters/adferry/adferrytest/supplemental/unknown-media-type.json
@@ -1,0 +1,20 @@
+{
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }]
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "r", "imp": [{ "id": "i", "tagid": "111c7fb088", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }] },
+      "impIDs": ["i"]
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": { "id": "r", "cur": "USD", "seatbid": [{ "seat": "adferry", "bid": [{ "id": "b", "impid": "no-such-imp", "price": 1.0, "adm": "x" }] }] }
+    }
+  }],
+  "expectedBidResponses": [{ "currency": "USD", "bids": [] }],
+  "expectedMakeBidsErrors": [
+    { "value": "unsupported mtype 0 for bid b (imp no-such-imp)", "comparison": "literal" }
+  ]
+}

--- a/adapters/adferry/adferrytest/supplemental/unparsable-response.json
+++ b/adapters/adferry/adferrytest/supplemental/unparsable-response.json
@@ -1,0 +1,16 @@
+{
+  "mockBidRequest": {
+    "id": "r", "imp": [{ "id": "i", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }]
+  },
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://rtb.adferry.co/api/ortb/prebid",
+      "body": { "id": "r", "imp": [{ "id": "i", "tagid": "111c7fb088", "video": { "mimes": ["video/mp4"], "w": 640, "h": 480 }, "ext": { "bidder": { "placementId": "111c7fb088" } } }] },
+      "impIDs": ["i"]
+    },
+    "mockResponse": { "status": 200, "body": "not-json" }
+  }],
+  "expectedMakeBidsErrors": [
+    { "value": "json: cannot unmarshal string into Go value of type openrtb2.BidResponse", "comparison": "literal" }
+  ]
+}

--- a/adapters/adferry/params_test.go
+++ b/adapters/adferry/params_test.go
@@ -1,0 +1,44 @@
+package adferry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+// The bidder-params schema (static/bidder-params/adferry.json) must accept the
+// shapes publishers actually write and reject a missing placementId.
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+	for _, p := range []string{
+		`{"placementId": "a1b2c3d4"}`,
+		`{"placementId": "111c7fb088", "bidFloor": 2.5, "currency": "USD"}`,
+	} {
+		if err := validator.Validate(openrtb_ext.BidderAdferry, json.RawMessage(p)); err != nil {
+			t.Errorf("Schema rejected valid params: %s", p)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+	for _, p := range []string{
+		``,
+		`null`,
+		`{}`,
+		`{"placementId": ""}`,
+		`{"placementId": 123}`,
+		`{"bidFloor": 1.0}`,
+	} {
+		if err := validator.Validate(openrtb_ext.BidderAdferry, json.RawMessage(p)); err == nil {
+			t.Errorf("Schema allowed invalid params: %s", p)
+		}
+	}
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/adagio"
 	"github.com/prebid/prebid-server/v4/adapters/adelement"
 	"github.com/prebid/prebid-server/v4/adapters/adf"
+	"github.com/prebid/prebid-server/v4/adapters/adferry"
 	"github.com/prebid/prebid-server/v4/adapters/adgeneration"
 	"github.com/prebid/prebid-server/v4/adapters/adhese"
 	"github.com/prebid/prebid-server/v4/adapters/adkernel"
@@ -287,6 +288,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderAdagio:            adagio.Builder,
 		openrtb_ext.BidderAdelement:         adelement.Builder,
 		openrtb_ext.BidderAdf:               adf.Builder,
+		openrtb_ext.BidderAdferry:           adferry.Builder,
 		openrtb_ext.BidderAdgeneration:      adgeneration.Builder,
 		openrtb_ext.BidderAdhese:            adhese.Builder,
 		openrtb_ext.BidderAdkernel:          adkernel.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -25,6 +25,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderAdagio,
 	BidderAdelement,
 	BidderAdf,
+	BidderAdferry,
 	BidderAdgeneration,
 	BidderAdhese,
 	BidderAdkernel,
@@ -410,6 +411,7 @@ const (
 	BidderAdagio            BidderName = "adagio"
 	BidderAdelement         BidderName = "adelement"
 	BidderAdf               BidderName = "adf"
+	BidderAdferry           BidderName = "adferry"
 	BidderAdgeneration      BidderName = "adgeneration"
 	BidderAdhese            BidderName = "adhese"
 	BidderAdkernel          BidderName = "adkernel"

--- a/static/bidder-info/adferry.yaml
+++ b/static/bidder-info/adferry.yaml
@@ -1,0 +1,20 @@
+endpoint: "https://rtb.adferry.co/api/ortb/prebid"
+maintainer:
+  email: admin@adferry.co
+gvlVendorID: 0
+capabilities:
+  app:
+    mediaTypes:
+      - video
+      - banner
+      - audio
+  site:
+    mediaTypes:
+      - video
+      - banner
+      - audio
+  dooh:
+    mediaTypes:
+      - video
+# No user sync: Adferry is CTV/app-first and runs no cookie-match endpoint.
+# Declaring one here would make PBS expect a usersync URL that does not exist.

--- a/static/bidder-params/adferry.json
+++ b/static/bidder-params/adferry.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Adferry Adapter Params",
+  "description": "A schema which validates params accepted by the Adferry adapter",
+  "type": "object",
+  "properties": {
+    "placementId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Tag ID from the Adferry portal (New Tag > Prebid)"
+    },
+    "bidFloor": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Floor CPM for this placement"
+    },
+    "currency": {
+      "type": "string",
+      "description": "Floor currency, defaults to USD"
+    }
+  },
+  "required": ["placementId"]
+}


### PR DESCRIPTION
## New adapter: Adferry (server-to-server)

Server-to-server bidder adapter for **Adferry**, oRTB 2.6. Companion to the Prebid.js adapter (prebid/Prebid.js#15476) and its docs (prebid/prebid.github.io#6716) — same `placementId` param, same endpoint.

- **Maintainer:** admin@adferry.co
- **Endpoint:** `https://rtb.adferry.co/api/ortb/prebid`
- **Media types:** banner, video, audio (app + site)
- `MakeRequests` copies `placementId` → `imp.tagid`, one request per impression (the endpoint caps concurrency per tag).
- `MakeBids` sets the bid media type from `bid.mtype` (banner/video/audio).
- No user sync — Adferry is CTV/app-first and runs no cookie-match endpoint.

### Verification (local, prebid-server v4, go1.27)

- `go test ./adapters/adferry/...` — exemplary (video, banner, audio) + supplemental (204/400/500, unparsable, invalid imp.ext, invalid bidder params, missing placementId, unknown mtype) + params validation — all pass.
- `go test ./config/... ./openrtb_ext/... ./exchange/...` — bidder-info yaml, params schema, and builder registration all pass.
- Coverage 97.3%; `gofmt` and `go vet` clean.