### PR TITLE
Config: Replace stale OpenRTBInfo comments with actual usage

### DIFF
--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -97,12 +97,20 @@ type AdapterXAPI struct {
 }
 
 // OpenRTBInfo specifies the versions/aspects of openRTB that a bidder supports
-// Version is not yet actively supported
-// GPPSupported is not yet actively supported
 type OpenRTBInfo struct {
-	Version              string `yaml:"version" mapstructure:"version"`
-	GPPSupported         bool   `yaml:"gpp-supported" mapstructure:"gpp-supported"`
-	MultiformatSupported *bool  `yaml:"multiformat-supported" mapstructure:"multiformat-supported"`
+	// Version is the highest OpenRTB version the bidder supports. Requests to bidders which
+	// do not declare "2.6" are down converted to OpenRTB 2.5 before being sent.
+	Version string `yaml:"version" mapstructure:"version"`
+
+	// GPPSupported indicates the bidder can read the GPP privacy signals directly. Requests to
+	// bidders which do not support GPP have the legacy regs.gdpr, user.consent and regs.us_privacy
+	// fields populated from the GPP string.
+	GPPSupported bool `yaml:"gpp-supported" mapstructure:"gpp-supported"`
+
+	// MultiformatSupported indicates the bidder can handle an imp offering multiple media types.
+	// When false, each imp is reduced to the preferred media type before being sent. Unset is
+	// treated as supported.
+	MultiformatSupported *bool `yaml:"multiformat-supported" mapstructure:"multiformat-supported"`
 }
 
 // Syncer specifies the user sync settings for a bidder. This struct is shared by the account config,


### PR DESCRIPTION

### Summary

The `OpenRTBInfo` struct in `config/bidderinfo.go` carried two comments stating that
`Version` and `GPPSupported` are "not yet actively supported". Both flags have been
actively driving request behavior for a long time, so the comments are misleading to
anyone reading the config schema or deciding whether to set the flags in a
`static/bidder-info/*.yaml` file.

This PR removes the stale comments and replaces them with per-field documentation
describing what each flag actually controls.

### Why the comments are stale

Those comments were introduced in "Initial infrastructure to support bidder openRTB
support flags" (#2540), when the flags were only defined and not yet read anywhere.
The follow-up PR "Support GDPR and USPrivacy from GPP downgrade for adapters that do
not support GPP" (#2621) started consuming `GPPSupported`, and the OpenRTB 2.5 down
conversion started consuming `Version`, but the comments were never updated.

Current usage:

| Field | Used by | Effect |
| --- | --- | --- |
| `Version` | `exchange/utils.go` (`cleanOpenRTBRequests`) | Bidders that do not declare `"2.6"` have their request down converted via `openrtb_ext.ConvertDownTo25`. |
| `GPPSupported` | `exchange/utils.go` (`shouldSetLegacyPrivacy` → `setLegacyGDPRFromGPP` / `setLegacyUSPFromGPP`) | Bidders that do not support GPP get the legacy `regs.gdpr`, `user.consent` and `regs.us_privacy` fields populated from the GPP string. |
| `MultiformatSupported` | `adapters/infoawarebidder.go` (`IsMultiFormatSupported`) | Bidders that do not support multi-format get each imp reduced to the preferred media type. Unset is treated as supported. |

`gpp-supported: true` is currently set by 26 bidder YAML files (pubmatic, rubicon, ix,
openx, criteo, and others), so this is a flag adopters actively rely on.

### Changes

- `config/bidderinfo.go`: replace the two outdated struct-level comments with field-level
  comments for `Version`, `GPPSupported` and `MultiformatSupported`.

### Testing

Comments only — no behavior change, no test changes. `./validate.sh` passes.

### Related

- #2540 — introduced the flags and the "not yet actively supported" comments
- #2621 — started using `GPPSupported` for the GPP downgrade
