### PR TITLE
Mobkoi: do not hardcode bid seat, to support aliases

### DIFF
--- a/adapters/mobkoi/mobkoi.go
+++ b/adapters/mobkoi/mobkoi.go
@@ -96,10 +96,12 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 
 	for _, seatBid := range response.SeatBid {
 		for i := range seatBid.Bid {
+			// Seat is intentionally left unset (defaults to the requested bidder
+			// code) so that Mobkoi aliases are labeled correctly instead of
+			// always being reported as "mobkoi".
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
 				Bid:     &seatBid.Bid[i],
 				BidType: openrtb_ext.BidTypeBanner,
-				Seat:    "mobkoi",
 			})
 
 		}

--- a/adapters/mobkoi/mobkoi_test.go
+++ b/adapters/mobkoi/mobkoi_test.go
@@ -3,9 +3,12 @@ package mobkoi
 import (
 	"testing"
 
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
 	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonSamples(t *testing.T) {
@@ -18,4 +21,41 @@ func TestJsonSamples(t *testing.T) {
 	}
 
 	adapterstest.RunJSONBidderTest(t, "mobkoitest", bidder)
+}
+
+// TestMakeBidsDoesNotHardcodeSeat guards against re-introducing a hardcoded
+// "mobkoi" bid seat. Aliases of the mobkoi bidder (e.g. a publisher-specific
+// alias configured in request.ext.prebid.aliases) rely on TypedBid.Seat being
+// left empty so the exchange labels the bid with the requested bidder code
+// (see exchange/bidder.go, which only overrides the alias-derived bidder name
+// when Seat is non-empty) instead of always reporting it under the core
+// "mobkoi" seat.
+func TestMakeBidsDoesNotHardcodeSeat(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderMobkoi, config.Adapter{
+		Endpoint: "http://dev.mobkoi.com/bid"},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	response := `{
+		"id": "resp-id",
+		"cur": "USD",
+		"seatbid": [{
+			"seat": "mobkoi",
+			"type": "banner",
+			"bid": [{"id": "bid-1", "impid": "imp-1", "price": 1.5}]
+		}]
+	}`
+
+	bidderResponse, errs := bidder.MakeBids(
+		&openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "imp-1"}}},
+		&adapters.RequestData{},
+		&adapters.ResponseData{StatusCode: 200, Body: []byte(response)},
+	)
+
+	assert.Empty(t, errs)
+	if assert.Len(t, bidderResponse.Bids, 1) {
+		assert.Empty(t, bidderResponse.Bids[0].Seat, "Seat must be left empty so aliases are labeled with the requested bidder code")
+	}
 }

--- a/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/banner-web.json
@@ -137,8 +137,7 @@
             "lurl": "mobkoi/loss",
             "nurl": "mobkoi/win"
           },
-          "type": "banner",
-          "seat": "mobkoi"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/placement-id-overrides-tagid.json
@@ -137,8 +137,7 @@
             "lurl": "mobkoi/loss",
             "nurl": "mobkoi/win"
           },
-          "type": "banner",
-          "seat": "mobkoi"
+          "type": "banner"
         }
       ]
     }

--- a/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
+++ b/adapters/mobkoi/mobkoitest/exemplary/use-tag-id.json
@@ -133,8 +133,7 @@
             "lurl": "mobkoi/loss",
             "nurl": "mobkoi/win"
           },
-          "type": "banner",
-          "seat": "mobkoi"
+          "type": "banner"
         }
       ]
     }


### PR DESCRIPTION
## Problem

`MobkoiAdapter.MakeBids` (`adapters/mobkoi/mobkoi.go`) hardcoded every returned `TypedBid.Seat` to the literal `"mobkoi"`:

```go
bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
    Bid:     &seatBid.Bid[i],
    BidType: openrtb_ext.BidTypeBanner,
    Seat:    "mobkoi",
})
```

`exchange/bidder.go` only substitutes the alias-resolved requested bidder name for a bid's seat when the adapter leaves `Seat` empty:

```go
bidderName := bidderRequest.BidderName
if bidResponse.Bids[i].Seat != "" {
    bidderName = bidResponse.Bids[i].Seat
}
```

(`bidderRequest.BidderName` is the *requested* bidder code — i.e. an alias name such as `mobkoi_alias` when the request used a publisher-configured Mobkoi alias, not the core `mobkoi` name.)

Because Mobkoi always set `Seat: "mobkoi"`, every bid from every Mobkoi alias was unconditionally labeled under the core `"mobkoi"` seat, breaking per-alias bid attribution/reporting for any publisher using a Mobkoi alias — exactly the same defect class fixed on the PBS-Java side.

## Verification this is real and current

- Confirmed `adapters/mobkoi/mobkoi.go` still hardcodes `Seat: "mobkoi"` on current `master`.
- Confirmed the `TypedBid.Seat` doc comment (`adapters/bidder.go`): *"new seat under which the bid should [be] placed. Default is adapter name"* — i.e. leaving it unset is the intended way to defer to the exchange's own bidder-name resolution.
- Traced `exchange/bidder.go`'s seat-resolution logic above to confirm empty `Seat` does defer to the request's (possibly-aliased) bidder name.
- This is the confirmed Go-side counterpart of prebid-server-java#4549: https://github.com/prebid/prebid-server-java/pull/4549 ("Mobkoi: do not hardcode bid seat, to support aliases"), tracked by the bot-filed port issue https://github.com/prebid/prebid-server/issues/4905. The Java fix is the identical one-line change (drop the hardcoded seat literal from the `BidderBid.of(...)` call) plus a test asserting the seat is left unset — mirrored here.

## Fix

Removed the hardcoded `Seat: "mobkoi"` field so it defaults to the zero value, letting the exchange label the bid with the requested (possibly aliased) bidder code.

## Tests

- Added `TestMakeBidsDoesNotHardcodeSeat` (direct `MakeBids` unit test) asserting the returned bid's `Seat` is empty.
- Updated the three exemplary JSON fixtures (`banner-web.json`, `placement-id-overrides-tagid.json`, `use-tag-id.json`) whose `expectedBidResponses[].bids[].seat` asserted the old hardcoded `"mobkoi"` value — removed, matching the convention used by other simple adapters that don't set `Seat` (they omit the JSON key entirely).

**Revert-and-reconfirm:** Reverted the `mobkoi.go` change alone (keeping the tests/fixtures) and confirmed both `TestJsonSamples` (2 of the 3 updated fixtures) and the new `TestMakeBidsDoesNotHardcodeSeat` fail deterministically:
```
Error: Not equal: expected: "" actual: "mobkoi"
```
Restored the fix and confirmed all `adapters/mobkoi` tests pass. Full `go build ./...` and `go vet ./...` clean; `gofmt -l adapters/mobkoi/` reports no files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFth3sHBrJbHuFeA8Cegdc
