### PR TITLE
Fix: returnCreative applied globally instead of per media type

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -47,7 +47,11 @@ import (
 )
 
 type extCacheInstructions struct {
-	cacheBids, cacheVAST, returnCreative bool
+	cacheBids, cacheVAST bool
+	// returnBidsCreative and returnVastCreative independently control whether the
+	// creative markup (adm) is stripped from non-video and video bids respectively,
+	// mirroring ext.prebid.cache.bids.returnCreative and ext.prebid.cache.vastXml.returnCreative.
+	returnBidsCreative, returnVastCreative bool
 }
 
 // Exchange runs Auctions. Implementations must be threadsafe, and will be shared across many goroutines.
@@ -535,7 +539,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	e.bidValidationEnforcement.SetBannerCreativeMaxSize(r.Account.Validations)
 
 	// Build the response
-	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions.returnCreative, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
+	bidResponse := e.buildBidResponse(ctx, liveAdapters, adapterBids, r.BidRequestWrapper, adapterExtra, auc, bidResponseExt, cacheInstructions.returnBidsCreative, cacheInstructions.returnVastCreative, r.ImpExtInfoMap, r.PubID, errs, &seatNonBidBuilder)
 	bidResponse = adservertargeting.Apply(r.BidRequestWrapper, r.ResolvedBidRequest, bidResponse, r.QueryParams, bidResponseExt, r.Account.TruncateTargetAttribute)
 
 	bidResponse.Ext, err = encodeBidResponseExt(bidResponseExt)
@@ -954,7 +958,7 @@ func errsToBidderWarnings(errs []error) []openrtb_ext.ExtBidderMessage {
 }
 
 // This piece takes all the bids supplied by the adapters and crafts an openRTB response to send back to the requester
-func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterSeatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, bidRequest *openrtb_ext.RequestWrapper, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, pubID string, errList []error, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.BidResponse {
+func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_ext.BidderName, adapterSeatBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid, bidRequest *openrtb_ext.RequestWrapper, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, bidResponseExt *openrtb_ext.ExtBidResponse, returnBidsCreative, returnVastCreative bool, impExtInfoMap map[string]ImpExtInfo, pubID string, errList []error, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.BidResponse {
 	bidResponse := new(openrtb2.BidResponse)
 
 	bidResponse.ID = bidRequest.ID
@@ -969,7 +973,7 @@ func (e *exchange) buildBidResponse(ctx context.Context, liveAdapters []openrtb_
 	for a, adapterSeatBids := range adapterSeatBids {
 		//while processing every single bib, do we need to handle categories here?
 		if adapterSeatBids != nil && len(adapterSeatBids.Bids) > 0 {
-			sb := e.makeSeatBid(adapterSeatBids, a, adapterExtra, auc, returnCreative, impExtInfoMap, bidRequest, bidResponseExt, pubID, seatNonBidBuilder)
+			sb := e.makeSeatBid(adapterSeatBids, a, adapterExtra, auc, returnBidsCreative, returnVastCreative, impExtInfoMap, bidRequest, bidResponseExt, pubID, seatNonBidBuilder)
 			seatBids = append(seatBids, *sb)
 			bidResponse.Cur = adapterSeatBids.Currency
 		}
@@ -1288,14 +1292,14 @@ func (e *exchange) makeExtBidResponse(adapterBids map[openrtb_ext.BidderName]*en
 
 // Return an openrtb seatBid for a bidder
 // buildBidResponse is responsible for ensuring nil bid seatbids are not included
-func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, pubID string, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.SeatBid {
+func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter openrtb_ext.BidderName, adapterExtra map[openrtb_ext.BidderName]*seatResponseExtra, auc *auction, returnBidsCreative, returnVastCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, pubID string, seatNonBidBuilder *SeatNonBidBuilder) *openrtb2.SeatBid {
 	seatBid := &openrtb2.SeatBid{
 		Seat:  adapter.String(),
 		Group: 0, // Prebid cannot support roadblocking
 	}
 
 	var errList []error
-	seatBid.Bid, errList = e.makeBid(adapterBid.Bids, auc, returnCreative, impExtInfoMap, bidRequest, bidResponseExt, adapter, pubID, seatNonBidBuilder)
+	seatBid.Bid, errList = e.makeBid(adapterBid.Bids, auc, returnBidsCreative, returnVastCreative, impExtInfoMap, bidRequest, bidResponseExt, adapter, pubID, seatNonBidBuilder)
 	if len(errList) > 0 {
 		adapterExtra[adapter].Errors = append(adapterExtra[adapter].Errors, errsToBidderErrors(errList)...)
 	}
@@ -1303,7 +1307,7 @@ func (e *exchange) makeSeatBid(adapterBid *entities.PbsOrtbSeatBid, adapter open
 	return seatBid
 }
 
-func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, adapter openrtb_ext.BidderName, pubID string, seatNonBidBuilder *SeatNonBidBuilder) ([]openrtb2.Bid, []error) {
+func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnBidsCreative, returnVastCreative bool, impExtInfoMap map[string]ImpExtInfo, bidRequest *openrtb_ext.RequestWrapper, bidResponseExt *openrtb_ext.ExtBidResponse, adapter openrtb_ext.BidderName, pubID string, seatNonBidBuilder *SeatNonBidBuilder) ([]openrtb2.Bid, []error) {
 	result := make([]openrtb2.Bid, 0, len(bids))
 	errs := make([]error, 0, 1)
 
@@ -1362,6 +1366,11 @@ func (e *exchange) makeBid(bids []*entities.PbsOrtbBid, auc *auction, returnCrea
 			result = append(result, *bid.Bid)
 			resultBid := &result[len(result)-1]
 			resultBid.Ext = bidExtJSON
+			// vastXml.returnCreative governs video bids; bids.returnCreative governs every other media type.
+			returnCreative := returnBidsCreative
+			if bid.BidType == openrtb_ext.BidTypeVideo {
+				returnCreative = returnVastCreative
+			}
 			if !returnCreative {
 				resultBid.AdM = ""
 			}

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -172,7 +172,7 @@ func TestCharacterEscape(t *testing.T) {
 	var errList []error
 
 	// 	4) Build bid response
-	bidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, true, nil, "", errList, &SeatNonBidBuilder{})
+	bidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, nil, nil, true, true, nil, "", errList, &SeatNonBidBuilder{})
 
 	// 	5) Assert we have no errors and one '&' character as we are supposed to
 	if len(errList) > 0 {
@@ -1003,11 +1003,15 @@ func TestFloorsSignalling(t *testing.T) {
 func TestReturnCreativeEndToEnd(t *testing.T) {
 	sampleAd := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST ...></VAST>"
 
-	// Define test cases
+	// Define test cases. Each case returns one banner bid and one video bid for the same
+	// impression, so the outcome for each media type can be asserted independently -
+	// ext.prebid.cache.bids.returnCreative must only affect the banner bid and
+	// ext.prebid.cache.vastXml.returnCreative must only affect the video bid.
 	type aTest struct {
-		desc   string
-		inExt  json.RawMessage
-		outAdM string
+		desc         string
+		inExt        json.RawMessage
+		outBannerAdM string
+		outVideoAdM  string
 	}
 	testGroups := []struct {
 		groupDesc   string
@@ -1015,81 +1019,93 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 		expectError bool
 	}{
 		{
-			groupDesc: "Valid bidRequest Ext but no returnCreative value specified, default to returning creative",
+			groupDesc: "Valid bidRequest Ext but no returnCreative value specified, default to returning creative for every media type",
 			testCases: []aTest{
 				{
 					"Nil ext in bidRequest",
 					nil,
+					sampleAd,
 					sampleAd,
 				},
 				{
 					"empty ext",
 					json.RawMessage(``),
 					sampleAd,
+					sampleAd,
 				},
 				{
 					"bids doesn't come with returnCreative value",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{}}}}`),
+					sampleAd,
 					sampleAd,
 				},
 				{
 					"vast doesn't come with returnCreative value",
 					json.RawMessage(`{"prebid":{"cache":{"vastXml":{}}}}`),
 					sampleAd,
+					sampleAd,
 				},
 			},
 		},
 		{
-			groupDesc: "Bids field comes with returnCreative value",
+			groupDesc: "Bids field comes with returnCreative value: only the banner bid is affected, the video bid keeps its default",
 			testCases: []aTest{
 				{
-					"Bids returnCreative set to true, return ad markup in response",
+					"Bids returnCreative set to true, banner keeps ad markup, video keeps its default (true)",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true}}}}`),
 					sampleAd,
+					sampleAd,
 				},
 				{
-					"Bids returnCreative set to false, don't return ad markup in response",
+					"Bids returnCreative set to false, banner ad markup stripped, video keeps its default (true)",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false}}}}`),
 					"",
+					sampleAd,
 				},
 			},
 		},
 		{
-			groupDesc: "Vast field comes with returnCreative value",
+			groupDesc: "Vast field comes with returnCreative value: only the video bid is affected, the banner bid keeps its default",
 			testCases: []aTest{
 				{
-					"Vast returnCreative set to true, return ad markup in response",
+					"Vast returnCreative set to true, video keeps ad markup, banner keeps its default (true)",
 					json.RawMessage(`{"prebid":{"cache":{"vastXml":{"returnCreative":true}}}}`),
 					sampleAd,
+					sampleAd,
 				},
 				{
-					"Vast returnCreative set to false, don't return ad markup in response",
+					"Vast returnCreative set to false, video ad markup stripped, banner keeps its default (true)",
 					json.RawMessage(`{"prebid":{"cache":{"vastXml":{"returnCreative":false}}}}`),
+					sampleAd,
 					"",
 				},
 			},
 		},
 		{
-			groupDesc: "Both Bids and Vast come with their own returnCreative value",
+			groupDesc: "Both Bids and Vast come with their own returnCreative value, applied independently per media type",
 			testCases: []aTest{
 				{
-					"Both false, expect empty AdM",
+					"Both false, expect empty ad markup for both media types",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":false}}}}`),
+					"",
 					"",
 				},
 				{
-					"Bids returnCreative is true, expect valid AdM",
+					"Bids returnCreative true, Vast returnCreative false: banner keeps ad markup, video is stripped",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true},"vastXml":{"returnCreative":false}}}}`),
 					sampleAd,
+					"",
 				},
 				{
-					"Vast returnCreative is true, expect valid AdM",
+					"Bids returnCreative false, Vast returnCreative true: banner is stripped, video keeps ad markup",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":false},"vastXml":{"returnCreative":true}}}}`),
+					"",
 					sampleAd,
 				},
 				{
-					"Both field's returnCreative set to true, expect valid AdM",
+					"Both field's returnCreative set to true, expect valid ad markup for both media types",
 					json.RawMessage(`{"prebid":{"cache":{"bids":{"returnCreative":true},"vastXml":{"returnCreative":true}}}}`),
+					sampleAd,
 					sampleAd,
 				},
 			},
@@ -1116,7 +1132,12 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 		bidResponse: &adapters.BidderResponse{
 			Bids: []*adapters.TypedBid{
 				{
-					Bid: &openrtb2.Bid{AdM: sampleAd},
+					BidType: openrtb_ext.BidTypeBanner,
+					Bid:     &openrtb2.Bid{ID: "banner-bid", ImpID: "some-impression-id", AdM: sampleAd},
+				},
+				{
+					BidType: openrtb_ext.BidTypeVideo,
+					Bid:     &openrtb2.Bid{ID: "video-bid", ImpID: "some-impression-id", AdM: sampleAd},
 				},
 			},
 		},
@@ -1185,10 +1206,15 @@ func TestReturnCreativeEndToEnd(t *testing.T) {
 			if !assert.NotEmpty(t, outBidResponse.SeatBid, "%s: %s. outBidResponse.SeatBid is empty \n", testGroup.groupDesc, test.desc) {
 				return
 			}
-			if !assert.NotEmpty(t, outBidResponse.SeatBid[0].Bid, "%s: %s. outBidResponse.SeatBid[0].Bid is empty \n", testGroup.groupDesc, test.desc) {
+			if !assert.Len(t, outBidResponse.SeatBid[0].Bid, 2, "%s: %s. expected exactly one banner and one video bid \n", testGroup.groupDesc, test.desc) {
 				return
 			}
-			assert.Equal(t, test.outAdM, outBidResponse.SeatBid[0].Bid[0].AdM, "Ad markup string doesn't match in: %s - %s \n", testGroup.groupDesc, test.desc)
+			adMByBidID := make(map[string]string, len(outBidResponse.SeatBid[0].Bid))
+			for _, bid := range outBidResponse.SeatBid[0].Bid {
+				adMByBidID[bid.ID] = bid.AdM
+			}
+			assert.Equal(t, test.outBannerAdM, adMByBidID["banner-bid"], "Banner ad markup string doesn't match in: %s - %s \n", testGroup.groupDesc, test.desc)
+			assert.Equal(t, test.outVideoAdM, adMByBidID["video-bid"], "Video ad markup string doesn't match in: %s - %s \n", testGroup.groupDesc, test.desc)
 		}
 	}
 }
@@ -1346,7 +1372,7 @@ func TestGetBidCacheInfoEndToEnd(t *testing.T) {
 	var errList []error
 
 	// 	4) Build bid response
-	bid_resp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, true, nil, "", errList, &SeatNonBidBuilder{})
+	bid_resp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, adapterExtra, auc, nil, true, true, nil, "", errList, &SeatNonBidBuilder{})
 
 	expectedBidResponse := &openrtb2.BidResponse{
 		SeatBid: []openrtb2.SeatBid{
@@ -1436,7 +1462,7 @@ func TestBidReturnsCreative(t *testing.T) {
 
 	//Run tests
 	for _, test := range testCases {
-		resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, test.inReturnCreative, nil, &openrtb_ext.RequestWrapper{}, nil, "", "", &SeatNonBidBuilder{})
+		resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, test.inReturnCreative, test.inReturnCreative, nil, &openrtb_ext.RequestWrapper{}, nil, "", "", &SeatNonBidBuilder{})
 
 		assert.Equal(t, 0, len(resultingErrs), "%s. Test should not return errors \n", test.description)
 		assert.Equal(t, test.expectedCreativeMarkup, resultingBids[0].AdM, "%s. Ad markup string doesn't match expected \n", test.description)
@@ -1721,7 +1747,7 @@ func TestBidResponseCurrency(t *testing.T) {
 	}
 	// Run tests
 	for i := range testCases {
-		actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, bidResponseExt, true, nil, "", errList, &SeatNonBidBuilder{})
+		actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, testCases[i].adapterBids, bidRequest, adapterExtra, nil, bidResponseExt, true, true, nil, "", errList, &SeatNonBidBuilder{})
 		assert.Equalf(t, testCases[i].expectedBidResponse, actualBidResp, fmt.Sprintf("[TEST_FAILED] Objects must be equal for test: %s \n Expected: >>%s<< \n Actual: >>%s<< ", testCases[i].description, testCases[i].expectedBidResponse.Ext, actualBidResp.Ext))
 	}
 }
@@ -1789,7 +1815,7 @@ func TestBidResponseImpExtInfo(t *testing.T) {
 
 	expectedBidResponseExt := `{"origbidcpm":0,"prebid":{"meta":{"adaptercode":"appnexus"},"type":"video","passthrough":{"imp_passthrough_val":1}},"storedrequestattributes":{"h":480,"mimes":["video/mp4"]}}`
 
-	actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, nil, nil, nil, true, impExtInfo, "", errList, &SeatNonBidBuilder{})
+	actualBidResp := e.buildBidResponse(context.Background(), liveAdapters, adapterBids, bidRequest, nil, nil, nil, true, true, impExtInfo, "", errList, &SeatNonBidBuilder{})
 
 	resBidExt := string(actualBidResp.SeatBid[0].Bid[0].Ext)
 	assert.Equalf(t, expectedBidResponseExt, resBidExt, "Expected bid response extension is incorrect")
@@ -4930,7 +4956,7 @@ func TestMakeBidWithValidation(t *testing.T) {
 			e.bidValidationEnforcement = test.givenValidations
 			sampleBids := test.givenBids
 			nonBids := &SeatNonBidBuilder{}
-			resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, true, ImpExtInfoMap, bidRequest, bidExtResponse, test.givenSeat, "", nonBids)
+			resultingBids, resultingErrs := e.makeBid(sampleBids, sampleAuction, true, true, ImpExtInfoMap, bidRequest, bidExtResponse, test.givenSeat, "", nonBids)
 
 			assert.Equal(t, 0, len(resultingErrs))
 			assert.Equal(t, test.expectedNumOfBids, len(resultingBids))

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -906,31 +906,26 @@ func randomizeList(list []openrtb_ext.BidderName) {
 }
 
 func getExtCacheInstructions(requestExtPrebid *openrtb_ext.ExtRequestPrebid) extCacheInstructions {
-	//returnCreative defaults to true
-	cacheInstructions := extCacheInstructions{returnCreative: true}
-	foundBidsRC := false
-	foundVastRC := false
+	// returnBidsCreative and returnVastCreative each default to true and are set
+	// independently, per media type, so that ext.prebid.cache.bids.returnCreative only
+	// affects non-video bids and ext.prebid.cache.vastXml.returnCreative only affects
+	// video bids (they must not be merged into a single flag applied to every bid).
+	cacheInstructions := extCacheInstructions{returnBidsCreative: true, returnVastCreative: true}
 
 	if requestExtPrebid != nil && requestExtPrebid.Cache != nil {
 		if requestExtPrebid.Cache.Bids != nil {
 			cacheInstructions.cacheBids = true
 			if requestExtPrebid.Cache.Bids.ReturnCreative != nil {
-				cacheInstructions.returnCreative = *requestExtPrebid.Cache.Bids.ReturnCreative
-				foundBidsRC = true
+				cacheInstructions.returnBidsCreative = *requestExtPrebid.Cache.Bids.ReturnCreative
 			}
 		}
 
 		if requestExtPrebid.Cache.VastXML != nil {
 			cacheInstructions.cacheVAST = true
 			if requestExtPrebid.Cache.VastXML.ReturnCreative != nil {
-				cacheInstructions.returnCreative = *requestExtPrebid.Cache.VastXML.ReturnCreative
-				foundVastRC = true
+				cacheInstructions.returnVastCreative = *requestExtPrebid.Cache.VastXML.ReturnCreative
 			}
 		}
-	}
-
-	if foundBidsRC && foundVastRC {
-		cacheInstructions.returnCreative = *requestExtPrebid.Cache.Bids.ReturnCreative || *requestExtPrebid.Cache.VastXML.ReturnCreative
 	}
 
 	return cacheInstructions

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -1750,27 +1750,29 @@ func TestGetExtCacheInstructions(t *testing.T) {
 		outCacheInstructions extCacheInstructions
 	}{
 		{
-			desc:             "Nil request ext, all cache flags false except for returnCreative that defaults to true",
+			desc:             "Nil request ext, all cache flags false except for returnBidsCreative/returnVastCreative that default to true",
 			requestExtPrebid: nil,
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil request ext, nil Cache field, all cache flags false except for returnCreative that defaults to true",
+			desc: "Non-nil request ext, nil Cache field, all cache flags false except for returnBidsCreative/returnVastCreative that default to true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: nil,
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil Cache field, both ExtRequestPrebidCacheBids and ExtRequestPrebidCacheVAST nil returnCreative that defaults to true",
+			desc: "Non-nil Cache field, both ExtRequestPrebidCacheBids and ExtRequestPrebidCacheVAST nil, returnBidsCreative/returnVastCreative default to true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    nil,
@@ -1778,13 +1780,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          false,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST with unspecified ReturnCreative field, cacheVAST = true and returnCreative defaults to true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST with unspecified ReturnCreative field, cacheVAST = true and returnVastCreative defaults to true; returnBidsCreative unaffected",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    nil,
@@ -1792,13 +1795,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: true, // default value
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnBidsCreative: true, // default value
+				returnVastCreative: true, // default value
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to false, cacheVAST = true and returnCreative = false",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to false, cacheVAST = true and only returnVastCreative = false; returnBidsCreative stays at its true default",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    nil,
@@ -1806,13 +1810,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: false,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to true, cacheVAST = true and returnCreative = true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST where ReturnCreative is set to true, cacheVAST = true and returnVastCreative = true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    nil,
@@ -1820,13 +1825,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      false,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          false,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids with unspecified ReturnCreative field, cacheBids = true and returnCreative defaults to true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids with unspecified ReturnCreative field, cacheBids = true and returnBidsCreative defaults to true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
@@ -1834,13 +1840,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: true, // default value
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnBidsCreative: true, // default value
+				returnVastCreative: true, // default value
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to false, cacheBids = true and returnCreative  = false",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to false, cacheBids = true and only returnBidsCreative = false; returnVastCreative stays at its true default",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
@@ -1848,13 +1855,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnBidsCreative: false,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to true, cacheBids = true and returnCreative  = true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids where ReturnCreative is set to true, cacheBids = true and returnBidsCreative = true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
@@ -1862,9 +1870,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      false,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          false,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
@@ -1876,13 +1885,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets ReturnCreative to true, all extCacheInstructions fields set to true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST both set ReturnCreative to true, all extCacheInstructions fields set to true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
@@ -1890,13 +1900,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheBids and ExtRequest.Cache.ExtRequestPrebidCacheVAST sets ReturnCreative to false, returnCreative = false",
+			desc: "Only ExtRequestPrebidCacheVAST sets ReturnCreative to false; returnBidsCreative (unspecified) stays at its true default and is unaffected by the VAST-only setting",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{},
@@ -1904,13 +1915,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: false,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets ReturnCreative to true, all extCacheInstructions fields set to true",
+			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids both set ReturnCreative to true, all extCacheInstructions fields set to true",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
@@ -1918,13 +1930,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids sets ReturnCreative to false, returnCreative = false",
+			desc: "Only ExtRequestPrebidCacheBids sets ReturnCreative to false; returnVastCreative (unspecified) stays at its true default and is unaffected by the Bids-only setting",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
@@ -1932,13 +1945,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: false,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: false,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			desc: "ExtRequestPrebidCacheVAST and ExtRequestPrebidCacheBids set different ReturnCreative values: each flag is applied independently, not OR-merged into a single value",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolFalse},
@@ -1946,13 +1960,14 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: false,
+				returnVastCreative: true,
 			},
 		},
 		{
-			desc: "Non-nil ExtRequest.Cache.ExtRequestPrebidCacheVAST and ExtRequest.Cache.ExtRequestPrebidCacheBids set different ReturnCreative values, returnCreative = true because one of them is true",
+			desc: "ExtRequestPrebidCacheVAST and ExtRequestPrebidCacheBids set different ReturnCreative values (reversed): each flag is applied independently, not OR-merged into a single value",
 			requestExtPrebid: &openrtb_ext.ExtRequestPrebid{
 				Cache: &openrtb_ext.ExtRequestPrebidCache{
 					Bids:    &openrtb_ext.ExtRequestPrebidCacheBids{ReturnCreative: boolTrue},
@@ -1960,9 +1975,10 @@ func TestGetExtCacheInstructions(t *testing.T) {
 				},
 			},
 			outCacheInstructions: extCacheInstructions{
-				cacheBids:      true,
-				cacheVAST:      true,
-				returnCreative: true,
+				cacheBids:          true,
+				cacheVAST:          true,
+				returnBidsCreative: true,
+				returnVastCreative: false,
 			},
 		},
 	}
@@ -1972,7 +1988,8 @@ func TestGetExtCacheInstructions(t *testing.T) {
 
 		assert.Equal(t, test.outCacheInstructions.cacheBids, cacheInstructions.cacheBids, "%s. Unexpected shouldCacheBids value. \n", test.desc)
 		assert.Equal(t, test.outCacheInstructions.cacheVAST, cacheInstructions.cacheVAST, "%s. Unexpected shouldCacheVAST value. \n", test.desc)
-		assert.Equal(t, test.outCacheInstructions.returnCreative, cacheInstructions.returnCreative, "%s. Unexpected returnCreative value. \n", test.desc)
+		assert.Equal(t, test.outCacheInstructions.returnBidsCreative, cacheInstructions.returnBidsCreative, "%s. Unexpected returnBidsCreative value. \n", test.desc)
+		assert.Equal(t, test.outCacheInstructions.returnVastCreative, cacheInstructions.returnVastCreative, "%s. Unexpected returnVastCreative value. \n", test.desc)
 	}
 }
 


### PR DESCRIPTION
## Problem

`ext.prebid.cache.bids.returnCreative` and `ext.prebid.cache.vastXml.returnCreative` are documented and named as independent, per-media-type controls over whether creative markup (`adm`) is stripped from a bid before it's returned — `bids` governing non-video bids, `vastXml` governing video/VAST bids.

`getExtCacheInstructions` (`exchange/utils.go`) instead merged both into a **single** `extCacheInstructions.returnCreative bool`:

```go
if foundBidsRC && foundVastRC {
    cacheInstructions.returnCreative = *requestExtPrebid.Cache.Bids.ReturnCreative || *requestExtPrebid.Cache.VastXML.ReturnCreative
}
```

and that single value was then applied uniformly to **every** bid in the response regardless of media type (`exchange.makeBid`, `if !returnCreative { resultBid.AdM = "" }`), with no awareness of `bid.BidType`.

Concretely, this produces two observable bugs, both reproducible against current `master`:

1. If `bids.returnCreative=false` and `vastXml.returnCreative=true`, the OR-merge makes the effective flag `true` for **every** bid — including banner bids the caller explicitly asked to have their markup stripped.
2. If only `vastXml.returnCreative=false` is set (no `bids` object at all), the single merged flag is `false` and applies to **all** bids, silently stripping `adm` from banner/non-video bids too, even though only the VAST-specific setting was touched.

This matches [#2584](https://github.com/prebid/prebid-server/issues/2584), which reports exactly this symptom ("ad markup is returned in bid responses for ALL bids, regardless of type" / "ad markup is NOT returned for ANY bid responses" when only one of the two fields is set).

## Verification this is real and current

Read `getExtCacheInstructions` and the `makeBid` call chain (`buildBidResponse` → `makeSeatBid` → `makeBid`) in current `exchange/exchange.go` / `exchange/utils.go` — the OR-merge and the type-blind application are both still present. The existing `TestGetExtCacheInstructions` table in `exchange/utils_test.go` explicitly asserted the merged behavior (test case comment: *"returnCreative = true because one of them is true"*), and the existing `TestReturnCreativeEndToEnd` in `exchange/exchange_test.go` only ever exercised a single bid with an unset `BidType`, so it never actually tested the claimed per-media-type behavior — it happened to pass while encoding the bug.

## Fix

- `extCacheInstructions.returnCreative` (single bool) → `returnBidsCreative` and `returnVastCreative` (independent bools, each defaulting to `true`), set directly from `ext.prebid.cache.bids.returnCreative` / `ext.prebid.cache.vastXml.returnCreative` respectively. Removed the OR-merge entirely.
- Threaded both flags through `buildBidResponse` → `makeSeatBid` → `makeBid`. `makeBid` now selects the applicable flag per bid based on `bid.BidType`: `BidTypeVideo` uses `returnVastCreative`, every other media type uses `returnBidsCreative`.

This mirrors the pattern already used one field over in the same struct — `cacheBids`/`cacheVAST` (whether to cache in Prebid Cache) were already independent, per-type bools; only `returnCreative` had been incorrectly merged.

## Tests

- Rewrote `TestGetExtCacheInstructions` (`exchange/utils_test.go`) to assert the two flags are set independently (no OR-merge), including cases where only one of `bids`/`vastXml` is set and the other flag must stay at its default.
- Rewrote `TestReturnCreativeEndToEnd` (`exchange/exchange_test.go`) so the mock bidder returns **one banner bid and one video bid** for the same impression, and assertions check each bid's `adm` independently by bid ID. This directly exercises the per-media-type behavior the original single-untyped-bid test could not.

**Revert-and-reconfirm:** Reintroduced the old OR-merge/type-blind logic on top of the new (already-refactored) function signatures — i.e., changed only the *behavior*, not the signatures, to isolate the actual logic bug — and reran the new tests. Both `TestReturnCreativeEndToEnd` and `TestGetExtCacheInstructions` failed deterministically, reproducing the two reported symptoms exactly (vastXml-only `false` stripping `adm` from the banner bid; independent true/false combinations collapsing to a single merged value). Restored the fix and confirmed both pass.

`go build ./...`, `go vet ./...`, and `go test ./exchange/...` all pass. `gofmt` clean. Full `go test ./...` has 3 pre-existing, unrelated failures (`adapters/adtarget`, `adapters/adtelligent`, `adapters/bidmatic` — a Go stdlib JSON error-message wording difference in `TestJsonSamples`), confirmed present identically on unmodified `master` before this change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./exchange/...` (full package, not cached)
- [x] `gofmt -l` clean on all changed files
- [x] Reverted the logic fix only (kept new tests) and confirmed both new/updated tests fail with the exact reported symptom; restored fix and confirmed they pass