### PR TITLE
fix(auction): detect gzip-compressed requests via gzip=1 query param. Fixes #4474

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -422,6 +422,13 @@ func (deps *endpointDeps) parseRequest(httpRequest *http.Request, labels *metric
 	var errL []error
 	var r io.ReadCloser = httpRequest.Body
 	reqContentEncoding := httputil.ContentEncoding(httpRequest.Header.Get("Content-Encoding"))
+	if reqContentEncoding == "" && httpRequest.URL.Query().Get("gzip") == "1" {
+		// Prebid.js's endpointCompression option gzip-compresses the request body but
+		// intentionally omits the Content-Encoding header (setting it would trigger a
+		// CORS preflight request), signaling compression via this query param instead.
+		// See https://github.com/prebid/prebid-server/issues/4474.
+		reqContentEncoding = httputil.ContentEncodingGZIP
+	}
 	if reqContentEncoding != "" {
 		if !deps.cfg.Compression.Request.IsSupported(reqContentEncoding) {
 			errs = []error{fmt.Errorf("Content-Encoding of type %s is not supported", reqContentEncoding)}

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -3788,11 +3788,12 @@ func TestParseRequestParseImpInfoError(t *testing.T) {
 func TestParseGzipedRequest(t *testing.T) {
 	testCases :=
 		[]struct {
-			desc           string
-			reqContentEnc  string
-			maxReqSize     int64
-			compressionCfg config.Compression
-			expectedErr    string
+			desc              string
+			reqContentEnc     string
+			useGzipQueryParam bool
+			maxReqSize        int64
+			compressionCfg    config.Compression
+			expectedErr       string
 		}{
 			{
 				desc:           "Gzip compression enabled, request size exceeds max request size",
@@ -3827,6 +3828,24 @@ func TestParseGzipedRequest(t *testing.T) {
 				maxReqSize:     2000,
 				compressionCfg: config.Compression{Request: config.CompressionInfo{GZIP: true}},
 				expectedErr:    "",
+			},
+			{
+				// Prebid.js's endpointCompression option gzip-compresses the body but
+				// deliberately omits the Content-Encoding header, signaling via
+				// ?gzip=1 instead (see https://github.com/prebid/prebid-server/issues/4474).
+				desc:              "Gzip signaled via gzip=1 query param, no Content-Encoding header, compression enabled",
+				reqContentEnc:     "gzip",
+				useGzipQueryParam: true,
+				maxReqSize:        2000,
+				compressionCfg:    config.Compression{Request: config.CompressionInfo{GZIP: true}},
+				expectedErr:       "",
+			},
+			{
+				desc:              "Gzip signaled via gzip=1 query param, but Gzip compression is disabled",
+				reqContentEnc:     "gzip",
+				useGzipQueryParam: true,
+				compressionCfg:    config.Compression{Request: config.CompressionInfo{GZIP: false}},
+				expectedErr:       "Content-Encoding of type gzip is not supported",
 			},
 		}
 
@@ -3866,8 +3885,14 @@ func TestParseGzipedRequest(t *testing.T) {
 			assert.NoError(t, err, "Error writing gzip compressed request body", test.desc)
 			assert.NoError(t, gw.Close(), "Error closing gzip writer", test.desc)
 
-			req = httptest.NewRequest("POST", "/openrtb2/auction", bytes.NewReader(compressed.Bytes()))
-			req.Header.Set("Content-Encoding", "gzip")
+			path := "/openrtb2/auction"
+			if test.useGzipQueryParam {
+				path += "?gzip=1"
+			}
+			req = httptest.NewRequest("POST", path, bytes.NewReader(compressed.Bytes()))
+			if !test.useGzipQueryParam {
+				req.Header.Set("Content-Encoding", "gzip")
+			}
 		} else {
 			req = httptest.NewRequest("POST", "/openrtb2/auction", bytes.NewReader(reqBody))
 		}


### PR DESCRIPTION
## Summary
Fixes #4474. Prebid.js's `endpointCompression` option gzip-compresses
the request body sent to Prebid Server, but deliberately omits the
`Content-Encoding` header — setting it would trigger a CORS preflight
request — signaling compression via a `gzip=1` URL query param instead.

`parseRequest` only checked the `Content-Encoding` header, so requests
using this Prebid.js feature were never decompressed: the gzip-compressed
bytes were fed straight to the JSON parser and failed with
`FailedToUnmarshal`.

## Fix
Falls back to treating the request as gzip-compressed when
`Content-Encoding` is absent and `gzip=1` is present in the query
string, per the resolution agreed in the issue thread ("PBS will rely
on `gzip=1` for applying compression" — `@bsardo`). This still goes
through the existing `Compression.Request` config gate, so operators
who have gzip decompression disabled get the same "not supported" error
as they would for the header form.

## Test plan
- [x] Extended `TestParseGzipedRequest` with two new cases: gzip
      signaled via `?gzip=1` with no `Content-Encoding` header (should
      succeed when compression is enabled), and the same but with
      compression disabled (should still error). Verified the new
      "enabled" case fails against the old code with
      `FailedToUnmarshal` (reproducing the exact reported bug) and
      passes with the fix.
- [x] `go build ./...` passes, `gofmt`/`go vet` clean.
- [x] Note: `go test ./endpoints/openrtb2/...` reports an overall
      package `FAIL` with no individual failing test — confirmed this
      is pre-existing on unmodified `master` (unrelated to this
      change) before relying on it here.