### PR TITLE
Adding changes to conditionally add filtered bidder list to non seat bid list

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -892,6 +892,9 @@ func setSeatNonBid(finalExtBidResponse *openrtb_ext.ExtBidResponse, request *ope
 	if finalExtBidResponse.Prebid == nil {
 		finalExtBidResponse.Prebid = &openrtb_ext.ExtResponsePrebid{}
 	}
+	if len(finalExtBidResponse.Prebid.SeatNonBid) > 0 {
+		return true
+	}
 	finalExtBidResponse.Prebid.SeatNonBid = auctionResponse.GetSeatNonBid()
 	return true
 }

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -5225,6 +5225,25 @@ func TestSetSeatNonBidRaw(t *testing.T) {
 	}
 }
 
+func TestSetSeatNonBidRawPreservesExistingSeatNonBid(t *testing.T) {
+	request := &openrtb_ext.RequestWrapper{BidRequest: &openrtb2.BidRequest{Ext: []byte(`{"prebid": { "returnallbidstatus" : true, "returnbidfilterstatus": true }}`)}}
+	auctionResponse := &exchange.AuctionResponse{
+		ExtBidResponse: &openrtb_ext.ExtBidResponse{Prebid: &openrtb_ext.ExtResponsePrebid{SeatNonBid: []openrtb_ext.SeatNonBid{{
+			Seat: "regular",
+			NonBid: []openrtb_ext.NonBid{{
+				ImpId:      "imp1",
+				StatusCode: 101,
+			}},
+		}}}},
+		BidResponse: &openrtb2.BidResponse{Ext: []byte(`{"prebid":{"seatnonbid":[{"seat":"filtered","nonbid":[{"impid":"imp1","statuscode":200,"ext":{"prebid":{"type":"geo"}}}]}]}}`)},
+	}
+
+	err := setSeatNonBidRaw(request, auctionResponse)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"prebid":{"seatnonbid":[{"seat":"filtered","nonbid":[{"impid":"imp1","statuscode":200,"ext":{"prebid":{"bid":{},"type":"geo"}}}]}]}}`, string(auctionResponse.BidResponse.Ext))
+}
+
 func TestValidateAliases(t *testing.T) {
 	// This test runs against a real list of bidders, so we must use real bidder names for core bidders,
 	// but can use test values for the alias names.

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -241,6 +241,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	if err != nil {
 		return nil, err
 	}
+	// Processed-auction hooks can filter bidders before adapter fanout and return status for reporting.
 	filteredSeatNonBidBuilder := SeatNonBidBuilder{}
 	filteredSeatNonBidBuilder.appendSeatNonBids(seatNonBidFromHookOutcomes(r.HookExecutor))
 
@@ -540,12 +541,16 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
 	bidResponse = adservertargeting.Apply(r.BidRequestWrapper, r.ResolvedBidRequest, bidResponse, r.QueryParams, bidResponseExt, r.Account.TruncateTargetAttribute)
 
-	bidResponseExt = setSeatNonBid(bidResponseExt, seatNonBidForResponse(requestExtPrebid, seatNonBidBuilder, filteredSeatNonBidBuilder))
+	// Encode only the seatnonbid entries requested for this response. The endpoint layer
+	// still handles the existing returnallbidstatus path for non-filtered statuses.
+	bidResponseExt = setSeatNonBid(bidResponseExt, buildResponseSeatNonBid(requestExtPrebid, seatNonBidBuilder, filteredSeatNonBidBuilder))
 
 	bidResponse.Ext, err = encodeBidResponseExt(bidResponseExt)
 	if err != nil {
 		return nil, err
 	}
+	// Preserve the existing non-filtered statuses on AuctionResponse for endpoint-level handling.
+	bidResponseExt = setSeatNonBid(bidResponseExt, seatNonBidBuilder)
 	return &AuctionResponse{
 		BidResponse:    bidResponse,
 		ExtBidResponse: bidResponseExt,
@@ -572,15 +577,20 @@ func seatNonBidFromHookOutcomes(executor hookexecution.StageExecutor) []openrtb_
 	return seatNonBids
 }
 
-func seatNonBidForResponse(prebid *openrtb_ext.ExtRequestPrebid, all SeatNonBidBuilder, filtered SeatNonBidBuilder) SeatNonBidBuilder {
+func buildResponseSeatNonBid(prebid *openrtb_ext.ExtRequestPrebid, all SeatNonBidBuilder, filtered SeatNonBidBuilder) SeatNonBidBuilder {
 	if prebid == nil || !prebid.ReturnBidFilterStatus {
-		return all
+		return nil
 	}
 	if !prebid.ReturnAllBidStatus {
 		return filtered
 	}
-	all.append(filtered)
-	return all
+	return joinedSeatNonBids(all, filtered)
+}
+
+func joinedSeatNonBids(builders ...SeatNonBidBuilder) SeatNonBidBuilder {
+	joined := SeatNonBidBuilder{}
+	joined.append(builders...)
+	return joined
 }
 
 // getBidderPreferredMediaType reads the preferred media type from the request and account and returns a map of bidder to preferred media type. Preference given to the request over account.

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -241,6 +241,8 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	if err != nil {
 		return nil, err
 	}
+	filteredSeatNonBidBuilder := SeatNonBidBuilder{}
+	filteredSeatNonBidBuilder.appendSeatNonBids(seatNonBidFromHookOutcomes(r.HookExecutor))
 
 	requestExt, err := r.BidRequestWrapper.GetRequestExt()
 	if err != nil {
@@ -538,16 +540,47 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
 	bidResponse = adservertargeting.Apply(r.BidRequestWrapper, r.ResolvedBidRequest, bidResponse, r.QueryParams, bidResponseExt, r.Account.TruncateTargetAttribute)
 
+	bidResponseExt = setSeatNonBid(bidResponseExt, seatNonBidForResponse(requestExtPrebid, seatNonBidBuilder, filteredSeatNonBidBuilder))
+
 	bidResponse.Ext, err = encodeBidResponseExt(bidResponseExt)
 	if err != nil {
 		return nil, err
 	}
-	bidResponseExt = setSeatNonBid(bidResponseExt, seatNonBidBuilder)
-
 	return &AuctionResponse{
 		BidResponse:    bidResponse,
 		ExtBidResponse: bidResponseExt,
 	}, nil
+}
+
+type hookOutcomeReader interface {
+	GetOutcomes() []hookexecution.StageOutcome
+}
+
+func seatNonBidFromHookOutcomes(executor hookexecution.StageExecutor) []openrtb_ext.SeatNonBid {
+	reader, ok := executor.(hookOutcomeReader)
+	if !ok {
+		return nil
+	}
+	var seatNonBids []openrtb_ext.SeatNonBid
+	for _, stage := range reader.GetOutcomes() {
+		for _, group := range stage.Groups {
+			for _, outcome := range group.InvocationResults {
+				seatNonBids = append(seatNonBids, outcome.SeatNonBid...)
+			}
+		}
+	}
+	return seatNonBids
+}
+
+func seatNonBidForResponse(prebid *openrtb_ext.ExtRequestPrebid, all SeatNonBidBuilder, filtered SeatNonBidBuilder) SeatNonBidBuilder {
+	if prebid == nil || !prebid.ReturnBidFilterStatus {
+		return all
+	}
+	if !prebid.ReturnAllBidStatus {
+		return filtered
+	}
+	all.append(filtered)
+	return all
 }
 
 // getBidderPreferredMediaType reads the preferred media type from the request and account and returns a map of bidder to preferred media type. Preference given to the request over account.

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -6115,6 +6115,22 @@ func TestSetSeatNonBid(t *testing.T) {
 	}
 }
 
+func TestSeatNonBidForResponse(t *testing.T) {
+	newAll := func() SeatNonBidBuilder {
+		return SeatNonBidBuilder{"regular": {{ImpId: "imp-regular", StatusCode: int(ErrorGeneral)}}}
+	}
+	filtered := SeatNonBidBuilder{"filtered": {{ImpId: "imp-filtered", StatusCode: int(RequestBlockedGeneral)}}}
+
+	assert.Equal(t, newAll(), seatNonBidForResponse(nil, newAll(), filtered))
+	assert.Equal(t, newAll(), seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{}, newAll(), filtered))
+	assert.Equal(t, filtered, seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnBidFilterStatus: true}, newAll(), filtered))
+	assert.Equal(t, newAll(), seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true}, newAll(), filtered))
+
+	allAndFiltered := seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true, ReturnBidFilterStatus: true}, newAll(), filtered)
+	assert.ElementsMatch(t, []openrtb_ext.NonBid{{ImpId: "imp-regular", StatusCode: int(ErrorGeneral)}}, allAndFiltered["regular"])
+	assert.ElementsMatch(t, []openrtb_ext.NonBid{{ImpId: "imp-filtered", StatusCode: int(RequestBlockedGeneral)}}, allAndFiltered["filtered"])
+}
+
 func TestBuildMultiBidMap(t *testing.T) {
 	type testCase struct {
 		desc     string

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -6121,14 +6121,16 @@ func TestSeatNonBidForResponse(t *testing.T) {
 	}
 	filtered := SeatNonBidBuilder{"filtered": {{ImpId: "imp-filtered", StatusCode: int(RequestBlockedGeneral)}}}
 
-	assert.Equal(t, newAll(), seatNonBidForResponse(nil, newAll(), filtered))
-	assert.Equal(t, newAll(), seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{}, newAll(), filtered))
-	assert.Equal(t, filtered, seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnBidFilterStatus: true}, newAll(), filtered))
-	assert.Equal(t, newAll(), seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true}, newAll(), filtered))
+	assert.Nil(t, buildResponseSeatNonBid(nil, newAll(), filtered))
+	assert.Nil(t, buildResponseSeatNonBid(&openrtb_ext.ExtRequestPrebid{}, newAll(), filtered))
+	assert.Equal(t, filtered, buildResponseSeatNonBid(&openrtb_ext.ExtRequestPrebid{ReturnBidFilterStatus: true}, newAll(), filtered))
+	assert.Nil(t, buildResponseSeatNonBid(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true}, newAll(), filtered))
 
-	allAndFiltered := seatNonBidForResponse(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true, ReturnBidFilterStatus: true}, newAll(), filtered)
+	all := newAll()
+	allAndFiltered := buildResponseSeatNonBid(&openrtb_ext.ExtRequestPrebid{ReturnAllBidStatus: true, ReturnBidFilterStatus: true}, all, filtered)
 	assert.ElementsMatch(t, []openrtb_ext.NonBid{{ImpId: "imp-regular", StatusCode: int(ErrorGeneral)}}, allAndFiltered["regular"])
 	assert.ElementsMatch(t, []openrtb_ext.NonBid{{ImpId: "imp-filtered", StatusCode: int(RequestBlockedGeneral)}}, allAndFiltered["filtered"])
+	assert.NotContains(t, all, "filtered")
 }
 
 func TestBuildMultiBidMap(t *testing.T) {

--- a/exchange/non_bid_reason.go
+++ b/exchange/non_bid_reason.go
@@ -17,6 +17,7 @@ const (
 	ErrorGeneral                           NonBidReason = 100 // Error - General
 	ErrorTimeout                           NonBidReason = 101 // Error - Timeout
 	ErrorBidderUnreachable                 NonBidReason = 103 // Error - Bidder Unreachable
+	RequestBlockedGeneral                  NonBidReason = 200 // Request Blocked - General
 	ResponseRejectedGeneral                NonBidReason = 300
 	ResponseRejectedBelowFloor             NonBidReason = 301 // Response Rejected - Below Floor
 	ResponseRejectedCategoryMappingInvalid NonBidReason = 303 // Response Rejected - Category Mapping Invalid

--- a/exchange/seat_non_bids.go
+++ b/exchange/seat_non_bids.go
@@ -51,6 +51,15 @@ func (b SeatNonBidBuilder) rejectImps(impIds []string, nonBidReason NonBidReason
 	}
 }
 
+func (b SeatNonBidBuilder) appendSeatNonBids(seatNonBids []openrtb_ext.SeatNonBid) {
+	if b == nil {
+		return
+	}
+	for _, seatNonBid := range seatNonBids {
+		b[seatNonBid.Seat] = append(b[seatNonBid.Seat], seatNonBid.NonBid...)
+	}
+}
+
 // slice transforms the seat non bid map into a slice of SeatNonBid objects representing the non-bids for each seat
 func (b SeatNonBidBuilder) Slice() []openrtb_ext.SeatNonBid {
 	seatNonBid := make([]openrtb_ext.SeatNonBid, 0)

--- a/hooks/hookexecution/enricher_test.go
+++ b/hooks/hookexecution/enricher_test.go
@@ -31,14 +31,15 @@ type GroupOutcomeTest struct {
 
 type HookOutcomeTest struct {
 	ExecutionTime
-	AnalyticsTags hookanalytics.Analytics `json:"analytics_tags"`
-	HookID        HookID                  `json:"hook_id"`
-	Status        Status                  `json:"status"`
-	Action        Action                  `json:"action"`
-	Message       string                  `json:"message"`
-	DebugMessages []string                `json:"debug_messages"`
-	Errors        []string                `json:"errors"`
-	Warnings      []string                `json:"warnings"`
+	AnalyticsTags hookanalytics.Analytics  `json:"analytics_tags"`
+	HookID        HookID                   `json:"hook_id"`
+	Status        Status                   `json:"status"`
+	Action        Action                   `json:"action"`
+	Message       string                   `json:"message"`
+	DebugMessages []string                 `json:"debug_messages"`
+	Errors        []string                 `json:"errors"`
+	Warnings      []string                 `json:"warnings"`
+	SeatNonBid    []openrtb_ext.SeatNonBid `json:"-"`
 }
 
 func TestEnrichBidResponse(t *testing.T) {

--- a/hooks/hookexecution/execution.go
+++ b/hooks/hookexecution/execution.go
@@ -203,6 +203,7 @@ func handleHookResponse[P any](
 		Warnings:      hr.Result.Warnings,
 		DebugMessages: hr.Result.DebugMessages,
 		AnalyticsTags: hr.Result.AnalyticsTags,
+		SeatNonBid:    hr.Result.SeatNonBid,
 		ExecutionTime: ExecutionTime{ExecutionTimeMillis: hr.ExecutionTime},
 	}
 

--- a/hooks/hookexecution/outcome.go
+++ b/hooks/hookexecution/outcome.go
@@ -78,15 +78,16 @@ type GroupOutcome struct {
 type HookOutcome struct {
 	// ExecutionTime is the execution time of a specific hook without applying its result.
 	ExecutionTime
-	AnalyticsTags hookanalytics.Analytics  `json:"analytics_tags"`
-	HookID        HookID                   `json:"hook_id"`
-	Status        Status                   `json:"status"`
-	Action        Action                   `json:"action"`
-	Message       string                   `json:"message"` // arbitrary string value returned from hook execution
-	DebugMessages []string                 `json:"debug_messages,omitempty"`
-	Errors        []string                 `json:"-"`
-	Warnings      []string                 `json:"-"`
-	SeatNonBid    []openrtb_ext.SeatNonBid `json:"-"`
+	AnalyticsTags hookanalytics.Analytics `json:"analytics_tags"`
+	HookID        HookID                  `json:"hook_id"`
+	Status        Status                  `json:"status"`
+	Action        Action                  `json:"action"`
+	Message       string                  `json:"message"` // arbitrary string value returned from hook execution
+	DebugMessages []string                `json:"debug_messages,omitempty"`
+	Errors        []string                `json:"-"`
+	Warnings      []string                `json:"-"`
+	// SeatNonBid is internal response metadata, not part of hook trace output.
+	SeatNonBid []openrtb_ext.SeatNonBid `json:"-"`
 }
 
 // HookID points to the specific hook defined by the hook execution plan.

--- a/hooks/hookexecution/outcome.go
+++ b/hooks/hookexecution/outcome.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/prebid/prebid-server/v4/hooks/hookanalytics"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
 )
 
 // Status indicates the result of hook execution.
@@ -77,14 +78,15 @@ type GroupOutcome struct {
 type HookOutcome struct {
 	// ExecutionTime is the execution time of a specific hook without applying its result.
 	ExecutionTime
-	AnalyticsTags hookanalytics.Analytics `json:"analytics_tags"`
-	HookID        HookID                  `json:"hook_id"`
-	Status        Status                  `json:"status"`
-	Action        Action                  `json:"action"`
-	Message       string                  `json:"message"` // arbitrary string value returned from hook execution
-	DebugMessages []string                `json:"debug_messages,omitempty"`
-	Errors        []string                `json:"-"`
-	Warnings      []string                `json:"-"`
+	AnalyticsTags hookanalytics.Analytics  `json:"analytics_tags"`
+	HookID        HookID                   `json:"hook_id"`
+	Status        Status                   `json:"status"`
+	Action        Action                   `json:"action"`
+	Message       string                   `json:"message"` // arbitrary string value returned from hook execution
+	DebugMessages []string                 `json:"debug_messages,omitempty"`
+	Errors        []string                 `json:"-"`
+	Warnings      []string                 `json:"-"`
+	SeatNonBid    []openrtb_ext.SeatNonBid `json:"-"`
 }
 
 // HookID points to the specific hook defined by the hook execution plan.

--- a/hooks/hookstage/invocation.go
+++ b/hooks/hookstage/invocation.go
@@ -20,7 +20,7 @@ type HookResult[T any] struct {
 	DebugMessages []string
 	AnalyticsTags hookanalytics.Analytics
 	SeatNonBid    []openrtb_ext.SeatNonBid // SeatNonBid carries hook-produced bidder status that may be surfaced in the auction response.
-	ModuleContext *ModuleContext // holds values that the module wants to pass to itself at later stages
+	ModuleContext *ModuleContext           // holds values that the module wants to pass to itself at later stages
 }
 
 // ModuleInvocationContext holds data passed to the module hook during invocation.

--- a/hooks/hookstage/invocation.go
+++ b/hooks/hookstage/invocation.go
@@ -19,7 +19,7 @@ type HookResult[T any] struct {
 	Warnings      []string
 	DebugMessages []string
 	AnalyticsTags hookanalytics.Analytics
-	SeatNonBid    []openrtb_ext.SeatNonBid
+	SeatNonBid    []openrtb_ext.SeatNonBid // SeatNonBid carries hook-produced bidder status that may be surfaced in the auction response.
 	ModuleContext *ModuleContext // holds values that the module wants to pass to itself at later stages
 }
 

--- a/hooks/hookstage/invocation.go
+++ b/hooks/hookstage/invocation.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/prebid/prebid-server/v4/hooks/hookanalytics"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
 )
 
 // HookResult represents the result of execution the concrete hook instance.
@@ -18,6 +19,7 @@ type HookResult[T any] struct {
 	Warnings      []string
 	DebugMessages []string
 	AnalyticsTags hookanalytics.Analytics
+	SeatNonBid    []openrtb_ext.SeatNonBid
 	ModuleContext *ModuleContext // holds values that the module wants to pass to itself at later stages
 }
 

--- a/modules/prebid/rulesengine/hook_processed_auction.go
+++ b/modules/prebid/rulesengine/hook_processed_auction.go
@@ -5,6 +5,7 @@ import (
 
 	hs "github.com/prebid/prebid-server/v4/hooks/hookstage"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/rules"
 	"github.com/prebid/prebid-server/v4/util/randomutil"
 )
 
@@ -12,8 +13,9 @@ type RequestWrapper = openrtb_ext.RequestWrapper
 type ModelGroup = cacheModelGroup[RequestWrapper, ProcessedAuctionHookResult]
 
 type ProcessedAuctionHookResult struct {
-	HookResult     hs.HookResult[hs.ProcessedAuctionRequestPayload]
-	AllowedBidders map[string]struct{}
+	HookResult      hs.HookResult[hs.ProcessedAuctionRequestPayload]
+	AllowedBidders  map[string]struct{}
+	IncludeContexts []rules.ResultFunctionMeta
 }
 
 func handleProcessedAuctionHook(
@@ -44,6 +46,7 @@ func handleProcessedAuctionHook(
 		}
 	}
 
+	appendInclusionWarnings(payload.Request, &result)
 	return result.HookResult, nil
 }
 

--- a/modules/prebid/rulesengine/result_functions.go
+++ b/modules/prebid/rulesengine/result_functions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/prebid/prebid-server/v4/modules/prebid/rulesengine/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
@@ -17,6 +18,19 @@ type ProcessedAuctionResultFunc = rules.ResultFunction[openrtb_ext.RequestWrappe
 const (
 	ExcludeBiddersName = "excludeBidders"
 	IncludeBiddersName = "includeBidders"
+)
+
+type FilterType string
+
+const (
+	FilterTypeGeo        FilterType = "geo"
+	FilterTypeDatacenter FilterType = "datacenter"
+	FilterTypeChannel    FilterType = "channel"
+	FilterTypeIdentity   FilterType = "identity"
+	FilterTypeFPD        FilterType = "fpd"
+	FilterTypePrivacy    FilterType = "privacy"
+	FilterTypeTraffic    FilterType = "traffic"
+	FilterTypeUnknown    FilterType = "unknown"
 )
 
 // NewProcessedAuctionRequestResultFunction is a factory function that creates a new result function based on the provided name and parameters.
@@ -67,6 +81,7 @@ func (eb *ExcludeBidders) Call(req *openrtb_ext.RequestWrapper, result *Processe
 	}
 
 	result.HookResult.ChangeSet.ProcessedAuctionRequest().Bidders().Delete(excludedBidders)
+	result.HookResult.SeatNonBid = append(result.HookResult.SeatNonBid, filteredSeatNonBids(req, eb.Args.Bidders, filterTypeFromMeta(meta))...)
 	return nil
 }
 
@@ -100,9 +115,123 @@ func (ib *IncludeBidders) Call(req *openrtb_ext.RequestWrapper, result *Processe
 	for _, bidderName := range ib.Args.Bidders {
 		result.AllowedBidders[bidderName] = struct{}{} // Ensure the bidder is included in the allowed bidders
 	}
+	result.IncludeContexts = append(result.IncludeContexts, meta)
 	return nil
 }
 
 func (ib *IncludeBidders) Name() string {
 	return IncludeBiddersName
+}
+
+func appendInclusionWarnings(req *openrtb_ext.RequestWrapper, result *ProcessedAuctionHookResult) {
+	if len(result.AllowedBidders) == 0 || len(result.IncludeContexts) == 0 {
+		return
+	}
+
+	allowed := make([]string, 0, len(result.AllowedBidders))
+	for bidder := range result.AllowedBidders {
+		allowed = append(allowed, bidder)
+	}
+
+	removedBidders := biddersNotAllowed(req, result.AllowedBidders)
+	if len(removedBidders) == 0 {
+		return
+	}
+	meta := result.IncludeContexts[len(result.IncludeContexts)-1]
+	warning := fmt.Sprintf("Bidders [%s] were removed from the request by the rules engine include list [%s]", strings.Join(removedBidders, ", "), strings.Join(allowed, ", "))
+	result.HookResult.Warnings = append(result.HookResult.Warnings, warning)
+	result.HookResult.SeatNonBid = append(result.HookResult.SeatNonBid, filteredSeatNonBids(req, removedBidders, filterTypeFromMeta(meta))...)
+}
+
+func filteredSeatNonBids(req *openrtb_ext.RequestWrapper, bidders []string, filterType FilterType) []openrtb_ext.SeatNonBid {
+	bidderSet := make(map[string]struct{}, len(bidders))
+	for _, bidder := range bidders {
+		bidderSet[bidder] = struct{}{}
+	}
+
+	seatNonBidsBySeat := make(map[string][]openrtb_ext.NonBid)
+	if req == nil {
+		return nil
+	}
+	for _, impWrapper := range req.GetImp() {
+		impExt, err := impWrapper.GetImpExt()
+		if err != nil {
+			continue
+		}
+		impPrebid := impExt.GetPrebid()
+		if impPrebid == nil {
+			continue
+		}
+		for bidder := range impPrebid.Bidder {
+			if _, ok := bidderSet[bidder]; !ok {
+				continue
+			}
+			seatNonBidsBySeat[bidder] = append(seatNonBidsBySeat[bidder], openrtb_ext.NonBid{
+				ImpId:      impWrapper.ID,
+				StatusCode: 200,
+				Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
+					Type: string(filterType),
+				}},
+			})
+		}
+	}
+
+	seatNonBids := make([]openrtb_ext.SeatNonBid, 0, len(seatNonBidsBySeat))
+	for seat, nonBids := range seatNonBidsBySeat {
+		seatNonBids = append(seatNonBids, openrtb_ext.SeatNonBid{
+			Seat:   seat,
+			NonBid: nonBids,
+		})
+	}
+	return seatNonBids
+}
+
+func biddersNotAllowed(req *openrtb_ext.RequestWrapper, allowed map[string]struct{}) []string {
+	if req == nil {
+		return nil
+	}
+	removed := make(map[string]struct{})
+	for _, impWrapper := range req.GetImp() {
+		impExt, err := impWrapper.GetImpExt()
+		if err != nil {
+			continue
+		}
+		impPrebid := impExt.GetPrebid()
+		if impPrebid == nil {
+			continue
+		}
+		for bidder := range impPrebid.Bidder {
+			if _, ok := allowed[bidder]; !ok {
+				removed[bidder] = struct{}{}
+			}
+		}
+	}
+
+	bidders := make([]string, 0, len(removed))
+	for bidder := range removed {
+		bidders = append(bidders, bidder)
+	}
+	return bidders
+}
+
+func filterTypeFromMeta(meta rules.ResultFunctionMeta) FilterType {
+	for _, step := range meta.SchemaFunctionResults {
+		switch step.FuncName {
+		case rules.DeviceCountry, rules.DeviceCountryIn:
+			return FilterTypeGeo
+		case rules.DataCenter, rules.DataCenterIn:
+			return FilterTypeDatacenter
+		case rules.Channel:
+			return FilterTypeChannel
+		case rules.EidAvailable, rules.EidIn:
+			return FilterTypeIdentity
+		case rules.FpdAvailable, rules.UserFpdAvailable:
+			return FilterTypeFPD
+		case rules.TcfInScope, rules.GppSidAvailable, rules.GppSidIn:
+			return FilterTypePrivacy
+		case rules.Percent:
+			return FilterTypeTraffic
+		}
+	}
+	return FilterTypeUnknown
 }

--- a/modules/prebid/rulesengine/result_functions.go
+++ b/modules/prebid/rulesengine/result_functions.go
@@ -81,7 +81,7 @@ func (eb *ExcludeBidders) Call(req *openrtb_ext.RequestWrapper, result *Processe
 	}
 
 	result.HookResult.ChangeSet.ProcessedAuctionRequest().Bidders().Delete(excludedBidders)
-	result.HookResult.SeatNonBid = append(result.HookResult.SeatNonBid, filteredSeatNonBids(req, eb.Args.Bidders, filterTypeFromMeta(meta))...)
+	result.HookResult.SeatNonBid = appendUniqueFilteredSeatNonBids(result.HookResult.SeatNonBid, filteredSeatNonBids(req, eb.Args.Bidders, filterTypeFromMeta(meta)))
 	return nil
 }
 
@@ -140,16 +140,52 @@ func appendInclusionWarnings(req *openrtb_ext.RequestWrapper, result *ProcessedA
 	meta := result.IncludeContexts[len(result.IncludeContexts)-1]
 	warning := fmt.Sprintf("Bidders [%s] were removed from the request by the rules engine include list [%s]", strings.Join(removedBidders, ", "), strings.Join(allowed, ", "))
 	result.HookResult.Warnings = append(result.HookResult.Warnings, warning)
-	result.HookResult.SeatNonBid = append(result.HookResult.SeatNonBid, filteredSeatNonBids(req, removedBidders, filterTypeFromMeta(meta))...)
+	result.HookResult.SeatNonBid = appendUniqueFilteredSeatNonBids(result.HookResult.SeatNonBid, filteredSeatNonBids(req, removedBidders, filterTypeFromMeta(meta)))
 }
 
+// Keep filtered statuses to one entry per bidder even if multiple rules remove the same bidder.
+func appendUniqueFilteredSeatNonBids(existing []openrtb_ext.SeatNonBid, additions []openrtb_ext.SeatNonBid) []openrtb_ext.SeatNonBid {
+	seen := make(map[string]struct{}, len(existing)+len(additions))
+	for _, seatNonBid := range existing {
+		for _, nonBid := range seatNonBid.NonBid {
+			if nonBid.ImpId != "" || nonBid.StatusCode != 200 || nonBid.Ext == nil {
+				continue
+			}
+			seen[filteredSeatNonBidKey(seatNonBid.Seat)] = struct{}{}
+		}
+	}
+	for _, seatNonBid := range additions {
+		if len(seatNonBid.NonBid) == 0 {
+			continue
+		}
+		nonBid := seatNonBid.NonBid[0]
+		if nonBid.Ext == nil {
+			existing = append(existing, seatNonBid)
+			continue
+		}
+		key := filteredSeatNonBidKey(seatNonBid.Seat)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		existing = append(existing, seatNonBid)
+	}
+	return existing
+}
+
+func filteredSeatNonBidKey(seat string) string {
+	return seat
+}
+
+// Rules filtering is bidder/request scoped today, so emit one status per filtered bidder
+// without impid instead of repeating the same reason for every impression.
 func filteredSeatNonBids(req *openrtb_ext.RequestWrapper, bidders []string, filterType FilterType) []openrtb_ext.SeatNonBid {
 	bidderSet := make(map[string]struct{}, len(bidders))
 	for _, bidder := range bidders {
 		bidderSet[bidder] = struct{}{}
 	}
 
-	seatNonBidsBySeat := make(map[string][]openrtb_ext.NonBid)
+	filteredSeats := make(map[string]struct{}, len(bidders))
 	if req == nil {
 		return nil
 	}
@@ -166,21 +202,20 @@ func filteredSeatNonBids(req *openrtb_ext.RequestWrapper, bidders []string, filt
 			if _, ok := bidderSet[bidder]; !ok {
 				continue
 			}
-			seatNonBidsBySeat[bidder] = append(seatNonBidsBySeat[bidder], openrtb_ext.NonBid{
-				ImpId:      impWrapper.ID,
+			filteredSeats[bidder] = struct{}{}
+		}
+	}
+
+	seatNonBids := make([]openrtb_ext.SeatNonBid, 0, len(filteredSeats))
+	for seat := range filteredSeats {
+		seatNonBids = append(seatNonBids, openrtb_ext.SeatNonBid{
+			Seat: seat,
+			NonBid: []openrtb_ext.NonBid{{
 				StatusCode: 200,
 				Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
 					Type: string(filterType),
 				}},
-			})
-		}
-	}
-
-	seatNonBids := make([]openrtb_ext.SeatNonBid, 0, len(seatNonBidsBySeat))
-	for seat, nonBids := range seatNonBidsBySeat {
-		seatNonBids = append(seatNonBids, openrtb_ext.SeatNonBid{
-			Seat:   seat,
-			NonBid: nonBids,
+			}},
 		})
 	}
 	return seatNonBids

--- a/modules/prebid/rulesengine/result_functions_test.go
+++ b/modules/prebid/rulesengine/result_functions_test.go
@@ -128,6 +128,32 @@ func TestExcludeBiddersCall(t *testing.T) {
 	}
 }
 
+func TestExcludeBiddersAddsFilteredSeatNonBid(t *testing.T) {
+	eb := &ExcludeBidders{Args: config.ResultFuncParams{Bidders: []string{"bidder1", "not-present"}}}
+	result := &ProcessedAuctionHookResult{
+		HookResult: hs.HookResult[hs.ProcessedAuctionRequestPayload]{
+			ChangeSet: hs.ChangeSet[hs.ProcessedAuctionRequestPayload]{},
+		},
+		AllowedBidders: make(map[string]struct{}),
+	}
+
+	err := eb.Call(mockRequestWrapperWithBidders(t, []string{"bidder1", "bidder2"}), result, rules.ResultFunctionMeta{
+		SchemaFunctionResults: []rules.SchemaFunctionStep{{FuncName: rules.DeviceCountryIn, FuncResult: "true"}},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []openrtb_ext.SeatNonBid{{
+		Seat: "bidder1",
+		NonBid: []openrtb_ext.NonBid{{
+			ImpId:      "imp1",
+			StatusCode: 200,
+			Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
+				Type: "geo",
+			}},
+		}},
+	}}, result.HookResult.SeatNonBid)
+}
+
 func TestIncludeBiddersName(t *testing.T) {
 	ib := &IncludeBidders{}
 	actualName := ib.Name()
@@ -188,6 +214,34 @@ func TestIncludeBiddersCall(t *testing.T) {
 			assert.Len(t, result.AllowedBidders, len(tt.argBidders))
 		})
 	}
+}
+
+func TestIncludeBiddersAddsFilteredSeatNonBid(t *testing.T) {
+	ib := &IncludeBidders{Args: config.ResultFuncParams{Bidders: []string{"bidder1"}}}
+	result := &ProcessedAuctionHookResult{
+		HookResult: hs.HookResult[hs.ProcessedAuctionRequestPayload]{
+			ChangeSet: hs.ChangeSet[hs.ProcessedAuctionRequestPayload]{},
+		},
+		AllowedBidders: make(map[string]struct{}),
+	}
+	req := mockRequestWrapperWithBidders(t, []string{"bidder1", "bidder2"})
+
+	err := ib.Call(req, result, rules.ResultFunctionMeta{
+		SchemaFunctionResults: []rules.SchemaFunctionStep{{FuncName: rules.DataCenterIn, FuncResult: "true"}},
+	})
+	appendInclusionWarnings(req, result)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []openrtb_ext.SeatNonBid{{
+		Seat: "bidder2",
+		NonBid: []openrtb_ext.NonBid{{
+			ImpId:      "imp1",
+			StatusCode: 200,
+			Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
+				Type: "datacenter",
+			}},
+		}},
+	}}, result.HookResult.SeatNonBid)
 }
 
 // Helper function to mock RequestWrapper with bidders

--- a/modules/prebid/rulesengine/result_functions_test.go
+++ b/modules/prebid/rulesengine/result_functions_test.go
@@ -145,7 +145,35 @@ func TestExcludeBiddersAddsFilteredSeatNonBid(t *testing.T) {
 	assert.Equal(t, []openrtb_ext.SeatNonBid{{
 		Seat: "bidder1",
 		NonBid: []openrtb_ext.NonBid{{
-			ImpId:      "imp1",
+			StatusCode: 200,
+			Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
+				Type: "geo",
+			}},
+		}},
+	}}, result.HookResult.SeatNonBid)
+}
+
+func TestExcludeBiddersAddsUniqueFilteredSeatNonBid(t *testing.T) {
+	result := &ProcessedAuctionHookResult{
+		HookResult: hs.HookResult[hs.ProcessedAuctionRequestPayload]{
+			ChangeSet: hs.ChangeSet[hs.ProcessedAuctionRequestPayload]{},
+		},
+		AllowedBidders: make(map[string]struct{}),
+	}
+	req := mockRequestWrapperWithBidders(t, []string{"bidder1"})
+
+	geoExclude := &ExcludeBidders{Args: config.ResultFuncParams{Bidders: []string{"bidder1"}}}
+	datacenterExclude := &ExcludeBidders{Args: config.ResultFuncParams{Bidders: []string{"bidder1"}}}
+	assert.NoError(t, geoExclude.Call(req, result, rules.ResultFunctionMeta{
+		SchemaFunctionResults: []rules.SchemaFunctionStep{{FuncName: rules.DeviceCountryIn, FuncResult: "true"}},
+	}))
+	assert.NoError(t, datacenterExclude.Call(req, result, rules.ResultFunctionMeta{
+		SchemaFunctionResults: []rules.SchemaFunctionStep{{FuncName: rules.DataCenterIn, FuncResult: "true"}},
+	}))
+
+	assert.Equal(t, []openrtb_ext.SeatNonBid{{
+		Seat: "bidder1",
+		NonBid: []openrtb_ext.NonBid{{
 			StatusCode: 200,
 			Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
 				Type: "geo",
@@ -235,7 +263,6 @@ func TestIncludeBiddersAddsFilteredSeatNonBid(t *testing.T) {
 	assert.Equal(t, []openrtb_ext.SeatNonBid{{
 		Seat: "bidder2",
 		NonBid: []openrtb_ext.NonBid{{
-			ImpId:      "imp1",
 			StatusCode: 200,
 			Ext: &openrtb_ext.NonBidExt{Prebid: openrtb_ext.ExtResponseNonBidPrebid{
 				Type: "datacenter",

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -85,6 +85,9 @@ type ExtRequestPrebid struct {
 	// either rejected, nobid, input error
 	ReturnAllBidStatus bool `json:"returnallbidstatus,omitempty"`
 
+	// ReturnBidFilterStatus if true populates bidresponse.ext.prebid.seatnonbid with bidders filtered by Prebid rules.
+	ReturnBidFilterStatus bool `json:"returnbidfilterstatus,omitempty"`
+
 	// Trace controls the level of detail in the output information returned from executing hooks.
 	// There are two options:
 	// - verbose: sets maximum level of output information

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -131,9 +131,9 @@ type NonBidExt struct {
 	Prebid ExtResponseNonBidPrebid `json:"prebid"`
 }
 
-// NonBid represnts the Non Bid Reason (statusCode) for given impression ID
+// NonBid represents the Non Bid Reason. ImpId is populated for impression-scoped statuses.
 type NonBid struct {
-	ImpId      string     `json:"impid"`
+	ImpId      string     `json:"impid,omitempty"`
 	StatusCode int        `json:"statuscode"`
 	Ext        *NonBidExt `json:"ext,omitempty"`
 }

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -123,7 +123,8 @@ type NonBidObject struct {
 
 // ExtResponseNonBidPrebid represents bidresponse.ext.prebid.seatnonbid[].nonbid[].ext
 type ExtResponseNonBidPrebid struct {
-	Bid NonBidObject `json:"bid"`
+	Bid  NonBidObject `json:"bid"`
+	Type string       `json:"type,omitempty"`
 }
 
 type NonBidExt struct {


### PR DESCRIPTION
There is a requirement to return back bidders which got filtered with filter reason to upstream for proper reporting. Adding a change which on enabling "returnbidfilterstatus" flag returns those filtered bidders with filtering type to upstream for processing. 

https://github.com/prebid/prebid-server/issues/4722