### PR TITLE
Mobkoi: Remove hardcoded bid seat so aliases work

### DIFF
--- a/adapters/mobkoi/mobkoi.go
+++ b/adapters/mobkoi/mobkoi.go
@@ -99,7 +99,6 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
 				Bid:     &seatBid.Bid[i],
 				BidType: openrtb_ext.BidTypeBanner,
-				Seat:    "mobkoi",
 			})
 
 		}

--- a/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
@@ -137,8 +137,7 @@
             "lurl": "mobkoi/loss",
             "nurl": "mobkoi/win"
           },
-          "type": "banner",
-          "seat": "mobkoi"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
@@ -133,8 +133,7 @@
             "lurl": "mobkoi/loss",
             "nurl": "mobkoi/win"
           },
-          "type": "banner",
-          "seat": "mobkoi"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/supplemental/seat-not-hardcoded.json
+++ b/adapters/mobkoi/mobkoitest/supplemental/seat-not-hardcoded.json
@@ -21,7 +21,7 @@
     "imp": [
       {
         "id": "some-impression-id1",
-        "tagid": "originalTagId",
+        "tagid": "",
         "banner": {
           "w": 320,
           "h": 50
@@ -105,13 +105,11 @@
                   ],
                   "crid": "20",
                   "w": 320,
-                  "h": 50,
-                  "lurl": "mobkoi/loss",
-                  "nurl": "mobkoi/win"
+                  "h": 50
                 }
               ],
               "type": "banner",
-              "seat": "mobkoi"
+              "seat": "mobkoi-request-alias"
             }
           ],
           "cur": "USD"
@@ -133,9 +131,7 @@
               "awesome.com"
             ],
             "w": 320,
-            "h": 50,
-            "lurl": "mobkoi/loss",
-            "nurl": "mobkoi/win"
+            "h": 50
           },
           "type": "banner"
         }


### PR DESCRIPTION
## Problem

Related tracking issue: [#4905](https://github.com/prebid/prebid-server/issues/4905) (auto-generated "Port PR from PBS-Java" issue tracking [prebid-server-java#4549](https://github.com/prebid/prebid-server-java/pull/4549)).

`MakeBids` in `adapters/mobkoi/mobkoi.go` unconditionally sets every `TypedBid.Seat` to the literal string `"mobkoi"`:

```go
bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
    Bid:     &seatBid.Bid[i],
    BidType: openrtb_ext.BidTypeBanner,
    Seat:    "mobkoi",
})
```

`adapters.TypedBid.Seat`'s own doc comment says: "new seat under which the bid should be placed. Default is adapter name." The intended contract is that an adapter only sets `Seat` when it needs to *override* the default (e.g. a true multi-seat response from an upstream exchange) — leaving it empty lets the default (the bidder request's own name) apply.

In `exchange/bidder.go`:

```go
bidderName := bidderRequest.BidderName
if bidResponse.Bids[i].Seat != "" {
    bidderName = bidResponse.Bids[i].Seat
}

if valid, err := alternateBidderCodes.IsValidBidderCode(bidderRequest.BidderName.String(), bidderName.String()); !valid {
    ...
    continue // bid is dropped
}
```

`bidderRequest.BidderName` is the request-level bidder key, which for a **request-level alias** (`req.ext.prebid.aliases`, e.g. `{"mobkoiCustom": "mobkoi"}`) is the alias name (`"mobkoiCustom"`), not the core bidder name (`"mobkoi"`). Because mobkoi's adapter always overrides with the hardcoded `"mobkoi"`, `bidderName` becomes `"mobkoi"` while `bidderRequest.BidderName` is `"mobkoiCustom"`. `IsValidBidderCode("mobkoiCustom", "mobkoi")` (`openrtb_ext/alternatebiddercodes.go`) is not a case-fold match, `alternateBidderCodes` is disabled by default, so the check returns `false` and **every bid from an aliased mobkoi request is silently dropped** — the alias would receive zero bids regardless of what mobkoi's endpoint actually returned.

## Verification

Confirmed the defect is live on current `master`: `adapters/mobkoi/mobkoi.go` has a single history commit (`New Adapter: Mobkoi`), no later commit touched the `Seat` field. Traced `exchange/bidder.go`'s seat-resolution/validation logic and `openrtb_ext/alternatebiddercodes.go`'s `IsValidBidderCode` to confirm the exact failure mode described above. Checked that no other file in the repo references `"mobkoi"` as a hardcoded seat/bidder string outside the adapter package itself.

## Fix

Removed the hardcoded `Seat: "mobkoi"` line, matching the fix already merged on PBS-Java (`prebid-server-java#4549`, which removed the equivalent hardcoded seat argument from `BidderBid.of(...)`). This is also the pattern already used by other simple, single-seat adapters in this codebase (e.g. `adapters/teal/teal.go`, which never sets `TypedBid.Seat` at all).

Updated the 3 existing exemplary JSON fixtures whose `expectedBidResponses` asserted the hardcoded `"seat": "mobkoi"` (the mock upstream response itself still returns `"seat": "mobkoi"` — only the adapter's own forced echo of it into `TypedBid.Seat` is removed). Added a new supplemental fixture, `seat-not-hardcoded.json`, mocking an upstream response labeled with a *different* seat (`"mobkoi-request-alias"`) and asserting the adapter's output carries no forced seat at all — proving the adapter no longer injects its own name regardless of what the upstream response says.

## Revert-and-reconfirm

Reverted `adapters/mobkoi/mobkoi.go` alone (keeping the updated fixtures) and confirmed `TestJsonSamples` fails on all 3 exemplary fixtures plus the new supplemental fixture:

```
Error: Not equal:
expected: ""
actual  : "mobkoi"
Messages: mobkoitest/exemplary/banner-web.json: typedBid[0].seat "mobkoi" does not match expected "."
```

Restored the fix and confirmed `TestJsonSamples` passes. `go build ./...`, `go vet ./adapters/mobkoi/...`, `gofmt -l adapters/mobkoi/`, and `go test ./adapters/mobkoi/... -race` all clean.

## Scope

Narrowly scoped to the one hardcoded-seat line and its direct test fixtures. No other behavior of the adapter is touched.
