### PR TITLE
vtrack: relax Impression tag matching for VAST injection

### DIFF
--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -27,6 +27,14 @@ const (
 	IntegrationParameter = "int"
 	ImpressionCloseTag   = "</Impression>"
 	ImpressionOpenTag    = "<Impression>"
+)
+
+// impressionOpenTagRegex and impressionCloseTagRegex match real-world <Impression> tags, which vary
+// in case and may carry whitespace or attributes (e.g. "<  impression id=\"1\" >"), unlike the exact
+// literal ImpressionOpenTag/ImpressionCloseTag strings above, which are only ever used to emit new tags.
+var (
+	impressionOpenTagRegex  = regexp.MustCompile(`(?i)<\s*impression(?:>|\s.*?>)`)
+	impressionCloseTagRegex = regexp.MustCompile(`(?i)<\s*/\s*impression(?:>|\s.*?>)`)
 )
 
 type vtrackEndpoint struct {
@@ -298,22 +306,22 @@ func getIntegrationType(httpRequest *http.Request) (string, error) {
 
 // ModifyVastXmlString rewrites and returns the string vastXML and a flag indicating if it was modified
 func ModifyVastXmlString(externalUrl, vast, bidid, bidder, accountID string, timestamp int64, integrationType string) (string, bool) {
-	ci := strings.Index(vast, ImpressionCloseTag)
+	closeTagLoc := impressionCloseTagRegex.FindStringIndex(vast)
 
 	// no impression tag - pass it as it is
-	if ci == -1 {
+	if closeTagLoc == nil {
 		return vast, false
 	}
 
 	vastUrlTracking := GetVastUrlTracking(externalUrl, bidid, bidder, accountID, timestamp, integrationType)
 	impressionUrl := "<![CDATA[" + vastUrlTracking + "]]>"
-	oi := strings.Index(vast, ImpressionOpenTag)
+	openTagLoc := impressionOpenTagRegex.FindStringIndex(vast)
 
-	if ci-oi == len(ImpressionOpenTag) {
-		return strings.Replace(vast, ImpressionOpenTag, ImpressionOpenTag+impressionUrl, 1), true
+	if openTagLoc != nil && closeTagLoc[0] == openTagLoc[1] {
+		return vast[:openTagLoc[1]] + impressionUrl + vast[openTagLoc[1]:], true
 	}
 
-	return strings.Replace(vast, ImpressionCloseTag, ImpressionCloseTag+ImpressionOpenTag+impressionUrl+ImpressionCloseTag, 1), true
+	return vast[:closeTagLoc[1]] + ImpressionOpenTag + impressionUrl + ImpressionCloseTag + vast[closeTagLoc[1]:], true
 }
 
 // ModifyVastXmlJSON modifies BidCacheRequest element Vast XML data

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -836,3 +836,62 @@ func TestGetIntegrationType(t *testing.T) {
 		}
 	}
 }
+
+func TestModifyVastXmlString(t *testing.T) {
+	const (
+		externalUrl     = "http://external.url"
+		bidid           = "bid-id"
+		bidder          = "bidder"
+		accountID       = "account-id"
+		timestamp       = int64(1000)
+		integrationType = ""
+	)
+	vastUrlTracking := GetVastUrlTracking(externalUrl, bidid, bidder, accountID, timestamp, integrationType)
+	impressionUrl := "<![CDATA[" + vastUrlTracking + "]]>"
+
+	testCases := []struct {
+		description  string
+		givenVast    string
+		expectedVast string
+		expectedOk   bool
+	}{
+		{
+			description:  "No impression tag at all - vast returned unmodified",
+			givenVast:    vastXmlWithoutImpression,
+			expectedVast: vastXmlWithoutImpression,
+			expectedOk:   false,
+		},
+		{
+			description:  "Exact-case empty impression tag - tracking inserted inside the pair",
+			givenVast:    vastXmlWithImpressionWithoutContent,
+			expectedVast: "<VAST version=\"3.0\"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Impression>" + impressionUrl + "</Impression><Creatives></Creatives></Wrapper></Ad></VAST>",
+			expectedOk:   true,
+		},
+		{
+			description:  "Exact-case impression tag with existing content - a new tag is appended after it",
+			givenVast:    vastXmlWithImpressionWithContent,
+			expectedVast: "<VAST version=\"3.0\"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Impression>content</Impression>" + ImpressionOpenTag + impressionUrl + ImpressionCloseTag + "<Creatives></Creatives></Wrapper></Ad></VAST>",
+			expectedOk:   true,
+		},
+		{
+			description:  "Lowercase empty impression tag - tracking still inserted inside the pair",
+			givenVast:    "<VAST><Ad><Wrapper><impression></impression></Wrapper></Ad></VAST>",
+			expectedVast: "<VAST><Ad><Wrapper><impression>" + impressionUrl + "</impression></Wrapper></Ad></VAST>",
+			expectedOk:   true,
+		},
+		{
+			description:  "Impression tag with whitespace, attributes, and mismatched case - a new tag is appended after it",
+			givenVast:    "<Wrapper><  impreSSion garbage >http://test.com<  /ImPression  garbage ></Wrapper>",
+			expectedVast: "<Wrapper><  impreSSion garbage >http://test.com<  /ImPression  garbage >" + ImpressionOpenTag + impressionUrl + ImpressionCloseTag + "</Wrapper>",
+			expectedOk:   true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			result, ok := ModifyVastXmlString(externalUrl, test.givenVast, bidid, bidder, accountID, timestamp, integrationType)
+			assert.Equal(t, test.expectedOk, ok)
+			assert.Equal(t, test.expectedVast, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #3579, a port of [prebid-server-java#3059](https://github.com/prebid/prebid-server-java/pull/3059).

`ModifyVastXmlString` (`endpoints/events/vtrack.go`) is the shared function used both by the `/vtrack` endpoint and by `exchange/events.go`'s own VAST event-tracking injection during a normal auction. It matched the literal strings `"<Impression>"`/`"</Impression>"` only. Real-world VAST XML from different vendors varies in case, whitespace, and attribute/self-closing formatting (e.g. `"<  Impression id=\"1\" >"`), none of which the exact-string match would find — silently skipping impression-tracking injection for otherwise well-formed VAST. PBS-Java had the identical defect and fixed it with tolerant regexes.

## Changes
- `endpoints/events/vtrack.go`: replaces the literal `strings.Index`/`strings.Replace` calls with case-insensitive regexes (`impressionOpenTagRegex`/`impressionCloseTagRegex`) that tolerate whitespace and attributes, while preserving the exact same insertion-point logic — insert tracking inside an adjacent empty tag pair if one exists, otherwise append a new tag right after the matched close tag — and still emitting canonically-cased `<Impression>`/`</Impression>` tags for newly inserted content (the existing `ImpressionOpenTag`/`ImpressionCloseTag` constants are unchanged and still used for that).
- `endpoints/events/vtrack_test.go`: adds `TestModifyVastXmlString`, which didn't exist as a standalone unit test before (the function was previously only exercised indirectly through higher-level integration tests). Covers both of the original exact-match cases and two new tolerant-matching cases, including the same adversarial mismatched-case/whitespace/attribute example used in the Java PR's own test.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./endpoints/events/...`
- [x] `go test ./endpoints/events/... ./exchange/...` — all pass, including the existing exact-match integration tests (`TestShouldSendToCacheExpectedPuts...`), confirming no regression to current behavior.
- [x] Verified the new test actually catches the regression: reverted `vtrack.go` alone and confirmed `TestModifyVastXmlString` fails on the tolerant-matching cases, then restored the fix and confirmed the full package passes again.