### PR TITLE
Tappx: accept new-style endpoints with suffixes longer than 3 chars

### DIFF
--- a/adapters/tappx/tappx.go
+++ b/adapters/tappx/tappx.go
@@ -135,7 +135,7 @@ func (a *TappxAdapter) buildEndpointURL(params *openrtb_ext.ExtImpTappx, test in
 			Message: "Tappx key undefined",
 		}
 	}
-	isNewEndpoint, err := regexp.Match(`^(zz|vz)[0-9]{3,}([a-z]{2,3}|test)$`, []byte(params.Endpoint))
+	isNewEndpoint, err := regexp.Match(`^(zz|vz)[0-9]{3,}([a-z]{2,}|test)$`, []byte(params.Endpoint))
 	if err != nil {
 		return "", &errortypes.BadInput{
 			Message: "Unable to match params.Endpoint " + string(params.Endpoint) + "): " + err.Error(),

--- a/adapters/tappx/tappx_test.go
+++ b/adapters/tappx/tappx_test.go
@@ -54,3 +54,20 @@ func TestTsValue(t *testing.T) {
 	}
 	assert.True(t, match)
 }
+
+func TestNewEndpointWithSuffixLongerThanThreeChars(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderTappx, config.Adapter{
+		Endpoint: "http://{{.Host}}"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	require.NoError(t, buildErr, "Builder")
+
+	bidderTappx := bidder.(*TappxAdapter)
+
+	var tappxExt openrtb_ext.ExtImpTappx
+	tappxExt.Endpoint = "zz123456abcd"
+	tappxExt.TappxKey = "dummy-tappx-key"
+
+	url, err := bidderTappx.buildEndpointURL(&tappxExt, 1)
+	require.NoError(t, err, "buildEndpointURL")
+
+	assert.Equal(t, "http://zz123456abcd.pub.tappx.com/rtb/?tappxkey=dummy-tappx-key&type_cnn=prebid&v=1.6", url)
+}


### PR DESCRIPTION
### Problem

`buildEndpointURL` classifies an endpoint as new-style with:

```go
`^(zz|vz)[0-9]{3,}([a-z]{2,3}|test)$`
```

The alpha suffix is capped at 3 characters. Tappx also issues endpoint ids with longer
suffixes (shape `zz123456abcd`). Those fail the match, fall through to the legacy branch, and
are POSTed to `ssp.api.tappx.com/rtb/v2/<endpoint>`, which returns **404** for them — instead
of `<endpoint>.pub.tappx.com/rtb/`, which serves normally.

Because the failure is a bidder-level HTTP error, the auction still returns 200 with no
seatbid and the only trace is `ext.errors.tappx` (`code 4, "Server responded with failure
status: 404"`). Affected publishers look like they simply never bid.

### Why the cap is wrong

Tappx's own Prebid.js adapter treats **any** `zz*`/`vz*` value as a new-style endpoint
([`modules/tappxBidAdapter.js`](https://github.com/prebid/Prebid.js/blob/master/modules/tappxBidAdapter.js)
uses `^(vz.*|zz.*)\.*$`). The Go adapter is stricter than the vendor's own reference
implementation, so an endpoint id issued by Tappx can be unroutable here while working in
Prebid.js.

This has also happened before: #2444 ("Tappx: Fix bug in regex") widened the same expression
from `[a-z]{2}` to `[a-z]{2,3}` for exactly this reason. Rather than bump the bound again to
`{2,4}` and wait for the next recurrence, this makes it `{2,}`.

### Change

One character: `[a-z]{2,3}` → `[a-z]{2,}`, plus a regression test asserting a 4-character
suffix resolves to the new-style host.

Behaviour is unchanged for every id that matches today. The only ids affected are `zz`/`vz` +
digits + 4-or-more lowercase letters, which currently 404. Legacy uppercase ids
(`ZZ123456PS`) are unaffected — the expression is case-sensitive and they continue to take
the legacy path. The `|test` alternative is now subsumed by `[a-z]{2,}` but is left in place
to keep the diff minimal and the intent readable.

### Security note

The relaxed pattern still admits only `[a-z0-9]`, anchored at both ends — no dots, slashes,
`@`, or colons — so it remains strictly narrower than `urlutil.IsSafeHost`, and the
defense-in-depth check added for a future relaxation of this regex stays unreachable. No new
SSRF surface.

### Testing

`go test ./adapters/tappx/...` passes. The new test fails without the source change and
reproduces the wrong URL (`ssp.api.tappx.com/rtb/v2/...`), confirming it pins the regression.
The test uses a synthetic endpoint id and a dummy key.
