### PR TITLE
OMS: use pid query param instead of publisherId

### DIFF
--- a/adapters/oms/oms.go
+++ b/adapters/oms/oms.go
@@ -43,9 +43,9 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			return nil, []error{err}
 		}
 
-		uri = fmt.Sprintf("%s?publisherId=%s", a.endpoint, omsImpExt.Pid)
+		uri = fmt.Sprintf("%s?pid=%s", a.endpoint, omsImpExt.Pid)
 		if omsImpExt.Pid == "" && omsImpExt.PublisherID > 0 {
-			uri = fmt.Sprintf("%s?publisherId=%d", a.endpoint, omsImpExt.PublisherID)
+			uri = fmt.Sprintf("%s?pid=%d", a.endpoint, omsImpExt.PublisherID)
 		}
 	}
 

--- a/adapters/oms/omstest/exemplary/simple-banner-cookie-uid.json
+++ b/adapters/oms/omstest/exemplary/simple-banner-cookie-uid.json
@@ -35,7 +35,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id",

--- a/adapters/oms/omstest/exemplary/simple-banner-multiple-bids.json
+++ b/adapters/oms/omstest/exemplary/simple-banner-multiple-bids.json
@@ -62,7 +62,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id-multiple-bids",

--- a/adapters/oms/omstest/exemplary/simple-banner-uid-with-publisher-id.json
+++ b/adapters/oms/omstest/exemplary/simple-banner-uid-with-publisher-id.json
@@ -46,7 +46,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id",

--- a/adapters/oms/omstest/exemplary/simple-banner-uid.json
+++ b/adapters/oms/omstest/exemplary/simple-banner-uid.json
@@ -46,7 +46,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id",

--- a/adapters/oms/omstest/exemplary/simple-multi-type-banner.json
+++ b/adapters/oms/omstest/exemplary/simple-multi-type-banner.json
@@ -52,7 +52,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id",

--- a/adapters/oms/omstest/exemplary/simple-video.json
+++ b/adapters/oms/omstest/exemplary/simple-video.json
@@ -51,7 +51,7 @@
     "httpCalls": [
         {
             "expectedRequest": {
-                "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+                "uri": "http://rt.marphezis.com/pbs?pid=12345",
                 "headers": {},
                 "body": {
                     "id": "test-request-id",

--- a/adapters/oms/omstest/supplemental/204-response-from-target.json
+++ b/adapters/oms/omstest/supplemental/204-response-from-target.json
@@ -37,7 +37,7 @@
     "httpCalls": [
       {
         "expectedRequest": {
-          "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+          "uri": "http://rt.marphezis.com/pbs?pid=12345",
           "headers": {},
           "body": {
             "id": "test-request-id",

--- a/adapters/oms/omstest/supplemental/400-response-from-target.json
+++ b/adapters/oms/omstest/supplemental/400-response-from-target.json
@@ -37,7 +37,7 @@
     "httpCalls": [
       {
         "expectedRequest": {
-          "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+          "uri": "http://rt.marphezis.com/pbs?pid=12345",
           "headers": {},
           "body": {
             "id": "test-request-id",

--- a/adapters/oms/omstest/supplemental/500-response-from-target.json
+++ b/adapters/oms/omstest/supplemental/500-response-from-target.json
@@ -37,7 +37,7 @@
     "httpCalls": [
       {
         "expectedRequest": {
-          "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+          "uri": "http://rt.marphezis.com/pbs?pid=12345",
           "headers": {},
           "body": {
             "id": "test-request-id",

--- a/adapters/oms/omstest/supplemental/simple-banner-with-ipv6.json
+++ b/adapters/oms/omstest/supplemental/simple-banner-with-ipv6.json
@@ -42,7 +42,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "http://rt.marphezis.com/pbs?publisherId=12345",
+        "uri": "http://rt.marphezis.com/pbs?pid=12345",
         "headers": {},
         "body": {
           "id": "test-request-id",


### PR DESCRIPTION
## Summary
Fixes #4705, a port of [prebid-server-java#4409](https://github.com/prebid/prebid-server-java/pull/4409).

OMS's endpoint now expects the publisher ID as `?pid=`; PBS-Go was still building the outgoing URL with `?publisherId=`, matching what PBS-Java sent before OMS's own PR updated it to the current contract. Both PBS-Go and PBS-Java send requests to the identical OMS endpoint (`rt.marphezis.com`), so the outgoing wire format is shared between them — this isn't an internal PBS behavior choice, it's syncing to the SSP's actual current endpoint contract.

Given this changes the outbound request format to a live third-party endpoint, please double check against OMS's current documentation/expectations during review if possible — I'm going on the Java-side PR as the source of truth here since I don't have independent access to OMS's API docs.

## Changes
- `adapters/oms/oms.go`: both `fmt.Sprintf` calls building the request URL now use `?pid=` instead of `?publisherId=`.
- `adapters/oms/omstest/{exemplary,supplemental}/*.json`: updated the expected `uri` in all 9 affected fixtures to match.

## Test plan
- [x] `go build ./adapters/oms/...`
- [x] `go test ./adapters/oms/...` — all pass