### PR TITLE
Fix: ScrubUserFPD panics with nil pointer when request has no user object

### DIFF
--- a/privacy/scrubber.go
+++ b/privacy/scrubber.go
@@ -132,7 +132,9 @@ func ScrubUserFPD(reqWrapper *openrtb_ext.RequestWrapper) {
 	scrubDeviceIDs(reqWrapper)
 	scrubUserIDs(reqWrapper)
 	scrubUserExt(reqWrapper, "data")
-	reqWrapper.User.EIDs = nil
+	if reqWrapper.User != nil {
+		reqWrapper.User.EIDs = nil
+	}
 }
 
 func ScrubGdprID(reqWrapper *openrtb_ext.RequestWrapper) {

--- a/privacy/scrubber_test.go
+++ b/privacy/scrubber_test.go
@@ -173,6 +173,51 @@ func TestScrubEids(t *testing.T) {
 	}
 }
 
+func TestScrubUserFPD(t *testing.T) {
+	testCases := []struct {
+		name           string
+		deviceIn       *openrtb2.Device
+		userIn         *openrtb2.User
+		expectedDevice *openrtb2.Device
+		expectedUser   *openrtb2.User
+	}{
+		{
+			name:           "all",
+			deviceIn:       &openrtb2.Device{DIDMD5: "MD5", IFA: "IFA"},
+			userIn:         &openrtb2.User{ID: "ID", BuyerUID: "bID", Yob: 2000, Gender: "M", Keywords: "keywords", EIDs: []openrtb2.EID{{Source: "source"}}, Ext: json.RawMessage(`{"data":"123","test":1}`)},
+			expectedDevice: &openrtb2.Device{DIDMD5: "", IFA: ""},
+			expectedUser:   &openrtb2.User{ID: "", BuyerUID: "", Yob: 0, Gender: "", Keywords: "", EIDs: nil, Ext: json.RawMessage(`{"test":1}`)},
+		},
+		{
+			// Regression test: reqWrapper.User must not be assumed non-nil. A request with no
+			// user object at all (e.g. app traffic, or a first visit with no established user
+			// state) combined with the transmitUserFPD activity being disallowed for a bidder,
+			// module, or analytics adapter must not panic with a nil pointer dereference.
+			name:           "nil_user",
+			deviceIn:       &openrtb2.Device{DIDMD5: "MD5"},
+			userIn:         nil,
+			expectedDevice: &openrtb2.Device{DIDMD5: ""},
+			expectedUser:   nil,
+		},
+		{
+			name:           "nil_device_and_user",
+			deviceIn:       nil,
+			userIn:         nil,
+			expectedDevice: nil,
+			expectedUser:   nil,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			brw := &openrtb_ext.RequestWrapper{BidRequest: &openrtb2.BidRequest{Device: test.deviceIn, User: test.userIn}}
+			assert.NotPanics(t, func() { ScrubUserFPD(brw) })
+			brw.RebuildRequest()
+			assert.Equal(t, test.expectedDevice, brw.Device)
+			assert.Equal(t, test.expectedUser, brw.User)
+		})
+	}
+}
+
 func TestScrubTID(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
## Problem

`ScrubUserFPD` (`privacy/scrubber.go`) is the function used to strip first-party user data from a bidder/module/analytics request when the `transmitUserFPD` Activity Control disallows it. It ends with:

```go
func ScrubUserFPD(reqWrapper *openrtb_ext.RequestWrapper) {
	scrubDeviceIDs(reqWrapper)
	scrubUserIDs(reqWrapper)
	scrubUserExt(reqWrapper, "data")
	reqWrapper.User.EIDs = nil   // <-- no nil check
}
```

Every other scrub helper in the same file (`scrubDeviceIDs`, `scrubUserIDs`, `scrubUserDemographics`, `scrubUserExt`, `ScrubEIDs`) guards its `User` field access with `if reqWrapper.User != nil`. This one line does not. Since `openrtb2.BidRequest.User` is an optional OpenRTB field (there is no `user` object at all for a lot of legitimate traffic — app-only requests, or a web request before any user identifier/cookie exists), this is a nil pointer dereference panic waiting to happen on any request with no `user` object.

## Reachability

`ScrubUserFPD` is called from three independent, normal-operation code paths, all triggered simply by the `transmitUserFPD` Activity Control (a standard, documented Prebid Server privacy feature — not an obscure edge case) being disallowed for some scope:

- `exchange/utils.go`'s `applyPrivacy`, whenever `transmitUserFPD` is disallowed for a bidder
- `hooks/hookexecution/execution.go`'s `handleModuleActivities`, whenever it's disallowed for a module/hook scope
- `analytics/build/build.go`'s `evaluateActivities`, whenever it's disallowed for an analytics adapter

Any host company using Activity Controls to restrict `transmitUserFPD` (for GDPR/CCPA/first-party-data governance reasons — exactly what the activity exists for) on traffic that doesn't always carry a `user` object will panic the request.

## Verification this is real and current

- Read `privacy/scrubber.go` on current `master`: the unguarded line is present, unchanged.
- `git log -S "reqWrapper.User.EIDs = nil" -- privacy/scrubber.go` shows it was introduced by commit `6a20c0e19` ("Privacy scrubber refactoring", PR #3108, merged 2023-11-16) and has never been touched since.
- `grep -rn "ScrubUserFPD" --include="*_test.go" .` returns nothing — this function has **no** test coverage at all, direct or indirect, in the current test suite (the higher-level integration tests that exercise it apparently always happen to construct requests with a non-nil `User`).
- Reproduced the panic directly with a minimal standalone test calling `ScrubUserFPD` on a `RequestWrapper` with `User: nil` before writing the fix.

## Fix

Added the same `if reqWrapper.User != nil` guard already used by every sibling function in this file — no behavior change for the (previously only tested-by-coincidence) non-nil case.

## Tests

Added `TestScrubUserFPD` to `privacy/scrubber_test.go`, following the existing table-driven style used by the other `Test*` functions in this file (e.g. `TestScrubUserIDs`, `TestScrubEids`). Includes:
- `all`: full field population, confirming device IDs, user IDs/demographics, `ext.data`, and `eids` are all still scrubbed correctly.
- `nil_user`: the regression case — a request with `Device` set but `User: nil`, wrapped in `assert.NotPanics` so the panic is asserted explicitly rather than relying on an incidental pass/fail.
- `nil_device_and_user`: both nil, for completeness.

**Revert-and-reconfirm:** Removed the nil guard (keeping the new test) and reran — `TestScrubUserFPD/nil_user` and `TestScrubUserFPD/nil_device_and_user` both failed with a runtime nil pointer dereference panic, stack-traced directly to the unguarded line in `ScrubUserFPD`. Restored the fix and confirmed all three subtests pass.

`go build ./...`, `go vet ./...`, and `go test ./privacy/... ./exchange/... ./hooks/... ./analytics/...` all pass. `gofmt` clean.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./privacy/... ./exchange/... ./hooks/... ./analytics/...`
- [x] `gofmt -l` clean on changed files
- [x] Removed the fix (kept the new test) and confirmed it fails with the exact panic described above; restored the fix and confirmed it passes