### PR TITLE
Missena: add GPP params to cookie sync URL

### DIFF
--- a/config/bidderinfo_test.go
+++ b/config/bidderinfo_test.go
@@ -585,6 +585,24 @@ func TestBidderInfoFiles(t *testing.T) {
 	}
 }
 
+// TestMissenaUserSyncForwardsGPP guards against static/bidder-info/missena.yaml's usersync
+// iframe URL regressing to omit the GPP consent macros. Missena's cookie-sync URL previously
+// forwarded gdpr/gdpr_consent/us_privacy but not gpp/gpp_sid, so GPP-covered consent (e.g. US
+// state privacy laws routed through the IAB Global Privacy Platform) was never communicated to
+// Missena's sync endpoint, unlike the overwhelming majority of other syncers in this repo.
+func TestMissenaUserSyncForwardsGPP(t *testing.T) {
+	bidderInfos, err := LoadBidderInfoFromDisk(bidderInfoRelativePath)
+	require.NoError(t, err)
+
+	missena, ok := bidderInfos["missena"]
+	require.True(t, ok, "missena bidder-info not found")
+	require.NotNil(t, missena.Syncer)
+	require.NotNil(t, missena.Syncer.IFrame)
+
+	assert.Contains(t, missena.Syncer.IFrame.URL, "{{.GPP}}", "missena usersync iframe URL must forward the GPP consent string")
+	assert.Contains(t, missena.Syncer.IFrame.URL, "{{.GPPSID}}", "missena usersync iframe URL must forward the GPP Section ID")
+}
+
 func TestBidderInfoValidationPositive(t *testing.T) {
 	bidderInfos := BidderInfos{
 		"bidderA": BidderInfo{

--- a/static/bidder-info/missena.yaml
+++ b/static/bidder-info/missena.yaml
@@ -12,5 +12,5 @@ capabilities:
       - banner
 userSync:
   iframe:
-    url: https://sync.missena.io/iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}
+    url: https://sync.missena.io/iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}
     userMacro: $UID


### PR DESCRIPTION
## Problem

`static/bidder-info/missena.yaml`'s usersync iframe URL forwards `gdpr`, `gdpr_consent`, and `us_privacy` but omits the GPP (IAB Global Privacy Platform) consent macros:

```yaml
userSync:
  iframe:
    url: https://sync.missena.io/iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}
    userMacro: $UID
```

`{{.GPP}}`/`{{.GPPSID}}` are standard macros already populated unconditionally by `usersync.Syncer.GetSync` (via `macros.UserSyncPrivacy`) for every request — 86 other bidder-info YAML files in this repo already include them in their usersync URLs (e.g. Teal's, which correctly has `&gpp={{.GPP}}&gpp_sid={{.GPPSID}}`). Because Missena's template never references these macros, its cookie-sync request to `sync.missena.io` never communicates GPP consent (which conveys, among other things, US state privacy law consent signals) even though the consent state is available in the same request as every other privacy macro.

## Verification this is real and current

- Confirmed `static/bidder-info/missena.yaml` still lacks the GPP macros on current `master`.
- Confirmed `{{.GPP}}`/`{{.GPPSID}}` are a well-established, unconditionally-populated macro pair (`grep -rl "gpp={{.GPP}}&gpp_sid={{.GPPSID}}" static/bidder-info/` → 86 files), so this is a simple omission, not a feature gap requiring new plumbing.
- This is the confirmed Go-side counterpart of prebid-server-java#4383: https://github.com/prebid/prebid-server-java/pull/4383 ("Missena Bid Adapter: add GPP params to cookie sync URL"), tracked by the bot-filed port issue https://github.com/prebid/prebid-server/issues/4702.
- The Java PR also added `endpoint-compression: gzip`, an unrelated change describing whether Missena's live endpoint accepts gzip-compressed requests — not verifiable from this repository alone, so it is intentionally left out of this PR to keep the change scoped to the GPP defect the issue title describes.

## Fix

Added `&gpp={{.GPP}}&gpp_sid={{.GPPSID}}` to Missena's usersync iframe URL template, matching the convention used by the other 86 bidders that already forward these macros.

## Tests

Added `TestMissenaUserSyncForwardsGPP` in `config/bidderinfo_test.go` (next to the existing `TestBidderInfoFiles`), which loads all bidder-info YAML from disk and asserts Missena's syncer iframe URL contains both `{{.GPP}}` and `{{.GPPSID}}`.

**Revert-and-reconfirm:** Reverted `static/bidder-info/missena.yaml` alone (keeping the new test) and confirmed the test fails:
```
Error: "https://sync.missena.io/iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}" does not contain "{{.GPP}}"
```
Restored the fix and confirmed the test passes. Full `go build ./...` and `go vet ./...` clean; `go test ./config/... ./adapters/missena/... ./usersync/...` all pass; `gofmt -l config/ static/` reports no files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFth3sHBrJbHuFeA8Cegdc
