### PR TITLE
Task_1: IntentIQ tracing module for Prebid Server

### DIFF
--- a/modules/builder.go
+++ b/modules/builder.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	fiftyonedegreesDevicedetection "github.com/prebid/prebid-server/v4/modules/fiftyonedegrees/devicedetection"
+	intentiqTracing "github.com/prebid/prebid-server/v4/modules/intentiq/tracing"
 	prebidOrtb2blocking "github.com/prebid/prebid-server/v4/modules/prebid/ortb2blocking"
 	prebidRulesengine "github.com/prebid/prebid-server/v4/modules/prebid/rulesengine"
 	wurflDevicedetection "github.com/prebid/prebid-server/v4/modules/scientiamobile/wurfl_devicedetection"
@@ -14,6 +15,9 @@ func builders() ModuleBuilders {
 	return ModuleBuilders{
 		"fiftyonedegrees": {
 			"devicedetection": fiftyonedegreesDevicedetection.Builder,
+		},
+		"intentiq": {
+			"tracing": intentiqTracing.Builder,
 		},
 		"prebid": {
 			"ortb2blocking": prebidOrtb2blocking.Builder,

--- a/modules/intentiq/tracing/README.md
+++ b/modules/intentiq/tracing/README.md
@@ -1,0 +1,19 @@
+# Overview
+
+The `intentiq.tracing` module traces the `/openrtb2/auction` request lifecycle for a
+hardcoded set of partners (see `Rules` in `rules.go`) and prints each collected trace packet
+as JSON directly to stdout.
+
+For every account whose resolved `Account.ID` matches a rule's `PartnerID`, the module
+collects:
+
+1. The incoming `BidRequest` and its timestamp.
+2. Each outgoing `BidRequest` sent to a bidder, its timestamp, and the bidder's name.
+3. Each incoming `BidResponse` from a bidder, its timestamp, and the bidder's name.
+4. The final auction `BidResponse` sent back to the client, and its timestamp.
+
+Tracing for a partner stops (permanently) as soon as either the `Duration` since its first
+traced request elapses, or its `TracePacketsAmount` budget - shared across all four packet
+types above - is exhausted. The module never mutates the request/response or rejects the
+auction; it is a pure observability sidecar, and only acts on the `/openrtb2/auction`
+endpoint.

--- a/modules/intentiq/tracing/module.go
+++ b/modules/intentiq/tracing/module.go
@@ -1,0 +1,126 @@
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/prebid/prebid-server/v4/hooks/hookexecution"
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+	"github.com/prebid/prebid-server/v4/logger"
+	"github.com/prebid/prebid-server/v4/modules/moduledeps"
+)
+
+// Builder builds the tracing module. Tracing rules are hardcoded (see rules.go) per the
+// task requirement; the config argument is intentionally unused.
+func Builder(_ json.RawMessage, _ moduledeps.ModuleDeps) (interface{}, error) {
+	return Module{
+		tracer: NewTracer(Rules),
+		output: os.Stdout,
+		now:    time.Now,
+		mu:     &sync.Mutex{},
+	}, nil
+}
+
+// Module traces auction lifecycle data (incoming/outgoing bid requests and responses) for
+// accounts matching a hardcoded set of rules, printing each collected trace packet as JSON
+// directly to stdout. It only acts on the /openrtb2/auction endpoint.
+//
+// The bidder_request and raw_bidder_response stages run once per bidder, concurrently, so
+// writes to output are serialized through mu to keep each printed JSON line intact.
+type Module struct {
+	tracer *Tracer
+	output io.Writer
+	now    func() time.Time
+	mu     *sync.Mutex
+}
+
+// HandleProcessedAuctionHook traces the incoming BidRequest.
+func (m Module) HandleProcessedAuctionHook(
+	_ context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.ProcessedAuctionRequestPayload,
+) (hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload], error) {
+	result := hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload]{}
+	if !inScope(miCtx) || payload.Request == nil || payload.Request.BidRequest == nil {
+		return result, nil
+	}
+
+	m.trace(miCtx.AccountID, PacketTypeIncomingBidRequest, "", payload.Request.BidRequest)
+	return result, nil
+}
+
+// HandleBidderRequestHook traces the outgoing BidRequest sent to a specific bidder.
+func (m Module) HandleBidderRequestHook(
+	_ context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.BidderRequestPayload,
+) (hookstage.HookResult[hookstage.BidderRequestPayload], error) {
+	result := hookstage.HookResult[hookstage.BidderRequestPayload]{}
+	if !inScope(miCtx) || payload.Request == nil || payload.Request.BidRequest == nil {
+		return result, nil
+	}
+
+	m.trace(miCtx.AccountID, PacketTypeOutgoingBidRequest, payload.Bidder, payload.Request.BidRequest)
+	return result, nil
+}
+
+// HandleRawBidderResponseHook traces the incoming BidResponse from a specific bidder.
+func (m Module) HandleRawBidderResponseHook(
+	_ context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.RawBidderResponsePayload,
+) (hookstage.HookResult[hookstage.RawBidderResponsePayload], error) {
+	result := hookstage.HookResult[hookstage.RawBidderResponsePayload]{}
+	if !inScope(miCtx) || payload.BidderResponse == nil {
+		return result, nil
+	}
+
+	m.trace(miCtx.AccountID, PacketTypeIncomingBidResponse, payload.Bidder, payload.BidderResponse)
+	return result, nil
+}
+
+// HandleAuctionResponseHook traces the final auction response sent back to the client.
+func (m Module) HandleAuctionResponseHook(
+	_ context.Context,
+	miCtx hookstage.ModuleInvocationContext,
+	payload hookstage.AuctionResponsePayload,
+) (hookstage.HookResult[hookstage.AuctionResponsePayload], error) {
+	result := hookstage.HookResult[hookstage.AuctionResponsePayload]{}
+	if !inScope(miCtx) || payload.BidResponse == nil {
+		return result, nil
+	}
+
+	m.trace(miCtx.AccountID, PacketTypeAuctionResponse, "", payload.BidResponse)
+	return result, nil
+}
+
+// inScope reports whether the hook is executing for the /openrtb2/auction endpoint, the
+// only endpoint this module is allowed to affect.
+func inScope(miCtx hookstage.ModuleInvocationContext) bool {
+	return miCtx.Endpoint == hookexecution.EndpointAuction
+}
+
+// trace collects and prints a single trace packet for partnerID, if the tracer's hardcoded
+// rules still allow it.
+func (m Module) trace(partnerID string, packetType PacketType, bidder string, value any) {
+	now := m.now()
+	if !m.tracer.Allow(partnerID, now) {
+		return
+	}
+
+	packet, err := newPacket(partnerID, packetType, bidder, now, value)
+	if err != nil {
+		logger.Warnf("intentiq.tracing: failed to build trace packet: %s", err)
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := emit(m.output, packet); err != nil {
+		logger.Warnf("intentiq.tracing: failed to write trace packet: %s", err)
+	}
+}

--- a/modules/intentiq/tracing/module_test.go
+++ b/modules/intentiq/tracing/module_test.go
@@ -1,0 +1,402 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/hooks/hookexecution"
+	"github.com/prebid/prebid-server/v4/hooks/hookstage"
+	"github.com/prebid/prebid-server/v4/modules/moduledeps"
+	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tracedPartner   = "traced-partner"
+	untracedPartner = "untraced-partner"
+	testBidderName  = "appnexus"
+	otherEndpoint   = "/openrtb2/amp"
+	auctionEndpoint = hookexecution.EndpointAuction
+)
+
+func TestBuilder(t *testing.T) {
+	// Act
+	result, err := Builder(nil, moduledeps.ModuleDeps{})
+
+	// Assert
+	assert.NoError(t, err)
+	module, ok := result.(Module)
+	assert.True(t, ok)
+	assert.NotNil(t, module.tracer)
+	assert.NotNil(t, module.output)
+	assert.NotNil(t, module.now)
+	assert.NotNil(t, module.mu)
+}
+
+func newTestModule(buf *bytes.Buffer, now time.Time) Module {
+	return Module{
+		tracer: NewTracer([]Rule{
+			{PartnerID: tracedPartner, Duration: time.Hour, TracePacketsAmount: 100},
+		}),
+		output: buf,
+		now:    func() time.Time { return now },
+		mu:     &sync.Mutex{},
+	}
+}
+
+func TestHandleProcessedAuctionHook(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bidRequest := &openrtb2.BidRequest{ID: "req-1"}
+
+	testCases := []struct {
+		description  string
+		accountID    string
+		endpoint     string
+		payload      hookstage.ProcessedAuctionRequestPayload
+		expectOutput bool
+	}{
+		{
+			description:  "traced partner on the auction endpoint emits a packet",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.ProcessedAuctionRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}},
+			expectOutput: true,
+		},
+		{
+			description:  "untraced partner emits nothing",
+			accountID:    untracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.ProcessedAuctionRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}},
+			expectOutput: false,
+		},
+		{
+			description:  "traced partner on a different endpoint emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     otherEndpoint,
+			payload:      hookstage.ProcessedAuctionRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}},
+			expectOutput: false,
+		},
+		{
+			description:  "nil request wrapper emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.ProcessedAuctionRequestPayload{Request: nil},
+			expectOutput: false,
+		},
+		{
+			description:  "nil bid request emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.ProcessedAuctionRequestPayload{Request: &openrtb_ext.RequestWrapper{}},
+			expectOutput: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Arrange
+			var buf bytes.Buffer
+			module := newTestModule(&buf, now)
+			miCtx := hookstage.ModuleInvocationContext{AccountID: test.accountID, Endpoint: test.endpoint}
+
+			// Act
+			result, err := module.HandleProcessedAuctionHook(context.Background(), miCtx, test.payload)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, hookstage.HookResult[hookstage.ProcessedAuctionRequestPayload]{}, result)
+			if test.expectOutput {
+				assert.Contains(t, buf.String(), `"type":"incoming_bid_request"`)
+				assert.Contains(t, buf.String(), `"partner_id":"`+test.accountID+`"`)
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestHandleBidderRequestHook(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bidRequest := &openrtb2.BidRequest{ID: "req-1"}
+
+	testCases := []struct {
+		description  string
+		accountID    string
+		endpoint     string
+		payload      hookstage.BidderRequestPayload
+		expectOutput bool
+	}{
+		{
+			description:  "traced partner on the auction endpoint emits a packet with bidder name",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.BidderRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}, Bidder: testBidderName},
+			expectOutput: true,
+		},
+		{
+			description:  "untraced partner emits nothing",
+			accountID:    untracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.BidderRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}, Bidder: testBidderName},
+			expectOutput: false,
+		},
+		{
+			description:  "traced partner on a different endpoint emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     otherEndpoint,
+			payload:      hookstage.BidderRequestPayload{Request: &openrtb_ext.RequestWrapper{BidRequest: bidRequest}, Bidder: testBidderName},
+			expectOutput: false,
+		},
+		{
+			description:  "nil bid request emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.BidderRequestPayload{Request: &openrtb_ext.RequestWrapper{}, Bidder: testBidderName},
+			expectOutput: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Arrange
+			var buf bytes.Buffer
+			module := newTestModule(&buf, now)
+			miCtx := hookstage.ModuleInvocationContext{AccountID: test.accountID, Endpoint: test.endpoint}
+
+			// Act
+			result, err := module.HandleBidderRequestHook(context.Background(), miCtx, test.payload)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, hookstage.HookResult[hookstage.BidderRequestPayload]{}, result)
+			if test.expectOutput {
+				assert.Contains(t, buf.String(), `"type":"outgoing_bid_request"`)
+				assert.Contains(t, buf.String(), `"bidder":"`+testBidderName+`"`)
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestHandleRawBidderResponseHook(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bidderResponse := &adapters.BidderResponse{Currency: "USD"}
+
+	testCases := []struct {
+		description  string
+		accountID    string
+		endpoint     string
+		payload      hookstage.RawBidderResponsePayload
+		expectOutput bool
+	}{
+		{
+			description:  "traced partner on the auction endpoint emits a packet with bidder name",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.RawBidderResponsePayload{BidderResponse: bidderResponse, Bidder: testBidderName},
+			expectOutput: true,
+		},
+		{
+			description:  "untraced partner emits nothing",
+			accountID:    untracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.RawBidderResponsePayload{BidderResponse: bidderResponse, Bidder: testBidderName},
+			expectOutput: false,
+		},
+		{
+			description:  "traced partner on a different endpoint emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     otherEndpoint,
+			payload:      hookstage.RawBidderResponsePayload{BidderResponse: bidderResponse, Bidder: testBidderName},
+			expectOutput: false,
+		},
+		{
+			description:  "nil bidder response emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.RawBidderResponsePayload{BidderResponse: nil, Bidder: testBidderName},
+			expectOutput: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Arrange
+			var buf bytes.Buffer
+			module := newTestModule(&buf, now)
+			miCtx := hookstage.ModuleInvocationContext{AccountID: test.accountID, Endpoint: test.endpoint}
+
+			// Act
+			result, err := module.HandleRawBidderResponseHook(context.Background(), miCtx, test.payload)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, hookstage.HookResult[hookstage.RawBidderResponsePayload]{}, result)
+			if test.expectOutput {
+				assert.Contains(t, buf.String(), `"type":"incoming_bid_response"`)
+				assert.Contains(t, buf.String(), `"bidder":"`+testBidderName+`"`)
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestHandleAuctionResponseHook(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bidResponse := &openrtb2.BidResponse{ID: "resp-1"}
+
+	testCases := []struct {
+		description  string
+		accountID    string
+		endpoint     string
+		payload      hookstage.AuctionResponsePayload
+		expectOutput bool
+	}{
+		{
+			description:  "traced partner on the auction endpoint emits a packet",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.AuctionResponsePayload{BidResponse: bidResponse},
+			expectOutput: true,
+		},
+		{
+			description:  "untraced partner emits nothing",
+			accountID:    untracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.AuctionResponsePayload{BidResponse: bidResponse},
+			expectOutput: false,
+		},
+		{
+			description:  "traced partner on a different endpoint emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     otherEndpoint,
+			payload:      hookstage.AuctionResponsePayload{BidResponse: bidResponse},
+			expectOutput: false,
+		},
+		{
+			description:  "nil bid response emits nothing",
+			accountID:    tracedPartner,
+			endpoint:     auctionEndpoint,
+			payload:      hookstage.AuctionResponsePayload{BidResponse: nil},
+			expectOutput: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Arrange
+			var buf bytes.Buffer
+			module := newTestModule(&buf, now)
+			miCtx := hookstage.ModuleInvocationContext{AccountID: test.accountID, Endpoint: test.endpoint}
+
+			// Act
+			result, err := module.HandleAuctionResponseHook(context.Background(), miCtx, test.payload)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, hookstage.HookResult[hookstage.AuctionResponsePayload]{}, result)
+			if test.expectOutput {
+				assert.Contains(t, buf.String(), `"type":"auction_response"`)
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestModuleTraceStopsAfterAmountLimitReached(t *testing.T) {
+	// Arrange
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	module := Module{
+		tracer: NewTracer([]Rule{{PartnerID: tracedPartner, Duration: time.Hour, TracePacketsAmount: 1}}),
+		output: &buf,
+		now:    func() time.Time { return now },
+		mu:     &sync.Mutex{},
+	}
+
+	// Act
+	module.trace(tracedPartner, PacketTypeAuctionResponse, "", map[string]string{"a": "b"})
+	firstOutput := buf.String()
+	buf.Reset()
+	module.trace(tracedPartner, PacketTypeAuctionResponse, "", map[string]string{"a": "b"})
+
+	// Assert
+	assert.NotEmpty(t, firstOutput)
+	assert.Empty(t, buf.String())
+}
+
+func TestModuleTraceHandlesMarshalError(t *testing.T) {
+	// Arrange
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	module := newTestModule(&buf, now)
+
+	// Act
+	module.trace(tracedPartner, PacketTypeAuctionResponse, "", unmarshalable{})
+
+	// Assert
+	assert.Empty(t, buf.String())
+}
+
+func TestModuleTraceHandlesWriteError(t *testing.T) {
+	// Arrange
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	module := Module{
+		tracer: NewTracer([]Rule{{PartnerID: tracedPartner, Duration: time.Hour, TracePacketsAmount: 100}}),
+		output: failingWriter{},
+		now:    func() time.Time { return now },
+		mu:     &sync.Mutex{},
+	}
+
+	// Act & Assert (must not panic)
+	assert.NotPanics(t, func() {
+		module.trace(tracedPartner, PacketTypeAuctionResponse, "", map[string]string{"a": "b"})
+	})
+}
+
+// TestModuleTraceConcurrentWritesDoNotInterleave guards against the bidder_request and
+// raw_bidder_response stages (invoked once per bidder, concurrently, by the exchange) tearing
+// each other's JSON lines apart when writing to the shared output.
+func TestModuleTraceConcurrentWritesDoNotInterleave(t *testing.T) {
+	// Arrange
+	const workers = 100
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	module := Module{
+		tracer: NewTracer([]Rule{{PartnerID: tracedPartner, Duration: time.Hour, TracePacketsAmount: workers}}),
+		output: &buf,
+		now:    func() time.Time { return now },
+		mu:     &sync.Mutex{},
+	}
+
+	// large-ish payload to make interleaving likely if writes aren't serialized
+	largeValue := map[string]string{"padding": strings.Repeat("x", 8192)}
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(bidder string) {
+			defer wg.Done()
+			module.trace(tracedPartner, PacketTypeOutgoingBidRequest, bidder, largeValue)
+		}(testBidderName)
+	}
+	wg.Wait()
+
+	// Assert: every line is valid, independently parseable JSON
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, workers)
+	for _, line := range lines {
+		var packet Packet
+		assert.NoError(t, json.Unmarshal([]byte(line), &packet))
+	}
+}

--- a/modules/intentiq/tracing/packet.go
+++ b/modules/intentiq/tracing/packet.go
@@ -1,0 +1,54 @@
+package tracing
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+// PacketType identifies which point of the auction lifecycle a Packet was collected at.
+type PacketType string
+
+const (
+	PacketTypeIncomingBidRequest  PacketType = "incoming_bid_request"
+	PacketTypeOutgoingBidRequest  PacketType = "outgoing_bid_request"
+	PacketTypeIncomingBidResponse PacketType = "incoming_bid_response"
+	PacketTypeAuctionResponse     PacketType = "auction_response"
+)
+
+// Packet is a single collected trace event.
+type Packet struct {
+	PartnerID string          `json:"partner_id"`
+	Type      PacketType      `json:"type"`
+	Timestamp time.Time       `json:"timestamp"`
+	Bidder    string          `json:"bidder,omitempty"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// newPacket builds a Packet, marshaling value as its payload.
+func newPacket(partnerID string, packetType PacketType, bidder string, timestamp time.Time, value any) (Packet, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return Packet{}, err
+	}
+
+	return Packet{
+		PartnerID: partnerID,
+		Type:      packetType,
+		Timestamp: timestamp,
+		Bidder:    bidder,
+		Payload:   payload,
+	}, nil
+}
+
+// emit writes packet to w as a single line of JSON.
+func emit(w io.Writer, packet Packet) error {
+	data, err := json.Marshal(packet)
+	if err != nil {
+		return err
+	}
+
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}

--- a/modules/intentiq/tracing/packet_test.go
+++ b/modules/intentiq/tracing/packet_test.go
@@ -1,0 +1,94 @@
+package tracing
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type unmarshalable struct{}
+
+func (unmarshalable) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("boom")
+}
+
+func TestNewPacket(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		description   string
+		partnerID     string
+		packetType    PacketType
+		bidder        string
+		value         any
+		expectedJSON  string
+		expectedError string
+	}{
+		{
+			description:  "builds a packet with a bidder set",
+			partnerID:    "p1",
+			packetType:   PacketTypeOutgoingBidRequest,
+			bidder:       "appnexus",
+			value:        map[string]string{"id": "req-1"},
+			expectedJSON: `{"partner_id":"p1","type":"outgoing_bid_request","timestamp":"2026-01-01T12:00:00Z","bidder":"appnexus","payload":{"id":"req-1"}}`,
+		},
+		{
+			description:  "builds a packet without a bidder",
+			partnerID:    "p1",
+			packetType:   PacketTypeIncomingBidRequest,
+			bidder:       "",
+			value:        map[string]string{"id": "req-1"},
+			expectedJSON: `{"partner_id":"p1","type":"incoming_bid_request","timestamp":"2026-01-01T12:00:00Z","payload":{"id":"req-1"}}`,
+		},
+		{
+			description:   "returns an error if the value cannot be marshaled",
+			partnerID:     "p1",
+			packetType:    PacketTypeAuctionResponse,
+			value:         unmarshalable{},
+			expectedError: "boom",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Act
+			packet, err := newPacket(test.partnerID, test.packetType, test.bidder, ts, test.value)
+
+			// Assert
+			if test.expectedError != "" {
+				assert.ErrorContains(t, err, test.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+
+			var buf bytes.Buffer
+			assert.NoError(t, emit(&buf, packet))
+			assert.JSONEq(t, test.expectedJSON, buf.String())
+		})
+	}
+}
+
+func TestEmitWriteError(t *testing.T) {
+	// Arrange
+	packet, err := newPacket("p1", PacketTypeAuctionResponse, "", testTime(), map[string]string{"a": "b"})
+	assert.NoError(t, err)
+
+	// Act
+	err = emit(failingWriter{}, packet)
+
+	// Assert
+	assert.ErrorContains(t, err, "write failed")
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func testTime() time.Time {
+	return time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+}

--- a/modules/intentiq/tracing/rules.go
+++ b/modules/intentiq/tracing/rules.go
@@ -1,0 +1,20 @@
+package tracing
+
+import "time"
+
+// testTaskPartnerID is the account resolved for testTask/01-bid-request-example.json
+// (site.publisher.ext.prebid.parentAccount), used for manual end-to-end verification.
+const testTaskPartnerID = "664-025-677-881"
+
+// Rules holds the hardcoded tracing rules for the module, per the task requirement that
+// tracing parameters be hardcoded rather than driven by account-level config.
+//
+// A trace is initiated whenever an incoming BidRequest's resolved Account.ID matches a
+// rule's PartnerID. Edit this slice to change which accounts are traced and their limits.
+var Rules = []Rule{
+	{
+		PartnerID:          testTaskPartnerID,
+		Duration:           5 * time.Minute,
+		TracePacketsAmount: 20,
+	},
+}

--- a/modules/intentiq/tracing/tracer.go
+++ b/modules/intentiq/tracing/tracer.go
@@ -1,0 +1,70 @@
+package tracing
+
+import (
+	"sync"
+	"time"
+)
+
+// Rule is a hardcoded tracing rule for a single partner.
+type Rule struct {
+	PartnerID          string
+	Duration           time.Duration
+	TracePacketsAmount int
+}
+
+type partnerState struct {
+	firstSeen time.Time
+	count     int
+}
+
+// Tracer decides, for a given partner, whether a new trace packet may still be collected,
+// based on the hardcoded rules and previously observed activity for that partner.
+type Tracer struct {
+	mu    sync.Mutex
+	rules map[string]Rule
+	state map[string]*partnerState
+}
+
+// NewTracer builds a Tracer from a set of hardcoded rules, keyed by PartnerID.
+func NewTracer(rules []Rule) *Tracer {
+	byPartner := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		byPartner[rule.PartnerID] = rule
+	}
+	return &Tracer{
+		rules: byPartner,
+		state: make(map[string]*partnerState),
+	}
+}
+
+// Allow reports whether a trace packet for partnerID may be collected at time now.
+//
+// The first call for a partner starts its tracing window. Every allowed call consumes one
+// unit of that partner's TracePacketsAmount budget. Once either the Duration since the first
+// call or the TracePacketsAmount budget is exhausted, tracing stops permanently for that
+// partner - it never resumes, even if called again later.
+func (t *Tracer) Allow(partnerID string, now time.Time) bool {
+	rule, ok := t.rules[partnerID]
+	if !ok {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state, ok := t.state[partnerID]
+	if !ok {
+		state = &partnerState{firstSeen: now}
+		t.state[partnerID] = state
+	}
+
+	if now.Sub(state.firstSeen) > rule.Duration {
+		return false
+	}
+	if state.count >= rule.TracePacketsAmount {
+		return false
+	}
+
+	state.count++
+	return true
+}

--- a/modules/intentiq/tracing/tracer_test.go
+++ b/modules/intentiq/tracing/tracer_test.go
@@ -1,0 +1,145 @@
+package tracing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracerAllow(t *testing.T) {
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		description string
+		rules       []Rule
+		partnerID   string
+		calls       []time.Time // one Allow() call per entry, in order
+		expected    []bool      // expected Allow() result per call
+	}{
+		{
+			description: "unknown partner is never allowed",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: 5}},
+			partnerID:   "unknown",
+			calls:       []time.Time{baseTime},
+			expected:    []bool{false},
+		},
+		{
+			description: "first call for a known partner is allowed and starts the window",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: 5}},
+			partnerID:   "p1",
+			calls:       []time.Time{baseTime},
+			expected:    []bool{true},
+		},
+		{
+			description: "amount limit stops tracing once reached",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: 2}},
+			partnerID:   "p1",
+			calls:       []time.Time{baseTime, baseTime, baseTime},
+			expected:    []bool{true, true, false},
+		},
+		{
+			description: "zero amount never allows any packet",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: 0}},
+			partnerID:   "p1",
+			calls:       []time.Time{baseTime},
+			expected:    []bool{false},
+		},
+		{
+			description: "time limit stops tracing once duration since first trace elapses",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Minute, TracePacketsAmount: 100}},
+			partnerID:   "p1",
+			calls: []time.Time{
+				baseTime,
+				baseTime.Add(30 * time.Second),
+				baseTime.Add(61 * time.Second),
+			},
+			expected: []bool{true, true, false},
+		},
+		{
+			description: "call exactly at the duration boundary is still allowed",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Minute, TracePacketsAmount: 100}},
+			partnerID:   "p1",
+			calls: []time.Time{
+				baseTime,
+				baseTime.Add(time.Minute),
+			},
+			expected: []bool{true, true},
+		},
+		{
+			description: "once stopped, tracing does not resume even if called again later",
+			rules:       []Rule{{PartnerID: "p1", Duration: time.Minute, TracePacketsAmount: 1}},
+			partnerID:   "p1",
+			calls: []time.Time{
+				baseTime,
+				baseTime.Add(2 * time.Minute),
+				baseTime.Add(3 * time.Minute),
+			},
+			expected: []bool{true, false, false},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// Arrange
+			tracer := NewTracer(test.rules)
+
+			// Act
+			actual := make([]bool, len(test.calls))
+			for i, callTime := range test.calls {
+				actual[i] = tracer.Allow(test.partnerID, callTime)
+			}
+
+			// Assert
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestTracerAllowIsIndependentPerPartner(t *testing.T) {
+	// Arrange
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tracer := NewTracer([]Rule{
+		{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: 1},
+		{PartnerID: "p2", Duration: time.Hour, TracePacketsAmount: 1},
+	})
+
+	// Act
+	p1First := tracer.Allow("p1", baseTime)
+	p2First := tracer.Allow("p2", baseTime)
+	p1Second := tracer.Allow("p1", baseTime)
+	p2Second := tracer.Allow("p2", baseTime)
+
+	// Assert
+	assert.True(t, p1First)
+	assert.True(t, p2First)
+	assert.False(t, p1Second)
+	assert.False(t, p2Second)
+}
+
+func TestTracerAllowConcurrentCallsRespectAmountLimit(t *testing.T) {
+	// Arrange
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	const amount = 50
+	tracer := NewTracer([]Rule{{PartnerID: "p1", Duration: time.Hour, TracePacketsAmount: amount}})
+
+	const workers = 200
+	results := make(chan bool, workers)
+
+	// Act
+	for i := 0; i < workers; i++ {
+		go func() {
+			results <- tracer.Allow("p1", now)
+		}()
+	}
+
+	allowedCount := 0
+	for i := 0; i < workers; i++ {
+		if <-results {
+			allowedCount++
+		}
+	}
+
+	// Assert
+	assert.Equal(t, amount, allowedCount)
+}


### PR DESCRIPTION
Implement a custom Prebid Server module (in Go) that traces and collects specific auction data throughout the request lifecycle. 
