### PR TITLE
Teal Adapter - bid type fix

### DIFF
--- a/adapters/teal/teal.go
+++ b/adapters/teal/teal.go
@@ -319,26 +319,27 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData
 // getBidType resolves the bid's media type. Teal declares multiformat-supported,
 // so a single impression can carry more than one media type (e.g. banner+video);
 // introspecting the imp alone cannot disambiguate which format a given bid is for.
-// The authoritative signal is the response's own bid.mtype (OpenRTB 2.6), so it is
+// The authoritative signal is the response's own bid.ext.prebid.type, so it is
 // consulted first.
 //
-// Only when the response omits mtype does getBidType fall back to introspecting the
+// Only when the response omits bid.ext.prebid.type does getBidType fall back to introspecting the
 // matching impression, looked up by ID via impsByID (built once in MakeBids to avoid
 // a per-bid scan of request.Imp), in banner > video > native order. Audio is omitted
 // because it is not in Teal's declared capabilities.
 //
-// When neither the bid's mtype nor a matching imp yields a recognized media type,
+// When neither bid.ext.prebid.type nor a matching imp yields a recognized media type,
 // getBidType returns an error so MakeBids can skip the bid and surface the problem in
 // logs rather than silently mis-typing it.
 func getBidType(bid *openrtb2.Bid, impsByID map[string]openrtb2.Imp) (openrtb_ext.BidType, error) {
-	switch bid.MType {
-	case openrtb2.MarkupBanner:
-		return openrtb_ext.BidTypeBanner, nil
-	case openrtb2.MarkupVideo:
-		return openrtb_ext.BidTypeVideo, nil
-	case openrtb2.MarkupNative:
-		return openrtb_ext.BidTypeNative, nil
+	// 1. Check if the bid type exists in bid.ext.prebid.type
+	if len(bid.Ext) > 0 {
+		var bidExt openrtb_ext.ExtBid
+		if err := jsonutil.Unmarshal(bid.Ext, &bidExt); err == nil && bidExt.Prebid != nil && bidExt.Prebid.Type != "" {
+			return bidExt.Prebid.Type, nil
+		}
 	}
+
+	// 2. Fall back to inferring from the impression
 	if imp, ok := impsByID[bid.ImpID]; ok {
 		switch {
 		case imp.Banner != nil:

--- a/adapters/teal/teal_test.go
+++ b/adapters/teal/teal_test.go
@@ -134,19 +134,46 @@ func TestMakeRequests_NoImps(t *testing.T) {
 	assert.Nil(t, errs)
 }
 
-// TestGetBidType_Undeterminable — getBidType returns an explicit error (not a
-// silent banner default) when the imp is missing or declares no media type, so
-// MakeBids can skip the bid and surface the issue in logs.
-func TestGetBidType_Undeterminable(t *testing.T) {
-	bid := &openrtb2.Bid{ImpID: "imp1"}
+// TestGetBidType pins media type resolution priorities and error pathways.
+func TestGetBidType(t *testing.T) {
+	t.Run("explicit prebid type overrides impression fallback", func(t *testing.T) {
+		bid := &openrtb2.Bid{ImpID: "imp1", Ext: json.RawMessage(`{"prebid":{"type":"video"}}`)}
+		imp := openrtb2.Imp{ID: "imp1", Banner: &openrtb2.Banner{}}
+
+		bidType, err := getBidType(bid, map[string]openrtb2.Imp{imp.ID: imp})
+		require.NoError(t, err)
+		assert.Equal(t, openrtb_ext.BidTypeVideo, bidType)
+	})
+
+	t.Run("falls back to impression type when bid.ext.prebid.type is absent", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			imp  openrtb2.Imp
+			want openrtb_ext.BidType
+		}{
+			{name: "banner", imp: openrtb2.Imp{ID: "imp1", Banner: &openrtb2.Banner{}}, want: openrtb_ext.BidTypeBanner},
+			{name: "video", imp: openrtb2.Imp{ID: "imp1", Video: &openrtb2.Video{}}, want: openrtb_ext.BidTypeVideo},
+			{name: "native", imp: openrtb2.Imp{ID: "imp1", Native: &openrtb2.Native{}}, want: openrtb_ext.BidTypeNative},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				bid := &openrtb2.Bid{ImpID: "imp1"}
+				bidType, err := getBidType(bid, map[string]openrtb2.Imp{tc.imp.ID: tc.imp})
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, bidType)
+			})
+		}
+	})
 
 	t.Run("imp not found", func(t *testing.T) {
+		bid := &openrtb2.Bid{ImpID: "imp1"}
 		_, err := getBidType(bid, map[string]openrtb2.Imp{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `failed to determine bid type for imp "imp1"`)
 	})
 
-	t.Run("imp has no media type", func(t *testing.T) {
+	t.Run("bid and imp have no type", func(t *testing.T) {
+		bid := &openrtb2.Bid{ImpID: "imp1"}
 		imp := openrtb2.Imp{ID: "imp1"}
 		_, err := getBidType(bid, map[string]openrtb2.Imp{imp.ID: imp})
 		require.Error(t, err)

--- a/adapters/teal/tealtest/exemplary/multi-format-imp-bid-type.json
+++ b/adapters/teal/tealtest/exemplary/multi-format-imp-bid-type.json
@@ -104,24 +104,36 @@
                   "impid": "test-imp-multi-format",
                   "price": 1.75,
                   "adm": "<div>Teal Banner Ad</div>",
-                  "mtype": 1,
-                  "crid": "creative-banner"
+                  "crid": "creative-banner",
+                  "ext": {
+                    "prebid": {
+                      "type": "banner"
+                    }
+                  }
                 },
                 {
                   "id": "bid-video",
                   "impid": "test-imp-multi-format",
                   "price": 2.10,
                   "adm": "<VAST>Teal Video Ad</VAST>",
-                  "mtype": 2,
-                  "crid": "creative-video"
+                  "crid": "creative-video",
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
                 },
                 {
                   "id": "bid-native",
                   "impid": "test-imp-multi-format",
                   "price": 0.90,
                   "adm": "{\"native\":{\"assets\":[]}}",
-                  "mtype": 4,
-                  "crid": "creative-native"
+                  "crid": "creative-native",
+                  "ext": {
+                    "prebid": {
+                      "type": "native"
+                    }
+                  }
                 }
               ]
             }
@@ -140,8 +152,12 @@
             "impid": "test-imp-multi-format",
             "price": 1.75,
             "adm": "<div>Teal Banner Ad</div>",
-            "mtype": 1,
-            "crid": "creative-banner"
+            "crid": "creative-banner",
+            "ext": {
+              "prebid": {
+                "type": "banner"
+              }
+            }
           },
           "type": "banner"
         },
@@ -151,8 +167,12 @@
             "impid": "test-imp-multi-format",
             "price": 2.10,
             "adm": "<VAST>Teal Video Ad</VAST>",
-            "mtype": 2,
-            "crid": "creative-video"
+            "crid": "creative-video",
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
+            }
           },
           "type": "video"
         },
@@ -162,8 +182,12 @@
             "impid": "test-imp-multi-format",
             "price": 0.90,
             "adm": "{\"native\":{\"assets\":[]}}",
-            "mtype": 4,
-            "crid": "creative-native"
+            "crid": "creative-native",
+            "ext": {
+              "prebid": {
+                "type": "native"
+              }
+            }
           },
           "type": "native"
         }


### PR DESCRIPTION
This is a fix to the Teal adapter to use bid.ext.prebid.type instead of bid.mtype to retrieve the correct bid type. If this is not found then the logic will fallback to use the imp media type.

This makes the logic consistent with the equivalent Java fix that has been merged: https://github.com/prebid/prebid-server-java/pull/4545).