### PR TITLE
Allow imp.ext.prebid.adunitcode through to bidders

### DIFF
--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -729,6 +729,7 @@ func mergeImpFPD(imp *openrtb2.Imp, fpd json.RawMessage, index int) error {
 var allowedImpExtPrebidFields = map[string]interface{}{
 	openrtb_ext.IsRewardedInventoryKey: struct{}{},
 	openrtb_ext.OptionsKey:             struct{}{},
+	openrtb_ext.AdUnitCodeKey:          struct{}{},
 }
 
 var deniedImpExtFields = map[string]interface{}{

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -594,9 +594,10 @@ func TestCreateSanitizedImpExt(t *testing.T) {
 				"bidder":                json.RawMessage(`"anyBidder"`),
 				"is_rewarded_inventory": json.RawMessage(`"anyIsRewardedInventory"`),
 				"options":               json.RawMessage(`"anyOptions"`),
+				"adunitcode":            json.RawMessage(`"anyAdUnitCode"`),
 			},
 			expected: map[string]json.RawMessage{
-				"prebid":  json.RawMessage(`{"is_rewarded_inventory":"anyIsRewardedInventory","options":"anyOptions"}`),
+				"prebid":  json.RawMessage(`{"adunitcode":"anyAdUnitCode","is_rewarded_inventory":"anyIsRewardedInventory","options":"anyOptions"}`),
 				"data":    json.RawMessage(`"anyData"`),
 				"context": json.RawMessage(`"anyContext"`),
 				"skadn":   json.RawMessage(`"anySKAdNetwork"`),

--- a/openrtb_ext/imp.go
+++ b/openrtb_ext/imp.go
@@ -24,6 +24,9 @@ const IsRewardedInventoryKey = "is_rewarded_inventory"
 // OptionsKey is the json key for ExtImpPrebid.Options
 const OptionsKey = "options"
 
+// AdUnitCodeKey is the json key for ExtImpPrebid.AdUnitCode
+const AdUnitCodeKey = "adunitcode"
+
 // ExtImpPrebid defines the contract for bidrequest.imp[i].ext.prebid
 type ExtImpPrebid struct {
 	// StoredRequest specifies which stored impression to use, if any.


### PR DESCRIPTION
## Summary
Fixes #4077.

`splitImps` builds each bidder's per-impression `ext` through `createSanitizedImpExt`, which only forwards `imp.ext.prebid` fields present in `allowedImpExtPrebidFields` — currently just `is_rewarded_inventory` and `options`. `adunitcode` is defined on `ExtImpPrebid` (`openrtb_ext/imp.go`) but was never added to that allowlist, so it's silently stripped from every bidder-facing request before any adapter's `MakeRequests` ever sees it.

This isn't just a documentation gap — `adapters/gumgum/gumgum.go` already reads `imp.ext.prebid.adunitcode` directly (to set `imp.TagID`), a call site that has therefore never actually fired in production.

Per the issue thread, the maintainers reached consensus on treating `imp[].ext.prebid`'s bidder-visible fields as an explicit exception list: `adunitcode`, `storedrequest`, `is_rewarded_inventory`, `options.echovideoattrs`. This PR adds `adunitcode` — the field this issue and gumgum's existing code both need. It intentionally leaves `storedrequest` out: that would be a separate, unverified change, since several adapters (`nextmillennium`, `relevantdigital`, `teal`, `unicorn`) already read `imp.ext.prebid.storedrequest` too and would need checking against the same allowlist gap independently before touching it.

## Changes
- `openrtb_ext/imp.go`: add `AdUnitCodeKey = "adunitcode"` constant, matching the existing `IsRewardedInventoryKey`/`OptionsKey` pattern.
- `exchange/utils.go`: add `openrtb_ext.AdUnitCodeKey` to `allowedImpExtPrebidFields`.
- `exchange/utils_test.go`: extend the existing `TestCreateSanitizedImpExt` "Bidder + Other Allowed Values" case to assert `adunitcode` passes through.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./exchange/... ./openrtb_ext/...`
- [x] `go test ./exchange/... ./openrtb_ext/... ./adapters/gumgum/...` — all pass
- [x] Verified the updated test actually catches the regression: reverted `exchange/utils.go` alone and confirmed `TestCreateSanitizedImpExt` fails (adunitcode missing from the sanitized `ext.prebid`), then restored the fix and confirmed it passes again.