### PR TITLE
Fix: Rules engine hook can block auction requests on tree manager channel

### DIFF
--- a/modules/prebid/rulesengine/module.go
+++ b/modules/prebid/rulesengine/module.go
@@ -74,7 +74,7 @@ func (m Module) HandleProcessedAuctionHook(
 			accountID: miCtx.AccountID,
 			config:    &miCtx.AccountConfig,
 		}
-		m.TreeManager.requests <- bi
+		sendBuildInstruction(m.TreeManager, bi)
 
 		// TODO: return with reject or no reject, possible config option
 		return hs.HookResult[hs.ProcessedAuctionRequestPayload]{
@@ -87,7 +87,7 @@ func (m Module) HandleProcessedAuctionHook(
 			accountID: miCtx.AccountID,
 			config:    &miCtx.AccountConfig,
 		}
-		m.TreeManager.requests <- bi
+		sendBuildInstruction(m.TreeManager, bi)
 	}
 
 	if !co.enabled {
@@ -104,6 +104,21 @@ func (m Module) HandleProcessedAuctionHook(
 func (m Module) Shutdown() {
 	m.TreeManager.Shutdown()
 	<-m.TreeManager.done
+}
+
+// sendBuildInstruction enqueues a build instruction for the tree manager without blocking
+// the auction request that triggered it. The tree manager's requests channel is unbuffered
+// and drained by a single background goroutine, so a blocking send here would stall the
+// current request (and, with it, the hook execution timeout budget) until the tree manager
+// is free to receive - defeating the "for future requests" fire-and-forget design of the
+// cache-miss/refresh path. If the tree manager is busy, the instruction is dropped; the
+// account's cache entry stays as-is and will be considered for (re)build again on a
+// subsequent request.
+func sendBuildInstruction(tm *treeManager, bi buildInstruction) {
+	select {
+	case tm.requests <- bi:
+	default:
+	}
 }
 
 // rebuildTrees returns true if the trees need to be rebuilt; false otherwise

--- a/modules/prebid/rulesengine/module_test.go
+++ b/modules/prebid/rulesengine/module_test.go
@@ -1,12 +1,14 @@
 package rulesengine
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	hs "github.com/prebid/prebid-server/v4/hooks/hookstage"
 	"github.com/prebid/prebid-server/v4/modules/moduledeps"
 	"github.com/stretchr/testify/assert"
 )
@@ -256,6 +258,67 @@ func TestGetRefreshRate(t *testing.T) {
 				assert.NoError(t, err, "Expected no error but got one")
 			}
 			assert.Equal(t, tc.expectedRefreshRate, res)
+		})
+	}
+}
+
+// TestHandleProcessedAuctionHookDoesNotBlockOnBusyTreeManager proves that
+// Module.HandleProcessedAuctionHook never blocks the auction request goroutine waiting to
+// enqueue a tree-build instruction. The tree manager's requests channel is unbuffered and
+// drained by a single background goroutine (treeManager.Run); if nothing is reading from it
+// (e.g. because that goroutine is busy building trees for another account, or - as
+// reproduced directly here - hasn't started at all), a blocking send would hang the current
+// auction request indefinitely. That directly contradicts the hook's own stated intent of
+// only "loading rules engine account configuration for future requests".
+func TestHandleProcessedAuctionHookDoesNotBlockOnBusyTreeManager(t *testing.T) {
+	testCases := []struct {
+		name string
+		// seedCache, when set, pre-populates the cache so the hook takes the
+		// cache-hit-needs-rebuild path instead of the cache-miss path.
+		seedCache bool
+	}{
+		{name: "cache_miss"},
+		{name: "cache_hit_needs_rebuild", seedCache: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A 1-second refresh rate combined with the zero-value (year 1) timestamp on
+			// the seeded cache entry below ensures rebuildTrees reports the entry expired,
+			// so the "cache hit, needs rebuild" case actually exercises the tree-manager
+			// send path instead of skipping it.
+			cache := NewCache(1)
+			tm := &treeManager{
+				// Unbuffered and intentionally never drained by a Run goroutine in this
+				// test, to deterministically simulate a tree manager that is busy (or not
+				// yet available to receive) at the moment the hook fires.
+				requests: make(chan buildInstruction),
+				done:     make(chan struct{}),
+			}
+			m := Module{Cache: cache, TreeManager: tm}
+
+			accountID := "acct-1"
+			if tc.seedCache {
+				cache.Set(accountID, &cacheEntry{hashedConfig: "some-old-hash"})
+			}
+
+			miCtx := hs.ModuleInvocationContext{
+				AccountID:     accountID,
+				AccountConfig: json.RawMessage(`{"enabled": true, "ruleSets": []}`),
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _ = m.HandleProcessedAuctionHook(context.Background(), miCtx, hs.ProcessedAuctionRequestPayload{})
+			}()
+
+			select {
+			case <-done:
+				// Hook returned promptly, as intended for a fire-and-forget cache trigger.
+			case <-time.After(2 * time.Second):
+				t.Fatal("HandleProcessedAuctionHook blocked sending to treeManager.requests instead of returning promptly")
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Type of change
- [x] bugfix

### Problem

`Module.HandleProcessedAuctionHook` (`modules/prebid/rulesengine/module.go`) enqueues a
`buildInstruction` for the tree manager to (re)build an account's rule trees in the
background:

```go
tm := treeManager{
    done:            make(chan struct{}),
    requests:        make(chan buildInstruction), // unbuffered
    ...
}
```

Both the cache-miss and the cache-hit-needs-rebuild branches of `HandleProcessedAuctionHook`
send on this channel directly:

```go
if co == nil {
    bi := buildInstruction{...}
    m.TreeManager.requests <- bi
    return hs.HookResult[...]{
        Message: "skipped, loading rules engine account configuration for future requests",
    }, nil
}
```

`requests` is unbuffered and drained by exactly one background goroutine
(`treeManager.Run`), which processes one `buildInstruction` at a time - including
synchronous JSON-schema validation (`config.NewConfig`) and rule-tree construction
(`NewCacheEntry`). Because the send is unbuffered and blocking, any auction request that
hits this code path while the tree manager goroutine is still busy with a prior
instruction (its own or another account's) will hang on `m.TreeManager.requests <- bi`
until the tree manager is free to receive it.

This directly contradicts the hook's own documented intent - the returned message says
"loading rules engine account configuration for **future requests**", i.e. this is meant to
be a fire-and-forget trigger that must never gate the *current* request. As written, under
concurrent load (e.g. many requests for different/expired accounts arriving close together,
or at startup when caches are cold), the single-threaded tree manager becomes a serialization
point that can add unbounded latency to the auction request path, and any request whose hook
execution timeout fires while blocked on this send still leaves the underlying goroutine
parked on the channel send in the background.

Confirmed still present and unmodified on current `master` (`8537cb10d`) - the unbuffered
channel and blocking send have been present unchanged since the module's introduction
(#4407) through the two follow-up PRs that touched this file (#4423, #4509).

### Fix

Added `sendBuildInstruction`, which performs a non-blocking send via `select`/`default`:

```go
func sendBuildInstruction(tm *treeManager, bi buildInstruction) {
	select {
	case tm.requests <- bi:
	default:
	}
}
```

If the tree manager isn't immediately ready to receive, the instruction is simply dropped;
the account's cache entry is left as-is and will be considered for (re)build again on a
subsequent request, consistent with the existing best-effort refresh semantics (nothing
about correctness depends on any single trigger succeeding - `rebuildTrees`/cache-miss
detection re-evaluates on every request). Both call sites in `HandleProcessedAuctionHook`
now go through this helper; no other behavior changes.

### Test plan

Added `TestHandleProcessedAuctionHookDoesNotBlockOnBusyTreeManager` in
`modules/prebid/rulesengine/module_test.go`, covering both the cache-miss and the
cache-hit-needs-rebuild paths. It builds a `treeManager` whose `requests` channel has no
active reader (simulating a busy/unavailable tree manager) and asserts
`HandleProcessedAuctionHook` still returns within 2 seconds.

**Revert-and-reconfirm:** reverted only the `module.go` change (kept the test) and
re-ran the new test - both subtests fail with "blocked sending to treeManager.requests
instead of returning promptly" (2s timeout each), reproducing the hang. Restored the fix
and confirmed both subtests pass immediately.

`go build ./...`, `go vet ./modules/prebid/rulesengine/...`, `gofmt -l` (clean), and
`go test ./modules/prebid/rulesengine/... -race` all pass, along with the full existing
`modules/prebid/rulesengine` suite (unchanged, all passing) and the broader `modules/...`
suite.