### PR TITLE
fix(amp): check the errs slice from ProcessStoredResponses, not a stale err var. Fixes #4541

### DIFF
--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -566,8 +566,7 @@ func (deps *endpointDeps) loadRequestJSONForAmp(httpRequest *http.Request, label
 	}
 
 	storedAuctionResponses, storedBidResponses, bidderImpReplaceImp, errs = stored_responses.ProcessStoredResponses(ctx, &openrtb_ext.RequestWrapper{BidRequest: req}, deps.storedRespFetcher)
-	if err != nil {
-		errs = []error{err}
+	if len(errs) > 0 {
 		return
 	}
 

--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -243,6 +243,43 @@ func TestAMPPageInfo(t *testing.T) {
 	assert.Equal(t, "test.somepage.co.uk", exchange.lastRequest.Site.Domain)
 }
 
+// TestLoadRequestJSONForAmpProcessStoredResponsesError reproduces
+// https://github.com/prebid/prebid-server/issues/4541: loadRequestJSONForAmp checked the
+// wrong (already-nil) `err` variable after calling stored_responses.ProcessStoredResponses,
+// instead of the errs slice ProcessStoredResponses actually returns. That meant a real error
+// from ProcessStoredResponses never caused an early return - execution fell through to the
+// end of the function, where `errs = deps.overrideWithParams(...)` unconditionally overwrote
+// errs, silently discarding the original error entirely.
+func TestLoadRequestJSONForAmpProcessStoredResponsesError(t *testing.T) {
+	// This imp has ext.prebid.storedauctionresponse set without the required "id" field,
+	// which makes stored_responses.ProcessStoredResponses (via extractStoredResponsesIds)
+	// return a non-empty errs slice.
+	const storedRequestID = "1"
+	stored := map[string]json.RawMessage{
+		storedRequestID: json.RawMessage(`{
+			"id": "some-request-id",
+			"imp": [{
+				"id": "imp1",
+				"banner": {"format": [{"w": 300, "h": 250}]},
+				"ext": {"prebid": {"storedauctionresponse": {}}}
+			}]
+		}`),
+	}
+
+	deps := &endpointDeps{
+		storedReqFetcher:  &mockAmpStoredReqFetcher{stored},
+		storedRespFetcher: empty_fetcher.EmptyFetcher{},
+		cfg:               &config.Configuration{StoredRequestsTimeout: 1000},
+	}
+
+	httpRequest := httptest.NewRequest("GET", "/openrtb2/auction/amp?tag_id="+storedRequestID, nil)
+
+	_, _, _, _, errs := deps.loadRequestJSONForAmp(httpRequest, metrics.Labels{})
+
+	require.NotEmpty(t, errs, "the ProcessStoredResponses error must be returned, not silently discarded")
+	assert.Contains(t, errs[0].Error(), "storedauctionresponse")
+}
+
 func TestGDPRConsent(t *testing.T) {
 	consent := "CPdiPIJPdiPIJACABBENAzCv_____3___wAAAQNd_X9cAAAAAAAA"
 	existingConsent := "BONV8oqONXwgmADACHENAO7pqzAAppY"


### PR DESCRIPTION
## Summary
Fixes #4541. `loadRequestJSONForAmp` assigned the `errs` slice returned by
`stored_responses.ProcessStoredResponses` into the function's named `errs`
return value, then checked `if err != nil` to decide whether to return
early. That `err` variable was last set (and already nil-checked) several
lines earlier by `amp.ParseParams`, and `ProcessStoredResponses` never
touches it — so the check was always false.

With the check never tripping, execution fell through to the end of the
function, where `errs = deps.overrideWithParams(...)` unconditionally
overwrites `errs` with an unrelated result — silently discarding any real
error from `ProcessStoredResponses` instead of returning it.

## Fix
Check `len(errs) > 0` instead, matching every other `errs`-slice check in
this same function (and the fix suggested in the issue).

## Test plan
- [x] Added `TestLoadRequestJSONForAmpProcessStoredResponsesError`, which
      feeds a stored request with an imp whose
      `ext.prebid.storedauctionresponse` is missing the required `id`
      field (making `ProcessStoredResponses` return a real error) and
      asserts the error is actually returned. Verified it fails against
      the old code (empty `errs` — the error gets silently discarded) and
      passes with the fix.
- [x] `go test ./endpoints/openrtb2/...` passes.
- [x] `go build ./...` passes, `gofmt` clean.

Checklist:
- [x] This is a bug fix.
- [x] Bugfix includes a regression test.