### PR TITLE
Add Ybidder as a disabled-by-default alias of Nexx360

### DIFF
--- a/static/bidder-info/ybidder.yaml
+++ b/static/bidder-info/ybidder.yaml
@@ -1,0 +1,5 @@
+disabled: true
+aliasOf: "nexx360"
+maintainer:
+  email: "team@yieldbird.com"
+gvlVendorID: 1253


### PR DESCRIPTION
## Summary
Fixes #4753, a port of [prebid-server-java#4467](https://github.com/prebid/prebid-server-java/pull/4467).

Nexx360 already has three aliases registered in this repo (`1accord`, `easybid`, `prismassp`), each as a single `static/bidder-info/<alias>.yaml` file with `aliasOf: "nexx360"` and nothing else — no adapter code, no bidder-params schema, since an alias reuses its parent bidder's `Builder`/adapter logic and params validation as-is (confirmed via `git log`/`git show` on the commit that added the Nexx360 adapter and its existing aliases). Ybidder was the one alias from that Java PR not yet ported.

## Changes
- `static/bidder-info/ybidder.yaml` (new): `aliasOf: "nexx360"`, `disabled: true`, plus its own `maintainer.email`/`gvlVendorID`, following the same disabled-alias-with-its-own-maintainer pattern already used elsewhere in this repo (e.g. `selectmedia.yaml`/`m152.yaml`, aliases of `teqblaze`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./config/... ./exchange/... ./openrtb_ext/... ./router/...` — all pass