### PR TITLE
Fix: Query-escape required event tracking URL parameters

### DIFF
--- a/endpoints/events/event.go
+++ b/endpoints/events/event.go
@@ -139,7 +139,11 @@ func (e *eventEndpoint) Handle(w http.ResponseWriter, r *http.Request, _ httprou
 
 // EventRequestToUrl converts an analytics.EventRequest to an URL
 func EventRequestToUrl(externalUrl string, request *analytics.EventRequest) string {
-	s := fmt.Sprintf(TemplateUrl, externalUrl, request.Type, request.BidID, request.AccountID)
+	s := fmt.Sprintf(TemplateUrl, externalUrl,
+		url.QueryEscape(string(request.Type)),
+		url.QueryEscape(request.BidID),
+		url.QueryEscape(request.AccountID),
+	)
 
 	return s + optionalParameters(request)
 }

--- a/endpoints/events/event_test.go
+++ b/endpoints/events/event_test.go
@@ -724,6 +724,18 @@ func TestEventRequestToUrl(t *testing.T) {
 			},
 			want: "http://localhost:8000/event?t=win&b=bidid&a=accountId&bidder=bidder&f=i&int=integration&ts=1234567&x=0",
 		},
+		"encodes reserved characters in bid and account ids": {
+			er: &analytics.EventRequest{
+				Type:      analytics.Imp,
+				BidID:     "bid&extra=1",
+				AccountID: "acct=prod",
+				Bidder:    "bidder",
+				Timestamp: 1234567,
+				Format:    analytics.Blank,
+				Analytics: analytics.Enabled,
+			},
+			want: "http://localhost:8000/event?t=imp&b=bid%26extra%3D1&a=acct%3Dprod&bidder=bidder&f=b&ts=1234567&x=1",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Maintenance

## Description of change
`EventRequestToUrl` built `t`, `b`, and `a` with `fmt.Sprintf`. Optional parameters already went through `url.Values.Encode()`. Required values now use `url.QueryEscape` so reserved characters in bid id or account id stay inside those fields.

Fixes #4958

## Other information
`go test ./endpoints/events/ ./exchange/`