### PR TITLE
fix(exchange): look up request-alias bidderInfo by core bidder name

### DIFF
--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -219,7 +219,19 @@ func (rs *requestSplitter) cleanOpenRTBRequests(ctx context.Context,
 		}
 
 		// down convert
-		info, ok := rs.bidderInfo[bidder]
+		//
+		// For a request alias (declared in req.ext.prebid.aliases, as opposed to a
+		// YAML-declared static alias), rs.bidderInfo has no entry keyed by the alias
+		// name at all -- only real/YAML-aliased bidder names are loaded into it at
+		// startup -- so looking it up by "bidder" always misses and silently downgrades
+		// every request-alias bidder request to OpenRTB 2.5, regardless of the core
+		// bidder's actual declared version. Look it up by the resolved core bidder name
+		// instead in that case; the non-alias lookup key is left unchanged.
+		bidderInfoKey := bidder
+		if isRequestAlias {
+			bidderInfoKey = string(coreBidder)
+		}
+		info, ok := rs.bidderInfo[bidderInfoKey]
 		if !ok || info.OpenRTB == nil || info.OpenRTB.Version != "2.6" {
 			reqWrapperCopy.Regs = ortb.CloneRegs(reqWrapperCopy.Regs)
 			if err := openrtb_ext.ConvertDownTo25(reqWrapperCopy); err != nil {

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -852,6 +852,63 @@ func TestCleanOpenRTBRequestsWithFPD(t *testing.T) {
 	}
 }
 
+// TestCleanOpenRTBRequestsRequestAliasOpenRTBVersion is a regression test for a bug where a
+// request-level alias (declared in req.ext.prebid.aliases, as opposed to a YAML-declared
+// static alias) always had its OpenRTB version looked up under its own alias name in
+// rs.bidderInfo. Since rs.bidderInfo is only ever populated with real bidder names (and
+// YAML-declared aliases) at startup, that lookup always missed for a request alias, so its
+// outgoing request was unconditionally downgraded to OpenRTB 2.5 even when the alias pointed
+// at a core bidder explicitly configured for OpenRTB 2.6. The lookup must use the resolved
+// core bidder name instead.
+func TestCleanOpenRTBRequestsRequestAliasOpenRTBVersion(t *testing.T) {
+	buildRequest := func() *openrtb2.BidRequest {
+		return &openrtb2.BidRequest{
+			Site: &openrtb2.Site{Page: "www.some.domain.com"},
+			User: &openrtb2.User{
+				EIDs: []openrtb2.EID{{Source: "eids-source", UIDs: []openrtb2.UID{{ID: "id"}}}},
+			},
+			Imp: []openrtb2.Imp{{
+				ID:     "some-imp-id",
+				Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}},
+				Ext:    json.RawMessage(`{"prebid":{"bidder":{"somealias": {"placementId": 1}}}}`),
+			}},
+			Ext: json.RawMessage(`{"prebid":{"aliases":{"somealias":"appnexus"}}}`),
+		}
+	}
+
+	emptyTCF2Config := gdpr.NewTCF2Config(config.TCF2{}, config.AccountGDPR{})
+	gdprPermsBuilder := fakePermissionsBuilder{
+		permissions: &permissionsMock{allowAllBidders: true},
+	}.Builder
+
+	reqSplitter := &requestSplitter{
+		bidderToSyncerKey: map[string]string{},
+		me:                &metrics.MetricsEngineMock{},
+		gdprPermsBuilder:  gdprPermsBuilder,
+		hostSChainNode:    nil,
+		// Only the core bidder "appnexus" is known to bidderInfo, exactly as it would be
+		// in production -- request aliases never get their own bidderInfo entry.
+		bidderInfo: config.BidderInfos{"appnexus": config.BidderInfo{OpenRTB: &config.OpenRTBInfo{Version: "2.6"}}},
+	}
+
+	auctionReq := AuctionRequest{
+		BidRequestWrapper: &openrtb_ext.RequestWrapper{BidRequest: buildRequest()},
+		UserSyncs:         &emptyUsersync{},
+		TCF2Config:        emptyTCF2Config,
+	}
+
+	bidderRequests, _, errs := reqSplitter.cleanOpenRTBRequests(context.Background(), auctionReq, nil, map[string]float64{})
+	assert.Empty(t, errs)
+	require.Len(t, bidderRequests, 1)
+
+	aliasRequest := bidderRequests[0]
+	assert.Equal(t, openrtb_ext.BidderName("somealias"), aliasRequest.BidderName)
+	assert.True(t, aliasRequest.IsRequestAlias)
+	// If the request were incorrectly downgraded to OpenRTB 2.5, ConvertDownTo25 would move
+	// user.eids into user.ext.eids and clear the top-level EIDs slice.
+	assert.NotNil(t, aliasRequest.BidRequest.User.EIDs, "request alias should inherit the core bidder's OpenRTB 2.6 version and not be downgraded")
+}
+
 func TestExtractAdapterReqBidderParamsMap(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Problem

Fixes #4266.

`cleanOpenRTBRequests` (`exchange/utils.go`) decides whether to downgrade a
per-bidder outgoing request from OpenRTB 2.6 to 2.5 by looking up the
bidder's declared version in `rs.bidderInfo`:

```go
info, ok := rs.bidderInfo[bidder]
if !ok || info.OpenRTB == nil || info.OpenRTB.Version != "2.6" {
    // downgrade to 2.5
}
```

`bidder` here is the request-level bidder key from the `impsByBidder` map
(e.g. `imp.ext.prebid.bidder.<key>`). For a **request-level alias** —
declared per-request in `req.ext.prebid.aliases` (as opposed to a
YAML-declared static alias in `static/bidder-info/`) — that key is the alias
name itself (e.g. `"pubmatic_alias"`), not the core bidder name
(`"pubmatic"`).

`rs.bidderInfo` (`config.BidderInfos`) is populated once at startup from the
static per-bidder YAML configs, so it only ever has entries for real bidder
names and *statically*-declared aliases. A request alias has no entry there
at all. The lookup above therefore always misses for a request alias
(`ok == false`), and the request is unconditionally downgraded to OpenRTB
2.5 — even when the core bidder it resolves to is explicitly configured for
OpenRTB 2.6.

Concretely: if `pubmatic` is configured with `openrtb.version: "2.6"` and a
request declares `"aliases": {"pubmatic_alias": "pubmatic"}`, PubMatic's
endpoint ends up receiving two differently-versioned requests for what
should be the identical protocol version — `pubmatic` at 2.6 and
`pubmatic_alias` at 2.5.

## Verification

Confirmed against current `master` (`exchange/utils.go`, the `// down
convert` block) that the lookup is still keyed by the raw `bidder` string
with no alias-aware branching — the bug described in #4266 is still present.

`coreBidder, isRequestAlias := resolveBidder(bidder, requestAliases)` is
already computed earlier in the same loop iteration and gives exactly the
resolved core bidder name needed here.

## Fix

For a request alias, look the OpenRTB version up by the resolved core
bidder name instead of the raw per-request bidder key; the non-alias lookup
key is left completely unchanged (still `bidder`, exactly as before) to
avoid any behavior change outside the specific request-alias case.

## Test

Added `TestCleanOpenRTBRequestsRequestAliasOpenRTBVersion` in
`exchange/utils_test.go`: builds a request with `user.eids` set and a
request alias `"somealias" -> "appnexus"`, with `rs.bidderInfo` populated
only for the core bidder `"appnexus"` at OpenRTB 2.6 (exactly as it would be
in production — request aliases never get their own `bidderInfo` entry).
Asserts the alias's outgoing request keeps `user.eids` at the top level
(OpenRTB 2.6 location) rather than being moved into `user.ext.eids` by
`ConvertDownTo25` (which is exactly what a 2.5 downgrade does, per
`openrtb_ext/convert_down.go`'s `moveEIDFrom26To25`).

Proved this is a real regression test via revert-and-reconfirm:
- Reverted only the `exchange/utils.go` change (kept the new test) →
  `TestCleanOpenRTBRequestsRequestAliasOpenRTBVersion` fails with
  `Expected value not to be nil` (EIDs were moved into `user.ext.eids`,
  i.e. the alias request was downgraded to 2.5).
- Restored the fix → the test passes.

An earlier version of this fix looked the OpenRTB version up by
`string(coreBidder)` unconditionally (not just for request aliases), which
broke `TestCleanOpenRTBRequestsEidPermissionsRaceCondition`: that test uses
fictional, unregistered bidder names (`"bidderA"`/`"bidderB"`/`"bidderC"`)
that `openrtb_ext.NormalizeBidderName` can't resolve, so `coreBidder` came
back empty for the non-alias case. The fix was narrowed to only change the
lookup key when `isRequestAlias` is true, which resolves the issue without
touching the non-alias code path or its existing test expectations at all.

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l exchange/utils.go exchange/utils_test.go` — clean
- `go test ./exchange/...` — all pass (including the new test)

Note for reviewers: `go test ./exchange/... -race` and
`go test ./endpoints/openrtb2/...` each have one pre-existing, unrelated
failure on unmodified `master` in this environment
(`TestTwoBiddersDebugDisabledAndEnabled` — a data race in test-only global
JSON config state under `-race`; `TestSendAuctionResponse_LogsErrors` — a Go
stdlib JSON error-message string difference). Both reproduce identically on
`master` without this change and are unrelated to it.

## Scope

Narrowly scoped to the OpenRTB-version lookup for request aliases in
`cleanOpenRTBRequests`. The issue also flags `applyBidAdjustmentToFloor` and
`prepareUser` as other places that "might" need the core bidder name instead
of the alias — those are separate, independently-verifiable call sites and
are intentionally left out of this PR to keep the change minimal and
reviewable.