### PR TITLE
Fix: Relax VAST tag matching when injecting impression trackers

### DIFF
--- a/endpoints/events/vtrack.go
+++ b/endpoints/events/vtrack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -27,6 +28,19 @@ const (
 	IntegrationParameter = "int"
 	ImpressionCloseTag   = "</Impression>"
 	ImpressionOpenTag    = "<Impression>"
+	emptyImpressionTag   = ImpressionOpenTag + ImpressionCloseTag
+	trackingImpressionCD = "<![CDATA["
+	trackingImpressionCE = "]]>"
+)
+
+// Tag matchers ported from PBS-Java VastModifier (prebid-server-java#3059).
+// VAST tags may differ in case, carry attributes, and include extra whitespace.
+var (
+	wrapperOpenTagPattern     = regexp.MustCompile(`(?i)<\s*wrapper(?:>|\s.*?>)`)
+	wrapperCloseTagPattern    = regexp.MustCompile(`(?i)<\s*/\s*wrapper(?:>|\s.*?>)`)
+	inlineOpenTagPattern      = regexp.MustCompile(`(?i)<\s*inline(?:>|\s.*?>)`)
+	inlineCloseTagPattern     = regexp.MustCompile(`(?i)<\s*/\s*inline(?:>|\s.*?>)`)
+	impressionCloseTagPattern = regexp.MustCompile(`(?i)<\s*/\s*impression(?:>|\s.*?>)`)
 )
 
 type vtrackEndpoint struct {
@@ -296,24 +310,65 @@ func getIntegrationType(httpRequest *http.Request) (string, error) {
 	return integrationType, nil
 }
 
-// ModifyVastXmlString rewrites and returns the string vastXML and a flag indicating if it was modified
+// ModifyVastXmlString rewrites and returns the string vastXML and a flag indicating if it was modified.
+// Matching follows PBS-Java: InLine first, then Wrapper; insert after the last Impression close tag,
+// or before the parent close tag when no Impression exists (#1967). Neither parent: unchanged.
 func ModifyVastXmlString(externalUrl, vast, bidid, bidder, accountID string, timestamp int64, integrationType string) (string, bool) {
-	ci := strings.Index(vast, ImpressionCloseTag)
+	trackingURL := func() string {
+		return GetVastUrlTracking(externalUrl, bidid, bidder, accountID, timestamp, integrationType)
+	}
+	if result, found, changed := appendTrackingURL(vast, trackingURL, inlineOpenTagPattern, inlineCloseTagPattern); found {
+		return result, changed
+	}
+	if result, found, changed := appendTrackingURL(vast, trackingURL, wrapperOpenTagPattern, wrapperCloseTagPattern); found {
+		return result, changed
+	}
+	return vast, false
+}
 
-	// no impression tag - pass it as it is
-	if ci == -1 {
-		return vast, false
+func appendTrackingURL(vast string, trackingURL func() string, openTag, closeTag *regexp.Regexp) (string, bool, bool) {
+	openLoc := openTag.FindStringIndex(vast)
+	if openLoc == nil {
+		return vast, false, false
+	}
+	from := openLoc[1]
+	searchEnd := len(vast)
+	closeRel := closeTag.FindStringIndex(vast[from:])
+	if closeRel != nil {
+		searchEnd = from + closeRel[0]
 	}
 
-	vastUrlTracking := GetVastUrlTracking(externalUrl, bidid, bidder, accountID, timestamp, integrationType)
-	impressionUrl := "<![CDATA[" + vastUrlTracking + "]]>"
-	oi := strings.Index(vast, ImpressionOpenTag)
-
-	if ci-oi == len(ImpressionOpenTag) {
-		return strings.Replace(vast, ImpressionOpenTag, ImpressionOpenTag+impressionUrl, 1), true
+	// PBS-Go nurl wrappers emit a canonical empty <Impression></Impression>. Fill that
+	// in place so makeVAST results stay a single Impression (exchange event fixtures).
+	if i := strings.Index(vast[from:searchEnd], emptyImpressionTag); i >= 0 {
+		at := from + i + len(ImpressionOpenTag)
+		return vast[:at] + trackingImpressionCD + trackingURL() + trackingImpressionCE + vast[at:], true, true
 	}
 
-	return strings.Replace(vast, ImpressionCloseTag, ImpressionCloseTag+ImpressionOpenTag+impressionUrl+ImpressionCloseTag, 1), true
+	if end, ok := lastMatchEnd(impressionCloseTagPattern, vast[:searchEnd], from); ok {
+		return insertTrackingImpression(vast, trackingURL(), end), true, true
+	}
+
+	if closeRel == nil {
+		return vast, true, false
+	}
+	return insertTrackingImpression(vast, trackingURL(), from+closeRel[0]), true, true
+}
+
+func lastMatchEnd(re *regexp.Regexp, s string, start int) (int, bool) {
+	if start > len(s) {
+		return 0, false
+	}
+	locs := re.FindAllStringIndex(s[start:], -1)
+	if len(locs) == 0 {
+		return 0, false
+	}
+	return start + locs[len(locs)-1][1], true
+}
+
+func insertTrackingImpression(vast, trackingURL string, index int) string {
+	tag := ImpressionOpenTag + trackingImpressionCD + trackingURL + trackingImpressionCE + ImpressionCloseTag
+	return vast[:index] + tag + vast[index:]
 }
 
 // ModifyVastXmlJSON modifies BidCacheRequest element Vast XML data

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -801,6 +801,119 @@ func getVTrackRequestData(wi bool, wic bool) (db []byte, e error) {
 	return data.Bytes(), e
 }
 
+func TestModifyVastXmlString(t *testing.T) {
+	const (
+		external    = "http://external-url"
+		bidID       = "bidId"
+		bidder      = "bidder"
+		accountID   = "accountId"
+		ts          = int64(1000)
+		integration = "integrationType"
+	)
+	tracking := GetVastUrlTracking(external, bidID, bidder, accountID, ts, integration)
+	tag := ImpressionOpenTag + "<![CDATA[" + tracking + "]]>" + ImpressionCloseTag
+
+	tests := []struct {
+		name string
+		vast string
+		want string
+		ok   bool
+	}{
+		{
+			name: "append after existing wrapper impression",
+			vast: `<Wrapper><Impression>http:/test.com</Impression></Wrapper>`,
+			want: `<Wrapper><Impression>http:/test.com</Impression>` + tag + `</Wrapper>`,
+			ok:   true,
+		},
+		{
+			name: "append after last of multiple impressions",
+			vast: `<InLine><Impression>http:/test.com</Impression><Impression>http:/test2.com</Impression><Creatives></Creatives></InLine>`,
+			want: `<InLine><Impression>http:/test.com</Impression><Impression>http:/test2.com</Impression>` + tag + `<Creatives></Creatives></InLine>`,
+			ok:   true,
+		},
+		{
+			name: "case and whitespace on wrapper and impression",
+			vast: `<  wraPPer garbage><Impression>http:/test.com</Impression><  / wraPPer garbage>`,
+			want: `<  wraPPer garbage><Impression>http:/test.com</Impression>` + tag + `<  / wraPPer garbage>`,
+			ok:   true,
+		},
+		{
+			name: "case and whitespace on impression close",
+			vast: `<Wrapper><  impreSSion garbage >http:/test.com<  /ImPression  garbage ></Wrapper>`,
+			want: `<Wrapper><  impreSSion garbage >http:/test.com<  /ImPression  garbage >` + tag + `</Wrapper>`,
+			ok:   true,
+		},
+		{
+			name: "wrapper attributes",
+			vast: `<Wrapper followAdditionalWrappers="0"><Impression>http:/test.com</Impression></Wrapper>`,
+			want: `<Wrapper followAdditionalWrappers="0"><Impression>http:/test.com</Impression>` + tag + `</Wrapper>`,
+			ok:   true,
+		},
+		{
+			name: "insert before inline close when no impression",
+			vast: `<InLine></InLine>`,
+			want: `<InLine>` + tag + `</InLine>`,
+			ok:   true,
+		},
+		{
+			name: "insert before wrapper close when no impression",
+			vast: `<wrapper></wrapper>`,
+			want: `<wrapper>` + tag + `</wrapper>`,
+			ok:   true,
+		},
+		{
+			name: "insert before wrapper close in full vast with no impression",
+			vast: vastXmlWithoutImpression,
+			want: `<VAST version="3.0"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Creatives></Creatives>` + tag + `</Wrapper></Ad></VAST>`,
+			ok:   true,
+		},
+		{
+			name: "fill canonical empty impression from nurl wrapper",
+			vast: `<VAST version="3.0"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[nurl]]></VASTAdTagURI><Impression></Impression><Creatives></Creatives></Wrapper></Ad></VAST>`,
+			want: `<VAST version="3.0"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[nurl]]></VASTAdTagURI><Impression><![CDATA[` + tracking + `]]></Impression><Creatives></Creatives></Wrapper></Ad></VAST>`,
+			ok:   true,
+		},
+		{
+			name: "lowercase inline",
+			vast: `<Inline><Impression>http:/test.com</Impression></Inline>`,
+			want: `<Inline><Impression>http:/test.com</Impression>` + tag + `</Inline>`,
+			ok:   true,
+		},
+		{
+			name: "inline without close tag is unchanged",
+			vast: `<InLine></SomeTag>`,
+			want: `<InLine></SomeTag>`,
+			ok:   false,
+		},
+		{
+			name: "wrapper without close tag is unchanged",
+			vast: `<wrapper><someTag>`,
+			want: `<wrapper><someTag>`,
+			ok:   false,
+		},
+		{
+			name: "no inline or wrapper is unchanged",
+			vast: `<Impression>http:/test.com</Impression>`,
+			want: `<Impression>http:/test.com</Impression>`,
+			ok:   false,
+		},
+		{
+			name: "prefer inline over wrapper",
+			vast: `<InLine><Impression>inline</Impression></InLine><Wrapper><Impression>wrap</Impression></Wrapper>`,
+			want: `<InLine><Impression>inline</Impression>` + tag + `</InLine><Wrapper><Impression>wrap</Impression></Wrapper>`,
+			ok:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ModifyVastXmlString(external, tt.vast, bidID, bidder, accountID, ts, integration)
+			assert.Equal(t, tt.ok, ok, tt.name)
+			assert.Equal(t, tt.want, got, tt.name)
+		})
+	}
+}
+
 func TestGetIntegrationType(t *testing.T) {
 	testCases := []struct {
 		description             string


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Maintenance

## Description of change
PBS-Go `ModifyVastXmlString` required an exact `</Impression>` substring. Tags with attributes, mixed case, or extra whitespace were skipped, and documents with no Impression were left unmodified.

This ports the PBS-Java `VastModifier` matchers from [prebid-server-java#3059](https://github.com/prebid/prebid-server-java/pull/3059):
- Match `InLine` / `Wrapper` / `Impression` case-insensitively, with optional attributes and whitespace
- Insert the PBS tracking Impression after the last existing Impression in that parent
- If there is no Impression, insert before `</InLine>` or `</Wrapper>`

Go still fills a canonical empty `<Impression></Impression>` in place. `makeVAST` emits that for nurl wrappers, and the exchange event fixtures depend on a single filled tag rather than a sibling.

Not a VAST validator. Same `/vtrack` and bid-event injection PBS already does.

Fixes #3579
Fixes #1967

## Other information
`go test ./endpoints/events/ ./exchange/`