### PR TITLE
RTBHouse: video ads support

### DIFF
--- a/adapters/rtbhouse/rtbhouse.go
+++ b/adapters/rtbhouse/rtbhouse.go
@@ -292,7 +292,14 @@ func (adapter *RTBHouseAdapter) MakeBids(
 		return nil, []error{err}
 	}
 
-	bidsCapacity := len(openRTBBidderResponse.SeatBid[0].Bid)
+	if len(openRTBBidderResponse.SeatBid) == 0 {
+		return nil, nil
+	}
+
+	bidsCapacity := 0
+	for _, seatBid := range openRTBBidderResponse.SeatBid {
+		bidsCapacity += len(seatBid.Bid)
+	}
 	bidderResponse = adapters.NewBidderResponseWithBidsCapacity(bidsCapacity)
 	var typedBid *adapters.TypedBid
 	for _, seatBid := range openRTBBidderResponse.SeatBid {

--- a/adapters/rtbhouse/rtbhouse.go
+++ b/adapters/rtbhouse/rtbhouse.go
@@ -305,8 +305,9 @@ func (adapter *RTBHouseAdapter) MakeBids(
 				continue
 			} else {
 				typedBid = &adapters.TypedBid{
-					Bid:     &bid,
-					BidType: bidType,
+					Bid:      &bid,
+					BidType:  bidType,
+					BidVideo: getBidVideo(bidType, &bid),
 				}
 
 				// for native bid responses fix Adm field
@@ -333,10 +334,28 @@ func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
 	switch bid.MType {
 	case openrtb2.MarkupBanner:
 		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
 	case openrtb2.MarkupNative:
 		return openrtb_ext.BidTypeNative, nil
 	default:
 		return "", fmt.Errorf("unrecognized bid type in response from rtbhouse for bid %s", bid.ImpID)
+	}
+}
+
+func getBidVideo(bidType openrtb_ext.BidType, bid *openrtb2.Bid) *openrtb_ext.ExtBidPrebidVideo {
+	if bidType != openrtb_ext.BidTypeVideo {
+		return nil
+	}
+
+	var primaryCategory string
+	if len(bid.Cat) > 0 {
+		primaryCategory = bid.Cat[0]
+	}
+
+	return &openrtb_ext.ExtBidPrebidVideo{
+		Duration:        int(bid.Dur),
+		PrimaryCategory: primaryCategory,
 	}
 }
 

--- a/adapters/rtbhouse/rtbhousetest/exemplary/app_video.json
+++ b/adapters/rtbhouse/rtbhousetest/exemplary/app_video.json
@@ -1,0 +1,119 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "app": {
+            "bundle": "com.prebid"
+        },
+        "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+        },
+        "imp": [{
+            "id": "test-imp-id",
+            "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480,
+                "minduration": 5,
+                "maxduration": 30
+            },
+            "ext": {
+                "bidder": {
+                    "publisherId": "PublisherId"
+                }
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "app": {
+                    "bundle": "com.prebid",
+                    "publisher": {
+                        "ext": {
+                            "prebid": {
+                                "publisherId": "PublisherId"
+                            }
+                        }
+                    }
+                },
+                "device": {
+                    "ua": "test-user-agent",
+                    "ip": "123.123.123.123",
+                    "language": "en",
+                    "dnt": 0
+                },
+                "imp": [{
+                    "id": "test-imp-id",
+                    "video": {
+                        "mimes": ["video/mp4"],
+                        "w": 640,
+                        "h": 480,
+                        "minduration": 5,
+                        "maxduration": 30
+                    },
+                    "ext": {
+                        "bidder": {
+                            "publisherId": "PublisherId"
+                        }
+                    },
+                    "tagid": "test-imp-id"
+                }]
+            },
+            "impIDs":["test-imp-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "seatbid": [{
+                    "seat": "rtbhouse",
+                    "bid": [{
+                        "id": "randomid",
+                        "impid": "test-imp-id",
+                        "price": 1.500000,
+                        "adid": "12345678",
+                        "adm": "<VAST version=\"4.0\"></VAST>",
+                        "cid": "987",
+                        "crid": "12345678",
+                        "dur": 15,
+                        "h": 480,
+                        "w": 640,
+                        "mtype": 2
+                    }]
+                }],
+                "cur": "USD"
+            }
+        }
+    }],
+
+    "expectedBidResponses": [{
+        "currency": "USD",
+        "bids": [{
+            "bid": {
+                "id": "randomid",
+                "impid": "test-imp-id",
+                "price": 1.5,
+                "adm": "<VAST version=\"4.0\"></VAST>",
+                "adid": "12345678",
+                "cid": "987",
+                "crid": "12345678",
+                "dur": 15,
+                "w": 640,
+                "h": 480,
+                "mtype": 2
+            },
+            "type": "video",
+            "video": {
+                "duration": 15,
+                "primary_category": ""
+            }
+        }]
+    }]
+}

--- a/adapters/rtbhouse/rtbhousetest/exemplary/banner-video-multiformat.json
+++ b/adapters/rtbhouse/rtbhousetest/exemplary/banner-video-multiformat.json
@@ -1,0 +1,150 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "site": {
+            "page": "https://good.site/url"
+        },
+        "imp": [{
+            "id": "test-imp-banner-id",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "video": {
+                "mimes": ["video/mp4"],
+                "w": 300,
+                "h": 250
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }, {
+            "id": "test-imp-video-id",
+            "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "site": {
+                    "page": "https://good.site/url"
+                },
+                "imp": [{
+                    "id": "test-imp-banner-id",
+                    "banner": {
+                        "format": [{
+                            "w": 300,
+                            "h": 250
+                        }]
+                    },
+                    "video": {
+                        "mimes": ["video/mp4"],
+                        "w": 300,
+                        "h": 250
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-banner-id"
+                }, {
+                    "id": "test-imp-video-id",
+                    "video": {
+                        "mimes": ["video/mp4"],
+                        "w": 640,
+                        "h": 480
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-video-id"
+                }]
+            },
+            "impIDs":["test-imp-banner-id", "test-imp-video-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "seatbid": [{
+                    "seat": "rtbhouse",
+                    "bid": [{
+                        "id": "randomid-banner",
+                        "impid": "test-imp-banner-id",
+                        "price": 0.500000,
+                        "adid": "12345678",
+                        "adm": "some-test-ad",
+                        "cid": "987",
+                        "crid": "12345678",
+                        "h": 250,
+                        "w": 300,
+                        "mtype": 1
+                    }, {
+                        "id": "randomid-video",
+                        "impid": "test-imp-video-id",
+                        "price": 1.500000,
+                        "adid": "87654321",
+                        "adm": "<VAST version=\"4.0\"></VAST>",
+                        "cid": "987",
+                        "crid": "87654321",
+                        "dur": 30,
+                        "h": 480,
+                        "w": 640,
+                        "mtype": 2
+                    }]
+                }],
+                "cur": "USD"
+            }
+        }
+    }],
+
+    "expectedBidResponses": [{
+        "currency": "USD",
+        "bids": [{
+            "bid": {
+                "id": "randomid-banner",
+                "impid": "test-imp-banner-id",
+                "price": 0.5,
+                "adm": "some-test-ad",
+                "adid": "12345678",
+                "cid": "987",
+                "crid": "12345678",
+                "w": 300,
+                "h": 250,
+                "mtype": 1
+            },
+            "type": "banner"
+        }, {
+            "bid": {
+                "id": "randomid-video",
+                "impid": "test-imp-video-id",
+                "price": 1.5,
+                "adm": "<VAST version=\"4.0\"></VAST>",
+                "adid": "87654321",
+                "cid": "987",
+                "crid": "87654321",
+                "dur": 30,
+                "w": 640,
+                "h": 480,
+                "mtype": 2
+            },
+            "type": "video",
+            "video": {
+                "duration": 30,
+                "primary_category": ""
+            }
+        }]
+    }]
+}

--- a/adapters/rtbhouse/rtbhousetest/exemplary/simple-video.json
+++ b/adapters/rtbhouse/rtbhousetest/exemplary/simple-video.json
@@ -1,0 +1,106 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "site": {
+            "page": "https://good.site/url"
+        },
+        "imp": [{
+            "id": "test-imp-id",
+            "video": {
+                "mimes": ["video/mp4"],
+                "protocols": [2, 3, 5, 6],
+                "w": 640,
+                "h": 480,
+                "minduration": 5,
+                "maxduration": 30,
+                "placement": 1,
+                "linearity": 1,
+                "skip": 1
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "site": {
+                    "page": "https://good.site/url"
+                },
+                "imp": [{
+                    "id": "test-imp-id",
+                    "video": {
+                        "mimes": ["video/mp4"],
+                        "protocols": [2, 3, 5, 6],
+                        "w": 640,
+                        "h": 480,
+                        "minduration": 5,
+                        "maxduration": 30,
+                        "placement": 1,
+                        "linearity": 1,
+                        "skip": 1
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-id"
+                }]
+            },
+            "impIDs":["test-imp-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "seatbid": [{
+                    "seat": "rtbhouse",
+                    "bid": [{
+                        "id": "randomid",
+                        "impid": "test-imp-id",
+                        "price": 1.500000,
+                        "adid": "12345678",
+                        "adm": "<VAST version=\"4.0\"></VAST>",
+                        "cid": "987",
+                        "crid": "12345678",
+                        "cat": ["IAB1-1"],
+                        "dur": 30,
+                        "h": 480,
+                        "w": 640,
+                        "mtype": 2
+                    }]
+                }],
+                "cur": "USD"
+            }
+        }
+    }],
+
+    "expectedBidResponses": [{
+        "currency": "USD",
+        "bids": [{
+            "bid": {
+                "id": "randomid",
+                "impid": "test-imp-id",
+                "price": 1.5,
+                "adm": "<VAST version=\"4.0\"></VAST>",
+                "adid": "12345678",
+                "cid": "987",
+                "crid": "12345678",
+                "cat": ["IAB1-1"],
+                "dur": 30,
+                "w": 640,
+                "h": 480,
+                "mtype": 2
+            },
+            "type": "video",
+            "video": {
+                "duration": 30,
+                "primary_category": "IAB1-1"
+            }
+        }]
+    }]
+}

--- a/adapters/rtbhouse/rtbhousetest/exemplary/video-resolve-macros.json
+++ b/adapters/rtbhouse/rtbhousetest/exemplary/video-resolve-macros.json
@@ -1,0 +1,94 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "site": {
+            "page": "https://good.site/url"
+        },
+        "imp": [{
+            "id": "test-imp-id",
+            "video": {
+                "mimes": ["video/mp4"],
+                "w": 640,
+                "h": 480
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "site": {
+                    "page": "https://good.site/url"
+                },
+                "imp": [{
+                    "id": "test-imp-id",
+                    "video": {
+                        "mimes": ["video/mp4"],
+                        "w": 640,
+                        "h": 480
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-id"
+                }]
+            },
+            "impIDs":["test-imp-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "seatbid": [{
+                    "seat": "rtbhouse",
+                    "bid": [{
+                        "id": "randomid",
+                        "impid": "test-imp-id",
+                        "price": 1.500000,
+                        "adid": "12345678",
+                        "adm": "<VAST version=\"4.0\"><Ad><InLine><Impression><![CDATA[https://endpoint.url/win-notify?a=xyz&price=${AUCTION_PRICE}]]></Impression></InLine></Ad></VAST>",
+                        "nurl": "https://endpoint.url/win?price=${AUCTION_PRICE}",
+                        "cid": "987",
+                        "crid": "12345678",
+                        "dur": 30,
+                        "h": 480,
+                        "w": 640,
+                        "mtype": 2
+                    }]
+                }],
+                "cur": "USD"
+            }
+        }
+    }],
+
+    "expectedBidResponses": [{
+        "currency": "USD",
+        "bids": [{
+            "bid": {
+                "id": "randomid",
+                "impid": "test-imp-id",
+                "price": 1.5,
+                "adm": "<VAST version=\"4.0\"><Ad><InLine><Impression><![CDATA[https://endpoint.url/win-notify?a=xyz&price=1.5]]></Impression></InLine></Ad></VAST>",
+                "nurl": "https://endpoint.url/win?price=1.5",
+                "adid": "12345678",
+                "cid": "987",
+                "crid": "12345678",
+                "dur": 30,
+                "w": 640,
+                "h": 480,
+                "mtype": 2
+            },
+            "type": "video",
+            "video": {
+                "duration": 30,
+                "primary_category": ""
+            }
+        }]
+    }]
+}

--- a/adapters/rtbhouse/rtbhousetest/supplemental/empty-seatbid.json
+++ b/adapters/rtbhouse/rtbhousetest/supplemental/empty-seatbid.json
@@ -1,0 +1,57 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "site": {
+            "page": "https://good.site/url"
+        },
+        "imp": [{
+            "id": "test-imp-id",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "site": {
+                    "page": "https://good.site/url"
+                },
+                "imp": [{
+                    "id": "test-imp-id",
+                    "banner": {
+                        "format": [{
+                            "w": 300,
+                            "h": 250
+                        }]
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-id"
+                }]
+            },
+            "impIDs":["test-imp-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "seatbid": [],
+                "cur": "USD"
+            }
+        }
+    }],
+
+    "expectedBidResponses": []
+}

--- a/adapters/rtbhouse/rtbhousetest/supplemental/no-seatbid.json
+++ b/adapters/rtbhouse/rtbhousetest/supplemental/no-seatbid.json
@@ -1,0 +1,56 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "site": {
+            "page": "https://good.site/url"
+        },
+        "imp": [{
+            "id": "test-imp-id",
+            "banner": {
+                "format": [{
+                    "w": 300,
+                    "h": 250
+                }]
+            },
+            "ext": {
+                "bidder": {}
+            }
+        }]
+    },
+
+    "httpCalls": [{
+        "expectedRequest": {
+            "uri": "http://localhost/prebid_server",
+            "body": {
+                "id": "test-request-id",
+                "cur": ["USD"],
+                "site": {
+                    "page": "https://good.site/url"
+                },
+                "imp": [{
+                    "id": "test-imp-id",
+                    "banner": {
+                        "format": [{
+                            "w": 300,
+                            "h": 250
+                        }]
+                    },
+                    "ext": {
+                        "bidder": {}
+                    },
+                    "tagid": "test-imp-id"
+                }]
+            },
+            "impIDs":["test-imp-id"]
+        },
+        "mockResponse": {
+            "status": 200,
+            "body": {
+                "id": "test-request-id",
+                "nbr": 2
+            }
+        }
+    }],
+
+    "expectedBidResponses": []
+}

--- a/static/bidder-info/rtbhouse.yaml
+++ b/static/bidder-info/rtbhouse.yaml
@@ -20,10 +20,12 @@ capabilities:
   app:
     mediaTypes:
       - banner
+      - video
       - native
   site:
     mediaTypes:
       - banner
+      - video
       - native
 userSync:
   # rtbhouse supports user syncing, but requires configuration by the host. contact this


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bid adapter update
- [x] enhancement
- [x] bugfix

### ✨ What's the context?
Related PR (Java): https://github.com/prebid/prebid-server-java/pull/3130
Video ads support has been available in PBS Java since May 2024, but never landed in PBS Go. `video` was missing from the adapter's declared capabilities, so core stripped `imp.video` before the adapter was reached, and `mtype: 2` bids were rejected as an unrecognized bid type. This PR brings the Go adapter to parity.

### 📋 Description
Video ads are now available to be processed and accessed by RTB House adapter:
1. `video` added to the app and site capabilities in `static/bidder-info/rtbhouse.yaml`
2. `mtype: 2` resolved to the video bid type
3. Video bid metadata exposed (`duration` from `bid.dur`, `primary_category` from `bid.cat[0]`) for ad pod handling and category deduplication

The outgoing request path needed no changes, `imp.video` is passed through untouched.

A second commit fixes an unrelated panic in `MakeBids`, which sized its bid slice from `SeatBid[0].Bid` and crashed on an HTTP 200 response with an empty or absent `seatbid` array.

### 🧪 Testing results
```Tests run: 40, Failures: 0, Errors: 0, Skipped: 0```
```coverage: 93.9% of statements```
All RTBHouse bidder tests pass successfully (coverage up from 93.5%). Updates:
- New exemplary tests for the feature (4 tests): site video, app video, `${AUCTION_PRICE}` resolution, banner + video multi-format
- New supplemental tests for the panic fix (2 tests): empty and absent `seatbid`
- No existing test cases required changes

### ℹ Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).
