### PR TITLE
feat(metrics): make Prometheus Go runtime metrics prefix optional. Fixes #4742

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -633,6 +633,14 @@ type PrometheusMetrics struct {
 	Namespace        string `mapstructure:"namespace"`
 	Subsystem        string `mapstructure:"subsystem"`
 	TimeoutMillisRaw int    `mapstructure:"timeout_ms"`
+	// DisableGoMetricsPrefix, when true, registers the standard Prometheus Go runtime
+	// metrics (go_goroutines, go_gc_duration_seconds, etc.) without the namespace/subsystem
+	// prefix applied to Prebid Server's own custom metrics. Prometheus client_golang
+	// recommends against prefixing these, since it breaks dashboards and alerts that expect
+	// the standard go_* names and prevents horizontal comparison across services. Defaults
+	// to false to preserve existing behavior for deployments that already rely on the
+	// prefixed names.
+	DisableGoMetricsPrefix bool `mapstructure:"disable_go_metrics_prefix"`
 }
 
 func (cfg *PrometheusMetrics) validate(errs []error) []error {
@@ -1020,6 +1028,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 	v.SetDefault("metrics.prometheus.namespace", "")
 	v.SetDefault("metrics.prometheus.subsystem", "")
 	v.SetDefault("metrics.prometheus.timeout_ms", 10000)
+	v.SetDefault("metrics.prometheus.disable_go_metrics_prefix", false)
 	v.SetDefault("category_mapping.filesystem.enabled", true)
 	v.SetDefault("category_mapping.filesystem.directorypath", "./static/category-mapping")
 	v.SetDefault("category_mapping.http.endpoint", "")

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -558,7 +558,20 @@ func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMet
 	}
 
 	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)
-	metrics.Registerer.MustRegister(promCollector.NewGoCollector())
+
+	// By default (DisableGoMetricsPrefix=false), the standard Prometheus Go runtime
+	// collector is registered on the namespace/subsystem-prefixed Registerer, same as
+	// Prebid Server's own custom metrics - preserving existing behavior for deployments
+	// that already rely on the prefixed names. Setting DisableGoMetricsPrefix registers it
+	// on the unprefixed reg instead, so its metrics keep the standard go_* names
+	// client_golang recommends (https://github.com/prometheus/client_golang/blob/main/prometheus/wrap.go#L62-L67);
+	// prefixing them breaks dashboards/alerts built against the standard names and prevents
+	// horizontal comparison across services.
+	if cfg.DisableGoMetricsPrefix {
+		reg.MustRegister(promCollector.NewGoCollector())
+	} else {
+		metrics.Registerer.MustRegister(promCollector.NewGoCollector())
+	}
 
 	preloadLabelValues(&metrics, syncerKeys, moduleStageNames)
 

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -25,6 +25,44 @@ func createMetricsForTesting() *Metrics {
 	}, config.DisabledMetrics{}, syncerKeys, modulesStages)
 }
 
+// TestGoMetricsPrefix covers https://github.com/prebid/prebid-server/issues/4742: the
+// standard Prometheus Go runtime collector (go_goroutines, go_gc_duration_seconds, etc.) was
+// always registered on the namespace/subsystem-prefixed Registerer, giving it names like
+// "prebid_server_go_goroutines" instead of the standard "go_goroutines" - breaking dashboards
+// and alerts that expect the standard names, and preventing horizontal comparison across
+// services (client_golang explicitly recommends against prefixing these).
+func TestGoMetricsPrefix(t *testing.T) {
+	gatheredMetricNames := func(disableGoMetricsPrefix bool) map[string]bool {
+		m := NewMetrics(config.PrometheusMetrics{
+			Port:                   8080,
+			Namespace:              "prebid",
+			Subsystem:              "server",
+			DisableGoMetricsPrefix: disableGoMetricsPrefix,
+		}, config.DisabledMetrics{}, []string{}, modulesStages)
+
+		metricFamilies, err := m.Gatherer.Gather()
+		assert.NoError(t, err, "gather metrics")
+
+		names := map[string]bool{}
+		for _, mf := range metricFamilies {
+			names[mf.GetName()] = true
+		}
+		return names
+	}
+
+	t.Run("default preserves existing prefixed behavior", func(t *testing.T) {
+		names := gatheredMetricNames(false)
+		assert.True(t, names["prebid_server_go_goroutines"], "expected the prefixed name to be present by default")
+		assert.False(t, names["go_goroutines"], "did not expect the unprefixed name by default")
+	})
+
+	t.Run("DisableGoMetricsPrefix registers standard unprefixed names", func(t *testing.T) {
+		names := gatheredMetricNames(true)
+		assert.True(t, names["go_goroutines"], "expected the standard unprefixed name when DisableGoMetricsPrefix is set")
+		assert.False(t, names["prebid_server_go_goroutines"], "did not expect the prefixed name when DisableGoMetricsPrefix is set")
+	})
+}
+
 func TestMetricCountGatekeeping(t *testing.T) {
 	m := createMetricsForTesting()
 


### PR DESCRIPTION
## Summary
Fixes #4742. The standard Prometheus Go runtime collector (`go_goroutines`,
`go_gc_duration_seconds`, etc.) was always registered on the
namespace/subsystem-prefixed `Registerer`, the same one used for Prebid
Server's own custom metrics. That gives Go runtime metrics names like
`prebid_server_go_goroutines` instead of the standard `go_goroutines`.

[client_golang's own docs](https://github.com/prometheus/client_golang/blob/main/prometheus/wrap.go#L62-L67)
recommend against prefixing these standard collectors. Prefixing breaks
dashboards/alerts built against the standard names and prevents
horizontal comparison of Go runtime health across services — as reported
in the issue.

## Fix
Per the discussion on the issue (`@SyntaxNode`: "I support making it
optional"), this adds `metrics.prometheus.disable_go_metrics_prefix`,
defaulting to `false` to preserve existing behavior for deployments that
already depend on the prefixed names. When set to `true`, the Go
collector is registered on the unprefixed registry instead, producing the
standard `go_*` metric names.

## Test plan
- [x] Added `TestGoMetricsPrefix` covering both the default (prefixed,
      unchanged) and opted-in (`disable_go_metrics_prefix: true`,
      standard names) behavior — verified it fails against the old
      unconditional-prefix code and passes with the fix.
- [x] `go test ./metrics/prometheus/...` and `go test ./config/...` pass.
- [x] `go build ./...` passes, `gofmt` clean.

Checklist:
- [x] This is a feature request the maintainers already agreed to
      ("I support making it optional" / "It's safe to make it optional").
- [x] Bugfix/feature includes tests.