### PR TITLE
fix(gdpr): exclude deleted vendors from the live GVL vendor ID set

### DIFF
--- a/gdpr/gvl_vendor_ids.go
+++ b/gdpr/gvl_vendor_ids.go
@@ -59,16 +59,24 @@ func NewGVLVendorIDTickerTask(interval time.Duration, client *http.Client, urlMa
 	})
 }
 
-// gvlVendorListContract is a lightweight contract for parsing only vendor IDs from GVL JSON
+// gvlVendorListContract is a lightweight contract for parsing only vendor IDs from GVL JSON.
+//
+// DeletedDate is present (as an ISO 8601 date string) only for a vendor that has been deleted
+// from the GVL. Per the IAB TCF spec, a deleted vendor is NOT removed from the "vendors" map --
+// it is left in place, marked with this field, so that historical GVL versions referencing it
+// remain interpretable. Any code that treats mere presence in this map as "valid" must check
+// this field and exclude deleted vendors, or it will treat deleted vendors as still valid.
 type gvlVendorListContract struct {
 	Vendors map[string]struct {
-		ID uint16 `json:"id"`
+		ID          uint16 `json:"id"`
+		DeletedDate string `json:"deletedDate,omitempty"`
 	} `json:"vendors"`
 }
 
 // FetchLatestGVLVendorIDs fetches the most recent Global Vendor List and returns a set of all
-// vendor IDs present in it. The returned map has vendor IDs as keys and empty structs as values.
-// If the fetch or parse fails, an empty map is returned.
+// non-deleted vendor IDs present in it (vendors marked with a "deletedDate" are excluded). The
+// returned map has vendor IDs as keys and empty structs as values. If the fetch or parse fails,
+// an empty map is returned.
 func FetchLatestGVLVendorIDs(ctx context.Context, client *http.Client, urlMaker func(uint16, uint16) string, me metrics.MetricsEngine) map[uint16]struct{} {
 	vendorIDs := make(map[uint16]struct{})
 
@@ -111,6 +119,11 @@ func FetchLatestGVLVendorIDs(ctx context.Context, client *http.Client, urlMaker 
 	}
 
 	for _, v := range contract.Vendors {
+		// Skip vendors marked as deleted -- they must be treated the same as if they never
+		// existed, not as still-valid entries just because they remain present in the list.
+		if v.DeletedDate != "" {
+			continue
+		}
 		vendorIDs[v.ID] = struct{}{}
 	}
 

--- a/gdpr/gvl_vendor_ids_test.go
+++ b/gdpr/gvl_vendor_ids_test.go
@@ -42,6 +42,31 @@ func TestFetchLatestGVLVendorIDs(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: a vendor marked with "deletedDate" is NOT removed from the GVL's
+			// "vendors" map per the IAB TCF spec -- it is left in place, just flagged. A deleted
+			// vendor must be excluded from the returned ID set, not treated as still valid merely
+			// because it is still present.
+			name: "fetch-excludes-deleted-vendor",
+			settings: serverSettings{
+				vendorListLatestVersion: 1,
+				vendorLists: map[int]map[int]string{
+					3: {
+						1: MarshalVendorList(vendorList{
+							GVLSpecificationVersion: 3,
+							VendorListVersion:       1,
+							Vendors: map[string]*vendor{
+								"10": {ID: 10},
+								"20": {ID: 20, DeletedDate: "2023-06-01"},
+							},
+						}),
+					},
+				},
+			},
+			expectedIDs: map[uint16]struct{}{
+				10: {},
+			},
+		},
+		{
 			name: "fetch-with-no-vendors",
 			settings: serverSettings{
 				vendorListLatestVersion: 1,

--- a/gdpr/vendorlist-fetching_test.go
+++ b/gdpr/vendorlist-fetching_test.go
@@ -313,6 +313,7 @@ type vendor struct {
 	LegIntPurposes   []int  `json:"legIntPurposes"`
 	FlexiblePurposes []int  `json:"flexiblePurposes"`
 	SpecialFeatures  []int  `json:"specialFeatures"`
+	DeletedDate      string `json:"deletedDate,omitempty"`
 }
 
 func MarshalVendorList(vendorList vendorList) string {


### PR DESCRIPTION
## Problem

Fixes #4800 (the dedicated tracking issue for this specific defect, opened
from a comment on #4439, "Handle deleted GVL entities" — the original design
discussion for the `LiveGVLVendorIDs` mechanism added in #4700).

`FetchLatestGVLVendorIDs` (`gdpr/gvl_vendor_ids.go`) fetches the latest
Global Vendor List and builds the set of vendor IDs `LiveGVLVendorIDs`
considers valid, by iterating every entry in the parsed `vendors` map:

```go
for _, v := range contract.Vendors {
    vendorIDs[v.ID] = struct{}{}
}
```

Per the IAB TCF spec, when a vendor is removed from the GVL it is **not**
deleted from the `vendors` map — it is left in place and marked with a
`deletedDate` field (so historical GVL versions that still reference it
remain interpretable). This code ignored that field entirely and treated
every vendor still *present* in the map as valid, which means a deleted
vendor was (and still is, on current `master`) added to the live vendor ID
set exactly as if it were active.

`LiveGVLVendorIDs.Contains` feeds directly into GDPR legal-basis enforcement
(`gdpr/impl.go:136`), so this is the exact scenario the mechanism in #4700
was built to catch, per the design consensus reached in #4439:

> Vendors, who are marked as deleted in the latest GVL, should be treated
> as deleted in all historical GVL versions too, for the purposes of
> privacy enforcement... Deleted GVL entries should be treated the same
> way as if such a vendor never existed in the first place.

and flagged as a concrete implementation bug in #4439 by @Lightwood13:

> I think the current implementation in #4700 is incorrect: it checks if
> vendor is present in the list instead of looking at the `deletedDate`
> field. When the vendor is deleted it is not removed from the list but
> just marked as deleted.

with @bsardo agreeing:

> We should use the `deletedDate` marker rather than looking for presence.

## Verification

Confirmed against current `master` that `gvlVendorListContract` and the
loop in `FetchLatestGVLVendorIDs` still have no knowledge of `deletedDate`
whatsoever (`grep -rni "deleted" gdpr/*.go` outside test files returns
nothing) — the bug described in #4439/#4800 is still present exactly as
reported.

## Fix

Added a `DeletedDate string` field (`json:"deletedDate,omitempty"`) to the
vendor entry in `gvlVendorListContract`, and skip any vendor with a non-empty
`DeletedDate` when building the valid ID set. Deleted vendors are now
excluded from `LiveGVLVendorIDs`, so `Contains` returns `false` for them —
the same result as if the vendor had never existed, matching the agreed
design.

## Test

Added a `"fetch-excludes-deleted-vendor"` case to the existing table-driven
`TestFetchLatestGVLVendorIDs` (`gdpr/gvl_vendor_ids_test.go`): a GVL response
with one active vendor (ID 10) and one vendor marked `deletedDate:
"2023-06-01"` (ID 20), asserting the returned set contains only ID 10.
Added the `DeletedDate` field to the shared test `vendor` fixture struct in
`gdpr/vendorlist-fetching_test.go` so the new case can set it.

Proved this is a real regression test via revert-and-reconfirm:
- Reverted only the skip-logic in `gdpr/gvl_vendor_ids.go` (kept the new
  test case and the `DeletedDate` field) → the new sub-test fails, returning
  `map[uint16]struct{}{10: {}, 20: {}}` (both vendors, deleted one included)
  instead of the expected `map[uint16]struct{}{10: {}}`.
- Restored the fix → the sub-test passes.

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l gdpr/gvl_vendor_ids.go gdpr/gvl_vendor_ids_test.go gdpr/vendorlist-fetching_test.go` — clean
- `go test ./gdpr/...` and `go test ./gdpr/... -race` — all pass
- `go test ./config/...` — pass (unaffected, sanity check since #4700 also touched `config`)

## Note for reviewers

#4800 is currently assigned to @bsardo. I did not see an open or merged PR
referencing #4800, #4439, `deletedDate`, or `gvl_vendor_ids` before starting
this work (checked via `gh pr list --search`), so I'm submitting this as a
small, self-contained fix in case it's useful — happy to have it closed as a
duplicate if there's already work in progress that I couldn't see.

## Scope

Narrowly scoped to the one function responsible for building the valid GVL
vendor ID set. Does not touch the separate, full-GVL-based TCF2
purpose/legal-basis vendor list parsing path (`gdpr/vendorlist-fetching.go`),
which is a different mechanism with its own (unrelated) vendor model and is
out of scope for this specific, already-confirmed defect.