### PR TITLE
New Adapter: Odeeo

### DIFF
--- a/.github/workflows/scripts/codepath-notification
+++ b/.github/workflows/scripts/codepath-notification
@@ -20,3 +20,4 @@ medianet: prebid@media.net
 gumgum: prebid@gumgum.com
 kargo: kraken@kargo.com
 proxistore: proxistore-technics@proxistore.com
+odeeo: prebid@odeeo.io

--- a/adapters/odeeo/odeeo.go
+++ b/adapters/odeeo/odeeo.go
@@ -1,0 +1,277 @@
+package odeeo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/buger/jsonparser"
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+const (
+	headerSP       = "x-odeeo-sp"
+	headerTK       = "x-odeeo-tk"
+	currencyUSD    = "USD"
+	openRTBVersion = "2.6"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the Odeeo adapter for the given bidder with the given config.
+func Builder(_ openrtb_ext.BidderName, config config.Adapter, _ config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: config.Endpoint}, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	var (
+		errs          []error
+		sp, tk        string
+		processedImps = make([]openrtb2.Imp, 0, len(request.Imp))
+	)
+
+	for _, imp := range request.Imp {
+		params, impExt, err := parseImpExt(imp)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if params.SP == "" || params.TK == "" {
+			// An absent or empty bidder object unmarshals cleanly, and params are not re-checked after
+			// auction hooks run - without this the request would go out with empty auth headers.
+			errs = append(
+				errs, &errortypes.BadInput{
+					Message: fmt.Sprintf("imp %q: sp and tk are required", imp.ID),
+				},
+			)
+			continue
+		}
+
+		if len(processedImps) > 0 && (params.SP != sp || params.TK != tk) {
+			// The pair is already fixed for this request, so an imp naming a different partner cannot be sent.
+			errs = append(
+				errs, &errortypes.BadInput{
+					Message: fmt.Sprintf("imp %q: all imps must have the same sp and tk", imp.ID),
+				},
+			)
+			continue
+		}
+
+		if err := convertBidFloorToUSD(&imp, requestInfo); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// One pair authenticates the whole request; mixed-partner requests are not supported.
+		// Tied to the slice so the pair always belongs to an imp that is actually sent.
+		if len(processedImps) == 0 {
+			sp, tk = params.SP, params.TK
+		}
+
+		imp.Ext = impExt
+		processedImps = append(processedImps, imp)
+	}
+
+	if len(processedImps) == 0 {
+		if len(errs) == 0 {
+			errs = append(errs, &errortypes.BadInput{Message: "no impressions in request"})
+		}
+		return nil, errs
+	}
+
+	// The request goes out as a single call; splitting multi-imp and multi-format is the endpoint's job.
+	requestCopy := *request
+	requestCopy.Imp = processedImps
+	// The endpoint accepts USD only, which is why the floors above were converted.
+	requestCopy.Cur = []string{currencyUSD}
+
+	body, err := jsonutil.Marshal(requestCopy)
+	if err != nil {
+		errs = append(errs, &errortypes.FailedToRequestBids{Message: fmt.Sprintf("unable to marshal request: %s", err.Error())})
+		return nil, errs
+	}
+
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+	headers.Add("x-openrtb-version", openRTBVersion)
+	// sp/tk identify the supply partner and are read from headers by the endpoint; they are not sent in the body.
+	headers.Add(headerSP, sp)
+	headers.Add(headerTK, tk)
+
+	requestData := &adapters.RequestData{
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    body,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(processedImps),
+	}
+
+	return []*adapters.RequestData{requestData}, errs
+}
+
+func parseImpExt(imp openrtb2.Imp) (openrtb_ext.ImpExtOdeeo, json.RawMessage, error) {
+	var params openrtb_ext.ImpExtOdeeo
+
+	var bidderExt adapters.ExtImpBidder
+	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return params, nil, &errortypes.BadInput{
+			Message: fmt.Sprintf("imp %q: invalid imp.ext: %s", imp.ID, err.Error()),
+		}
+	}
+
+	if err := jsonutil.Unmarshal(bidderExt.Bidder, &params); err != nil {
+		return params, nil, &errortypes.BadInput{
+			Message: fmt.Sprintf("imp %q: invalid imp.ext.bidder: %s", imp.ID, err.Error()),
+		}
+	}
+
+	// sp/tk travel in headers and nothing else in this object is declared in our schema.
+	// Splicing the key out leaves the rest of imp.ext exactly as the publisher sent it.
+	strippedExt := jsonparser.Delete(imp.Ext, "bidder")
+	if !hasAnyKey(strippedExt) {
+		return params, nil, nil
+	}
+
+	return params, strippedExt, nil
+}
+
+// hasAnyKey reports whether anything is left in imp.ext once the bidder params are removed.
+func hasAnyKey(ext []byte) bool {
+	found := false
+	_ = jsonparser.ObjectEach(ext, func([]byte, []byte, jsonparser.ValueType, int) error {
+		found = true
+		return nil
+	})
+
+	return found
+}
+
+func convertBidFloorToUSD(imp *openrtb2.Imp, requestInfo *adapters.ExtraRequestInfo) error {
+	if imp.BidFloor > 0 && imp.BidFloorCur != "" && !strings.EqualFold(imp.BidFloorCur, currencyUSD) {
+		converted, err := requestInfo.ConvertCurrency(imp.BidFloor, imp.BidFloorCur, currencyUSD)
+		if err != nil {
+			return &errortypes.BadInput{
+				Message: fmt.Sprintf(
+					"imp %q: unable to convert bidfloor from %s to %s: %s",
+					imp.ID, imp.BidFloorCur, currencyUSD, err.Error(),
+				),
+			}
+		}
+
+		imp.BidFloor = converted
+		imp.BidFloorCur = currencyUSD
+	}
+
+	return nil
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unable to parse bid response: %s", err.Error()),
+		}}
+	}
+
+	bidderResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+
+	if response.Cur != "" {
+		bidderResponse.Currency = response.Cur
+	}
+
+	var errs []error
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bid := &seatBid.Bid[i]
+
+			bidType, err := getBidType(bid)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			bidderResponse.Bids = append(bidderResponse.Bids, &adapters.TypedBid{
+				Bid:      bid,
+				BidType:  bidType,
+				BidMeta:  buildBidMeta(bid, seatBid.Seat, bidType),
+				BidVideo: buildBidVideo(bid, bidType),
+			})
+		}
+	}
+
+	return bidderResponse, errs
+}
+
+func getBidType(bid *openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupAudio:
+		return openrtb_ext.BidTypeAudio, nil
+	// mtype is mandatory in the 2.6 response contract; a missing value is a server error, not something to guess.
+	case 0:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("bid %q (imp %q): missing mtype", bid.ID, bid.ImpID),
+		}
+	default:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("bid %q (imp %q): unsupported mtype %d", bid.ID, bid.ImpID, bid.MType),
+		}
+	}
+}
+
+func buildBidMeta(bid *openrtb2.Bid, seat string, bidType openrtb_ext.BidType) *openrtb_ext.ExtBidPrebidMeta {
+	meta := &openrtb_ext.ExtBidPrebidMeta{
+		MediaType: string(bidType),
+		Seat:      seat,
+	}
+
+	if len(bid.ADomain) > 0 {
+		meta.AdvertiserDomains = bid.ADomain
+	}
+
+	if len(bid.Cat) > 0 {
+		meta.PrimaryCategoryID = bid.Cat[0]
+		if len(bid.Cat) > 1 {
+			meta.SecondaryCategoryIDs = bid.Cat[1:]
+		}
+	}
+
+	return meta
+}
+
+func buildBidVideo(bid *openrtb2.Bid, bidType openrtb_ext.BidType) *openrtb_ext.ExtBidPrebidVideo {
+	if bidType != openrtb_ext.BidTypeVideo {
+		return nil
+	}
+
+	var primaryCategory string
+	if len(bid.Cat) > 0 {
+		primaryCategory = bid.Cat[0]
+	}
+
+	return &openrtb_ext.ExtBidPrebidVideo{
+		Duration:        int(bid.Dur),
+		PrimaryCategory: primaryCategory,
+	}
+}

--- a/adapters/odeeo/odeeo_test.go
+++ b/adapters/odeeo/odeeo_test.go
@@ -1,0 +1,103 @@
+package odeeo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testEndpoint = "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s"
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderOdeeo, config.Adapter{Endpoint: testEndpoint}, config.Server{})
+	require.NoError(t, buildErr)
+
+	adapterstest.RunJSONBidderTest(t, "odeeotest", bidder)
+}
+
+func TestMakeBidsBidMeta(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderOdeeo, config.Adapter{Endpoint: testEndpoint}, config.Server{})
+	require.NoError(t, buildErr)
+
+	request := &openrtb2.BidRequest{
+		ID:  "req-1",
+		Imp: []openrtb2.Imp{{ID: "imp-1"}, {ID: "imp-2"}, {ID: "imp-3"}},
+	}
+
+	responseBody := []byte(`{
+		"id": "req-1",
+		"cur": "USD",
+		"seatbid": [{
+			"seat": "odeeo",
+			"bid": [
+				{
+					"id": "bid-1",
+					"impid": "imp-1",
+					"price": 2.5,
+					"adm": "<VAST version=\"4.0\"></VAST>",
+					"adomain": ["example-advertiser.com"],
+					"cat": ["IAB1-1", "IAB1-6", "IAB1-7"],
+					"mtype": 3
+				},
+				{
+					"id": "bid-2",
+					"impid": "imp-2",
+					"price": 1.0,
+					"adm": "<div></div>",
+					"mtype": 1
+				},
+				{
+					"id": "bid-3",
+					"impid": "imp-3",
+					"price": 1.5,
+					"adm": "<div></div>",
+					"cat": ["IAB1-1"],
+					"mtype": 1
+				}
+			]
+		}]
+	}`)
+
+	bidderResponse, errs := bidder.MakeBids(request, &adapters.RequestData{}, &adapters.ResponseData{
+		StatusCode: http.StatusOK,
+		Body:       responseBody,
+	})
+	require.Empty(t, errs)
+	require.NotNil(t, bidderResponse)
+	assert.Equal(t, "USD", bidderResponse.Currency)
+	require.Len(t, bidderResponse.Bids, 3)
+
+	fullMeta := bidderResponse.Bids[0]
+	assert.Equal(t, openrtb_ext.BidTypeAudio, fullMeta.BidType)
+	assert.Equal(t, openrtb_ext.BidderName(""), fullMeta.Seat, "TypedBid.Seat must stay at the default (adapter name)")
+	assert.Nil(t, fullMeta.BidVideo, "audio bids carry no video ext")
+	assert.Equal(t, &openrtb_ext.ExtBidPrebidMeta{
+		AdvertiserDomains:    []string{"example-advertiser.com"},
+		PrimaryCategoryID:    "IAB1-1",
+		SecondaryCategoryIDs: []string{"IAB1-6", "IAB1-7"},
+		Seat:                 "odeeo",
+		MediaType:            "audio",
+	}, fullMeta.BidMeta)
+
+	minimalMeta := bidderResponse.Bids[1]
+	assert.Equal(t, openrtb_ext.BidTypeBanner, minimalMeta.BidType)
+	assert.Nil(t, minimalMeta.BidVideo, "banner bids carry no video ext")
+	assert.Equal(t, &openrtb_ext.ExtBidPrebidMeta{
+		Seat:      "odeeo",
+		MediaType: "banner",
+	}, minimalMeta.BidMeta, "adomain/cat absent: only mediaType and seat are set")
+
+	singleCategoryMeta := bidderResponse.Bids[2]
+	assert.Equal(t, &openrtb_ext.ExtBidPrebidMeta{
+		PrimaryCategoryID: "IAB1-1",
+		Seat:              "odeeo",
+		MediaType:         "banner",
+	}, singleCategoryMeta.BidMeta, "single cat: primary set, no secondary")
+}

--- a/adapters/odeeo/odeeotest/exemplary/audio-app.json
+++ b/adapters/odeeo/odeeotest/exemplary/audio-app.json
@@ -1,0 +1,126 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game",
+      "name": "Example Game",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Dalvik/2.1.0",
+      "ip": "203.0.113.7",
+      "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+      "os": "android",
+      "devicetype": 4
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"],
+          "minduration": 5,
+          "maxduration": 30
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game",
+            "name": "Example Game",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Dalvik/2.1.0",
+            "ip": "203.0.113.7",
+            "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+            "os": "android",
+            "devicetype": 4
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"],
+                "minduration": 5,
+                "maxduration": 30
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 3.1,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1"],
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 3.1,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1"],
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/audio-site.json
+++ b/adapters/odeeo/odeeotest/exemplary/audio-site.json
@@ -1,0 +1,130 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/podcast",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.7",
+      "devicetype": 2
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4", "audio/mpeg"],
+          "minduration": 5,
+          "maxduration": 30
+        },
+        "bidfloor": 0.3,
+        "bidfloorcur": "USD",
+        "ext": {
+          "tid": "imp-tid-abc",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/podcast",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "ip": "203.0.113.7",
+            "devicetype": 2
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4", "audio/mpeg"],
+                "minduration": 5,
+                "maxduration": 30
+              },
+              "bidfloor": 0.3,
+              "bidfloorcur": "USD",
+              "ext": {
+                "tid": "imp-tid-abc"
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1", "IAB1-6"],
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1", "IAB1-6"],
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/banner-app.json
+++ b/adapters/odeeo/odeeotest/exemplary/banner-app.json
@@ -1,0 +1,144 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game",
+      "name": "Example Game",
+      "storeurl": "https://play.google.com/store/apps/details?id=com.example.game",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Dalvik/2.1.0",
+      "ip": "203.0.113.7",
+      "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+      "os": "android",
+      "devicetype": 4
+    },
+    "source": {
+      "tid": "d290f1ee"
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game",
+            "name": "Example Game",
+            "storeurl": "https://play.google.com/store/apps/details?id=com.example.game",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Dalvik/2.1.0",
+            "ip": "203.0.113.7",
+            "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+            "os": "android",
+            "devicetype": 4
+          },
+          "source": {
+            "tid": "d290f1ee"
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 1.75,
+                  "adm": "<div>banner creative</div>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB9-30"],
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 1.75,
+            "adm": "<div>banner creative</div>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB9-30"],
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/banner-site.json
+++ b/adapters/odeeo/odeeotest/exemplary/banner-site.json
@@ -1,0 +1,157 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/article",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.7",
+      "devicetype": 2
+    },
+    "source": {
+      "tid": "d290f1ee"
+    },
+    "regs": {
+      "gdpr": 0
+    },
+    "at": 1,
+    "tmax": 300,
+    "cur": ["EUR"],
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 0.5,
+        "bidfloorcur": "USD",
+        "ext": {
+          "tid": "imp-tid-xyz",
+          "gpid": "/1234/homepage#300x250",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/article",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "ip": "203.0.113.7",
+            "devicetype": 2
+          },
+          "source": {
+            "tid": "d290f1ee"
+          },
+          "regs": {
+            "gdpr": 0
+          },
+          "at": 1,
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 0.5,
+              "bidfloorcur": "USD",
+              "ext": {
+                "tid": "imp-tid-xyz",
+                "gpid": "/1234/homepage#300x250"
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<div>banner creative</div>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1", "IAB1-6"],
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<div>banner creative</div>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1", "IAB1-6"],
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/multi-format.json
+++ b/adapters/odeeo/odeeotest/exemplary/multi-format.json
@@ -1,0 +1,148 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/article",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.7",
+      "devicetype": 2
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "audio": {
+          "mimes": ["audio/mp4"],
+          "minduration": 5,
+          "maxduration": 30
+        },
+        "bidfloor": 0.5,
+        "bidfloorcur": "USD",
+        "ext": {
+          "tid": "imp-tid-xyz",
+          "gpid": "/1234/homepage#300x250",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/article",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "ip": "203.0.113.7",
+            "devicetype": 2
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "audio": {
+                "mimes": ["audio/mp4"],
+                "minduration": 5,
+                "maxduration": 30
+              },
+              "bidfloor": 0.5,
+              "bidfloorcur": "USD",
+              "ext": {
+                "tid": "imp-tid-xyz",
+                "gpid": "/1234/homepage#300x250"
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1", "IAB1-6"],
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1", "IAB1-6"],
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/multi-imp.json
+++ b/adapters/odeeo/odeeotest/exemplary/multi-imp.json
@@ -1,0 +1,187 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/article",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.7",
+      "devicetype": 2
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 0.5,
+        "bidfloorcur": "USD",
+        "ext": {
+          "tid": "imp-tid-1",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"],
+          "minduration": 5,
+          "maxduration": 30
+        },
+        "bidfloor": 0.3,
+        "bidfloorcur": "USD",
+        "ext": {
+          "tid": "imp-tid-2",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/article",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "ip": "203.0.113.7",
+            "devicetype": 2
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 0.5,
+              "bidfloorcur": "USD",
+              "ext": {
+                "tid": "imp-tid-1"
+              }
+            },
+            {
+              "id": "test-imp-id-2",
+              "audio": {
+                "mimes": ["audio/mp4"],
+                "minduration": 5,
+                "maxduration": 30
+              },
+              "bidfloor": 0.3,
+              "bidfloorcur": "USD",
+              "ext": {
+                "tid": "imp-tid-2"
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-1", "test-imp-id-2"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id-1",
+                  "price": 2.5,
+                  "adm": "<div>banner creative</div>",
+                  "crid": "creative-789",
+                  "adomain": ["example-advertiser.com"],
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                },
+                {
+                  "id": "bid-002",
+                  "impid": "test-imp-id-2",
+                  "price": 1.2,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "crid": "creative-790",
+                  "adomain": ["another-advertiser.com"],
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id-1",
+            "price": 2.5,
+            "adm": "<div>banner creative</div>",
+            "crid": "creative-789",
+            "adomain": ["example-advertiser.com"],
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "id": "bid-002",
+            "impid": "test-imp-id-2",
+            "price": 1.2,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "crid": "creative-790",
+            "adomain": ["another-advertiser.com"],
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/video-app.json
+++ b/adapters/odeeo/odeeotest/exemplary/video-app.json
@@ -1,0 +1,142 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game",
+      "name": "Example Game",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Dalvik/2.1.0",
+      "ip": "203.0.113.7",
+      "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+      "os": "android",
+      "devicetype": 4
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "minduration": 5,
+          "maxduration": 30,
+          "protocols": [2, 3, 5, 6],
+          "w": 320,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game",
+            "name": "Example Game",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Dalvik/2.1.0",
+            "ip": "203.0.113.7",
+            "ifa": "3fd3f5b4-4c11-4d3e-9d8d-2a6b1c0f9e21",
+            "os": "android",
+            "devicetype": 4
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "minduration": 5,
+                "maxduration": 30,
+                "protocols": [2, 3, 5, 6],
+                "w": 320,
+                "h": 480
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 4.2,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1"],
+                  "w": 320,
+                  "h": 480,
+                  "mtype": 2,
+                  "dur": 30
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 4.2,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1"],
+            "w": 320,
+            "h": 480,
+            "mtype": 2,
+            "dur": 30
+          },
+          "type": "video",
+          "video": {
+            "duration": 30,
+            "primary_category": "IAB1-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/exemplary/video-site.json
+++ b/adapters/odeeo/odeeotest/exemplary/video-site.json
@@ -1,0 +1,138 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/video",
+      "publisher": {
+        "id": "pub-42"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.7",
+      "devicetype": 2
+    },
+    "tmax": 300,
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "video": {
+          "mimes": ["video/mp4"],
+          "minduration": 5,
+          "maxduration": 30,
+          "protocols": [2, 3, 5, 6],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/video",
+            "publisher": {
+              "id": "pub-42"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0",
+            "ip": "203.0.113.7",
+            "devicetype": 2
+          },
+          "tmax": 300,
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "video": {
+                "mimes": ["video/mp4"],
+                "minduration": 5,
+                "maxduration": 30,
+                "protocols": [2, 3, 5, 6],
+                "w": 640,
+                "h": 480
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 4.2,
+                  "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+                  "adid": "ad-456",
+                  "adomain": ["example-advertiser.com"],
+                  "crid": "creative-789",
+                  "cat": ["IAB1-1", "IAB1-6"],
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2,
+                  "dur": 30
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 4.2,
+            "adm": "<VAST version=\"4.0\"><Ad><InLine></InLine></Ad></VAST>",
+            "adid": "ad-456",
+            "adomain": ["example-advertiser.com"],
+            "crid": "creative-789",
+            "cat": ["IAB1-1", "IAB1-6"],
+            "w": 640,
+            "h": 480,
+            "mtype": 2,
+            "dur": 30
+          },
+          "type": "video",
+          "video": {
+            "duration": 30,
+            "primary_category": "IAB1-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/bid-missing-mtype.json
+++ b/adapters/odeeo/odeeotest/supplemental/bid-missing-mtype.json
@@ -1,0 +1,85 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-789"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "bid \"bid-001\" (imp \"test-imp-id\"): missing mtype",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/bid-unsupported-mtype-partial.json
+++ b/adapters/odeeo/odeeotest/supplemental/bid-unsupported-mtype-partial.json
@@ -1,0 +1,134 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              }
+            },
+            {
+              "id": "test-imp-id-2",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-1", "test-imp-id-2"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id-1",
+                  "price": 2.5,
+                  "adm": "{\"native\":{}}",
+                  "crid": "creative-789",
+                  "mtype": 4
+                },
+                {
+                  "id": "bid-002",
+                  "impid": "test-imp-id-2",
+                  "price": 1.2,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-790",
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-002",
+            "impid": "test-imp-id-2",
+            "price": 1.2,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-790",
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "bid \"bid-001\" (imp \"test-imp-id-1\"): unsupported mtype 4",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion-failure.json
+++ b/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion-failure.json
@@ -1,0 +1,49 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 100,
+        "bidfloorcur": "JPY",
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ],
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "USD": {
+              "EUR": 0.8
+            }
+          },
+          "usepbsrates": false
+        }
+      }
+    }
+  },
+  "httpCalls": [],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id\": unable to convert bidfloor from JPY to USD: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion-partial-failure.json
+++ b/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion-partial-failure.json
@@ -1,0 +1,114 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 1.0,
+        "bidfloorcur": "EUR",
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "bidfloor": 100,
+        "bidfloorcur": "JPY",
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ],
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "USD": {
+              "EUR": 0.8
+            }
+          },
+          "usepbsrates": false
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 1.25,
+              "bidfloorcur": "USD"
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "currency": {
+                "rates": {
+                  "USD": {
+                    "EUR": 0.8
+                  }
+                },
+                "usepbsrates": false
+              }
+            }
+          }
+        },
+        "impIDs": ["test-imp-id-1"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id-2\": unable to convert bidfloor from JPY to USD: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion.json
+++ b/adapters/odeeo/odeeotest/supplemental/bidfloor-currency-conversion.json
@@ -1,0 +1,95 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "cur": ["EUR"],
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 1.0,
+        "bidfloorcur": "EUR",
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ],
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "USD": {
+              "EUR": 0.8
+            }
+          },
+          "usepbsrates": false
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 1.25,
+              "bidfloorcur": "USD"
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "currency": {
+                "rates": {
+                  "USD": {
+                    "EUR": 0.8
+                  }
+                },
+                "usepbsrates": false
+              }
+            }
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/odeeo/odeeotest/supplemental/bidfloor-no-currency.json
+++ b/adapters/odeeo/odeeotest/supplemental/bidfloor-no-currency.json
@@ -1,0 +1,68 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 1.5,
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "bidfloor": 1.5
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/odeeo/odeeotest/supplemental/empty-seatbid.json
+++ b/adapters/odeeo/odeeotest/supplemental/empty-seatbid.json
@@ -1,0 +1,66 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": []
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/empty-sp-tk.json
+++ b/adapters/odeeo/odeeotest/supplemental/empty-sp-tk.json
@@ -1,0 +1,100 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-empty",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "",
+            "tk": ""
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-tk-empty",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": ""
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-ok",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-ok",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-ok"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id-empty\": sp and tk are required",
+      "comparison": "literal"
+    },
+    {
+      "value": "imp \"test-imp-id-tk-empty\": sp and tk are required",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/extra-bidder-params.json
+++ b/adapters/odeeo/odeeotest/supplemental/extra-bidder-params.json
@@ -1,0 +1,95 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "tid": "imp-tid-1",
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4",
+            "placement": "lobby",
+            "priority": 7,
+            "meta": {
+              "a": 1,
+              "b": ["x", "y"]
+            }
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4",
+            "placement": "rewarded"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "tid": "imp-tid-1"
+              }
+            },
+            {
+              "id": "test-imp-id-2",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-1", "test-imp-id-2"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/odeeo/odeeotest/supplemental/headers-from-surviving-imp.json
+++ b/adapters/odeeo/odeeotest/supplemental/headers-from-surviving-imp.json
@@ -1,0 +1,105 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-dropped",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "bidfloor": 100,
+        "bidfloorcur": "JPY",
+        "ext": {
+          "bidder": {
+            "sp": "111111111",
+            "tk": "d4c3b2a1"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-sent",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "222222222",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ],
+    "ext": {
+      "prebid": {
+        "currency": {
+          "rates": {
+            "USD": {
+              "EUR": 0.8
+            }
+          },
+          "usepbsrates": false
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["222222222"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-sent",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ],
+          "ext": {
+            "prebid": {
+              "currency": {
+                "rates": {
+                  "USD": {
+                    "EUR": 0.8
+                  }
+                },
+                "usepbsrates": false
+              }
+            }
+          }
+        },
+        "impIDs": ["test-imp-id-sent"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id-dropped\": unable to convert bidfloor from JPY to USD: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/invalid-imp-ext-bidder-partial.json
+++ b/adapters/odeeo/odeeotest/supplemental/invalid-imp-ext-bidder-partial.json
@@ -1,0 +1,79 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": ["123456789"],
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-2",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-2"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id-1\": invalid imp.ext.bidder: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/invalid-imp-ext.json
+++ b/adapters/odeeo/odeeotest/supplemental/invalid-imp-ext.json
@@ -1,0 +1,30 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": "not-an-object"
+      }
+    ]
+  },
+  "httpCalls": [],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id\": invalid imp.ext: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/invalid-response-body.json
+++ b/adapters/odeeo/odeeotest/supplemental/invalid-response-body.json
@@ -1,0 +1,63 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "not-a-bid-response"
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unable to parse bid response: ",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/multi-imp-sp-tk-mismatch.json
+++ b/adapters/odeeo/odeeotest/supplemental/multi-imp-sp-tk-mismatch.json
@@ -1,0 +1,102 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-2",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "987654321",
+            "tk": "a1b2c3d4"
+          }
+        }
+      },
+      {
+        "id": "test-imp-id-3",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "site": {
+            "page": "https://example.com/article"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              }
+            },
+            {
+              "id": "test-imp-id-3",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id-1", "test-imp-id-3"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp \"test-imp-id-2\": all imps must have the same sp and tk",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/no-imps.json
+++ b/adapters/odeeo/odeeotest/supplemental/no-imps.json
@@ -1,0 +1,17 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://example.com/article"
+    },
+    "imp": []
+  },
+  "httpCalls": [],
+  "expectedBidResponses": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "no impressions in request",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/response-missing-cur.json
+++ b/adapters/odeeo/odeeotest/supplemental/response-missing-cur.json
@@ -1,0 +1,91 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-789",
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-789",
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/response-non-usd-cur.json
+++ b/adapters/odeeo/odeeotest/supplemental/response-non-usd-cur.json
@@ -1,0 +1,92 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "EUR",
+          "seatbid": [
+            {
+              "seat": "odeeo",
+              "bid": [
+                {
+                  "id": "bid-001",
+                  "impid": "test-imp-id",
+                  "price": 2.5,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-789",
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-001",
+            "impid": "test-imp-id",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-789",
+            "mtype": 3
+          },
+          "type": "audio"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/status-204.json
+++ b/adapters/odeeo/odeeotest/supplemental/status-204.json
@@ -1,0 +1,56 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/odeeo/odeeotest/supplemental/status-400.json
+++ b/adapters/odeeo/odeeotest/supplemental/status-400.json
@@ -1,0 +1,63 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/odeeotest/supplemental/status-500.json
+++ b/adapters/odeeo/odeeotest/supplemental/status-500.json
@@ -1,0 +1,63 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "app": {
+      "bundle": "com.example.game"
+    },
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "audio": {
+          "mimes": ["audio/mp4"]
+        },
+        "ext": {
+          "bidder": {
+            "sp": "123456789",
+            "tk": "a1b2c3d4"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s",
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"],
+          "X-Openrtb-Version": ["2.6"],
+          "X-Odeeo-Sp": ["123456789"],
+          "X-Odeeo-Tk": ["a1b2c3d4"]
+        },
+        "body": {
+          "id": "test-request-id",
+          "app": {
+            "bundle": "com.example.game"
+          },
+          "cur": ["USD"],
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "audio": {
+                "mimes": ["audio/mp4"]
+              }
+            }
+          ]
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/odeeo/params_test.go
+++ b/adapters/odeeo/params_test.go
@@ -1,0 +1,59 @@
+package odeeo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+var validParams = []string{
+	`{"sp": "123456789", "tk": "a1b2c3d4"}`,
+	`{"sp": "1", "tk": "a"}`,
+	`{"sp": "123456789", "tk": "a1b2c3d4", "extra": "ignored"}`,
+}
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderOdeeo, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected odeeo params: %s", validParam)
+		}
+	}
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`"123456789"`,
+	`[]`,
+	`{}`,
+	`{"sp": "123456789"}`,
+	`{"tk": "a1b2c3d4"}`,
+	`{"sp": "", "tk": ""}`,
+	`{"sp": "", "tk": "a1b2c3d4"}`,
+	`{"sp": "123456789", "tk": ""}`,
+	`{"sp": 123456789, "tk": "a1b2c3d4"}`,
+	`{"sp": "123456789", "tk": 1234}`,
+	`{"sp": null, "tk": "a1b2c3d4"}`,
+	`{"sp": ["123456789"], "tk": "a1b2c3d4"}`,
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderOdeeo, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -172,6 +172,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/nextmillennium"
 	"github.com/prebid/prebid-server/v4/adapters/nexx360"
 	"github.com/prebid/prebid-server/v4/adapters/nobid"
+	"github.com/prebid/prebid-server/v4/adapters/odeeo"
 	"github.com/prebid/prebid-server/v4/adapters/ogury"
 	"github.com/prebid/prebid-server/v4/adapters/oms"
 	"github.com/prebid/prebid-server/v4/adapters/onetag"
@@ -453,6 +454,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderNextMillennium:    nextmillennium.Builder,
 		openrtb_ext.BidderNexx360:           nexx360.Builder,
 		openrtb_ext.BidderNoBid:             nobid.Builder,
+		openrtb_ext.BidderOdeeo:             odeeo.Builder,
 		openrtb_ext.BidderOgury:             ogury.Builder,
 		openrtb_ext.BidderOms:               oms.Builder,
 		openrtb_ext.BidderOneTag:            onetag.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -190,6 +190,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderNextMillennium,
 	BidderNexx360,
 	BidderNoBid,
+	BidderOdeeo,
 	BidderOgury,
 	BidderOms,
 	BidderOneTag,
@@ -575,6 +576,7 @@ const (
 	BidderNextMillennium    BidderName = "nextmillennium"
 	BidderNexx360           BidderName = "nexx360"
 	BidderNoBid             BidderName = "nobid"
+	BidderOdeeo             BidderName = "odeeo"
 	BidderOgury             BidderName = "ogury"
 	BidderOms               BidderName = "oms"
 	BidderOneTag            BidderName = "onetag"

--- a/openrtb_ext/imp_odeeo.go
+++ b/openrtb_ext/imp_odeeo.go
@@ -1,0 +1,7 @@
+package openrtb_ext
+
+// ImpExtOdeeo defines the contract for bidrequest.imp[i].ext.prebid.bidder.odeeo
+type ImpExtOdeeo struct {
+	SP string `json:"sp"`
+	TK string `json:"tk"`
+}

--- a/static/bidder-info/odeeo.yaml
+++ b/static/bidder-info/odeeo.yaml
@@ -1,0 +1,22 @@
+endpoint: "https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s"
+endpointCompression: gzip
+geoscope:
+  - global
+maintainer:
+  email: "prebid@odeeo.io"
+gvlVendorID: 1039
+modifyingVastXmlAllowed: true
+openrtb:
+  version: 2.6
+  gpp-supported: false
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - audio
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - audio

--- a/static/bidder-params/odeeo.json
+++ b/static/bidder-params/odeeo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Odeeo Adapter Params",
+  "description": "A schema which validates params accepted by the Odeeo adapter",
+  "type": "object",
+  "properties": {
+    "sp": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Odeeo Supply Partner ID"
+    },
+    "tk": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Odeeo-issued verification code"
+    }
+  },
+  "required": ["sp", "tk"]
+}

--- a/static/bidder-params/odeeo.json
+++ b/static/bidder-params/odeeo.json
@@ -12,7 +12,7 @@
     "tk": {
       "type": "string",
       "minLength": 1,
-      "description": "Odeeo-issued verification code"
+      "description": "Odeeo-issued verification token"
     }
   },
   "required": ["sp", "tk"]


### PR DESCRIPTION
## Overview

Adds a new bid adapter for **Odeeo** (https://odeeo.io), an in-game audio and
display exchange.

- **Bidder code:** `odeeo`
- **Maintainer:** prebid@odeeo.io
- **GVL Vendor ID:** 1039 (registered as "Sonic Odeeo ltd")
- **Endpoint:** `https://ads.exchange.odeeo.io/v1/bidrequest/prebids2s`
- **OpenRTB:** 2.6; GPP not consumed (`gpp-supported: false`)
- **Capabilities:** site + app, banner / video / audio
- **Params:** `sp` (supply partner id) and `tk` (verification code), both required

## Documentation

Docs PR: [prebid/prebid.github.io#6721](https://github.com/prebid/prebid.github.io/pull/6721
)

## Test parameters

Live `sp` / `tk` for testing are available on request from prebid@odeeo.io