### PR TITLE
m152: Disable by default

### DIFF
--- a/static/bidder-info/m152.yaml
+++ b/static/bidder-info/m152.yaml
@@ -1,3 +1,4 @@
+disabled: true
 # We have the following regional endpoint domains: 'east' - for US_EAST, 'eu' - for EU
 # Please deploy this config in each of your datacenters with the appropriate regional subdomain
 aliasOf: "teqblaze"


### PR DESCRIPTION
Disable m152 by default to prevent hard failure on startup due to macro in endpoint that must be set accordingly by host in each region as defined in the YAML.