### PR TITLE
Fix: CloneUserAgent copies Ext onto the clone, not the original

### DIFF
--- a/ortb/clone.go
+++ b/ortb/clone.go
@@ -109,7 +109,7 @@ func CloneUserAgent(s *openrtb2.UserAgent) *openrtb2.UserAgent {
 		mobileCopy := *s.Mobile
 		c.Mobile = &mobileCopy
 	}
-	s.Ext = slices.Clone(s.Ext)
+	c.Ext = slices.Clone(s.Ext)
 
 	return &c
 }

--- a/ortb/clone_test.go
+++ b/ortb/clone_test.go
@@ -305,6 +305,16 @@ func TestCloneUserAgent(t *testing.T) {
 		assert.NotSame(t, given.Ext, result.Ext, "ext")
 	})
 
+	t.Run("ext-does-not-mutate-original", func(t *testing.T) {
+		given := &openrtb2.UserAgent{Ext: json.RawMessage(`{"anyField":1}`)}
+		originalExt := given.Ext
+		result := CloneUserAgent(given)
+		if assert.NotEmpty(t, originalExt) && assert.NotEmpty(t, given.Ext) && assert.NotEmpty(t, result.Ext) {
+			assert.Same(t, &originalExt[0], &given.Ext[0], "original-ext-backing")
+			assert.NotSame(t, &originalExt[0], &result.Ext[0], "clone-ext-backing")
+		}
+	})
+
 	t.Run("assumptions", func(t *testing.T) {
 		assert.ElementsMatch(t, discoverPointerFields(reflect.TypeOf(openrtb2.UserAgent{})),
 			[]string{


### PR DESCRIPTION
`CloneUserAgent` wrote `s.Ext = slices.Clone(s.Ext)` after the shallow copy. Every sibling clone (`CloneDevice`, `CloneUser`, `CloneGeo`, ...) writes `c.Ext`. The assignment replaced the input's backing array and left the returned clone sharing the original bytes, so `Device.SUA` was not a deep clone.

Existing `TestCloneUserAgent/populated` still passed: it compared `given.Ext` after the mutation, so `assert.NotSame` was true for the wrong reason. The new case captures `&originalExt[0]` before the call.

Fixes #4963