### PR TITLE
Lunamedia: stop blanking site.domain in outgoing requests

### DIFF
--- a/adapters/lunamedia/lunamedia.go
+++ b/adapters/lunamedia/lunamedia.go
@@ -168,7 +168,6 @@ func createBidRequest(prebidBidRequest *openrtb2.BidRequest, params *openrtb_ext
 		siteCopy := *bidRequest.Site
 		bidRequest.Site = &siteCopy
 		bidRequest.Site.Publisher = nil
-		bidRequest.Site.Domain = ""
 	}
 	if bidRequest.App != nil {
 		// Need to copy App as Request is a shallow copy

--- a/adapters/lunamedia/lunamediatest/supplemental/site.json
+++ b/adapters/lunamedia/lunamediatest/supplemental/site.json
@@ -2,7 +2,8 @@
   "mockBidRequest": {
       "id": "testid",
       "site": {
-          "id": "test"
+          "id": "test",
+          "domain": "www.example.com"
       },
       "imp": [
           {
@@ -57,7 +58,8 @@
                       }
                   ],
                   "site": {
-                      "id": "test"
+                      "id": "test",
+                      "domain": "www.example.com"
                   }
               },
               "impIDs":["testimpid"]


### PR DESCRIPTION
## Summary
Fixes #3408, a port of [prebid-server-java#2907](https://github.com/prebid/prebid-server-java/pull/2907).

`createBidRequest` in `adapters/lunamedia/lunamedia.go` copies the incoming `Site` object before forwarding it to LunaMedia, and explicitly did `bidRequest.Site.Domain = ""` — discarding the publisher's domain on every single request, regardless of what was actually present. PBS-Java had the identical line and fixed it by simply removing it; LunaMedia needs `site.domain`, and there's no reason for PBS to strip it before forwarding.

## Changes
- `adapters/lunamedia/lunamedia.go`: remove the `bidRequest.Site.Domain = ""` line. `Site.Publisher = nil` is untouched (unrelated, not part of this issue).
- `adapters/lunamedia/lunamediatest/supplemental/site.json`: the existing fixture testing `site` handling didn't set a `domain` value at all, so it couldn't have caught this — extended it with `"domain": "www.example.com"` in both the mock request and the expected outgoing request.

## Test plan
- [x] `go build ./adapters/lunamedia/...`
- [x] `go test ./adapters/lunamedia/...` — all pass
- [x] Verified the updated fixture actually catches the regression: reverted `lunamedia.go` alone and confirmed `TestJsonSamples` fails (domain missing from the outgoing request), then restored the fix and confirmed it passes again.