### PR TITLE
Rubicon: populate meta.advertiserId and meta.advertiserDomains

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -1092,7 +1092,10 @@ func cmpOverrideFromBidRequest(bidRequest *openrtb2.BidRequest) float64 {
 }
 
 func updateBidExtWithMeta(bid rubiconBid, buyer int, seat string) json.RawMessage {
-	if buyer <= 0 && seat == "" {
+	advertiserID := resolveAdvertiserID(bid.Ext)
+	advertiserDomains := bid.ADomain
+
+	if buyer <= 0 && seat == "" && advertiserID == 0 && len(advertiserDomains) == 0 {
 		return nil
 	}
 	var bidExt *extPrebid
@@ -1107,14 +1110,16 @@ func updateBidExtWithMeta(bid rubiconBid, buyer int, seat string) json.RawMessag
 			if bidExt.Prebid.Meta != nil {
 				bidExt.Prebid.Meta.NetworkID = buyer
 				bidExt.Prebid.Meta.Seat = seat
+				bidExt.Prebid.Meta.AdvertiserID = advertiserID
+				bidExt.Prebid.Meta.AdvertiserDomains = advertiserDomains
 			} else {
-				bidExt.Prebid.Meta = &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat}
+				bidExt.Prebid.Meta = &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat, AdvertiserID: advertiserID, AdvertiserDomains: advertiserDomains}
 			}
 		} else {
-			bidExt.Prebid = &openrtb_ext.ExtBidPrebid{Meta: &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat}}
+			bidExt.Prebid = &openrtb_ext.ExtBidPrebid{Meta: &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat, AdvertiserID: advertiserID, AdvertiserDomains: advertiserDomains}}
 		}
 	} else {
-		bidExt = &extPrebid{Prebid: &openrtb_ext.ExtBidPrebid{Meta: &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat}}}
+		bidExt = &extPrebid{Prebid: &openrtb_ext.ExtBidPrebid{Meta: &openrtb_ext.ExtBidPrebidMeta{NetworkID: buyer, Seat: seat, AdvertiserID: advertiserID, AdvertiserDomains: advertiserDomains}}}
 	}
 
 	marshalledExt, err := json.Marshal(&bidExt)
@@ -1122,4 +1127,21 @@ func updateBidExtWithMeta(bid rubiconBid, buyer int, seat string) json.RawMessag
 		return marshalledExt
 	}
 	return nil
+}
+
+// resolveAdvertiserID reads bid.ext.rp.advid, the advertiser ID rubicon includes in its own
+// response namespace, coercing either a numeric or string JSON representation to an int.
+func resolveAdvertiserID(bidExtRaw json.RawMessage) int {
+	if len(bidExtRaw) == 0 {
+		return 0
+	}
+	var rpExt struct {
+		RP struct {
+			AdvID jsonutil.StringInt `json:"advid"`
+		} `json:"rp"`
+	}
+	if err := jsonutil.Unmarshal(bidExtRaw, &rpExt); err != nil {
+		return 0
+	}
+	return int(rpExt.RP.AdvID)
 }

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1020,6 +1020,64 @@ func TestUpdateBidExtWithMeta_OnlySeatSet(t *testing.T) {
 	assert.Zero(t, extPrebidWrapper.Prebid.Meta.NetworkID, "NetworkID should be omitted or zero")
 }
 
+func TestUpdateBidExtWithMeta_AdvertiserIdFromRpAdvid(t *testing.T) {
+	testCases := []struct {
+		description string
+		rawExt      json.RawMessage
+	}{
+		{
+			description: "numeric advid",
+			rawExt:      json.RawMessage(`{"rp":{"advid":1}}`),
+		},
+		{
+			description: "string advid",
+			rawExt:      json.RawMessage(`{"rp":{"advid":"1"}}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			bid := rubiconBid{Bid: openrtb2.Bid{Ext: tc.rawExt}}
+
+			ext := updateBidExtWithMeta(bid, 0, "")
+			assert.NotNil(t, ext, "Expected non-nil ext when rp.advid is set")
+
+			var extPrebidWrapper struct {
+				Prebid struct {
+					Meta struct {
+						AdvertiserID int `json:"advertiserId"`
+					} `json:"meta"`
+				} `json:"prebid"`
+			}
+			err := json.Unmarshal(ext, &extPrebidWrapper)
+			assert.NoError(t, err, "Unmarshal should succeed")
+			assert.Equal(t, 1, extPrebidWrapper.Prebid.Meta.AdvertiserID)
+		})
+	}
+}
+
+func TestUpdateBidExtWithMeta_AdvertiserDomainsFromAdomain(t *testing.T) {
+	bid := rubiconBid{
+		Bid: openrtb2.Bid{
+			ADomain: []string{"advertiser.com"},
+		},
+	}
+
+	ext := updateBidExtWithMeta(bid, 0, "")
+	assert.NotNil(t, ext, "Expected non-nil ext when adomain is set")
+
+	var extPrebidWrapper struct {
+		Prebid struct {
+			Meta struct {
+				AdvertiserDomains []string `json:"advertiserDomains"`
+			} `json:"meta"`
+		} `json:"prebid"`
+	}
+	err := json.Unmarshal(ext, &extPrebidWrapper)
+	assert.NoError(t, err, "Unmarshal should succeed")
+	assert.Equal(t, []string{"advertiser.com"}, extPrebidWrapper.Prebid.Meta.AdvertiserDomains)
+}
+
 func TestOpenRTBResponseBidExtPrebidMetaPassthrough(t *testing.T) {
 	request := &openrtb2.BidRequest{
 		Imp: []openrtb2.Imp{{


### PR DESCRIPTION
## Summary
Fixes #4365, a port of [prebid-server-java#3960](https://github.com/prebid/prebid-server-java/pull/3960).

`updateBidExtWithMeta` in `adapters/rubicon/rubicon.go` already enriches `bid.ext.prebid.meta` with `networkId` and `seat` from Rubicon's response, but never populated `advertiserId` or `advertiserDomains` — even though `openrtb_ext.ExtBidPrebidMeta` has supported both fields for other bidders all along. Rubicon's response carries the advertiser ID at `bid.ext.rp.advid` (as either a number or a string, depending on response) and the advertiser domains directly on `bid.adomain`.

## Changes
- `adapters/rubicon/rubicon.go`:
  - `resolveAdvertiserID` reads `bid.ext.rp.advid`, using `jsonutil.StringInt` for the numeric-or-string coercion (the same pattern already used elsewhere in this codebase for exactly this kind of loosely-typed vendor field).
  - `updateBidExtWithMeta` now also sets `AdvertiserID`/`AdvertiserDomains` in every branch of its existing merge-into-`Meta` logic, and its early-return guard is extended so a bid with only an advertiser ID/domains (and no networkId/seat) still gets its meta populated.
- `adapters/rubicon/rubicon_test.go`: two new tests, `TestUpdateBidExtWithMeta_AdvertiserIdFromRpAdvid` (numeric and string `advid`) and `TestUpdateBidExtWithMeta_AdvertiserDomainsFromAdomain`, mirroring the two tests added in the Java PR.

## Test plan
- [x] `go build ./adapters/rubicon/...`
- [x] `go vet ./adapters/rubicon/...`
- [x] `go test ./adapters/rubicon/...` — all pass, including existing tests (`TestOpenRTBResponseBidExtPrebidMetaPassthrough`, `TestUpdateBidExtWithMeta_OnlySeatSet`) confirming no regression to the existing networkId/seat behavior.
- [x] Verified the new tests actually catch the regression: reverted `rubicon.go` alone and confirmed both new tests fail (`unexpected end of JSON input` / advertiserId not set), then restored the fix and confirmed the full package passes again.