### PR TITLE
feat(metrics): add optional bucket-boundary overrides to Prometheus histograms. Fixes #4957

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -629,10 +629,42 @@ type InfluxMetrics struct {
 }
 
 type PrometheusMetrics struct {
-	Port             int    `mapstructure:"port"`
-	Namespace        string `mapstructure:"namespace"`
-	Subsystem        string `mapstructure:"subsystem"`
-	TimeoutMillisRaw int    `mapstructure:"timeout_ms"`
+	Port             int                      `mapstructure:"port"`
+	Namespace        string                   `mapstructure:"namespace"`
+	Subsystem        string                   `mapstructure:"subsystem"`
+	TimeoutMillisRaw int                      `mapstructure:"timeout_ms"`
+	Buckets          PrometheusMetricsBuckets `mapstructure:"buckets"`
+}
+
+// PrometheusMetricsBuckets holds optional per-histogram-family bucket boundary overrides for
+// the Prometheus metrics NewMetrics() registers. Each field left empty (the default) falls
+// back to NewMetrics()'s existing hardcoded boundaries, so this struct is purely additive and
+// changes no behavior for operators who don't set it.
+type PrometheusMetricsBuckets struct {
+	// StandardTimeBuckets overrides the bucket boundaries (in seconds) for the majority of
+	// this package's request/stage timing histograms - auction, AMP, video, cookie sync,
+	// setuid, per-module-stage overhead, and similar. Defaults to
+	// {0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.75, 1}.
+	StandardTimeBuckets []float64 `mapstructure:"standard_time_buckets"`
+	// CacheWriteTimeBuckets overrides the bucket boundaries (in seconds) for the Prebid
+	// Cache write-time histogram. Defaults to
+	// {0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1}.
+	CacheWriteTimeBuckets []float64 `mapstructure:"cache_write_time_buckets"`
+	// PriceBuckets overrides the bucket boundaries (in the request's resolved currency's
+	// smallest reporting unit, e.g. cents) for the bid/imp price histogram. Defaults to
+	// {250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}.
+	PriceBuckets []float64 `mapstructure:"price_buckets"`
+	// QueuedRequestTimeBuckets overrides the bucket boundaries (in seconds) for the
+	// queued-request-time histogram. Defaults to {0, 1, 5, 30, 60, 120, 180, 240, 300}.
+	QueuedRequestTimeBuckets []float64 `mapstructure:"queued_request_time_buckets"`
+	// OverheadTimeBuckets overrides the bucket boundaries (in seconds) for the per-stage
+	// processing-overhead histogram. Defaults to
+	// {0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}.
+	OverheadTimeBuckets []float64 `mapstructure:"overhead_time_buckets"`
+	// RequestSizeBuckets overrides the bucket boundaries (in bytes) for the incoming
+	// request-size histogram. Defaults to
+	// {100, 500, 750, 1000, 2000, 4000, 7000, 10000, 15000, 20000, 50000, 75000}.
+	RequestSizeBuckets []float64 `mapstructure:"request_size_buckets"`
 }
 
 func (cfg *PrometheusMetrics) validate(errs []error) []error {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -167,14 +167,24 @@ const (
 	storedDataErrorLabel     = "stored_data_error"
 )
 
+// bucketsOrDefault returns configured if the operator supplied an override via
+// config.PrometheusMetricsBuckets, otherwise it returns defaultBuckets - this package's
+// existing hardcoded boundaries - so leaving the override unset changes no behavior.
+func bucketsOrDefault(configured []float64, defaultBuckets []float64) []float64 {
+	if len(configured) > 0 {
+		return configured
+	}
+	return defaultBuckets
+}
+
 // NewMetrics initializes a new Prometheus metrics instance with preloaded label values.
 func NewMetrics(cfg config.PrometheusMetrics, disabledMetrics config.DisabledMetrics, syncerKeys []string, moduleStageNames map[string][]string) *Metrics {
-	standardTimeBuckets := []float64{0.05, 0.1, 0.15, 0.20, 0.25, 0.3, 0.4, 0.5, 0.75, 1}
-	cacheWriteTimeBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1}
-	priceBuckets := []float64{250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
-	queuedRequestTimeBuckets := []float64{0, 1, 5, 30, 60, 120, 180, 240, 300}
-	overheadTimeBuckets := []float64{0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}
-	requestSizeBuckets := []float64{100, 500, 750, 1000, 2000, 4000, 7000, 10000, 15000, 20000, 50000, 75000}
+	standardTimeBuckets := bucketsOrDefault(cfg.Buckets.StandardTimeBuckets, []float64{0.05, 0.1, 0.15, 0.20, 0.25, 0.3, 0.4, 0.5, 0.75, 1})
+	cacheWriteTimeBuckets := bucketsOrDefault(cfg.Buckets.CacheWriteTimeBuckets, []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1})
+	priceBuckets := bucketsOrDefault(cfg.Buckets.PriceBuckets, []float64{250, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000})
+	queuedRequestTimeBuckets := bucketsOrDefault(cfg.Buckets.QueuedRequestTimeBuckets, []float64{0, 1, 5, 30, 60, 120, 180, 240, 300})
+	overheadTimeBuckets := bucketsOrDefault(cfg.Buckets.OverheadTimeBuckets, []float64{0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1})
+	requestSizeBuckets := bucketsOrDefault(cfg.Buckets.RequestSizeBuckets, []float64{100, 500, 750, 1000, 2000, 4000, 7000, 10000, 15000, 20000, 50000, 75000})
 
 	metrics := Metrics{}
 	reg := prometheus.NewRegistry()

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -2,6 +2,7 @@ package prometheusmetrics
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,67 @@ func createMetricsForTesting() *Metrics {
 		Namespace: "prebid",
 		Subsystem: "server",
 	}, config.DisabledMetrics{}, syncerKeys, modulesStages)
+}
+
+// bucketUpperBounds returns a histogram's configured bucket upper bounds, in order, as
+// reported by Prometheus (excluding the implicit +Inf bucket every histogram carries).
+func bucketUpperBounds(h *dto.Histogram) []float64 {
+	rawBuckets := h.GetBucket()
+	bounds := make([]float64, 0, len(rawBuckets))
+	for _, b := range rawBuckets {
+		if math.IsInf(b.GetUpperBound(), 1) {
+			continue
+		}
+		bounds = append(bounds, b.GetUpperBound())
+	}
+	return bounds
+}
+
+// TestPrometheusMetricsBucketsOverride covers https://github.com/prebid/prebid-server/issues/4957:
+// config.PrometheusMetricsBuckets lets an operator override NewMetrics()'s per-histogram-family
+// bucket boundaries, defaulting to today's exact hardcoded values so leaving it unset changes no
+// behavior. Exercises both a plain prometheus.Histogram family (StandardTimeBuckets, via
+// dnsLookupTimer) and a prometheus.HistogramVec family (RequestSizeBuckets, via requestsSize),
+// since NewMetrics wires the override through both constructors.
+func TestPrometheusMetricsBucketsOverride(t *testing.T) {
+	t.Run("default preserves the existing hardcoded buckets", func(t *testing.T) {
+		m := createMetricsForTesting()
+
+		m.RecordDNSTime(time.Second)
+		dnsMetric := dto.Metric{}
+		assert.NoError(t, m.dnsLookupTimer.Write(&dnsMetric))
+		assert.Equal(t, []float64{0.05, 0.1, 0.15, 0.20, 0.25, 0.3, 0.4, 0.5, 0.75, 1}, bucketUpperBounds(dnsMetric.GetHistogram()))
+
+		m.RecordRequest(metrics.Labels{RType: metrics.ReqTypeORTB2Web, RequestStatus: metrics.RequestStatusOK, RequestSize: 123})
+		sizeHistogram, found := getHistogramFromHistogramVec(m.requestsSize, requestEndpointLabel, string(metrics.EndpointAuction))
+		assert.True(t, found)
+		assert.Equal(t, []float64{100, 500, 750, 1000, 2000, 4000, 7000, 10000, 15000, 20000, 50000, 75000}, bucketUpperBounds(&sizeHistogram))
+	})
+
+	t.Run("configured buckets override the defaults", func(t *testing.T) {
+		customStandardBuckets := []float64{1, 2, 3}
+		customSizeBuckets := []float64{10, 20}
+
+		m := NewMetrics(config.PrometheusMetrics{
+			Port:      8080,
+			Namespace: "prebid",
+			Subsystem: "server",
+			Buckets: config.PrometheusMetricsBuckets{
+				StandardTimeBuckets: customStandardBuckets,
+				RequestSizeBuckets:  customSizeBuckets,
+			},
+		}, config.DisabledMetrics{}, []string{}, modulesStages)
+
+		m.RecordDNSTime(time.Second)
+		dnsMetric := dto.Metric{}
+		assert.NoError(t, m.dnsLookupTimer.Write(&dnsMetric))
+		assert.Equal(t, customStandardBuckets, bucketUpperBounds(dnsMetric.GetHistogram()))
+
+		m.RecordRequest(metrics.Labels{RType: metrics.ReqTypeORTB2Web, RequestStatus: metrics.RequestStatusOK, RequestSize: 5})
+		sizeHistogram, found := getHistogramFromHistogramVec(m.requestsSize, requestEndpointLabel, string(metrics.EndpointAuction))
+		assert.True(t, found)
+		assert.Equal(t, customSizeBuckets, bucketUpperBounds(&sizeHistogram))
+	})
 }
 
 func TestMetricCountGatekeeping(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #4957. `NewMetrics()` in `metrics/prometheus/prometheus.go` hardcodes
the bucket boundaries for all six histogram families (standard
request/stage timing, cache-write timing, price, queued-request timing,
per-stage overhead, and request size) as Go literals, while
`Namespace`/`Subsystem` in the same `config.PrometheusMetrics` struct
passed into the same `HistogramOpts{}` literals are already
operator-configurable. `requestSizeBuckets` in particular needed three
separate follow-up commits to retune within two weeks of its introduction
(PR #4495) - exactly the kind of iteration a config knob is meant to
absorb.

## Change
Added `config.PrometheusMetricsBuckets` (embedded as
`config.PrometheusMetrics.Buckets`, mapstructure key `buckets`) with one
optional `[]float64` field per histogram family, named to match the
internal variable names already used in `NewMetrics`. A small
`bucketsOrDefault()` helper falls back to exactly today's hardcoded
literal whenever the corresponding override is left empty - purely
additive, zero behavior change for any caller (viper-driven config or
direct `config.PrometheusMetrics{}` construction, e.g. in tests) that
doesn't set it.

One deliberate choice worth a second opinion: I did **not** duplicate the
hardcoded defaults into `SetupViper`'s `v.SetDefault` calls, since the
`bucketsOrDefault` fallback in `NewMetrics` already covers that and I'd
rather not keep two copies of the same magic-number arrays in sync across
`config.go` and `prometheus.go`. Happy to add the `v.SetDefault` entries
too if you'd prefer that as belt-and-suspenders/documentation.

## Test plan
- [x] Added `TestPrometheusMetricsBucketsOverride`, covering both a plain
      `prometheus.Histogram` family (`StandardTimeBuckets` via
      `dnsLookupTimer`) and a `prometheus.HistogramVec` family
      (`RequestSizeBuckets` via `requestsSize`), since `NewMetrics` wires
      the override through both constructors:
  - "default preserves the existing hardcoded buckets" - asserts the
    gathered histogram's bucket upper bounds equal today's literals when
    `Buckets` is left unset.
  - "configured buckets override the defaults" - asserts a custom bucket
    set passed via `config.PrometheusMetricsBuckets` is what actually
    gets registered.
- [x] Verified by reverting `config/config.go` and
      `metrics/prometheus/prometheus.go` locally: the test then fails to
      *compile* ("unknown field Buckets in struct literal of type
      config.PrometheusMetrics"), proving it depends on the real change;
      restoring the fix builds and passes cleanly.
- [x] `go build ./...`: clean.
- [x] `go test ./config/... ./metrics/prometheus/...`: both packages
      pass.
- [x] `go vet ./config/... ./metrics/prometheus/...`: clean.
- [x] `golangci-lint run ./config/... ./metrics/prometheus/...`: no new
      findings (pre-existing errcheck/staticcheck findings elsewhere in
      both packages are untouched by this change).