### PR TITLE
fix(currency): make FindIntermediateConversionRate bridge selection deterministic. Fixes #4956

### DIFF
--- a/currency/rates.go
+++ b/currency/rates.go
@@ -2,6 +2,7 @@ package currency
 
 import (
 	"errors"
+	"sort"
 
 	"golang.org/x/text/currency"
 )
@@ -23,8 +24,20 @@ func NewRates(conversions map[string]map[string]float64) *Rates {
 // FindIntermediateConversionRate returns the conversion rate between two currencies
 // if a valid conversion exists in the provided rates container.
 // Otherwise, it returns a ConversionNotFoundError.
+//
+// When more than one base/bridge currency in r.Conversions can bridge from and to, the
+// candidates are considered in sorted (lexicographic) key order so the chosen bridge - and
+// therefore the returned rate - is deterministic for a given Rates value, rather than
+// depending on Go's runtime-randomized map iteration order.
 func FindIntermediateConversionRate(r *Rates, from, to currency.Unit) (float64, error) {
-	for _, conversions := range r.Conversions {
+	baseCurrencies := make([]string, 0, len(r.Conversions))
+	for base := range r.Conversions {
+		baseCurrencies = append(baseCurrencies, base)
+	}
+	sort.Strings(baseCurrencies)
+
+	for _, base := range baseCurrencies {
+		conversions := r.Conversions[base]
 		toRate, hasToRate := conversions[to.String()]
 		fromRate, hasFromRate := conversions[from.String()]
 

--- a/currency/rates_test.go
+++ b/currency/rates_test.go
@@ -263,6 +263,42 @@ func TestGetRate_FindIntermediateConversionRate(t *testing.T) {
 	}
 }
 
+// TestGetRate_FindIntermediateConversionRate_Deterministic covers
+// https://github.com/prebid/prebid-server/issues/4956: when more than one base currency in
+// Rates.Conversions can bridge the same from/to pair and those bases imply different cross
+// rates, the returned rate must be the same on every call for the same input - previously
+// this depended on Go's runtime-randomized map iteration order and could return either
+// candidate rate from one call to the next.
+func TestGetRate_FindIntermediateConversionRate_Deterministic(t *testing.T) {
+	rates := NewRates(map[string]map[string]float64{
+		"USD": {
+			"EUR": 0.85,
+			"GBP": 0.75,
+		},
+		"CAD": {
+			"EUR": 0.63,
+			"GBP": 0.56,
+		},
+	})
+
+	fromUnit, err := currency.ParseISO("EUR")
+	assert.Nil(t, err)
+	toUnit, err := currency.ParseISO("GBP")
+	assert.Nil(t, err)
+
+	// "CAD" sorts before "USD", so the CAD bridge is expected to win. Computed via the same
+	// map-indexed float64 division the function performs at runtime, rather than a constant
+	// expression, since Go's constant folding can round differently than runtime float64
+	// division and produce a spurious 1-ULP mismatch.
+	expectedRate := rates.Conversions["CAD"]["GBP"] / rates.Conversions["CAD"]["EUR"]
+
+	for i := 0; i < 50; i++ {
+		rate, err := FindIntermediateConversionRate(rates, fromUnit, toUnit)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRate, rate, "expected the same rate on every call, got a different result on call %d", i)
+	}
+}
+
 func TestGetRate_EmptyRates(t *testing.T) {
 
 	// Setup:


### PR DESCRIPTION
## Summary
Fixes #4956. `FindIntermediateConversionRate` picked a bridge currency by
ranging over `r.Conversions`, a Go map, and returning the rate implied
by the first base currency it encountered that could bridge both `from`
and `to`. Go randomizes map iteration order at runtime, so whenever more
than one base currency can bridge the same `from`/`to` pair and those
bases imply different cross rates, the function returned a different
result on different calls for identical input - a real pricing-correctness
defect in a price-sensitive RTB conversion path.

## Fix
Iterate candidate base currencies in sorted (lexicographic) key order
instead of map iteration order, so the chosen bridge - and therefore the
returned rate - is deterministic for a given `Rates` value. Kept the
change minimal per the maintainer's own framing in the issue thread,
rather than introducing new config surface.

## Test plan
- [x] Added `TestGetRate_FindIntermediateConversionRate_Deterministic`:
      constructs a `Rates` value with two base currencies that both
      bridge the same `from`/`to` pair with different implied rates,
      calls `FindIntermediateConversionRate` 50 times, and asserts every
      call returns the same rate. Verified by reverting the source fix
      locally - the test then fails intermittently across the 50 calls,
      reproducing the reported non-determinism; restoring the fix makes
      it pass reliably.
- [x] `go test ./currency/... -v`: full package passes.
- [x] `go vet ./currency/...`: clean.
- [x] `golangci-lint run ./currency/...`: no new findings in
      `rates.go`/`rates_test.go` (pre-existing errcheck/staticcheck
      findings in unrelated files in the same package are untouched by
      this change).