### PR TITLE
New Adapter: OCM

### DIFF
--- a/.github/workflows/scripts/codepath-notification
+++ b/.github/workflows/scripts/codepath-notification
@@ -20,3 +20,4 @@ medianet: prebid@media.net
 gumgum: prebid@gumgum.com
 kargo: kraken@kargo.com
 proxistore: proxistore-technics@proxistore.com
+adapters/ocm|imp_ocm|ocm.json|ocm.yaml: devs-subs@orangeclickmedia.com

--- a/adapters/ocm/ocm.go
+++ b/adapters/ocm/ocm.go
@@ -101,12 +101,12 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 func parseImpExt(imp *openrtb2.Imp) (*openrtb_ext.ExtImpOcm, error) {
 	var bidderExt adapters.ExtImpBidder
 	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal ext: %s", err)
+		return nil, fmt.Errorf("unable to unmarshal ext: %w", err)
 	}
 
 	var impExt openrtb_ext.ExtImpOcm
 	if err := jsonutil.Unmarshal(bidderExt.Bidder, &impExt); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal ext.bidder: %s", err)
+		return nil, fmt.Errorf("unable to unmarshal ext.bidder: %w", err)
 	}
 
 	if strings.TrimSpace(impExt.PublisherID) == "" {
@@ -130,7 +130,7 @@ func setStoredRequestID(imp *openrtb2.Imp, placementID string) error {
 	ext := map[string]json.RawMessage{}
 	if len(imp.Ext) > 0 {
 		if err := jsonutil.Unmarshal(imp.Ext, &ext); err != nil {
-			return fmt.Errorf("unable to unmarshal ext: %s", err)
+			return fmt.Errorf("unable to unmarshal ext: %w", err)
 		}
 		if ext == nil {
 			ext = map[string]json.RawMessage{}
@@ -141,7 +141,7 @@ func setStoredRequestID(imp *openrtb2.Imp, placementID string) error {
 	prebid := map[string]json.RawMessage{}
 	if raw, exists := ext["prebid"]; exists && len(raw) > 0 {
 		if err := jsonutil.Unmarshal(raw, &prebid); err != nil {
-			return fmt.Errorf("unable to unmarshal ext.prebid: %s", err)
+			return fmt.Errorf("unable to unmarshal ext.prebid: %w", err)
 		}
 		if prebid == nil {
 			prebid = map[string]json.RawMessage{}
@@ -223,7 +223,7 @@ func removeParentAccount(publisherExt json.RawMessage) (json.RawMessage, error) 
 
 	ext := map[string]json.RawMessage{}
 	if err := jsonutil.Unmarshal(publisherExt, &ext); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal ext: %s", err)
+		return nil, fmt.Errorf("unable to unmarshal ext: %w", err)
 	}
 
 	prebidJSON, exists := ext[openrtb_ext.PrebidExtKey]
@@ -233,7 +233,7 @@ func removeParentAccount(publisherExt json.RawMessage) (json.RawMessage, error) 
 
 	prebid := map[string]json.RawMessage{}
 	if err := jsonutil.Unmarshal(prebidJSON, &prebid); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal ext.%s: %s", openrtb_ext.PrebidExtKey, err)
+		return nil, fmt.Errorf("unable to unmarshal ext.%s: %w", openrtb_ext.PrebidExtKey, err)
 	}
 	if _, exists := prebid["parentAccount"]; !exists {
 		return publisherExt, nil
@@ -260,7 +260,7 @@ func removeOCMAliases(request *openrtb2.BidRequest) error {
 
 	ext := map[string]json.RawMessage{}
 	if err := jsonutil.Unmarshal(request.Ext, &ext); err != nil {
-		return fmt.Errorf("unable to unmarshal request.ext: %s", err)
+		return fmt.Errorf("unable to unmarshal request.ext: %w", err)
 	}
 
 	prebidJSON, exists := ext[openrtb_ext.PrebidExtKey]
@@ -269,7 +269,7 @@ func removeOCMAliases(request *openrtb2.BidRequest) error {
 	}
 	prebid := map[string]json.RawMessage{}
 	if err := jsonutil.Unmarshal(prebidJSON, &prebid); err != nil {
-		return fmt.Errorf("unable to unmarshal request.ext.%s: %s", openrtb_ext.PrebidExtKey, err)
+		return fmt.Errorf("unable to unmarshal request.ext.%s: %w", openrtb_ext.PrebidExtKey, err)
 	}
 
 	aliasesJSON, exists := prebid["aliases"]
@@ -278,7 +278,7 @@ func removeOCMAliases(request *openrtb2.BidRequest) error {
 	}
 	aliases := map[string]string{}
 	if err := jsonutil.Unmarshal(aliasesJSON, &aliases); err != nil {
-		return fmt.Errorf("unable to unmarshal request.ext.%s.aliases: %s", openrtb_ext.PrebidExtKey, err)
+		return fmt.Errorf("unable to unmarshal request.ext.%s.aliases: %w", openrtb_ext.PrebidExtKey, err)
 	}
 
 	changed := false

--- a/adapters/ocm/ocm.go
+++ b/adapters/ocm/ocm.go
@@ -1,0 +1,294 @@
+package ocm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/jsonutil"
+)
+
+// mTypeUnset is the zero value of openrtb2.MarkupType, meaning the response did
+// not state a media type. OpenRTB defines no 0 markup type, so it is only ever an
+// omission.
+const mTypeUnset openrtb2.MarkupType = 0
+
+// adapter routes bid requests to the Orange Click Media exchange.
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the OCM adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, cfg config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: cfg.Endpoint}, nil
+}
+
+// MakeRequests packs every impression into a single OpenRTB request for the OCM
+// exchange.
+//
+// The publisherId param identifies the seller and is written to the request-level
+// publisher ID, so all impressions in one request must agree on it; a divergent
+// publisherId is a misconfiguration and rejects the whole request.
+//
+// The placementId param names the impression-level stored request that the OCM
+// endpoint expands into the impression's real configuration, so it is encoded as
+// imp.ext.prebid.storedrequest.id rather than as a plain slot identifier. It is
+// required: an impression referencing no stored request cannot be resolved
+// downstream, and would fail the whole request rather than just itself.
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	if len(request.Imp) == 0 {
+		return nil, nil
+	}
+
+	var publisherID string
+	for i := range request.Imp {
+		impExt, err := parseImpExt(&request.Imp[i])
+		if err != nil {
+			return nil, []error{&errortypes.BadInput{Message: fmt.Sprintf("imp[%d]: %s", i, err)}}
+		}
+
+		if i == 0 {
+			publisherID = impExt.PublisherID
+		} else if impExt.PublisherID != publisherID {
+			return nil, []error{&errortypes.BadInput{
+				Message: fmt.Sprintf("imp[%d]: all impressions must share the same publisherId, found %q and %q", i, impExt.PublisherID, publisherID),
+			}}
+		}
+
+		// Imp elements are safe to modify in place: prebid-server hands each
+		// adapter its own shallow copy of the imp slice.
+		if err := setStoredRequestID(&request.Imp[i], impExt.PlacementID); err != nil {
+			return nil, []error{&errortypes.BadInput{Message: fmt.Sprintf("imp[%d]: %s", i, err)}}
+		}
+	}
+
+	setPublisherID(request, publisherID)
+
+	body, err := jsonutil.Marshal(request)
+	if err != nil {
+		return nil, []error{fmt.Errorf("unable to marshal bid request: %w", err)}
+	}
+
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+
+	return []*adapters.RequestData{{
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    body,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+	}}, nil
+}
+
+// parseImpExt decodes imp.ext.bidder into ExtImpOcm and validates it. Both params
+// are required and must be non-blank; the JSON schema already enforces presence,
+// and the whitespace check here covers values the schema accepts but the OCM
+// endpoint cannot resolve.
+func parseImpExt(imp *openrtb2.Imp) (*openrtb_ext.ExtImpOcm, error) {
+	var bidderExt adapters.ExtImpBidder
+	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal ext: %s", err)
+	}
+
+	var impExt openrtb_ext.ExtImpOcm
+	if err := jsonutil.Unmarshal(bidderExt.Bidder, &impExt); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal ext.bidder: %s", err)
+	}
+
+	if strings.TrimSpace(impExt.PublisherID) == "" {
+		return nil, errors.New("publisherId is required and must not be blank")
+	}
+	if strings.TrimSpace(impExt.PlacementID) == "" {
+		return nil, errors.New("placementId is required and must not be blank")
+	}
+
+	return &impExt, nil
+}
+
+// setStoredRequestID records placementId as the impression's stored-request ID at
+// imp.ext.prebid.storedrequest.id, which is where the OCM endpoint looks for it.
+//
+// The surrounding ext is rebuilt through a generic map rather than a typed struct
+// so that keys this adapter knows nothing about — gpid, tid, data and any future
+// additions — survive the round trip untouched.
+func setStoredRequestID(imp *openrtb2.Imp, placementID string) error {
+	ext := map[string]json.RawMessage{}
+	if len(imp.Ext) > 0 {
+		if err := jsonutil.Unmarshal(imp.Ext, &ext); err != nil {
+			return fmt.Errorf("unable to unmarshal ext: %s", err)
+		}
+		if ext == nil {
+			ext = map[string]json.RawMessage{}
+		}
+	}
+
+	prebid := map[string]json.RawMessage{}
+	if raw, exists := ext["prebid"]; exists && len(raw) > 0 {
+		if err := jsonutil.Unmarshal(raw, &prebid); err != nil {
+			return fmt.Errorf("unable to unmarshal ext.prebid: %s", err)
+		}
+		if prebid == nil {
+			prebid = map[string]json.RawMessage{}
+		}
+	}
+
+	storedRequest, err := jsonutil.Marshal(openrtb_ext.ExtStoredRequest{ID: placementID})
+	if err != nil {
+		return err
+	}
+	prebid["storedrequest"] = storedRequest
+
+	prebidJSON, err := jsonutil.Marshal(prebid)
+	if err != nil {
+		return err
+	}
+	ext["prebid"] = prebidJSON
+
+	extJSON, err := jsonutil.Marshal(ext)
+	if err != nil {
+		return err
+	}
+
+	imp.Ext = extJSON
+	return nil
+}
+
+// setPublisherID writes publisherId to the request-level publisher ID. Site and App
+// are copied before mutation because prebid-server shares the BidRequest across
+// adapters and only imp elements may be modified in place.
+func setPublisherID(request *openrtb2.BidRequest, publisherID string) {
+	if request.Site != nil {
+		site := *request.Site
+		site.Publisher = publisherWithID(site.Publisher, publisherID)
+		request.Site = &site
+		return
+	}
+
+	if request.App != nil {
+		app := *request.App
+		app.Publisher = publisherWithID(app.Publisher, publisherID)
+		request.App = &app
+	}
+}
+
+// publisherWithID returns a copy of publisher carrying id, or a fresh Publisher
+// when the request did not include one.
+func publisherWithID(publisher *openrtb2.Publisher, id string) *openrtb2.Publisher {
+	if publisher == nil {
+		return &openrtb2.Publisher{ID: id}
+	}
+
+	cpy := *publisher
+	cpy.ID = id
+	return &cpy
+}
+
+// MakeBids unpacks the OCM exchange's OpenRTB bid response. Bids whose media
+// type cannot be resolved are skipped and reported, so one malformed bid does
+// not discard the rest of the seat.
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(responseData) {
+		return nil, nil
+	}
+
+	if err := adapters.CheckResponseStatusCodeForErrors(responseData); err != nil {
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{&errortypes.BadServerResponse{Message: err.Error()}}
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	if response.Cur != "" {
+		bidResponse.Currency = response.Cur
+	}
+
+	var errs []error
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			bidType, err := getMediaTypeForBid(seatBid.Bid[i])
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: bidType,
+			})
+		}
+	}
+
+	return bidResponse, errs
+}
+
+// getMediaTypeForBid resolves the bid's media type from the OpenRTB 2.6 bid.mtype
+// field, which is authoritative whenever it is set.
+//
+// Not every upstream populates mtype: a Prebid Server passes through whatever
+// mtype its winning adapter set, and reports the type it resolved in
+// bid.ext.prebid.type instead (see exchange/entities.PbsOrtbBid). Treating an
+// absent mtype as fatal would therefore discard perfectly good bids, so
+// ext.prebid.type is consulted in that one case.
+//
+// A set-but-unsupported mtype (audio, or a value this adapter does not know) is
+// rejected outright and never allowed to fall through to the extension. Doing
+// otherwise would let an ext of "banner" reclassify an audio bid, contradicting
+// the authoritative field and delivering a media type OCM does not declare.
+func getMediaTypeForBid(bid openrtb2.Bid) (openrtb_ext.BidType, error) {
+	switch bid.MType {
+	case openrtb2.MarkupBanner:
+		return openrtb_ext.BidTypeBanner, nil
+	case openrtb2.MarkupVideo:
+		return openrtb_ext.BidTypeVideo, nil
+	case openrtb2.MarkupNative:
+		return openrtb_ext.BidTypeNative, nil
+	case mTypeUnset:
+		if bidType, ok := mediaTypeFromBidExt(bid.Ext); ok {
+			return bidType, nil
+		}
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unable to determine media type for bid %q: no mtype and no ext.prebid.type", bid.ID),
+		}
+	default:
+		return "", &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unsupported mtype %d for bid %q", bid.MType, bid.ID),
+		}
+	}
+}
+
+// mediaTypeFromBidExt reads a media type from bid.ext.prebid.type, accepting
+// only the types OCM declares support for. A malformed or absent ext is not an
+// error here; the caller reports the failure to resolve a type.
+func mediaTypeFromBidExt(bidExt json.RawMessage) (openrtb_ext.BidType, bool) {
+	if len(bidExt) == 0 {
+		return "", false
+	}
+
+	var parsed struct {
+		Prebid struct {
+			Type openrtb_ext.BidType `json:"type"`
+		} `json:"prebid"`
+	}
+	if err := jsonutil.Unmarshal(bidExt, &parsed); err != nil {
+		return "", false
+	}
+
+	switch parsed.Prebid.Type {
+	case openrtb_ext.BidTypeBanner, openrtb_ext.BidTypeVideo, openrtb_ext.BidTypeNative:
+		return parsed.Prebid.Type, true
+	}
+
+	return "", false
+}

--- a/adapters/ocm/ocm.go
+++ b/adapters/ocm/ocm.go
@@ -69,7 +69,12 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 		}
 	}
 
-	setPublisherID(request, publisherID)
+	if err := setPublisherID(request, publisherID); err != nil {
+		return nil, []error{&errortypes.BadInput{Message: err.Error()}}
+	}
+	if err := removeOCMAliases(request); err != nil {
+		return nil, []error{&errortypes.BadInput{Message: err.Error()}}
+	}
 
 	body, err := jsonutil.Marshal(request)
 	if err != nil {
@@ -114,8 +119,9 @@ func parseImpExt(imp *openrtb2.Imp) (*openrtb_ext.ExtImpOcm, error) {
 	return &impExt, nil
 }
 
-// setStoredRequestID records placementId as the impression's stored-request ID at
-// imp.ext.prebid.storedrequest.id, which is where the OCM endpoint looks for it.
+// setStoredRequestID consumes imp.ext.bidder and records placementId as the
+// impression's stored-request ID at imp.ext.prebid.storedrequest.id, which is
+// where the OCM endpoint looks for it.
 //
 // The surrounding ext is rebuilt through a generic map rather than a typed struct
 // so that keys this adapter knows nothing about — gpid, tid, data and any future
@@ -130,6 +136,7 @@ func setStoredRequestID(imp *openrtb2.Imp, placementID string) error {
 			ext = map[string]json.RawMessage{}
 		}
 	}
+	delete(ext, "bidder")
 
 	prebid := map[string]json.RawMessage{}
 	if raw, exists := ext["prebid"]; exists && len(raw) > 0 {
@@ -162,34 +169,150 @@ func setStoredRequestID(imp *openrtb2.Imp, placementID string) error {
 	return nil
 }
 
-// setPublisherID writes publisherId to the request-level publisher ID. Site and App
-// are copied before mutation because prebid-server shares the BidRequest across
-// adapters and only imp elements may be modified in place.
-func setPublisherID(request *openrtb2.BidRequest, publisherID string) {
+// setPublisherID writes publisherId to the request-level publisher ID and removes
+// the originating host's parent account. Site, App, Publisher and publisher.ext
+// are copied before mutation because prebid-server shares them across adapters.
+func setPublisherID(request *openrtb2.BidRequest, publisherID string) error {
 	if request.Site != nil {
 		site := *request.Site
-		site.Publisher = publisherWithID(site.Publisher, publisherID)
+		publisher, err := publisherWithID(site.Publisher, publisherID)
+		if err != nil {
+			return fmt.Errorf("unable to update site.publisher: %w", err)
+		}
+		site.Publisher = publisher
 		request.Site = &site
-		return
+		return nil
 	}
 
 	if request.App != nil {
 		app := *request.App
-		app.Publisher = publisherWithID(app.Publisher, publisherID)
+		publisher, err := publisherWithID(app.Publisher, publisherID)
+		if err != nil {
+			return fmt.Errorf("unable to update app.publisher: %w", err)
+		}
+		app.Publisher = publisher
 		request.App = &app
 	}
+	return nil
 }
 
-// publisherWithID returns a copy of publisher carrying id, or a fresh Publisher
-// when the request did not include one.
-func publisherWithID(publisher *openrtb2.Publisher, id string) *openrtb2.Publisher {
+// publisherWithID returns a copy of publisher carrying id and without
+// ext.prebid.parentAccount, or a fresh Publisher when the request omitted one.
+func publisherWithID(publisher *openrtb2.Publisher, id string) (*openrtb2.Publisher, error) {
 	if publisher == nil {
-		return &openrtb2.Publisher{ID: id}
+		return &openrtb2.Publisher{ID: id}, nil
 	}
 
 	cpy := *publisher
 	cpy.ID = id
-	return &cpy
+
+	ext, err := removeParentAccount(publisher.Ext)
+	if err != nil {
+		return nil, err
+	}
+	cpy.Ext = ext
+	return &cpy, nil
+}
+
+// removeParentAccount removes only publisher.ext.prebid.parentAccount, retaining
+// every other publisher extension field.
+func removeParentAccount(publisherExt json.RawMessage) (json.RawMessage, error) {
+	if len(publisherExt) == 0 {
+		return publisherExt, nil
+	}
+
+	ext := map[string]json.RawMessage{}
+	if err := jsonutil.Unmarshal(publisherExt, &ext); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal ext: %s", err)
+	}
+
+	prebidJSON, exists := ext[openrtb_ext.PrebidExtKey]
+	if !exists || len(prebidJSON) == 0 {
+		return publisherExt, nil
+	}
+
+	prebid := map[string]json.RawMessage{}
+	if err := jsonutil.Unmarshal(prebidJSON, &prebid); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal ext.%s: %s", openrtb_ext.PrebidExtKey, err)
+	}
+	if _, exists := prebid["parentAccount"]; !exists {
+		return publisherExt, nil
+	}
+
+	delete(prebid, "parentAccount")
+	prebidJSON, err := jsonutil.Marshal(prebid)
+	if err != nil {
+		return nil, err
+	}
+	ext[openrtb_ext.PrebidExtKey] = prebidJSON
+
+	return jsonutil.Marshal(ext)
+}
+
+// removeOCMAliases removes aliases that resolve to this adapter before forwarding
+// the request to another Prebid Server. Other aliases and request extensions are
+// retained, and request.Ext receives new backing storage rather than mutating the
+// shared input bytes.
+func removeOCMAliases(request *openrtb2.BidRequest) error {
+	if len(request.Ext) == 0 {
+		return nil
+	}
+
+	ext := map[string]json.RawMessage{}
+	if err := jsonutil.Unmarshal(request.Ext, &ext); err != nil {
+		return fmt.Errorf("unable to unmarshal request.ext: %s", err)
+	}
+
+	prebidJSON, exists := ext[openrtb_ext.PrebidExtKey]
+	if !exists || len(prebidJSON) == 0 {
+		return nil
+	}
+	prebid := map[string]json.RawMessage{}
+	if err := jsonutil.Unmarshal(prebidJSON, &prebid); err != nil {
+		return fmt.Errorf("unable to unmarshal request.ext.%s: %s", openrtb_ext.PrebidExtKey, err)
+	}
+
+	aliasesJSON, exists := prebid["aliases"]
+	if !exists || len(aliasesJSON) == 0 {
+		return nil
+	}
+	aliases := map[string]string{}
+	if err := jsonutil.Unmarshal(aliasesJSON, &aliases); err != nil {
+		return fmt.Errorf("unable to unmarshal request.ext.%s.aliases: %s", openrtb_ext.PrebidExtKey, err)
+	}
+
+	changed := false
+	for alias, bidder := range aliases {
+		if bidder == string(openrtb_ext.BidderOcm) {
+			delete(aliases, alias)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	if len(aliases) == 0 {
+		delete(prebid, "aliases")
+	} else {
+		aliasesJSON, err := jsonutil.Marshal(aliases)
+		if err != nil {
+			return err
+		}
+		prebid["aliases"] = aliasesJSON
+	}
+	prebidJSON, err := jsonutil.Marshal(prebid)
+	if err != nil {
+		return err
+	}
+	ext[openrtb_ext.PrebidExtKey] = prebidJSON
+
+	requestExt, err := jsonutil.Marshal(ext)
+	if err != nil {
+		return err
+	}
+	request.Ext = requestExt
+	return nil
 }
 
 // MakeBids unpacks the OCM exchange's OpenRTB bid response. Bids whose media
@@ -224,13 +347,28 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 			}
 
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
-				Bid:     &seatBid.Bid[i],
-				BidType: bidType,
+				Bid:      &seatBid.Bid[i],
+				BidType:  bidType,
+				BidVideo: videoFromBidExt(seatBid.Bid[i].Ext, bidType),
 			})
 		}
 	}
 
 	return bidResponse, errs
+}
+
+// videoFromBidExt returns targeting metadata supplied by the receiving PBS for
+// video bids. Invalid, unrelated, and non-video bid extensions are ignored.
+func videoFromBidExt(bidExt json.RawMessage, bidType openrtb_ext.BidType) *openrtb_ext.ExtBidPrebidVideo {
+	if bidType != openrtb_ext.BidTypeVideo || len(bidExt) == 0 {
+		return nil
+	}
+
+	var ext openrtb_ext.ExtBid
+	if err := jsonutil.Unmarshal(bidExt, &ext); err != nil || ext.Prebid == nil {
+		return nil
+	}
+	return ext.Prebid.Video
 }
 
 // getMediaTypeForBid resolves the bid's media type from the OpenRTB 2.6 bid.mtype

--- a/adapters/ocm/ocm_test.go
+++ b/adapters/ocm/ocm_test.go
@@ -18,8 +18,8 @@ import (
 const testEndpoint = "https://pbam.test.invalid/openrtb2/auction"
 
 // End-to-end MakeRequests/MakeBids behavior lives in the JSON fixtures under
-// ocmtest/. The Go tests below cover only what those fixtures cannot: the error
-// *type* contract, since fixtures compare error messages alone.
+// ocmtest/. The Go tests below supplement them with error-type and shared-object
+// mutation contracts that JSON fixtures cannot express.
 
 func TestJsonSamples(t *testing.T) {
 	bidder, buildErr := Builder(openrtb_ext.BidderOcm,
@@ -127,6 +127,142 @@ func TestMakeRequestsSetsAppPublisher(t *testing.T) {
 	require.NotNil(t, sent.App.Publisher)
 	assert.Equal(t, "pub-a", sent.App.Publisher.ID)
 	assert.Nil(t, sent.Site)
+}
+
+func TestMakeRequestsSanitizesForwardedContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		setPublisher func(*openrtb2.BidRequest, *openrtb2.Publisher)
+		getPublisher func(*openrtb2.BidRequest) *openrtb2.Publisher
+	}{
+		{
+			name: "site",
+			setPublisher: func(request *openrtb2.BidRequest, publisher *openrtb2.Publisher) {
+				request.Site = &openrtb2.Site{Domain: "example.test", Publisher: publisher}
+			},
+			getPublisher: func(request *openrtb2.BidRequest) *openrtb2.Publisher {
+				return request.Site.Publisher
+			},
+		},
+		{
+			name: "app",
+			setPublisher: func(request *openrtb2.BidRequest, publisher *openrtb2.Publisher) {
+				request.App = &openrtb2.App{Bundle: "com.example.app", Publisher: publisher}
+			},
+			getPublisher: func(request *openrtb2.BidRequest) *openrtb2.Publisher {
+				return request.App.Publisher
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			publisherExt := json.RawMessage(`{
+				"prebid":{"parentAccount":"origin-host","unrelatedPrebid":"keep"},
+				"unrelatedPublisher":{"value":1}
+			}`)
+			sharedPublisher := &openrtb2.Publisher{
+				ID:   "origin-publisher",
+				Name: "shared publisher",
+				Ext:  publisherExt,
+			}
+			request := &openrtb2.BidRequest{
+				ID: "req",
+				Imp: []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{
+					"bidder":{"publisherId":"ocm-publisher","placementId":"placement-1"},
+					"gpid":"/1234/example#slot"
+				}`))},
+				Ext: json.RawMessage(`{
+					"prebid":{
+						"aliases":{"publisher_ocm":"ocm"},
+						"unrelatedPrebid":"keep"
+					},
+					"unrelatedRequest":{"value":2}
+				}`),
+			}
+			test.setPublisher(request, sharedPublisher)
+
+			requests, errs := newBidder(t).MakeRequests(request, &adapters.ExtraRequestInfo{})
+			require.Empty(t, errs)
+			require.Len(t, requests, 1)
+
+			var sent openrtb2.BidRequest
+			require.NoError(t, json.Unmarshal(requests[0].Body, &sent))
+			sentPublisher := test.getPublisher(&sent)
+			require.NotNil(t, sentPublisher)
+			assert.Equal(t, "ocm-publisher", sentPublisher.ID)
+			assert.Equal(t, "shared publisher", sentPublisher.Name)
+			assert.JSONEq(t, `{
+				"prebid":{"unrelatedPrebid":"keep"},
+				"unrelatedPublisher":{"value":1}
+			}`, string(sentPublisher.Ext))
+			assert.JSONEq(t, `{
+				"prebid":{
+					"unrelatedPrebid":"keep"
+				},
+				"unrelatedRequest":{"value":2}
+			}`, string(sent.Ext))
+			require.Len(t, sent.Imp, 1)
+			assert.JSONEq(t, `{
+				"gpid":"/1234/example#slot",
+				"prebid":{"storedrequest":{"id":"placement-1"}}
+			}`, string(sent.Imp[0].Ext))
+
+			// The publisher is shared by adapter requests. Sanitizing the OCM copy
+			// must not rewrite the object retained by the originating request.
+			assert.Equal(t, "origin-publisher", sharedPublisher.ID)
+			assert.Equal(t, publisherExt, sharedPublisher.Ext)
+			assert.NotSame(t, sharedPublisher, test.getPublisher(request))
+		})
+	}
+}
+
+func TestMakeBidsPreservesVideoMetadata(t *testing.T) {
+	request := &openrtb2.BidRequest{ID: "req", Imp: []openrtb2.Imp{{ID: "imp-1"}}}
+	response := &adapters.ResponseData{
+		StatusCode: http.StatusOK,
+		Body: []byte(`{
+			"id":"req",
+			"seatbid":[{"bid":[{
+				"id":"bid-1",
+				"impid":"imp-1",
+				"price":1.2,
+				"mtype":2,
+				"ext":{"prebid":{"type":"video","video":{"duration":30,"primary_category":"IAB1-2"}}}
+			}]}]
+		}`),
+	}
+
+	bidResponse, errs := newBidder(t).MakeBids(request, nil, response)
+	require.Empty(t, errs)
+	require.Len(t, bidResponse.Bids, 1)
+	assert.Equal(t, &openrtb_ext.ExtBidPrebidVideo{
+		Duration:        30,
+		PrimaryCategory: "IAB1-2",
+	}, bidResponse.Bids[0].BidVideo)
+}
+
+func TestMakeBidsIgnoresVideoMetadataForNonVideoBid(t *testing.T) {
+	request := &openrtb2.BidRequest{ID: "req", Imp: []openrtb2.Imp{{ID: "imp-1"}}}
+	response := &adapters.ResponseData{
+		StatusCode: http.StatusOK,
+		Body: []byte(`{
+			"id":"req",
+			"seatbid":[{"bid":[{
+				"id":"bid-1",
+				"impid":"imp-1",
+				"price":1.2,
+				"mtype":1,
+				"ext":{"prebid":{"type":"video","video":{"duration":30,"primary_category":"IAB1-2"}}}
+			}]}]
+		}`),
+	}
+
+	bidResponse, errs := newBidder(t).MakeBids(request, nil, response)
+	require.Empty(t, errs)
+	require.Len(t, bidResponse.Bids, 1)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidResponse.Bids[0].BidType)
+	assert.Nil(t, bidResponse.Bids[0].BidVideo)
 }
 
 func TestMakeBidsErrorTypes(t *testing.T) {
@@ -331,7 +467,7 @@ func TestSetStoredRequestID(t *testing.T) {
 		{
 			name:   "creates prebid and storedrequest",
 			impExt: `{"bidder":{"publisherId":"a"}}`,
-			want:   `{"bidder":{"publisherId":"a"},"prebid":{"storedrequest":{"id":"slot-1"}}}`,
+			want:   `{"prebid":{"storedrequest":{"id":"slot-1"}}}`,
 		},
 		{
 			name:   "merges into existing prebid",

--- a/adapters/ocm/ocm_test.go
+++ b/adapters/ocm/ocm_test.go
@@ -1,0 +1,410 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v4/config"
+	"github.com/prebid/prebid-server/v4/errortypes"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testEndpoint = "https://pbam.test.invalid/openrtb2/auction"
+
+// End-to-end MakeRequests/MakeBids behavior lives in the JSON fixtures under
+// ocmtest/. The Go tests below cover only what those fixtures cannot: the error
+// *type* contract, since fixtures compare error messages alone.
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(openrtb_ext.BidderOcm,
+		config.Adapter{Endpoint: testEndpoint},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1148, DataCenter: "2"})
+	require.NoError(t, buildErr, "Builder returned unexpected error")
+
+	adapterstest.RunJSONBidderTest(t, "ocmtest", bidder)
+}
+
+func TestBuilderStoresEndpoint(t *testing.T) {
+	bidder, err := Builder(openrtb_ext.BidderOcm, config.Adapter{Endpoint: testEndpoint}, config.Server{})
+	require.NoError(t, err)
+	assert.Equal(t, testEndpoint, bidder.(*adapter).endpoint)
+}
+
+func TestMakeRequestsNoImps(t *testing.T) {
+	requests, errs := newBidder(t).MakeRequests(&openrtb2.BidRequest{ID: "no-imps"}, &adapters.ExtraRequestInfo{})
+	assert.Nil(t, requests)
+	assert.Nil(t, errs)
+}
+
+// TestMakeRequestsErrorTypes pins every MakeRequests rejection to *errortypes.BadInput,
+// which is what makes prebid-server attribute the failure to the publisher's request
+// rather than to the OCM exchange.
+func TestMakeRequestsErrorTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		imps        []openrtb2.Imp
+		wantMessage string
+	}{
+		{
+			name:        "imp.ext is not an object",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`[]`))},
+			wantMessage: "imp[0]: unable to unmarshal ext",
+		},
+		{
+			name:        "imp.ext.bidder is not an object",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":[]}`))},
+			wantMessage: "imp[0]: unable to unmarshal ext.bidder",
+		},
+		{
+			name:        "publisherId missing",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":{"placementId":"p"}}`))},
+			wantMessage: "imp[0]: publisherId is required and must not be blank",
+		},
+		{
+			name:        "publisherId blank",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"   ","placementId":"p"}}`))},
+			wantMessage: "imp[0]: publisherId is required and must not be blank",
+		},
+		{
+			name:        "placementId missing",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"pub"}}`))},
+			wantMessage: "imp[0]: placementId is required and must not be blank",
+		},
+		{
+			name:        "placementId blank",
+			imps:        []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"pub","placementId":" "}}`))},
+			wantMessage: "imp[0]: placementId is required and must not be blank",
+		},
+		{
+			name: "publisher ids diverge across imps",
+			imps: []openrtb2.Imp{
+				bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"pub-a","placementId":"p1"}}`)),
+				bannerImp("imp-2", json.RawMessage(`{"bidder":{"publisherId":"pub-b","placementId":"p2"}}`)),
+			},
+			wantMessage: `imp[1]: all impressions must share the same publisherId, found "pub-b" and "pub-a"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := &openrtb2.BidRequest{
+				ID:   "req",
+				Imp:  test.imps,
+				Site: &openrtb2.Site{Domain: "example.gr"},
+			}
+
+			requests, errs := newBidder(t).MakeRequests(request, &adapters.ExtraRequestInfo{})
+			assert.Nil(t, requests)
+			require.Len(t, errs, 1)
+			assert.IsType(t, &errortypes.BadInput{}, errs[0])
+			assert.Contains(t, errs[0].Error(), test.wantMessage)
+		})
+	}
+}
+
+// TestMakeRequestsSetsAppPublisher covers the app branch of setPublisherID; the
+// site branch is exercised by the JSON fixtures.
+func TestMakeRequestsSetsAppPublisher(t *testing.T) {
+	request := &openrtb2.BidRequest{
+		ID:  "app-req",
+		Imp: []openrtb2.Imp{bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"pub-a","placementId":"p1"}}`))},
+		App: &openrtb2.App{Bundle: "com.orangeclickmedia.demo"},
+	}
+
+	requests, errs := newBidder(t).MakeRequests(request, &adapters.ExtraRequestInfo{})
+	require.Empty(t, errs)
+	require.Len(t, requests, 1)
+
+	var sent openrtb2.BidRequest
+	require.NoError(t, json.Unmarshal(requests[0].Body, &sent))
+	require.NotNil(t, sent.App)
+	require.NotNil(t, sent.App.Publisher)
+	assert.Equal(t, "pub-a", sent.App.Publisher.ID)
+	assert.Nil(t, sent.Site)
+}
+
+func TestMakeBidsErrorTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *adapters.ResponseData
+		wantType error
+	}{
+		{
+			name:     "400 is bad input",
+			response: &adapters.ResponseData{StatusCode: http.StatusBadRequest, Body: []byte(`{}`)},
+			wantType: &errortypes.BadInput{},
+		},
+		{
+			name:     "500 is bad server response",
+			response: &adapters.ResponseData{StatusCode: http.StatusInternalServerError, Body: []byte(`{}`)},
+			wantType: &errortypes.BadServerResponse{},
+		},
+		{
+			name:     "unparseable body is bad server response",
+			response: &adapters.ResponseData{StatusCode: http.StatusOK, Body: []byte(`not json`)},
+			wantType: &errortypes.BadServerResponse{},
+		},
+	}
+
+	request := &openrtb2.BidRequest{ID: "req", Imp: []openrtb2.Imp{{ID: "imp-1"}}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bidResponse, errs := newBidder(t).MakeBids(request, nil, test.response)
+			assert.Nil(t, bidResponse)
+			require.Len(t, errs, 1)
+			assert.IsType(t, test.wantType, errs[0])
+		})
+	}
+}
+
+func TestGetMediaTypeForBid(t *testing.T) {
+	tests := []struct {
+		name  string
+		mType openrtb2.MarkupType
+		want  openrtb_ext.BidType
+	}{
+		{name: "banner", mType: openrtb2.MarkupBanner, want: openrtb_ext.BidTypeBanner},
+		{name: "video", mType: openrtb2.MarkupVideo, want: openrtb_ext.BidTypeVideo},
+		{name: "native", mType: openrtb2.MarkupNative, want: openrtb_ext.BidTypeNative},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bidType, err := getMediaTypeForBid(openrtb2.Bid{ID: "bid-1", MType: test.mType})
+			require.NoError(t, err)
+			assert.Equal(t, test.want, bidType)
+		})
+	}
+
+	t.Run("audio is not supported", func(t *testing.T) {
+		bidType, err := getMediaTypeForBid(openrtb2.Bid{ID: "bid-1", MType: openrtb2.MarkupAudio})
+		assert.Empty(t, bidType)
+		require.Error(t, err)
+		assert.IsType(t, &errortypes.BadServerResponse{}, err)
+		assert.Contains(t, err.Error(), `unsupported mtype 3 for bid "bid-1"`)
+	})
+}
+
+// TestGetMediaTypeForBidUnsupportedMTypeIgnoresExt guards the precedence rule: a
+// set-but-unsupported mtype must never fall through to ext.prebid.type. Allowing it
+// would let an ext of "banner" relabel an audio bid, overriding the authoritative
+// OpenRTB field and yielding a media type OCM does not declare support for.
+func TestGetMediaTypeForBidUnsupportedMTypeIgnoresExt(t *testing.T) {
+	tests := []struct {
+		name    string
+		mType   openrtb2.MarkupType
+		bidExt  string
+		wantMsg string
+	}{
+		{
+			name:    "audio mtype with banner ext",
+			mType:   openrtb2.MarkupAudio,
+			bidExt:  `{"prebid":{"type":"banner"}}`,
+			wantMsg: `unsupported mtype 3 for bid "bid-1"`,
+		},
+		{
+			name:    "audio mtype with video ext",
+			mType:   openrtb2.MarkupAudio,
+			bidExt:  `{"prebid":{"type":"video"}}`,
+			wantMsg: `unsupported mtype 3 for bid "bid-1"`,
+		},
+		{
+			name:    "unknown mtype with banner ext",
+			mType:   openrtb2.MarkupType(99),
+			bidExt:  `{"prebid":{"type":"banner"}}`,
+			wantMsg: `unsupported mtype 99 for bid "bid-1"`,
+		},
+		{
+			name:    "negative mtype with banner ext",
+			mType:   openrtb2.MarkupType(-1),
+			bidExt:  `{"prebid":{"type":"banner"}}`,
+			wantMsg: `unsupported mtype -1 for bid "bid-1"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bidType, err := getMediaTypeForBid(openrtb2.Bid{
+				ID:    "bid-1",
+				MType: test.mType,
+				Ext:   json.RawMessage(test.bidExt),
+			})
+
+			assert.Empty(t, bidType, "an unsupported mtype must not be reclassified from ext")
+			require.Error(t, err)
+			assert.IsType(t, &errortypes.BadServerResponse{}, err)
+			assert.Contains(t, err.Error(), test.wantMsg)
+		})
+	}
+}
+
+// TestGetMediaTypeForBidExtFallback covers the ext.prebid.type fallback, which
+// matters when the upstream is itself a Prebid Server: it forwards the winning
+// adapter's mtype verbatim and reports the type it resolved in ext.prebid.type,
+// so a bid can legitimately arrive with mtype unset.
+func TestGetMediaTypeForBidExtFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		bidExt  string
+		want    openrtb_ext.BidType
+		wantErr bool
+	}{
+		{name: "banner from ext", bidExt: `{"prebid":{"type":"banner"}}`, want: openrtb_ext.BidTypeBanner},
+		{name: "video from ext", bidExt: `{"prebid":{"type":"video"}}`, want: openrtb_ext.BidTypeVideo},
+		{name: "native from ext", bidExt: `{"prebid":{"type":"native"}}`, want: openrtb_ext.BidTypeNative},
+		{name: "audio in ext is rejected", bidExt: `{"prebid":{"type":"audio"}}`, wantErr: true},
+		{name: "unknown type in ext is rejected", bidExt: `{"prebid":{"type":"banana"}}`, wantErr: true},
+		{name: "ext without prebid is rejected", bidExt: `{"origbidcpm":1.5}`, wantErr: true},
+		{name: "malformed ext is rejected", bidExt: `[]`, wantErr: true},
+		{name: "empty ext is rejected", bidExt: ``, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bid := openrtb2.Bid{ID: "bid-1"}
+			if test.bidExt != "" {
+				bid.Ext = json.RawMessage(test.bidExt)
+			}
+
+			bidType, err := getMediaTypeForBid(bid)
+			if test.wantErr {
+				assert.Empty(t, bidType)
+				require.Error(t, err)
+				assert.IsType(t, &errortypes.BadServerResponse{}, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, bidType)
+		})
+	}
+}
+
+// TestGetMediaTypeForBidMTypeWinsOverExt pins mtype as authoritative when it names
+// a supported type: a Prebid Server upstream can report a different type in ext
+// than the mtype it forwards, and OpenRTB makes mtype the normative signal. The
+// unsupported-mtype counterpart is TestGetMediaTypeForBidUnsupportedMTypeIgnoresExt.
+func TestGetMediaTypeForBidMTypeWinsOverExt(t *testing.T) {
+	bidType, err := getMediaTypeForBid(openrtb2.Bid{
+		ID:    "bid-1",
+		MType: openrtb2.MarkupBanner,
+		Ext:   json.RawMessage(`{"prebid":{"type":"video"}}`),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+}
+
+func newBidder(t *testing.T) adapters.Bidder {
+	t.Helper()
+
+	bidder, err := Builder(openrtb_ext.BidderOcm, config.Adapter{Endpoint: testEndpoint}, config.Server{})
+	require.NoError(t, err)
+	return bidder
+}
+
+func bannerImp(id string, ext json.RawMessage) openrtb2.Imp {
+	return openrtb2.Imp{
+		ID:     id,
+		Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}},
+		Ext:    ext,
+	}
+}
+
+// TestSetStoredRequestID covers the ext rewriting directly, including the
+// branches MakeRequests cannot reach because parseImpExt rejects a malformed
+// imp.ext before this runs.
+func TestSetStoredRequestID(t *testing.T) {
+	tests := []struct {
+		name    string
+		impExt  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "creates prebid and storedrequest",
+			impExt: `{"bidder":{"publisherId":"a"}}`,
+			want:   `{"bidder":{"publisherId":"a"},"prebid":{"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:   "merges into existing prebid",
+			impExt: `{"prebid":{"is_rewarded_inventory":1}}`,
+			want:   `{"prebid":{"is_rewarded_inventory":1,"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:   "overwrites an existing storedrequest",
+			impExt: `{"prebid":{"storedrequest":{"id":"stale"}}}`,
+			want:   `{"prebid":{"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:   "tolerates null prebid",
+			impExt: `{"prebid":null}`,
+			want:   `{"prebid":{"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:   "preserves unrelated keys",
+			impExt: `{"gpid":"/1/a","tid":"t-1"}`,
+			want:   `{"gpid":"/1/a","tid":"t-1","prebid":{"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:   "handles absent ext",
+			impExt: ``,
+			want:   `{"prebid":{"storedrequest":{"id":"slot-1"}}}`,
+		},
+		{
+			name:    "rejects non-object prebid",
+			impExt:  `{"prebid":"not-an-object"}`,
+			wantErr: "unable to unmarshal ext.prebid",
+		},
+		{
+			name:    "rejects non-object ext",
+			impExt:  `["nope"]`,
+			wantErr: "unable to unmarshal ext",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			imp := openrtb2.Imp{ID: "imp-1"}
+			if test.impExt != "" {
+				imp.Ext = json.RawMessage(test.impExt)
+			}
+
+			err := setStoredRequestID(&imp, "slot-1")
+			if test.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.JSONEq(t, test.want, string(imp.Ext))
+		})
+	}
+}
+
+// TestMakeRequestsMalformedImpExtPrebid pins the error type for an imp.ext whose
+// prebid member is not an object. adapters.ExtImpBidder types that member, so
+// parseImpExt rejects it before setStoredRequestID is ever reached; either way the
+// publisher gets a BadInput.
+func TestMakeRequestsMalformedImpExtPrebid(t *testing.T) {
+	imp := bannerImp("imp-1", json.RawMessage(`{"bidder":{"publisherId":"a","placementId":"p"},"prebid":"not-an-object"}`))
+	request := &openrtb2.BidRequest{
+		ID:   "req",
+		Imp:  []openrtb2.Imp{imp},
+		Site: &openrtb2.Site{Domain: "example.gr"},
+	}
+
+	requests, errs := newBidder(t).MakeRequests(request, &adapters.ExtraRequestInfo{})
+	assert.Nil(t, requests)
+	require.Len(t, errs, 1)
+	assert.IsType(t, &errortypes.BadInput{}, errs[0])
+	assert.Contains(t, errs[0].Error(), "imp[0]: unable to unmarshal ext")
+}

--- a/adapters/ocm/ocmtest/exemplary/app-banner.json
+++ b/adapters/ocm/ocmtest/exemplary/app-banner.json
@@ -50,10 +50,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-2",
-                  "placementId": "app-bottom-banner"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "app-bottom-banner"

--- a/adapters/ocm/ocmtest/exemplary/app-banner.json
+++ b/adapters/ocm/ocmtest/exemplary/app-banner.json
@@ -1,0 +1,127 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-app-req",
+    "imp": [
+      {
+        "id": "imp-app-1",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-2",
+            "placementId": "app-bottom-banner"
+          }
+        }
+      }
+    ],
+    "app": {
+      "bundle": "com.orangeclickmedia.demo",
+      "name": "OCM Demo",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    },
+    "device": {
+      "ifa": "38400000-8cf0-11bd-b23e-10b96e40000d",
+      "os": "android"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-app-req",
+          "imp": [
+            {
+              "id": "imp-app-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-2",
+                  "placementId": "app-bottom-banner"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "app-bottom-banner"
+                  }
+                }
+              }
+            }
+          ],
+          "app": {
+            "bundle": "com.orangeclickmedia.demo",
+            "name": "OCM Demo",
+            "publisher": {
+              "id": "ocm-pub-2"
+            }
+          },
+          "device": {
+            "ifa": "38400000-8cf0-11bd-b23e-10b96e40000d",
+            "os": "android"
+          }
+        },
+        "impIDs": [
+          "imp-app-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-app-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-app-1",
+                  "impid": "imp-app-1",
+                  "price": 0.92,
+                  "adm": "<div id=\"ocm-creative\">app banner</div>",
+                  "crid": "creative-app-3",
+                  "w": 320,
+                  "h": 50,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-app-1",
+            "impid": "imp-app-1",
+            "price": 0.92,
+            "adm": "<div id=\"ocm-creative\">app banner</div>",
+            "crid": "creative-app-3",
+            "w": 320,
+            "h": 50,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/imp-ext-passthrough.json
+++ b/adapters/ocm/ocmtest/exemplary/imp-ext-passthrough.json
@@ -54,10 +54,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "gpid": "/1234/homepage#top",
                 "tid": "b4c9a1de-0000-4000-8000-000000000001",
                 "data": {
@@ -80,7 +76,9 @@
             }
           }
         },
-        "impIDs": ["imp-banner-1"]
+        "impIDs": [
+          "imp-banner-1"
+        ]
       },
       "mockResponse": {
         "status": 200,

--- a/adapters/ocm/ocmtest/exemplary/imp-ext-passthrough.json
+++ b/adapters/ocm/ocmtest/exemplary/imp-ext-passthrough.json
@@ -1,0 +1,131 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-ext-passthrough-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          },
+          "gpid": "/1234/homepage#top",
+          "tid": "b4c9a1de-0000-4000-8000-000000000001",
+          "data": {
+            "pbadslot": "/1234/homepage#top"
+          },
+          "prebid": {
+            "is_rewarded_inventory": 1
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-ext-passthrough-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "gpid": "/1234/homepage#top",
+                "tid": "b4c9a1de-0000-4000-8000-000000000001",
+                "data": {
+                  "pbadslot": "/1234/homepage#top"
+                },
+                "prebid": {
+                  "is_rewarded_inventory": 1,
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": ["imp-banner-1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-ext-passthrough-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.4,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.4,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/mtype-absent-ext-prebid-type.json
+++ b/adapters/ocm/ocmtest/exemplary/mtype-absent-ext-prebid-type.json
@@ -44,10 +44,6 @@
                 "h": 480
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "article-instream"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "article-instream"

--- a/adapters/ocm/ocmtest/exemplary/mtype-absent-ext-prebid-type.json
+++ b/adapters/ocm/ocmtest/exemplary/mtype-absent-ext-prebid-type.json
@@ -1,0 +1,125 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-ext-type-req",
+    "imp": [
+      {
+        "id": "imp-video-1",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "article-instream"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/video",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-ext-type-req",
+          "imp": [
+            {
+              "id": "imp-video-1",
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "article-instream"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "article-instream"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/video",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-video-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-ext-type-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-video-1",
+                  "impid": "imp-video-1",
+                  "price": 5.5,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-video-22",
+                  "w": 640,
+                  "h": 480,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-video-1",
+            "impid": "imp-video-1",
+            "price": 5.5,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-video-22",
+            "w": 640,
+            "h": 480,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/multi-imp.json
+++ b/adapters/ocm/ocmtest/exemplary/multi-imp.json
@@ -62,10 +62,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"
@@ -83,10 +79,6 @@
                 "h": 480
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-instream"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-instream"

--- a/adapters/ocm/ocmtest/exemplary/multi-imp.json
+++ b/adapters/ocm/ocmtest/exemplary/multi-imp.json
@@ -1,0 +1,180 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-multi-imp-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      },
+      {
+        "id": "imp-video-1",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-instream"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-multi-imp-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            },
+            {
+              "id": "imp-video-1",
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-instream"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-instream"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1",
+          "imp-video-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-multi-imp-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.85,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                },
+                {
+                  "id": "bid-video-1",
+                  "impid": "imp-video-1",
+                  "price": 7.2,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-video-11",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.85,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        },
+        {
+          "bid": {
+            "id": "bid-video-1",
+            "impid": "imp-video-1",
+            "price": 7.2,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-video-11",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/publisher-ext-parent-account-removed.json
+++ b/adapters/ocm/ocmtest/exemplary/publisher-ext-parent-account-removed.json
@@ -1,0 +1,129 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-parent-account-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/",
+      "publisher": {
+        "id": "publisher-from-request",
+        "ext": {
+          "prebid": {
+            "parentAccount": "parent-account-1"
+          },
+          "custom": {
+            "tier": "gold"
+          }
+        }
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-parent-account-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1",
+              "ext": {
+                "prebid": {},
+                "custom": {
+                  "tier": "gold"
+                }
+              }
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-parent-account-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.85,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.85,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/request-ext-alias-removed.json
+++ b/adapters/ocm/ocmtest/exemplary/request-ext-alias-removed.json
@@ -1,0 +1,129 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-alias-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    },
+    "ext": {
+      "prebid": {
+        "aliases": {
+          "ocmAlias": "ocm",
+          "partnerAlias": "appnexus"
+        },
+        "debug": true
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-alias-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          },
+          "ext": {
+            "prebid": {
+              "aliases": {
+                "partnerAlias": "appnexus"
+              },
+              "debug": true
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-alias-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.85,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.85,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/simple-banner.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-banner.json
@@ -55,10 +55,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/exemplary/simple-banner.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-banner.json
@@ -1,0 +1,137 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-banner-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "id": "site-1",
+      "domain": "example.gr",
+      "page": "https://example.gr/news",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      "ip": "203.0.113.7",
+      "language": "el"
+    },
+    "user": {
+      "id": "ocm-user-1"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-banner-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "id": "site-1",
+            "domain": "example.gr",
+            "page": "https://example.gr/news",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+            "ip": "203.0.113.7",
+            "language": "el"
+          },
+          "user": {
+            "id": "ocm-user-1"
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-banner-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.85,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.85,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/simple-native.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-native.json
@@ -38,10 +38,6 @@
                 "ver": "1.2"
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "feed-native"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "feed-native"

--- a/adapters/ocm/ocmtest/exemplary/simple-native.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-native.json
@@ -1,0 +1,107 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-native-req",
+    "imp": [
+      {
+        "id": "imp-native-1",
+        "native": {
+          "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}}]}",
+          "ver": "1.2"
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "feed-native"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/feed",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-native-req",
+          "imp": [
+            {
+              "id": "imp-native-1",
+              "native": {
+                "request": "{\"ver\":\"1.2\",\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}}]}",
+                "ver": "1.2"
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "feed-native"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "feed-native"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/feed",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-native-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-native-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-native-1",
+                  "impid": "imp-native-1",
+                  "price": 2.15,
+                  "adm": "{\"native\":{\"link\":{\"url\":\"https://example.gr/landing\"},\"assets\":[]}}",
+                  "crid": "creative-native-7",
+                  "mtype": 4
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-native-1",
+            "impid": "imp-native-1",
+            "price": 2.15,
+            "adm": "{\"native\":{\"link\":{\"url\":\"https://example.gr/landing\"},\"assets\":[]}}",
+            "crid": "creative-native-7",
+            "mtype": 4
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/simple-video.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-video.json
@@ -1,0 +1,121 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-video-req",
+    "imp": [
+      {
+        "id": "imp-video-1",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480,
+          "minduration": 5,
+          "maxduration": 30
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "article-instream"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/video",
+      "publisher": {
+        "id": "publisher-from-request"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-video-req",
+          "imp": [
+            {
+              "id": "imp-video-1",
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480,
+                "minduration": 5,
+                "maxduration": 30
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "article-instream"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "article-instream"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/video",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-video-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-video-req",
+          "cur": "EUR",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-video-1",
+                  "impid": "imp-video-1",
+                  "price": 6.4,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-video-11",
+                  "w": 640,
+                  "h": 480,
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-video-1",
+            "impid": "imp-video-1",
+            "price": 6.4,
+            "adm": "<VAST version=\"4.0\"></VAST>",
+            "crid": "creative-video-11",
+            "w": 640,
+            "h": 480,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/simple-video.json
+++ b/adapters/ocm/ocmtest/exemplary/simple-video.json
@@ -48,10 +48,6 @@
                 "maxduration": 30
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "article-instream"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "article-instream"
@@ -89,7 +85,16 @@
                   "crid": "creative-video-11",
                   "w": 640,
                   "h": 480,
-                  "mtype": 2
+                  "mtype": 2,
+                  "ext": {
+                    "prebid": {
+                      "type": "video",
+                      "video": {
+                        "duration": 30,
+                        "primary_category": "IAB1-2"
+                      }
+                    }
+                  }
                 }
               ]
             }
@@ -111,9 +116,22 @@
             "crid": "creative-video-11",
             "w": 640,
             "h": 480,
-            "mtype": 2
+            "mtype": 2,
+            "ext": {
+              "prebid": {
+                "type": "video",
+                "video": {
+                  "duration": 30,
+                  "primary_category": "IAB1-2"
+                }
+              }
+            }
           },
-          "type": "video"
+          "type": "video",
+          "video": {
+            "duration": 30,
+            "primary_category": "IAB1-2"
+          }
         }
       ]
     }

--- a/adapters/ocm/ocmtest/exemplary/site-without-publisher.json
+++ b/adapters/ocm/ocmtest/exemplary/site-without-publisher.json
@@ -1,0 +1,116 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-no-publisher-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 600
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-3",
+            "placementId": "sidebar-halfpage"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/sports"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-no-publisher-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 600
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-3",
+                  "placementId": "sidebar-halfpage"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "sidebar-halfpage"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/sports",
+            "publisher": {
+              "id": "ocm-pub-3"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-no-publisher-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 3.05,
+                  "adm": "<div id=\"ocm-creative\">halfpage</div>",
+                  "crid": "creative-hp-5",
+                  "w": 300,
+                  "h": 600,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 3.05,
+            "adm": "<div id=\"ocm-creative\">halfpage</div>",
+            "crid": "creative-hp-5",
+            "w": 300,
+            "h": 600,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/exemplary/site-without-publisher.json
+++ b/adapters/ocm/ocmtest/exemplary/site-without-publisher.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-3",
-                  "placementId": "sidebar-halfpage"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "sidebar-halfpage"

--- a/adapters/ocm/ocmtest/supplemental/empty-seatbid.json
+++ b/adapters/ocm/ocmtest/supplemental/empty-seatbid.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/empty-seatbid.json
+++ b/adapters/ocm/ocmtest/supplemental/empty-seatbid.json
@@ -1,0 +1,86 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-empty-seatbid-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-empty-seatbid-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-empty-seatbid-req",
+          "cur": "USD",
+          "seatbid": []
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/invalid-bidder-ext.json
+++ b/adapters/ocm/ocmtest/supplemental/invalid-bidder-ext.json
@@ -1,0 +1,20 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-invalid-ext-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {"format": [{"w": 300, "h": 250}]},
+        "ext": {"bidder": {"publisherId": ""}}
+      }
+    ],
+    "site": {"domain": "example.gr", "page": "https://example.gr/"}
+  },
+  "httpCalls": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp[0]: publisherId is required and must not be blank",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/malformed-response.json
+++ b/adapters/ocm/ocmtest/supplemental/malformed-response.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/malformed-response.json
+++ b/adapters/ocm/ocmtest/supplemental/malformed-response.json
@@ -1,0 +1,82 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-malformed-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-malformed-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "this is not a bid response"
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "expect { or n, but found \"",
+      "comparison": "startswith"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/missing-mtype.json
+++ b/adapters/ocm/ocmtest/supplemental/missing-mtype.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/missing-mtype.json
+++ b/adapters/ocm/ocmtest/supplemental/missing-mtype.json
@@ -1,0 +1,105 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-missing-mtype-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-missing-mtype-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-missing-mtype-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-no-mtype",
+                  "impid": "imp-banner-1",
+                  "price": 1.0,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unable to determine media type for bid \"bid-no-mtype\": no mtype and no ext.prebid.type",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/mixed-valid-and-unsupported-mtype.json
+++ b/adapters/ocm/ocmtest/supplemental/mixed-valid-and-unsupported-mtype.json
@@ -1,0 +1,162 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-mixed-mtype-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      },
+      {
+        "id": "imp-audio-1",
+        "banner": {
+          "format": [
+            {
+              "w": 728,
+              "h": 90
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-leaderboard"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-mixed-mtype-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            },
+            {
+              "id": "imp-audio-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 728,
+                    "h": 90
+                  }
+                ]
+              },
+              "ext": {
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-leaderboard"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1",
+          "imp-audio-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-mixed-mtype-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-banner-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.85,
+                  "adm": "<div id=\"ocm-creative\">banner</div>",
+                  "crid": "creative-9001",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                },
+                {
+                  "id": "bid-audio-1",
+                  "impid": "imp-audio-1",
+                  "price": 3.4,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-audio-1",
+                  "mtype": 3
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "bid-banner-1",
+            "impid": "imp-banner-1",
+            "price": 1.85,
+            "adm": "<div id=\"ocm-creative\">banner</div>",
+            "crid": "creative-9001",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unsupported mtype 3 for bid \"bid-audio-1\"",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/placement-id-blank.json
+++ b/adapters/ocm/ocmtest/supplemental/placement-id-blank.json
@@ -1,0 +1,20 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-blank-placement-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {"format": [{"w": 300, "h": 250}]},
+        "ext": {"bidder": {"publisherId": "ocm-pub-1", "placementId": "   "}}
+      }
+    ],
+    "site": {"domain": "example.gr", "page": "https://example.gr/"}
+  },
+  "httpCalls": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp[0]: placementId is required and must not be blank",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/placement-id-missing.json
+++ b/adapters/ocm/ocmtest/supplemental/placement-id-missing.json
@@ -1,0 +1,20 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-missing-placement-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {"format": [{"w": 300, "h": 250}]},
+        "ext": {"bidder": {"publisherId": "ocm-pub-1"}}
+      }
+    ],
+    "site": {"domain": "example.gr", "page": "https://example.gr/"}
+  },
+  "httpCalls": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp[0]: placementId is required and must not be blank",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/publisher-id-mismatch.json
+++ b/adapters/ocm/ocmtest/supplemental/publisher-id-mismatch.json
@@ -1,0 +1,25 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-publisher-mismatch-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {"format": [{"w": 300, "h": 250}]},
+        "ext": {"bidder": {"publisherId": "ocm-pub-1", "placementId": "homepage-top"}}
+      },
+      {
+        "id": "imp-banner-2",
+        "banner": {"format": [{"w": 728, "h": 90}]},
+        "ext": {"bidder": {"publisherId": "ocm-pub-9", "placementId": "homepage-leaderboard"}}
+      }
+    ],
+    "site": {"domain": "example.gr", "page": "https://example.gr/"}
+  },
+  "httpCalls": [],
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "imp[1]: all impressions must share the same publisherId, found \"ocm-pub-9\" and \"ocm-pub-1\"",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/status-204.json
+++ b/adapters/ocm/ocmtest/supplemental/status-204.json
@@ -1,0 +1,77 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-204-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-204-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/ocm/ocmtest/supplemental/status-204.json
+++ b/adapters/ocm/ocmtest/supplemental/status-204.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/status-400.json
+++ b/adapters/ocm/ocmtest/supplemental/status-400.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/status-400.json
+++ b/adapters/ocm/ocmtest/supplemental/status-400.json
@@ -1,0 +1,82 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-400-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-400-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/status-500.json
+++ b/adapters/ocm/ocmtest/supplemental/status-500.json
@@ -43,10 +43,6 @@
                 ]
               },
               "ext": {
-                "bidder": {
-                  "publisherId": "ocm-pub-1",
-                  "placementId": "homepage-top"
-                },
                 "prebid": {
                   "storedrequest": {
                     "id": "homepage-top"

--- a/adapters/ocm/ocmtest/supplemental/status-500.json
+++ b/adapters/ocm/ocmtest/supplemental/status-500.json
@@ -1,0 +1,82 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-500-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "ocm-pub-1",
+            "placementId": "homepage-top"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.gr",
+      "page": "https://example.gr/"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-500-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "publisherId": "ocm-pub-1",
+                  "placementId": "homepage-top"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "homepage-top"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.gr",
+            "page": "https://example.gr/",
+            "publisher": {
+              "id": "ocm-pub-1"
+            }
+          }
+        },
+        "impIDs": [
+          "imp-banner-1"
+        ]
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/ocmtest/supplemental/unsupported-mtype-with-ext-type.json
+++ b/adapters/ocm/ocmtest/supplemental/unsupported-mtype-with-ext-type.json
@@ -21,7 +21,6 @@
               "id": "imp-banner-1",
               "banner": {"format": [{"w": 300, "h": 250}]},
               "ext": {
-                "bidder": {"publisherId": "ocm-pub-1", "placementId": "homepage-top"},
                 "prebid": {"storedrequest": {"id": "homepage-top"}}
               }
             }

--- a/adapters/ocm/ocmtest/supplemental/unsupported-mtype-with-ext-type.json
+++ b/adapters/ocm/ocmtest/supplemental/unsupported-mtype-with-ext-type.json
@@ -1,0 +1,74 @@
+{
+  "mockBidRequest": {
+    "id": "ocm-audio-mtype-req",
+    "imp": [
+      {
+        "id": "imp-banner-1",
+        "banner": {"format": [{"w": 300, "h": 250}]},
+        "ext": {"bidder": {"publisherId": "ocm-pub-1", "placementId": "homepage-top"}}
+      }
+    ],
+    "site": {"domain": "example.gr", "page": "https://example.gr/"}
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://pbam.test.invalid/openrtb2/auction",
+        "body": {
+          "id": "ocm-audio-mtype-req",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "banner": {"format": [{"w": 300, "h": 250}]},
+              "ext": {
+                "bidder": {"publisherId": "ocm-pub-1", "placementId": "homepage-top"},
+                "prebid": {"storedrequest": {"id": "homepage-top"}}
+              }
+            }
+          ],
+          "site": {"domain": "example.gr", "page": "https://example.gr/", "publisher": {"id": "ocm-pub-1"}}
+        },
+        "impIDs": ["imp-banner-1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "ocm-audio-mtype-req",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "ocm",
+              "bid": [
+                {
+                  "id": "bid-audio-1",
+                  "impid": "imp-banner-1",
+                  "price": 1.25,
+                  "adm": "<VAST version=\"4.0\"></VAST>",
+                  "crid": "creative-audio-1",
+                  "mtype": 3,
+                  "ext": {
+                    "prebid": {
+                      "type": "banner"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unsupported mtype 3 for bid \"bid-audio-1\"",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/ocm/params_test.go
+++ b/adapters/ocm/params_test.go
@@ -1,0 +1,57 @@
+package ocm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+)
+
+// This file intends to test static/bidder-params/ocm.json
+// These also validate the format of the external API: request.imp[i].ext.prebid.bidder.ocm
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderOcm, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected valid params: %s", validParam)
+		}
+	}
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderOcm, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed invalid params: %s", invalidParam)
+		}
+	}
+}
+
+var validParams = []string{
+	`{"publisherId":"ocm-pub-1","placementId":"homepage-top"}`,
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`4.2`,
+	`[]`,
+	`{}`,
+	`{"placementId":"homepage-top"}`,
+	`{"publisherId":"ocm-pub-1"}`,
+	`{"publisherId":123}`,
+	`{"publisherId":""}`,
+	`{"publisherId":"ocm-pub-1","placementId":42}`,
+	`{"publisherId":"ocm-pub-1","placementId":""}`,
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -172,6 +172,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/nextmillennium"
 	"github.com/prebid/prebid-server/v4/adapters/nexx360"
 	"github.com/prebid/prebid-server/v4/adapters/nobid"
+	"github.com/prebid/prebid-server/v4/adapters/ocm"
 	"github.com/prebid/prebid-server/v4/adapters/ogury"
 	"github.com/prebid/prebid-server/v4/adapters/oms"
 	"github.com/prebid/prebid-server/v4/adapters/onetag"
@@ -453,6 +454,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderNextMillennium:    nextmillennium.Builder,
 		openrtb_ext.BidderNexx360:           nexx360.Builder,
 		openrtb_ext.BidderNoBid:             nobid.Builder,
+		openrtb_ext.BidderOcm:               ocm.Builder,
 		openrtb_ext.BidderOgury:             ogury.Builder,
 		openrtb_ext.BidderOms:               oms.Builder,
 		openrtb_ext.BidderOneTag:            onetag.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -190,6 +190,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderNextMillennium,
 	BidderNexx360,
 	BidderNoBid,
+	BidderOcm,
 	BidderOgury,
 	BidderOms,
 	BidderOneTag,
@@ -575,6 +576,7 @@ const (
 	BidderNextMillennium    BidderName = "nextmillennium"
 	BidderNexx360           BidderName = "nexx360"
 	BidderNoBid             BidderName = "nobid"
+	BidderOcm               BidderName = "ocm"
 	BidderOgury             BidderName = "ogury"
 	BidderOms               BidderName = "oms"
 	BidderOneTag            BidderName = "onetag"

--- a/openrtb_ext/imp_ocm.go
+++ b/openrtb_ext/imp_ocm.go
@@ -1,0 +1,14 @@
+package openrtb_ext
+
+// ExtImpOcm defines the contract for bidrequest.imp[i].ext.prebid.bidder.ocm.
+type ExtImpOcm struct {
+	// PublisherID is the Orange Click Media publisher identifier. It is propagated
+	// to the request-level publisher ID, so every impression in a single request
+	// must carry the same value.
+	PublisherID string `json:"publisherId"`
+
+	// PlacementID names the impression's stored request on the OCM endpoint, which
+	// expands it into the impression's real configuration. It is required: an
+	// impression that references no stored request cannot be resolved.
+	PlacementID string `json:"placementId"`
+}

--- a/static/bidder-info/ocm.yaml
+++ b/static/bidder-info/ocm.yaml
@@ -1,0 +1,28 @@
+endpoint: "https://pbam.orangeclickmedia.com/openrtb2/auction"
+endpointCompression: gzip
+maintainer:
+  email: devs-subs@orangeclickmedia.com
+gvlVendorID: 1148
+geoscope:
+  - global
+openrtb:
+  version: 2.6
+  gpp-supported: true
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - native
+userSync:
+  redirect:
+    url: "https://pbam.orangeclickmedia.com/usersync/redirect?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"
+  iframe:
+    url: "https://pbam.orangeclickmedia.com/usersync/iframe?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-params/ocm.json
+++ b/static/bidder-params/ocm.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "OCM Adapter Params",
+  "description": "A schema which validates params accepted by the OCM adapter",
+  "type": "object",
+  "properties": {
+    "publisherId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Orange Click Media publisher identifier"
+    },
+    "placementId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Placement identifier, resolved as the impression's stored request"
+    }
+  },
+  "required": [
+    "publisherId",
+    "placementId"
+  ]
+}


### PR DESCRIPTION
## Overview

Adds a new bid adapter for **Orange Click Media** (https://orangeclickmedia.com).

- **Bidder code:** `ocm` — the same code as the existing Prebid.js `ocmBidAdapter`
- **Maintainer:** devs-subs@orangeclickmedia.com
- **GVL Vendor ID:** 1148
- **Endpoint:** `https://pbam.orangeclickmedia.com/openrtb2/auction` (global, HTTPS, gzip)
- **OpenRTB:** 2.6, GPP supported
- **Capabilities:** site + app, banner / video / native
- **Params:** `publisherId` and `placementId`, both required

## Design notes

The endpoint is itself a Prebid Server holding stored impression configs keyed by
placement, which drives the two things that are unusual here:

- **`placementId` is sent as `imp.ext.prebid.storedrequest.id`, not `imp.tagid`.** The
  stored impression config is the only thing that supplies `imp.ext.prebid.bidder`
  downstream, so the param is required — an impression referencing no stored request
  fails the whole request rather than just itself.
- **`publisherId` becomes the request-level publisher id**, selecting the account config
  downstream. That is why all impressions in one request must agree on it; a divergent
  value rejects the request instead of silently dropping impressions.

Both params carry the same names and meaning as in the Prebid.js `ocm` adapter, so a
publisher configures the bidder identically on either platform.

Other points a reviewer may look for:

- `imp.ext` is rewritten through a generic `map[string]json.RawMessage`, so `gpid`, `tid`,
  `data` and any pre-existing `ext.prebid` members survive untouched (covered by the
  `imp-ext-passthrough` exemplary test).
- `imp.ext.bidder` is deliberately left in place: once the stored impression merges,
  `ext.prebid.bidder` is present, so the envelope is never promoted to a bidder.
- `request.Site` / `request.App` are copied before the publisher id is written, since the
  BidRequest is shared across adapters; only imp elements are modified in place.
- Media type comes from `bid.mtype`, falling back to `bid.ext.prebid.type` only when mtype
  is absent — a Prebid Server upstream reports the type it resolved there. A set but
  unsupported mtype is rejected rather than allowed to fall through to the extension.
- No bid mutation, no transaction id creation, all networking through the core framework.

## User sync

Configured in bidder-info yaml for both iframe and redirect, with `userMacro: "$UID"` and
the `gdpr`, `gdpr_consent`, `us_privacy`, `gpp` and `gpp_sid` macros. No syncer key is set,
so the key is derived from the bidder name.

Both endpoints are deployed and were verified against the live service using the exact URLs
`usersync.NewSyncer` renders from this yaml:

- **redirect** returns 302 to the `{{.RedirectURL}}` target with `$UID` replaced by the
  user's id; **iframe** returns HTML that navigates to the same target. Declines are a 1x1
  GIF and a blank page respectively, matching the sync type.
- **Id stability:** a request carrying the existing cookie echoes the same id; a fresh
  client is issued a new one.
- **GDPR:** with `gdpr=1`, syncing requires both purpose 1 consent and vendor 1148 consent
  in the TC string — withholding either declines. No GDPR signal syncs.
- **US privacy:** `1YYN` declines, `1YNN` syncs.
- The sync cookie is set `HttpOnly; Secure; SameSite=None` with `Cache-Control: no-store`.
- The redirect target must be `https` and carry the `bidder` and `uid` parameters, which
  the core `user_sync.redirect_url` template always supplies. Host and path are not
  constrained, so PBS deployments behind a path prefix sync normally.

## Testing

- 8 exemplary JSON tests (banner / video / native, app, multi-imp, imp.ext passthrough,
  site without publisher, mtype-absent) and 11 supplemental tests (204 / 400 / 500,
  malformed body, empty seatbid, missing mtype, unsupported mtype, invalid bidder ext,
  blank and missing params, publisher id mismatch).
- Unit tests for the builder, params schema, imp.ext rewriting, publisher id handling and
  media type resolution.
- `./validate.sh` passes (full suite, fmt, vet).

## Documentation

Docs PR to prebid.github.io: prebid/prebid.github.io#6732
