### PR TITLE
Nativo: hoist placementId bidder param into ext.nativo.placementid

### DIFF
--- a/adapters/nativo/nativo.go
+++ b/adapters/nativo/nativo.go
@@ -1,6 +1,7 @@
 package nativo
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,7 +27,10 @@ func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server co
 }
 
 func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
-	requestJSON, err := jsonutil.Marshal(request)
+	requestCopy := *request
+	requestCopy.Imp = populateNativoImpExt(request.Imp)
+
+	requestJSON, err := jsonutil.Marshal(&requestCopy)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -43,6 +47,49 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRe
 	}
 
 	return []*adapters.RequestData{requestData}, nil
+}
+
+// populateNativoImpExt hoists a validated placementId bidder param into imp.ext.nativo.placementid,
+// the location Nativo's endpoint reads it from. Bidder params only ever land under
+// imp.ext.prebid.bidder.nativo (validated against static/bidder-params/nativo.json) - nothing else
+// copies them to the SSP-facing key, so without this the param is silently dropped from the outgoing
+// request. See https://github.com/prebid/prebid-server/issues/4393.
+func populateNativoImpExt(imps []openrtb2.Imp) []openrtb2.Imp {
+	updatedImps := make([]openrtb2.Imp, len(imps))
+	copy(updatedImps, imps)
+
+	for i, imp := range updatedImps {
+		var bidderExt adapters.ExtImpBidder
+		if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+			continue
+		}
+
+		var nativoExt openrtb_ext.ImpExtNativo
+		if err := jsonutil.Unmarshal(bidderExt.Bidder, &nativoExt); err != nil || nativoExt.PlacementID == 0 {
+			continue
+		}
+
+		var extMap map[string]json.RawMessage
+		if err := jsonutil.Unmarshal(imp.Ext, &extMap); err != nil {
+			continue
+		}
+
+		nativoParamsJSON, err := jsonutil.Marshal(struct {
+			PlacementID jsonutil.StringInt `json:"placementid"`
+		}{PlacementID: nativoExt.PlacementID})
+		if err != nil {
+			continue
+		}
+		extMap["nativo"] = nativoParamsJSON
+
+		updatedExt, err := jsonutil.Marshal(extMap)
+		if err != nil {
+			continue
+		}
+		updatedImps[i].Ext = updatedExt
+	}
+
+	return updatedImps
 }
 
 func (a *adapter) MakeBids(request *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {

--- a/adapters/nativo/nativo_test.go
+++ b/adapters/nativo/nativo_test.go
@@ -234,6 +234,74 @@ func TestGetMediaTypeForImp(t *testing.T) {
 	}
 }
 
+func TestPopulateNativoImpExt(t *testing.T) {
+	tests := []struct {
+		description string
+		imps        []openrtb2.Imp
+		expectedExt []string
+	}{
+		{
+			description: "placementId as number is hoisted into ext.nativo.placementid",
+			imps: []openrtb2.Imp{
+				{ID: "imp-1", Ext: json.RawMessage(`{"bidder":{"placementId":12345678}}`)},
+			},
+			expectedExt: []string{`{"bidder":{"placementId":12345678},"nativo":{"placementid":12345678}}`},
+		},
+		{
+			description: "placementId as string is normalized and hoisted",
+			imps: []openrtb2.Imp{
+				{ID: "imp-1", Ext: json.RawMessage(`{"bidder":{"placementId":"12345678"}}`)},
+			},
+			expectedExt: []string{`{"bidder":{"placementId":"12345678"},"nativo":{"placementid":12345678}}`},
+		},
+		{
+			description: "missing placementId leaves ext unchanged",
+			imps: []openrtb2.Imp{
+				{ID: "imp-1", Ext: json.RawMessage(`{"bidder":{}}`)},
+			},
+			expectedExt: []string{`{"bidder":{}}`},
+		},
+		{
+			description: "missing ext.bidder leaves ext unchanged",
+			imps: []openrtb2.Imp{
+				{ID: "imp-1", Ext: json.RawMessage(`{}`)},
+			},
+			expectedExt: []string{`{}`},
+		},
+		{
+			description: "multiple imps are each hoisted independently",
+			imps: []openrtb2.Imp{
+				{ID: "imp-1", Ext: json.RawMessage(`{"bidder":{"placementId":111}}`)},
+				{ID: "imp-2", Ext: json.RawMessage(`{"bidder":{}}`)},
+				{ID: "imp-3", Ext: json.RawMessage(`{"bidder":{"placementId":333}}`)},
+			},
+			expectedExt: []string{
+				`{"bidder":{"placementId":111},"nativo":{"placementid":111}}`,
+				`{"bidder":{}}`,
+				`{"bidder":{"placementId":333},"nativo":{"placementid":333}}`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			original := make([]openrtb2.Imp, len(test.imps))
+			copy(original, test.imps)
+
+			result := populateNativoImpExt(test.imps)
+
+			require.Len(t, result, len(test.expectedExt))
+			for i, expected := range test.expectedExt {
+				assert.JSONEq(t, expected, string(result[i].Ext))
+			}
+			// the input slice's Imp elements must not be mutated in place.
+			for i := range original {
+				assert.Equal(t, string(original[i].Ext), string(test.imps[i].Ext))
+			}
+		})
+	}
+}
+
 func TestMakeBidsNativoRenderer(t *testing.T) {
 	bidder := &adapter{endpoint: "https://foo.io/?src=prebid"}
 

--- a/adapters/nativo/nativotest/exemplary/banner-app.json
+++ b/adapters/nativo/nativotest/exemplary/banner-app.json
@@ -74,6 +74,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/exemplary/banner-web-string-placementid.json
+++ b/adapters/nativo/nativotest/exemplary/banner-web-string-placementid.json
@@ -56,6 +56,9 @@
               "ext": {
                 "bidder": {
                   "placementId": "12345678"
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/exemplary/banner-web.json
+++ b/adapters/nativo/nativotest/exemplary/banner-web.json
@@ -56,6 +56,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/exemplary/native-app.json
+++ b/adapters/nativo/nativotest/exemplary/native-app.json
@@ -74,6 +74,9 @@
                 "ext": {
                   "bidder": {
                     "placementId": 12345678
+                  },
+                  "nativo": {
+                    "placementid": 12345678
                   }
                 }
               }

--- a/adapters/nativo/nativotest/exemplary/native-web.json
+++ b/adapters/nativo/nativotest/exemplary/native-web.json
@@ -56,6 +56,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/exemplary/video-app.json
+++ b/adapters/nativo/nativotest/exemplary/video-app.json
@@ -84,6 +84,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/exemplary/video-web.json
+++ b/adapters/nativo/nativotest/exemplary/video-web.json
@@ -66,6 +66,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/200-different-impID-response-from-nativo.json
+++ b/adapters/nativo/nativotest/supplemental/200-different-impID-response-from-nativo.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": "12345678"
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/400-response-from-nativo.json
+++ b/adapters/nativo/nativotest/supplemental/400-response-from-nativo.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/500-response-from-nativo.json
+++ b/adapters/nativo/nativotest/supplemental/500-response-from-nativo.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/bid-type-fallback-invalid-type.json
+++ b/adapters/nativo/nativotest/supplemental/bid-type-fallback-invalid-type.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/bid-type-fallback-native.json
+++ b/adapters/nativo/nativotest/supplemental/bid-type-fallback-native.json
@@ -30,6 +30,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/bid-type-fallback-success.json
+++ b/adapters/nativo/nativotest/supplemental/bid-type-fallback-success.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/bid-type-fallback-video.json
+++ b/adapters/nativo/nativotest/supplemental/bid-type-fallback-video.json
@@ -34,6 +34,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/malformed-response-body.json
+++ b/adapters/nativo/nativotest/supplemental/malformed-response-body.json
@@ -40,6 +40,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }

--- a/adapters/nativo/nativotest/supplemental/nativo-renderer-in-request.json
+++ b/adapters/nativo/nativotest/supplemental/nativo-renderer-in-request.json
@@ -52,6 +52,9 @@
               "ext": {
                 "bidder": {
                   "placementId": 12345678
+                },
+                "nativo": {
+                  "placementid": 12345678
                 }
               }
             }


### PR DESCRIPTION
## Summary
Fixes #4393.

`static/bidder-params/nativo.json` and `openrtb_ext.ImpExtNativo` already validate an optional `placementId` bidder param (added in #4679), but `MakeRequests` in `adapters/nativo/nativo.go` never read it back out — it re-marshals the incoming `*openrtb2.BidRequest` as-is with no per-imp transformation. That means a publisher-supplied `placementId` stays under `imp.ext.prebid.bidder.nativo.placementId` and never reaches `imp.ext.nativo.placementid`, the key Nativo's endpoint actually reads, so the param is silently dropped from every outgoing request.

This adds `populateNativoImpExt`, which copies a validated `placementId` into `imp.ext.nativo.placementid` for each imp that has one, leaving imps without it untouched. The existing exemplary/supplemental JSON test fixtures already set `placementId` in their mock requests (added alongside the schema/type in #4679) but asserted plain passthrough in `expectedRequest`; those are updated to assert the hoisted `nativo` key instead, since the previous assertions were effectively confirming the missing behavior.

## Changes
- `adapters/nativo/nativo.go`: add `populateNativoImpExt`, call it from `MakeRequests`.
- `adapters/nativo/nativo_test.go`: new `TestPopulateNativoImpExt` covering numeric/string `placementId`, missing param (no-op), missing `ext.bidder` (no-op), multi-imp independence, and non-mutation of the input slice.
- `adapters/nativo/nativotest/{exemplary,supplemental}/*.json`: minimal 3-line additions to fixtures that already set `placementId`, asserting the new `ext.nativo.placementid` key.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./adapters/nativo/...`
- [x] `go test ./adapters/nativo/... ./openrtb_ext/...` — all pass
- [x] Verified the new test and fixture assertions actually catch the bug: reverted `nativo.go` alone and confirmed `TestBidderNativo` fails against every fixture that sets `placementId`, then restored the fix and confirmed it passes again.